### PR TITLE
[WIP] Reimplement conditional compilation of isa targets using cargo features

### DIFF
--- a/lib/cretonne/Cargo.toml
+++ b/lib/cretonne/Cargo.toml
@@ -13,6 +13,15 @@ build = "build.rs"
 [lib]
 name = "cretonne"
 
+[features]
+default = ["riscv", "intel", "arm32", "arm64"]
+
+# Names of the features should be in sync with isa targets defined in build.rs.
+riscv = []
+intel = []
+arm32 = []
+arm64 = []
+
 [dependencies]
 # It is a goal of the cretonne crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary

--- a/lib/cretonne/src/isa/mod.rs
+++ b/lib/cretonne/src/isa/mod.rs
@@ -55,16 +55,16 @@ use timing;
 use isa::enc_tables::Encodings;
 use std::fmt;
 
-#[cfg(build_riscv)]
+#[cfg(feature = "riscv")]
 mod riscv;
 
-#[cfg(build_intel)]
+#[cfg(feature = "intel")]
 mod intel;
 
-#[cfg(build_arm32)]
+#[cfg(feature = "arm32")]
 mod arm32;
 
-#[cfg(build_arm64)]
+#[cfg(feature = "arm64")]
 mod arm64;
 
 pub mod registers;
@@ -76,13 +76,13 @@ mod stack;
 /// Returns a builder that can create a corresponding `TargetIsa`
 /// or `Err(LookupError::Unsupported)` if not enabled.
 macro_rules! isa_builder {
-    ($module:ident, $name:ident) => {
+    ($name:ident, $feature:tt) => {
         {
-            #[cfg($name)]
+            #[cfg(feature = $feature)]
             fn $name() -> Result<Builder, LookupError> {
-                Ok($module::isa_builder())
+                Ok($name::isa_builder())
             };
-            #[cfg(not($name))]
+            #[cfg(not(feature = $feature))]
             fn $name() -> Result<Builder, LookupError> {
                 Err(LookupError::Unsupported)
             }
@@ -95,10 +95,10 @@ macro_rules! isa_builder {
 /// Return a builder that can create a corresponding `TargetIsa`.
 pub fn lookup(name: &str) -> Result<Builder, LookupError> {
     match name {
-        "riscv" => isa_builder!(riscv, build_riscv),
-        "intel" => isa_builder!(intel, build_intel),
-        "arm32" => isa_builder!(arm32, build_arm32),
-        "arm64" => isa_builder!(arm64, build_arm64),
+        "riscv" => isa_builder!(riscv, "riscv"),
+        "intel" => isa_builder!(intel, "intel"),
+        "arm32" => isa_builder!(arm32, "arm32"),
+        "arm64" => isa_builder!(arm64, "arm64"),
         _ => Err(LookupError::Unknown),
     }
 }

--- a/lib/cretonne/src/regalloc/pressure.rs
+++ b/lib/cretonne/src/regalloc/pressure.rs
@@ -267,7 +267,7 @@ impl fmt::Display for Pressure {
 }
 
 #[cfg(test)]
-#[cfg(build_arm32)]
+#[cfg(feature = "arm32")]
 mod tests {
     use isa::{TargetIsa, RegClass};
     use regalloc::AllocatableSet;

--- a/lib/cretonne/src/regalloc/solver.rs
+++ b/lib/cretonne/src/regalloc/solver.rs
@@ -1155,7 +1155,7 @@ impl fmt::Display for Solver {
 }
 
 #[cfg(test)]
-#[cfg(build_arm32)]
+#[cfg(feature = "arm32")]
 mod tests {
     use entity::EntityRef;
     use ir::Value;

--- a/lib/reader/src/lib.rs
+++ b/lib/reader/src/lib.rs
@@ -10,9 +10,9 @@
 extern crate cretonne;
 
 pub use error::{Location, Result, Error};
-pub use parser::{parse_functions, parse_test};
+pub use parser::{parse_functions, parse_test, parse_test_file};
 pub use testcommand::{TestCommand, TestOption};
-pub use testfile::{TestFile, Details, Comment};
+pub use testfile::{TestFile, Test, Details, Comment};
 pub use isaspec::{IsaSpec, parse_options};
 pub use sourcemap::SourceMap;
 

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -2579,7 +2579,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(build_riscv)]
     fn isa_spec() {
         assert!(
             parse_test(

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -2579,6 +2579,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "riscv")]
     fn isa_spec() {
         assert!(
             parse_test(

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -29,11 +29,9 @@ use sourcemap::SourceMap;
 /// Any test commands or ISA declarations are ignored.
 pub fn parse_functions(text: &str) -> Result<Vec<Function>> {
     let _tt = timing::parse_text();
-    parse_test(text).map(|test| {
-        match test {
-            Test::UnsupportedIsa => vec![],
-            Test::File(file) => file.functions.into_iter().map(|(func, _)| func).collect(),
-        }
+    parse_test(text).map(|test| match test {
+        Test::UnsupportedIsa => vec![],
+        Test::File(file) => file.functions.into_iter().map(|(func, _)| func).collect(),
     })
 }
 

--- a/lib/reader/src/sourcemap.rs
+++ b/lib/reader/src/sourcemap.rs
@@ -190,11 +190,11 @@ impl SourceMap {
 
 #[cfg(test)]
 mod tests {
-    use parse_test;
+    use parse_test_file;
 
     #[test]
     fn details() {
-        let tf = parse_test(
+        let tf = parse_test_file(
             "function %detail() {
                                ss10 = incoming_arg 13
                                jt10 = jump_table ebb0

--- a/lib/reader/src/testfile.rs
+++ b/lib/reader/src/testfile.rs
@@ -11,6 +11,14 @@ use isaspec::IsaSpec;
 use sourcemap::SourceMap;
 use error::Location;
 
+/// A parsed test.
+pub enum Test<'a> {
+    /// Represents a case when ISA is known but unsupported.
+    UnsupportedIsa,
+    /// An actual test case.
+    File(TestFile<'a>),
+}
+
 /// A parsed test case.
 ///
 /// This is the result of parsing a `.cton` file which contains a number of test commands and ISA

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -70,7 +70,9 @@ fn handle_module(
     let buffer = read_to_string(&path).map_err(
         |e| format!("{}: {}", name, e),
     )?;
-    let test_file = parse_test_file(&buffer).map_err(|e| format!("{}: {}", name, e))?;
+    let test_file = parse_test_file(&buffer).map_err(
+        |e| format!("{}: {}", name, e),
+    )?;
 
     // If we have an isa from the command-line, use that. Otherwise if the
     // file contains a unique isa, use that.

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -2,7 +2,7 @@
 //!
 //! Reads IR files into Cretonne IL and compiles it.
 
-use cton_reader::parse_test;
+use cton_reader::parse_test_file;
 use std::path::PathBuf;
 use cretonne::Context;
 use cretonne::settings::FlagsOrIsa;
@@ -70,7 +70,7 @@ fn handle_module(
     let buffer = read_to_string(&path).map_err(
         |e| format!("{}: {}", name, e),
     )?;
-    let test_file = parse_test(&buffer).map_err(|e| format!("{}: {}", name, e))?;
+    let test_file = parse_test_file(&buffer).map_err(|e| format!("{}: {}", name, e))?;
 
     // If we have an isa from the command-line, use that. Otherwise if the
     // file contains a unique isa, use that.

--- a/src/filetest/runone.rs
+++ b/src/filetest/runone.rs
@@ -8,7 +8,7 @@ use cretonne::isa::TargetIsa;
 use cretonne::settings::Flags;
 use cretonne::timing;
 use cretonne::verify_function;
-use cton_reader::parse_test;
+use cton_reader::{parse_test, Test};
 use cton_reader::IsaSpec;
 use utils::{read_to_string, pretty_verifier_error};
 use filetest::{TestResult, new_subtest};
@@ -22,7 +22,11 @@ pub fn run(path: &Path) -> TestResult {
     dbg!("---\nFile: {}", path.to_string_lossy());
     let started = time::Instant::now();
     let buffer = read_to_string(path).map_err(|e| e.to_string())?;
-    let testfile = parse_test(&buffer).map_err(|e| e.to_string())?;
+    let test = parse_test(&buffer).map_err(|e| e.to_string())?;
+    let testfile = match test {
+        Test::UnsupportedIsa => return Ok(started.elapsed()),
+        Test::File(f) => f,
+    };
     if testfile.functions.is_empty() {
         return Err("no functions found".to_string());
     }


### PR DESCRIPTION
This is a continuation of work started in #126 

I've realised that this design doesn't allow conditional compilation of other project in the tree. For example, if user wants ability to compile `cton_reader` only for concrete target. To support it for all projects we need to define the same features (isa targets) that are defined in `cretonne` for `cton-util`, `cton_reader` and `cton_frontend`. Besides if we want to support native targets each project should have own build.rs file that checks enabled cargo features and sets native isa target if needed (as implemented in this PR in `lib/cretonne/build.rs`)

Maybe there is a better way and I'm missing something?