### PR TITLE
Fixes #362: Finishes Cretonne renaming to Cranelift

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "cretonne-tools"
-authors = ["The Cretonne Project Developers"]
+name = "cranelift-tools"
+authors = ["The Cranelift Project Developers"]
 version = "0.13.0"
-description = "Binaries for testing the Cretonne libraries"
+description = "Binaries for testing the Cranelift libraries"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cretonne.readthedocs.io/"
-repository = "https://github.com/cretonne/cretonne"
+repository = "https://github.com/CraneStation/cranelift"
 publish = false
 
 [[bin]]
@@ -14,16 +14,16 @@ path = "src/cton-util.rs"
 
 [dependencies]
 cfg-if = "0.1"
-cretonne-codegen = { path = "lib/codegen", version = "0.13.0" }
-cretonne-reader = { path = "lib/reader", version = "0.13.0" }
-cretonne-frontend = { path = "lib/frontend", version = "0.13.0" }
-cretonne-wasm = { path = "lib/wasm", version = "0.13.0", optional = true }
-cretonne-native = { path = "lib/native", version = "0.13.0" }
-cretonne-filetests = { path = "lib/filetests", version = "0.13.0" }
-cretonne-module = { path = "lib/module", version = "0.13.0" }
-cretonne-faerie = { path = "lib/faerie", version = "0.13.0" }
-cretonne-simplejit = { path = "lib/simplejit", version = "0.13.0" }
-cretonne = { path = "lib/umbrella", version = "0.13.0" }
+cranelift-codegen = { path = "lib/codegen", version = "0.13.0" }
+cranelift-reader = { path = "lib/reader", version = "0.13.0" }
+cranelift-frontend = { path = "lib/frontend", version = "0.13.0" }
+cranelift-wasm = { path = "lib/wasm", version = "0.13.0", optional = true }
+cranelift-native = { path = "lib/native", version = "0.13.0" }
+cranelift-filetests = { path = "lib/filetests", version = "0.13.0" }
+cranelift-module = { path = "lib/module", version = "0.13.0" }
+cranelift-faerie = { path = "lib/faerie", version = "0.13.0" }
+cranelift-simplejit = { path = "lib/simplejit", version = "0.13.0" }
+cranelift = { path = "lib/umbrella", version = "0.13.0" }
 filecheck = "0.3.0"
 docopt = "1"
 serde = "1.0.8"
@@ -36,7 +36,7 @@ target-lexicon = "0.0.2"
 [features]
 default = ["disas", "wasm"]
 disas = ["capstone"]
-wasm = ["wabt", "cretonne-wasm"]
+wasm = ["wabt", "cranelift-wasm"]
 
 [workspace]
 

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -1,6 +1,6 @@
 # Fuzzing
 
-This document describes how to fuzz cretonne with [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz). The fuzz targets use `wasm-opt` from [`binaryen-rs`](https://github.com/pepyakin/binaryen-rs) to generate valid WebAssembly modules from the fuzzed input supplied by `cargo-fuzz` (via [libfuzzer](http://llvm.org/docs/LibFuzzer.html)). In this scheme coverage feedback from both cretonne and the `wasm-opt` input generation code is used to inform the fuzzer.
+This document describes how to fuzz cranelift with [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz). The fuzz targets use `wasm-opt` from [`binaryen-rs`](https://github.com/pepyakin/binaryen-rs) to generate valid WebAssembly modules from the fuzzed input supplied by `cargo-fuzz` (via [libfuzzer](http://llvm.org/docs/LibFuzzer.html)). In this scheme coverage feedback from both cranelift and the `wasm-opt` input generation code is used to inform the fuzzer.
 
 # Usage
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 =======================
-Cretonne Code Generator
+Cranelift Code Generator
 =======================
 
-Cretonne is a low-level retargetable code generator. It translates a `target-independent
+Cranelift is a low-level retargetable code generator. It translates a `target-independent
 intermediate representation <https://cretonne.readthedocs.io/en/latest/langref.html>`_ into executable
 machine code.
 
@@ -10,12 +10,12 @@ machine code.
     :target: https://cretonne.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
-.. image:: https://travis-ci.org/cretonne/cretonne.svg?branch=master
-    :target: https://travis-ci.org/cretonne/cretonne
+.. image:: https://travis-ci.org/CraneStation/cranelift.svg?branch=master
+    :target: https://travis-ci.org/CraneStation/cranelift
     :alt: Build Status
 
-.. image:: https://badges.gitter.im/cretonne/cretonne.svg
-    :target: https://gitter.im/cretonne/Lobby/~chat
+.. image:: https://badges.gitter.im/cranelift/cranelift.svg
+    :target: https://gitter.im/cranelift/Lobby/~chat
     :alt: Gitter chat
 
 For more information, see `the documentation
@@ -24,38 +24,38 @@ For more information, see `the documentation
 Status
 ------
 
-Cretonne currently supports enough functionality to run a wide variety of
+Cranelift currently supports enough functionality to run a wide variety of
 programs, including all the functionality needed to execute WebAssembly MVP
 functions, although it needs to be used within an external WebAssembly
 embedding to be part of a complete WebAssembly implementation.
 
 The x86-64 backend is currently the most complete and stable; other
-architectures are in various stages of development. Cretonne currently supports
+architectures are in various stages of development. Cranelift currently supports
 the System V AMD64 ABI calling convention used on many platforms, but does not
 yet support the Windows x64 calling convention. The performance of code
-produced by Cretonne is not yet impressive, though we have plans to fix that.
+produced by Cranelift is not yet impressive, though we have plans to fix that.
 
 The core codegen crates have minimal dependencies, support
 `no_std <#building-with-no-std>`_ mode, and do not require any host
 floating-point support.
 
-Cretonne does not yet perform mitigations for Spectre or related security
+Cranelift does not yet perform mitigations for Spectre or related security
 issues, though it may do so in the future. It does not currently make any
 security-relevant instruction timing guarantees. It has seen a fair amount
 of testing and fuzzing, although more work is needed before it would be
 ready for a production use case.
 
-Cretonne's APIs are not yet stable.
+Cranelift's APIs are not yet stable.
 
-Cretonne currently supports Rust 1.22.1 and later. We intend to always support
+Cranelift currently supports Rust 1.22.1 and later. We intend to always support
 the latest *stable* Rust. And, we currently support the version of Rust in the
 latest Ubuntu LTS, although whether we will always do so is not yet determined.
-Cretonne requires Python 2.7 or Python 3 to build.
+Cranelift requires Python 2.7 or Python 3 to build.
 
 Planned uses
 ------------
 
-Cretonne is designed to be a code generator for WebAssembly, but it is general enough to be useful
+Cranelift is designed to be a code generator for WebAssembly, but it is general enough to be useful
 elsewhere too. The initial planned uses that affected its design are:
 
 1. `WebAssembly compiler for the SpiderMonkey engine in Firefox
@@ -64,13 +64,13 @@ elsewhere too. The initial planned uses that affected its design are:
    <spidermonkey.rst#phase-2-ionmonkey>`_.
 3. `Debug build backend for the Rust compiler <rustc.rst>`_.
 
-Building Cretonne
+Building Cranelift
 -----------------
 
-Cretonne is using the Cargo package manager format. First, ensure you have
+Cranelift is using the Cargo package manager format. First, ensure you have
 installed a current stable rust (stable, beta, and nightly should all work, but
 only stable and beta are tested consistently). Then, change the working
-directory to your clone of cretonne and run::
+directory to your clone of cranelift and run::
 
     cargo build
 
@@ -89,30 +89,30 @@ Building with `no_std`
 ----------------------
 
 The following crates support `no_std`:
- - `cretonne-entity`
- - `cretonne-codegen`
- - `cretonne-frontend`
- - `cretonne-native`
- - `cretonne-wasm`
- - `cretonne-module`
- - `cretonne-simplejit`
- - `cretonne`
+ - `cranelift-entity`
+ - `cranelift-codegen`
+ - `cranelift-frontend`
+ - `cranelift-native`
+ - `cranelift-wasm`
+ - `cranelift-module`
+ - `cranelift-simplejit`
+ - `cranelift`
 
 To use `no_std` mode, disable the `std` feature and enable the `core` feature.
 This currently requires nightly rust.
 
-For example, to build `cretonne-codegen`:
+For example, to build `cranelift-codegen`:
 
 .. code-block:: sh
 
     cd lib/codegen
     cargo build --no-default-features --features core
 
-Or, when using `cretonne-codegen` as a dependency (in Cargo.toml):
+Or, when using `cranelift-codegen` as a dependency (in Cargo.toml):
 
 .. code-block::
 
-    [dependency.cretonne-codegen]
+    [dependency.cranelift-codegen]
     ...
     default-features = false
     features = ["core"]
@@ -125,7 +125,7 @@ build and test `no_std` when submitting patches. Accordingly, the
 There is a separate `./test-no_std.sh` script that tests the `no_std`
 support in packages which support it.
 
-It's important to note that cretonne still needs liballoc to compile.
+It's important to note that cranelift still needs liballoc to compile.
 Thus, whatever environment is used must implement an allocator.
 
 Also, to allow the use of HashMaps with `no_std`, an external crate called
@@ -136,11 +136,11 @@ Just something to think about.
 Building the documentation
 --------------------------
 
-To build the Cretonne documentation, you need the `Sphinx documentation
+To build the Cranelift documentation, you need the `Sphinx documentation
 generator <https://www.sphinx-doc.org/>`_::
 
     $ pip install sphinx sphinx-autobuild sphinx_rtd_theme
-    $ cd cretonne/docs
+    $ cd cranelift/docs
     $ make html
     $ open _build/html/index.html
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXABUILD  = sphinx-autobuild
-SPHINXPROJ    = cretonne
+SPHINXPROJ    = cranelift
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/compare-llvm.rst
+++ b/docs/compare-llvm.rst
@@ -1,5 +1,5 @@
 *************************
-Cretonne compared to LLVM
+Cranelift compared to LLVM
 *************************
 
 `LLVM <https://llvm.org>`_ is a collection of compiler components implemented as
@@ -10,18 +10,18 @@ popular. `Chris Lattner's chapter about LLVM
 Applications <https://aosabook.org/en/index.html>`_ book gives an excellent
 overview of the architecture and design of LLVM.
 
-Cretonne and LLVM are superficially similar projects, so it is worth
+Cranelift and LLVM are superficially similar projects, so it is worth
 highlighting some of the differences and similarities. Both projects:
 
 - Use an ISA-agnostic input language in order to mostly abstract away the
   differences between target instruction set architectures.
 - Depend extensively on SSA form.
 - Have both textual and in-memory forms of their primary intermediate
-  representation. (LLVM also has a binary bitcode format; Cretonne doesn't.)
+  representation. (LLVM also has a binary bitcode format; Cranelift doesn't.)
 - Can target multiple ISAs.
 - Can cross-compile by default without rebuilding the code generator.
 
-Cretonne's scope is much smaller than that of LLVM. The classical three main
+Cranelift's scope is much smaller than that of LLVM. The classical three main
 parts of a compiler are:
 
 1. The language-dependent front end parses and type-checks the input program.
@@ -29,9 +29,9 @@ parts of a compiler are:
    target ISA.
 3. The code generator which depends strongly on the target ISA.
 
-LLVM provides both common optimizations *and* a code generator. Cretonne only
+LLVM provides both common optimizations *and* a code generator. Cranelift only
 provides the last part, the code generator. LLVM additionally provides
-infrastructure for building assemblers and disassemblers. Cretonne does not
+infrastructure for building assemblers and disassemblers. Cranelift does not
 handle assembly at all---it only generates binary machine code.
 
 Intermediate representations
@@ -89,20 +89,20 @@ representation. Some target ISAs have a fast instruction selector that can
 translate simple code directly to MachineInstrs, bypassing SelectionDAG when
 possible.
 
-:doc:`Cretonne <langref>` uses a single intermediate representation to cover
-these levels of abstraction. This is possible in part because of Cretonne's
+:doc:`Cranelift <langref>` uses a single intermediate representation to cover
+these levels of abstraction. This is possible in part because of Cranelift's
 smaller scope.
 
-- Cretonne does not provide assemblers and disassemblers, so it is not
+- Cranelift does not provide assemblers and disassemblers, so it is not
   necessary to be able to represent every weird instruction in an ISA. Only
   those instructions that the code generator emits have a representation.
-- Cretonne's opcodes are ISA-agnostic, but after legalization / instruction
+- Cranelift's opcodes are ISA-agnostic, but after legalization / instruction
   selection, each instruction is annotated with an ISA-specific encoding which
   represents a native instruction.
 - SSA form is preserved throughout. After register allocation, each SSA value
   is annotated with an assigned ISA register or stack slot.
 
-The Cretonne intermediate representation is similar to LLVM IR, but at a slightly
+The Cranelift intermediate representation is similar to LLVM IR, but at a slightly
 lower level of abstraction.
 
 Program structure
@@ -112,22 +112,22 @@ In LLVM IR, the largest representable unit is the *module* which corresponds
 more or less to a C translation unit. It is a collection of functions and
 global variables that may contain references to external symbols too.
 
-In Cretonne IR, the largest representable unit is the *function*. This is so
+In Cranelift IR, the largest representable unit is the *function*. This is so
 that functions can easily be compiled in parallel without worrying about
-references to shared data structures. Cretonne does not have any
+references to shared data structures. Cranelift does not have any
 inter-procedural optimizations like inlining.
 
-An LLVM IR function is a graph of *basic blocks*. A Cretonne IR function is a
+An LLVM IR function is a graph of *basic blocks*. A Cranelift IR function is a
 graph of *extended basic blocks* that may contain internal branch instructions.
 The main difference is that an LLVM conditional branch instruction has two
-target basic blocks---a true and a false edge. A Cretonne branch instruction
+target basic blocks---a true and a false edge. A Cranelift branch instruction
 only has a single target and falls through to the next instruction when its
-condition is false. The Cretonne representation is closer to how machine code
+condition is false. The Cranelift representation is closer to how machine code
 works; LLVM's representation is more abstract.
 
 LLVM uses `phi instructions
 <https://llvm.org/docs/LangRef.html#phi-instruction>`_ in its SSA
-representation. Cretonne passes arguments to EBBs instead. The two
+representation. Cranelift passes arguments to EBBs instead. The two
 representations are equivalent, but the EBB arguments are better suited to
 handle EBBs that may contain multiple branches to the same destination block
 with different arguments. Passing arguments to an EBB looks a lot like passing
@@ -137,7 +137,7 @@ similarly. Arguments are assigned to registers or stack locations.
 Value types
 -----------
 
-:ref:`Cretonne's type system <value-types>` is mostly a subset of LLVM's type
+:ref:`Cranelift's type system <value-types>` is mostly a subset of LLVM's type
 system. It is less abstract and closer to the types that common ISA registers
 can hold.
 
@@ -146,30 +146,30 @@ can hold.
 - Floating point types are limited to :cton:type:`f32` and :cton:type:`f64`
   which is what WebAssembly provides. It is possible that 16-bit and 128-bit
   types will be added in the future.
-- Addresses are represented as integers---There are no Cretonne pointer types.
+- Addresses are represented as integers---There are no Cranelift pointer types.
   LLVM currently has rich pointer types that include the pointee type. It may
-  move to a simpler 'address' type in the future. Cretonne may add a single
+  move to a simpler 'address' type in the future. Cranelift may add a single
   address type too.
 - SIMD vector types are limited to a power-of-two number of vector lanes up to
   256. LLVM allows an arbitrary number of SIMD lanes.
-- Cretonne has no aggregate types. LLVM has named and anonymous struct types as
+- Cranelift has no aggregate types. LLVM has named and anonymous struct types as
   well as array types.
 
-Cretonne has multiple boolean types, whereas LLVM simply uses `i1`. The sized
-Cretonne boolean types are used to represent SIMD vector masks like ``b32x4``
+Cranelift has multiple boolean types, whereas LLVM simply uses `i1`. The sized
+Cranelift boolean types are used to represent SIMD vector masks like ``b32x4``
 where each lane is either all 0 or all 1 bits.
 
-Cretonne instructions and function calls can return multiple result values. LLVM
+Cranelift instructions and function calls can return multiple result values. LLVM
 instead models this by returning a single value of an aggregate type.
 
 Instruction set
 ---------------
 
 LLVM has a small well-defined basic instruction set and a large number of
-intrinsics, some of which are ISA-specific. Cretonne has a larger instruction
-set and no intrinsics. Some Cretonne instructions are ISA-specific.
+intrinsics, some of which are ISA-specific. Cranelift has a larger instruction
+set and no intrinsics. Some Cranelift instructions are ISA-specific.
 
-Since Cretonne instructions are used all the way until the binary machine code
+Since Cranelift instructions are used all the way until the binary machine code
 is emitted, there are opcodes for every native instruction that can be
 generated. There is a lot of overlap between different ISAs, so for example the
 :cton:inst:`iadd_imm` instruction is used by every ISA that can add an
@@ -180,20 +180,20 @@ instructions to model addressing modes.
 Undefined behavior
 ==================
 
-Cretonne does not generally exploit undefined behavior in its optimizations.
+Cranelift does not generally exploit undefined behavior in its optimizations.
 LLVM's mid-level optimizations do, but it should be noted that LLVM's low-level code
 generator rarely needs to make use of undefined behavior either.
 
 LLVM provides ``nsw`` and ``nuw`` flags for its arithmetic that invoke
-undefined behavior on overflow. Cretonne does not provide this functionality.
+undefined behavior on overflow. Cranelift does not provide this functionality.
 Its arithmetic instructions either produce a value or a trap.
 
 LLVM has an ``unreachable`` instruction which is used to indicate impossible
-code paths. Cretonne only has an explicit :cton:inst:`trap` instruction.
+code paths. Cranelift only has an explicit :cton:inst:`trap` instruction.
 
-Cretonne does make assumptions about aliasing. For example, it assumes that it
+Cranelift does make assumptions about aliasing. For example, it assumes that it
 has full control of the stack objects in a function, and that they can only be
 modified by function calls if their address have escaped. It is quite likely
-that Cretonne will admit more detailed aliasing annotations on load/store
+that Cranelift will admit more detailed aliasing annotations on load/store
 instructions in the future. When these annotations are incorrect, undefined
 behavior ensues.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# cretonne documentation build configuration file, created by
+# cranelift documentation build configuration file, created by
 # sphinx-quickstart on Fri Mar  2 12:49:24 2018.
 #
 # This file is execfile()d with the current directory set to its
@@ -21,7 +21,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
 
-# Also add the meta directory to sys.path so autodoc can find the Cretonne meta
+# Also add the meta directory to sys.path so autodoc can find the Cranelift meta
 # language definitions.
 sys.path.insert(0, os.path.abspath('../lib/codegen/meta'))
 
@@ -58,9 +58,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'cretonne'
-copyright = u'2018, Cretonne Developers'
-author = u'Cretonne Developers'
+project = u'cranelift'
+copyright = u'2018, Cranelift Developers'
+author = u'Cranelift Developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -113,7 +113,7 @@ html_theme = 'sphinx_rtd_theme'
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'cretonnedoc'
+htmlhelp_basename = 'craneliftdoc'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -140,7 +140,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'cretonne.tex', u'cretonne Documentation',
+    (master_doc, 'cranelift.tex', u'cranelift Documentation',
      author, 'manual'),
 ]
 
@@ -150,7 +150,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'cretonne', u'cretonne Documentation',
+    (master_doc, 'cranelift', u'cranelift Documentation',
      [author], 1)
 ]
 
@@ -161,8 +161,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'cretonne', u'cretonne Documentation',
-     author, 'cretonne', 'One line description of project.',
+    (master_doc, 'cranelift', u'cranelift Documentation',
+     author, 'cranelift', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/cton_domain.py
+++ b/docs/cton_domain.py
@@ -29,10 +29,10 @@ import sphinx.ext.autodoc
 
 class CtonObject(ObjectDescription):
     """
-    Any kind of Cretonne IR object.
+    Any kind of Cranelift IR object.
 
     This is a shared base class for the different kinds of indexable objects
-    in the Cretonne IR reference.
+    in the Cranelift IR reference.
     """
     option_spec = {
         'noindex': directives.flag,
@@ -57,7 +57,7 @@ class CtonObject(ObjectDescription):
             inv = self.env.domaindata['cton']['objects']
             if name in inv:
                 self.state_machine.reporter.warning(
-                    'duplicate Cretonne object description of %s, ' % name +
+                    'duplicate Cranelift object description of %s, ' % name +
                     'other instance in ' + self.env.doc2path(inv[name][0]),
                     line=self.lineno)
             inv[name] = (self.env.docname, self.objtype)
@@ -98,7 +98,7 @@ def parse_type(name, signode):
 
 
 class CtonType(CtonObject):
-    """A Cretonne IR type description."""
+    """A Cranelift IR type description."""
 
     def handle_signature(self, sig, signode):
         """
@@ -127,7 +127,7 @@ def parse_params(s, signode):
 
 
 class CtonInst(CtonObject):
-    """A Cretonne IR instruction."""
+    """A Cranelift IR instruction."""
 
     doc_field_types = [
         TypedField('argument', label=l_('Arguments'),
@@ -176,13 +176,13 @@ class CtonInst(CtonObject):
 
 
 class CtonInstGroup(CtonObject):
-    """A Cretonne IR instruction group."""
+    """A Cranelift IR instruction group."""
 
 
-class CretonneDomain(Domain):
-    """Cretonne domain for IR objects."""
+class CraneliftDomain(Domain):
+    """Cranelift domain for IR objects."""
     name = 'cton'
-    label = 'Cretonne'
+    label = 'Cranelift'
 
     object_types = {
         'type': ObjType(l_('type'), 'type'),
@@ -377,7 +377,7 @@ class InstGroupDocumenter(sphinx.ext.autodoc.ModuleLevelDocumenter):
 
 
 def setup(app):
-    app.add_domain(CretonneDomain)
+    app.add_domain(CraneliftDomain)
     app.add_autodocumenter(TypeDocumenter)
     app.add_autodocumenter(InstDocumenter)
     app.add_autodocumenter(InstGroupDocumenter)

--- a/docs/cton_lexer.py
+++ b/docs/cton_lexer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Pygments lexer for Cretonne.
+# Pygments lexer for Cranelift.
 from __future__ import absolute_import
 
 from pygments.lexer import RegexLexer, bygroups, words
@@ -12,8 +12,8 @@ def keywords(*args):
     return words(args, prefix=r'\b', suffix=r'\b')
 
 
-class CretonneLexer(RegexLexer):
-    name = 'Cretonne'
+class CraneliftLexer(RegexLexer):
+    name = 'Cranelift'
     aliases = ['cton']
     filenames = ['*.cton']
 
@@ -64,6 +64,6 @@ class CretonneLexer(RegexLexer):
 
 def setup(app):
     """Setup Sphinx extension."""
-    app.add_lexer('cton', CretonneLexer())
+    app.add_lexer('cton', CraneliftLexer())
 
     return {'version': '0.1'}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Cretonne Code Generator
+Cranelift Code Generator
 =======================
 
 Contents:
@@ -15,36 +15,36 @@ Contents:
 Rust Crate Documentation
 ========================
 
-`cretonne <https://docs.rs/cretonne/>`_
-    This is the core code generator crate. It takes Cretonne IR as input
+`cranelift <https://docs.rs/cranelift/>`_
+    This is the core code generator crate. It takes Cranelift IR as input
     and emits encoded machine instructions, along with symbolic relocations,
     as output.
 
-`cretonne-wasm <https://docs.rs/cretonne-wasm/>`_
-    This crate translates WebAssembly code into Cretonne IR.
+`cranelift-wasm <https://docs.rs/cranelift-wasm/>`_
+    This crate translates WebAssembly code into Cranelift IR.
 
-`cretonne-frontend <https://docs.rs/cretonne-frontend/>`_
-    This crate provides utilities for translating code into Cretonne IR.
+`cranelift-frontend <https://docs.rs/cranelift-frontend/>`_
+    This crate provides utilities for translating code into Cranelift IR.
 
-`cretonne-native <https://docs.rs/cretonne-native/>`_
-    This crate performs auto-detection of the host, allowing Cretonne to
+`cranelift-native <https://docs.rs/cranelift-native/>`_
+    This crate performs auto-detection of the host, allowing Cranelift to
     generate code optimized for the machine it's running on.
 
-`cretonne-reader <https://docs.rs/cretonne-reader/>`_
-    This crate translates from Cretonne IR's text format into Cretonne IR
+`cranelift-reader <https://docs.rs/cranelift-reader/>`_
+    This crate translates from Cranelift IR's text format into Cranelift IR
     in in-memory data structures.
 
-`cretonne-module <https://docs.rs/cretonne-module/>`_
+`cranelift-module <https://docs.rs/cranelift-module/>`_
     This crate manages compiling multiple functions and data objects
     together.
 
-`cretonne-faerie <https://docs.rs/cretonne-faerie/>`_
-    This crate provides a faerie-based backend for `cretonne-module`, which
+`cranelift-faerie <https://docs.rs/cranelift-faerie/>`_
+    This crate provides a faerie-based backend for `cranelift-module`, which
     emits native object files using the
     `faerie <https://crates.io/crates/faerie/>`_ library.
 
-`cretonne-simplejit <https://docs.rs/cretonne-simplejit/>`_
-    This crate provides a simple JIT backend for `cretonne-module`, which
+`cranelift-simplejit <https://docs.rs/cranelift-simplejit/>`_
+    This crate provides a simple JIT backend for `cranelift-module`, which
     emits code and data into memory.
 
 Indices and tables

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -1,14 +1,14 @@
 ***************************
-Cretonne Language Reference
+Cranelift Language Reference
 ***************************
 
 .. default-domain:: cton
 .. highlight:: cton
 
-The Cretonne intermediate representation (:term:`IR`) has two primary forms:
+The Cranelift intermediate representation (:term:`IR`) has two primary forms:
 an *in-memory data structure* that the code generator library is using, and a
 *text format* which is used for test cases and debug output.
-Files containing Cretonne textual IR have the ``.cton`` filename extension.
+Files containing Cranelift textual IR have the ``.cton`` filename extension.
 
 This reference uses the text format to describe IR semantics but glosses over
 the finer details of the lexical and syntactic structure of the format.
@@ -17,7 +17,7 @@ the finer details of the lexical and syntactic structure of the format.
 Overall structure
 =================
 
-Cretonne compiles functions independently. A ``.cton`` IR file may contain
+Cranelift compiles functions independently. A ``.cton`` IR file may contain
 multiple functions, and the programmatic API can create multiple function
 handles at the same time, but the functions don't share any data or reference
 each other directly.
@@ -27,7 +27,7 @@ This is a simple C function that computes the average of an array of floats:
 .. literalinclude:: example.c
     :language: c
 
-Here is the same function compiled into Cretonne IR:
+Here is the same function compiled into Cranelift IR:
 
 .. literalinclude:: example.cton
     :language: cton
@@ -59,7 +59,7 @@ The instructions in the function body use and produce *values* in SSA form. This
 means that every value is defined exactly once, and every use of a value must be
 dominated by the definition.
 
-Cretonne does not have phi instructions but uses :term:`EBB parameter`\s
+Cranelift does not have phi instructions but uses :term:`EBB parameter`\s
 instead. An EBB can be defined with a list of typed parameters. Whenever control
 is transferred to the EBB, argument values for the parameters must be provided.
 When entering a function, the incoming function parameters are passed as
@@ -74,11 +74,11 @@ SSA values: In the entry block, ``v4`` is the initial value. In the loop block
 variable during each iteration. Finally, ``v12`` is computed as the induction
 variable value for the next iteration.
 
-The `cretonne_frontend` crate contains utilities for translating from programs
+The `cranelift_frontend` crate contains utilities for translating from programs
 containing multiple assignments to the same variables into SSA form for
-Cretonne :term:`IR`.
+Cranelift :term:`IR`.
 
-Such variables can also be presented to Cretonne as :term:`stack slot`\s.
+Such variables can also be presented to Cranelift as :term:`stack slot`\s.
 Stack slots are accessed with the :inst:`stack_store` and :inst:`stack_load`
 instructions, and can have their address taken with :inst:`stack_addr`, which
 supports C-like programming languages where local variables can have their
@@ -420,7 +420,7 @@ baldrdash  SpiderMonkey WebAssembly convention
 ========== ===========================================
 
 The "not-ABI-stable" conventions do not follow an external specification and
-may change between versions of Cretonne.
+may change between versions of Cranelift.
 
 The "fastcall" convention is not yet implemented.
 
@@ -462,7 +462,7 @@ Indirect function calls use a signature declared in the preamble.
 Memory
 ======
 
-Cretonne provides fully general :inst:`load` and :inst:`store` instructions for
+Cranelift provides fully general :inst:`load` and :inst:`store` instructions for
 accessing memory, as well as :ref:`extending loads and truncating stores
 <extload-truncstore>`.
 
@@ -515,7 +515,7 @@ frame.
 
     Allocate a stack slot in the preamble.
 
-    If no alignment is specified, Cretonne will pick an appropriate alignment
+    If no alignment is specified, Cranelift will pick an appropriate alignment
     for the stack slot based on its size and access patterns.
 
     :arg Bytes: Stack slot size on bytes.
@@ -543,7 +543,7 @@ instructions before instruction selection::
     v1 = stack_addr ss3, 16
     v0 = load.f64 v1
 
-When Cretonne code is running in a sandbox, it can also be necessary to include
+When Cranelift code is running in a sandbox, it can also be necessary to include
 stack overflow checks in the prologue.
 
 .. inst:: stack_limit = GV
@@ -564,14 +564,14 @@ A *global value* is an object whose value is not known at compile time. The
 value is computed at runtime by :inst:`global_value`, possibly using
 information provided by the linker via relocations. There are multiple
 kinds of global values using different methods for determining their value.
-Cretonne does not track the type of a global value, for they are just
+Cranelift does not track the type of a global value, for they are just
 values stored in non-stack memory.
 
-When Cretonne is generating code for a virtual machine environment, globals can
+When Cranelift is generating code for a virtual machine environment, globals can
 be used to access data structures in the VM's runtime. This requires functions
 to have access to a *VM context pointer* which is used as the base address.
 Typically, the VM context pointer is passed as a hidden function argument to
-Cretonne functions.
+Cranelift functions.
 
 .. inst:: GV = vmctx+Offset
 
@@ -632,7 +632,7 @@ Heaps
 
 Code compiled from WebAssembly or asm.js runs in a sandbox where it can't access
 all process memory. Instead, it is given a small set of memory areas to work
-in, and all accesses are bounds checked. Cretonne models this through the
+in, and all accesses are bounds checked. Cranelift models this through the
 concept of *heaps*.
 
 A heap is declared in the function preamble and can be accessed with the
@@ -772,7 +772,7 @@ load a constant into an SSA value.
 Live range splitting
 --------------------
 
-Cretonne's register allocator assigns each SSA value to a register or a spill
+Cranelift's register allocator assigns each SSA value to a register or a spill
 slot on the stack for its entire live range. Since the live range of an SSA
 value can be quite large, it is sometimes beneficial to split the live range
 into smaller parts.
@@ -1014,7 +1014,7 @@ Most ISAs provide instructions that load an integer value smaller than a registe
 and extends it to the width of the register. Similarly, store instructions that
 only write the low bits of an integer register are common.
 
-In addition to the normal :inst:`load` and :inst:`store` instructions, Cretonne
+In addition to the normal :inst:`load` and :inst:`store` instructions, Cranelift
 provides extending loads and truncation stores for 8, 16, and 32-bit memory
 accesses.
 
@@ -1067,7 +1067,7 @@ Target ISAs may define further instructions in their own instruction groups:
 Implementation limits
 =====================
 
-Cretonne's intermediate representation imposes some limits on the size of
+Cranelift's intermediate representation imposes some limits on the size of
 functions and the number of entities allowed. If these limits are exceeded, the
 implementation will panic.
 
@@ -1098,7 +1098,7 @@ Number of arguments to a function
     At most :math:`2^{16}`.
 
     This follows from the limit on arguments to the entry EBB. Note that
-    Cretonne may add a handful of ABI register arguments as function signatures
+    Cranelift may add a handful of ABI register arguments as function signatures
     are lowered. This is for representing things like the link register, the
     incoming frame pointer, and callee-saved registers that are saved in the
     prologue.
@@ -1134,7 +1134,7 @@ Glossary
 
     entry block
         The :term:`EBB` that is executed first in a function. Currently, a
-        Cretonne function must have exactly one entry block which must be the
+        Cranelift function must have exactly one entry block which must be the
         first block in the function. The types of the entry block arguments must
         match the types of arguments in the function signature.
 
@@ -1152,7 +1152,7 @@ Glossary
 
         Note that some textbooks define an EBB as a maximal *subtree* in the
         control flow graph where only the root can be a join node. This
-        definition is not equivalent to Cretonne EBBs.
+        definition is not equivalent to Cranelift EBBs.
 
     EBB parameter
         A formal parameter for an EBB is an SSA value that dominates everything
@@ -1195,8 +1195,8 @@ Glossary
 
     intermediate representation
     IR
-        The language used to describe functions to Cretonne. This reference
-        describes the syntax and semantics of Cretonne IR. The IR has two
+        The language used to describe functions to Cranelift. This reference
+        describes the syntax and semantics of Cranelift IR. The IR has two
         forms: Textual, and an in-memory data structure.
 
     stack slot

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,7 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
-set SPHINXPROJ=cretonne
+set SPHINXPROJ=cranelift
 
 if "%1" == "" goto help
 

--- a/docs/metaref.rst
+++ b/docs/metaref.rst
@@ -1,12 +1,12 @@
 ********************************
-Cretonne Meta Language Reference
+Cranelift Meta Language Reference
 ********************************
 
 .. default-domain:: py
 .. highlight:: python
 .. module:: cdsl
 
-The Cretonne meta language is used to define instructions for Cretonne. It is a
+The Cranelift meta language is used to define instructions for Cranelift. It is a
 domain specific language embedded in Python. This document describes the Python
 modules that form the embedded DSL.
 
@@ -33,7 +33,7 @@ since the last build.
 Settings
 ========
 
-Settings are used by the environment embedding Cretonne to control the details
+Settings are used by the environment embedding Cranelift to control the details
 of code generation. Each setting is defined in the meta language so a compact
 and consistent Rust representation can be generated. Shared settings are defined
 in the :mod:`base.settings` module. Some settings are specific to a target ISA,
@@ -80,7 +80,7 @@ open :class:`InstructionGroup`.
 .. autoclass:: InstructionGroup
     :members:
 
-The basic Cretonne instruction set described in :doc:`langref` is defined by the
+The basic Cranelift instruction set described in :doc:`langref` is defined by the
 Python module :mod:`base.instructions`. This module has a global value
 :data:`base.instructions.GROUP` which is an :class:`InstructionGroup` instance
 containing all the base instructions.
@@ -94,7 +94,7 @@ must be instances of the :class:`Operand` class.
 
 .. autoclass:: Operand
 
-Cretonne uses two separate type systems for operand kinds and SSA values.
+Cranelift uses two separate type systems for operand kinds and SSA values.
 
 .. module:: cdsl.typevar
 
@@ -191,7 +191,7 @@ Instruction representation
 
 The Rust in-memory representation of instructions is derived from the
 instruction descriptions. Part of the representation is generated, and part is
-written as Rust code in the ``cretonne.instructions`` module. The instruction
+written as Rust code in the ``cranelift.instructions`` module. The instruction
 representation depends on the input operand kinds and whether the instruction
 can produce multiple results.
 
@@ -259,9 +259,9 @@ Encodings
 
 .. currentmodule:: cdsl.isa
 
-Encodings describe how Cretonne instructions are mapped to binary machine code
+Encodings describe how Cranelift instructions are mapped to binary machine code
 for the target architecture. After the legalization pass, all remaining
-instructions are expected to map 1-1 to native instruction encodings. Cretonne
+instructions are expected to map 1-1 to native instruction encodings. Cranelift
 instructions that can't be encoded for the current architecture are called
 :term:`illegal instruction`\s.
 
@@ -293,7 +293,7 @@ is false, the SSE 4.1 instructions are not available.
 Encodings also have a :term:`instruction predicate` which depends on the
 specific values of the instruction's immediate fields. This is used to ensure
 that immediate address offsets are within range, for example. The instructions
-in the base Cretonne instruction set can often represent a wider range of
+in the base Cranelift instruction set can often represent a wider range of
 immediates than any specific encoding. The fixed-size RISC-style encodings tend
 to have more range limitations than CISC-style variable length encodings like
 x86.
@@ -412,7 +412,7 @@ class which consists of all the XMM registers.
 Stack operands
 --------------
 
-Cretonne's register allocator can assign an SSA value to a stack slot if there
+Cranelift's register allocator can assign an SSA value to a stack slot if there
 isn't enough registers. It will insert :cton:inst:`spill` and :cton:inst:`fill`
 instructions as needed to satisfy instruction operand constraints, but it is
 also possible to have instructions that can access stack slots directly::
@@ -427,7 +427,7 @@ load.
 Targets
 =======
 
-Cretonne can be compiled with support for multiple target instruction set
+Cranelift can be compiled with support for multiple target instruction set
 architectures. Each ISA is represented by a :py:class:`cdsl.isa.TargetISA` instance.
 
 .. autoclass:: TargetISA

--- a/docs/regalloc.rst
+++ b/docs/regalloc.rst
@@ -1,11 +1,11 @@
 *******************************
-Register Allocation in Cretonne
+Register Allocation in Cranelift
 *******************************
 
 .. default-domain:: cton
 .. highlight:: cton
 
-Cretonne uses a *decoupled, SSA-based* register allocator. Decoupled means that
+Cranelift uses a *decoupled, SSA-based* register allocator. Decoupled means that
 register allocation is split into two primary phases: *spilling* and
 *coloring*. SSA-based means that the code stays in SSA form throughout the
 register allocator, and in fact is still in SSA form after register allocation.
@@ -162,13 +162,13 @@ linearly with the number of EBBs covered by a live range.
 This representation is very similar to LLVM's ``LiveInterval`` data structure
 with a few important differences:
 
-- The Cretonne ``LiveRange`` only covers a single SSA value, while LLVM's
+- The Cranelift ``LiveRange`` only covers a single SSA value, while LLVM's
   ``LiveInterval`` represents the union of multiple related SSA values in a
-  virtual register. This makes Cretonne's representation smaller because
+  virtual register. This makes Cranelift's representation smaller because
   individual segments don't have to annotated with a value number.
-- Cretonne stores the def-interval separately from a list of coalesced live-in
+- Cranelift stores the def-interval separately from a list of coalesced live-in
   intervals, while LLVM stores an array of segments. The two representations
-  are equivalent, but Cretonne optimizes for the common case of a value that is
+  are equivalent, but Cranelift optimizes for the common case of a value that is
   only used locally.
 - It is simpler to check if two live ranges are overlapping. The dominance
   properties of SSA form means that it is only necessary to check the
@@ -182,12 +182,12 @@ with a few important differences:
   allows 'tombstone' program points corresponding to instructions that have
   been deleted.
 
-  Cretonne uses a 32-bit program point representation that encodes an
+  Cranelift uses a 32-bit program point representation that encodes an
   instruction or EBB number directly. There are no 'tombstones' for deleted
   instructions, and no mirrored linked list of instructions. Live ranges must
   be updated when instructions are deleted.
 
-A consequence of Cretonne's more compact representation is that two program
+A consequence of Cranelift's more compact representation is that two program
 points can't be compared without the context of a function layout.
 
 Coalescing algorithm
@@ -273,7 +273,7 @@ extra registers to solve, raising the register pressure:
   the tied input value doesn't interfere with the output value by inserting a copy
   if needed.
 
-The spilling heuristic used by Cretonne is very simple. Whenever the spiller
+The spilling heuristic used by Cranelift is very simple. Whenever the spiller
 determines that the register pressure is too high at some instruction, it picks
 the live SSA value whose definition is farthest away as the spill candidate.
 Then it spills all values in the corresponding virtual register to the same

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,21 +1,21 @@
 ****************
-Testing Cretonne
+Testing Cranelift
 ****************
 
-Cretonne is tested at multiple levels of abstraction and integration. When
+Cranelift is tested at multiple levels of abstraction and integration. When
 possible, Rust unit tests are used to verify single functions and types. When
 testing the interaction between compiler passes, file-level tests are
 appropriate.
 
 The top-level shell script :file:`test-all.sh` runs all of the tests in the
-Cretonne repository.
+Cranelift repository.
 
 Rust tests
 ==========
 
 .. highlight:: rust
 
-Rust and Cargo have good support for testing. Cretonne uses unit tests, doc
+Rust and Cargo have good support for testing. Cranelift uses unit tests, doc
 tests, and integration tests where appropriate.
 
 Unit tests
@@ -51,7 +51,7 @@ tested::
     //!
     //! # Example
     //! ```
-    //! use cretonne_codegen::settings::{self, Configurable};
+    //! use cranelift_codegen::settings::{self, Configurable};
     //!
     //! let mut b = settings::builder();
     //! b.set("opt_level", "fastest");
@@ -72,7 +72,7 @@ individually. They are used to exercise the external API of the crates under
 test.
 
 These tests are usually found in the :file:`tests` top-level directory where
-they have access to all the crates in the Cretonne repository. The
+they have access to all the crates in the Cranelift repository. The
 :file:`lib/codegen` and :file:`lib/reader` crates have no external
 dependencies, which can make testing tedious. Integration tests that don't need
 to depend on other crates can be placed in :file:`lib/codegen/tests` and
@@ -89,7 +89,7 @@ easier to provide substantial input functions for the compiler tests.
 
 File tests are :file:`*.cton` files in the :file:`filetests/` directory
 hierarchy. Each file has a header describing what to test followed by a number
-of input functions in the :doc:`Cretonne textual intermediate representation
+of input functions in the :doc:`Cranelift textual intermediate representation
 <langref>`:
 
 .. productionlist::
@@ -111,7 +111,7 @@ header:
 The options given on the ``isa`` line modify the ISA-specific settings defined in
 :file:`lib/codegen/meta/isa/*/settings.py`.
 
-All types of tests allow shared Cretonne settings to be modified:
+All types of tests allow shared Cranelift settings to be modified:
 
 .. productionlist::
     settings      : { setting }
@@ -160,7 +160,7 @@ Note that LLVM's file tests don't separate filecheck directives by their
 associated function. It verifies the concatenated output against all filecheck
 directives in the test file. LLVM's :command:`FileCheck` command has a
 ``CHECK-LABEL:`` directive to help separate the output from different functions.
-Cretonne's tests don't need this.
+Cranelift's tests don't need this.
 
 `test cat`
 ----------
@@ -375,4 +375,4 @@ Each function is passed through the full ``Context::compile()`` function
 which is normally used to compile code. This type of test often depends
 on assertions or verifier errors, but it is also possible to use
 filecheck directives which will be matched against the final form of the
-Cretonne IR right before binary machine code emission.
+Cranelift IR right before binary machine code emission.

--- a/filetests/regalloc/coalescing-207.cton
+++ b/filetests/regalloc/coalescing-207.cton
@@ -1,7 +1,7 @@
 test regalloc
 target x86_64 haswell
 
-; Reported as https://github.com/cretonne/cretonne/issues/207
+; Reported as https://github.com/CraneStation/cranelift/issues/207
 ;
 ; The coalescer creates a virtual register with two interfering values.
 function %pr207(i64 vmctx, i32, i32) -> i32 system_v {

--- a/filetests/regalloc/coalescing-216.cton
+++ b/filetests/regalloc/coalescing-216.cton
@@ -1,7 +1,7 @@
 test regalloc
 target x86_64 haswell
 
-; Reported as https://github.com/cretonne/cretonne/issues/216 from the Binaryen fuzzer.
+; Reported as https://github.com/CraneStation/cranelift/issues/216 from the Binaryen fuzzer.
 ;
 ; The (old) coalescer creates a virtual register with two identical values.
 function %pr216(i32 [%rdi], i64 vmctx [%rsi]) -> i64 [%rax] system_v {

--- a/filetests/regalloc/reload-208.cton
+++ b/filetests/regalloc/reload-208.cton
@@ -3,7 +3,7 @@ target x86_64 haswell
 
 ; regex: V=v\d+
 
-; Filed as https://github.com/cretonne/cretonne/issues/208
+; Filed as https://github.com/CraneStation/cranelift/issues/208
 ;
 ; The verifier complains about a branch argument that is not in the same virtual register as the
 ; corresponding EBB argument.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 cargo-fuzz = "*"
 binaryen = { git = "https://github.com/pepyakin/binaryen-rs.git" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
-cretonne-wasm = { path = "../lib/wasm" }
+cranelift-wasm = { path = "../lib/wasm" }
 target-lexicon = "0.0.2"
 
 # Prevent this from interfering with workspaces

--- a/fuzz/fuzz_translate_module.rs
+++ b/fuzz/fuzz_translate_module.rs
@@ -2,10 +2,10 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 extern crate binaryen;
-extern crate cretonne_wasm;
+extern crate cranelift_wasm;
 #[macro_use]
 extern crate target_lexicon;
-use cretonne_wasm::{translate_module, DummyEnvironment};
+use cranelift_wasm::{translate_module, DummyEnvironment};
 use std::str::FromStr;
 
 fuzz_target!(|data: &[u8]| {

--- a/lib/codegen/Cargo.toml
+++ b/lib/codegen/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-authors = ["The Cretonne Project Developers"]
-name = "cretonne-codegen"
+authors = ["The Cranelift Project Developers"]
+name = "cranelift-codegen"
 version = "0.13.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cretonne.readthedocs.io/"
-repository = "https://github.com/cretonne/cretonne"
+repository = "https://github.com/CraneStation/cranelift"
 readme = "README.md"
 keywords = ["compile", "compiler", "jit"]
 build = "build.rs"
 
 [dependencies]
-cretonne-entity = { path = "../entity", version = "0.13.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.13.0", default-features = false }
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }
 hashmap_core = { version = "0.1.8", optional = true }
 target-lexicon = { version = "0.0.2", default-features = false }
-# It is a goal of the cretonne-codegen crate to have minimal external dependencies.
+# It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be
 # accomodated in `tests`.
@@ -26,9 +26,9 @@ target-lexicon = { version = "0.0.2", default-features = false }
 # of some minimal std-like replacement libraries. At least one of these two
 # features need to be enabled.
 default = ["std"]
-std = ["cretonne-entity/std", "target-lexicon/std"]
+std = ["cranelift-entity/std", "target-lexicon/std"]
 core = ["hashmap_core"]
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "cretonne/cretonne" }
+travis-ci = { repository = "CraneStation/cranelift" }

--- a/lib/codegen/README.md
+++ b/lib/codegen/README.md
@@ -1,2 +1,2 @@
-This crate contains the core Cretonne code generator. It translates code from an
+This crate contains the core Cranelift code generator. It translates code from an
 intermediate representation into executable machine code.

--- a/lib/codegen/build.rs
+++ b/lib/codegen/build.rs
@@ -24,12 +24,12 @@ use std::process;
 fn main() {
     let out_dir = env::var("OUT_DIR").expect("The OUT_DIR environment variable must be set");
     let target_triple = env::var("TARGET").expect("The TARGET environment variable must be set");
-    let cretonne_targets = env::var("CRETONNE_TARGETS").ok();
-    let cretonne_targets = cretonne_targets.as_ref().map(|s| s.as_ref());
+    let cranelift_targets = env::var("CRETONNE_TARGETS").ok();
+    let cranelift_targets = cranelift_targets.as_ref().map(|s| s.as_ref());
     let python = identify_python();
 
     // Configure isa targets cfg.
-    match isa_targets(cretonne_targets, &target_triple) {
+    match isa_targets(cranelift_targets, &target_triple) {
         Ok(isa_targets) => {
             for isa in &isa_targets {
                 println!("cargo:rustc-cfg=build_{}", isa.name());
@@ -84,7 +84,7 @@ fn identify_python() -> &'static str {
             return python;
         }
     }
-    panic!("The Cretonne build requires Python (version 2.7 or version 3)");
+    panic!("The Cranelift build requires Python (version 2.7 or version 3)");
 }
 
 /// Represents known ISA target.
@@ -142,8 +142,8 @@ impl Isa {
 }
 
 /// Returns isa targets to configure conditional compilation.
-fn isa_targets(cretonne_targets: Option<&str>, target_triple: &str) -> Result<Vec<Isa>, String> {
-    match cretonne_targets {
+fn isa_targets(cranelift_targets: Option<&str>, target_triple: &str) -> Result<Vec<Isa>, String> {
+    match cranelift_targets {
         Some("native") => Isa::from_arch(target_triple.split('-').next().unwrap())
             .map(|isa| vec![isa])
             .ok_or_else(|| {

--- a/lib/codegen/meta/base/__init__.py
+++ b/lib/codegen/meta/base/__init__.py
@@ -1,1 +1,1 @@
-"""Definitions for the base Cretonne language."""
+"""Definitions for the base Cranelift language."""

--- a/lib/codegen/meta/base/entities.py
+++ b/lib/codegen/meta/base/entities.py
@@ -1,6 +1,6 @@
 """
-The `cretonne.entities` module predefines all the Cretonne entity reference
-operand types. There are corresponding definitions in the `cretonne.entities`
+The `cranelift.entities` module predefines all the Cranelift entity reference
+operand types. There are corresponding definitions in the `cranelift.entities`
 Rust module.
 """
 from __future__ import absolute_import

--- a/lib/codegen/meta/base/formats.py
+++ b/lib/codegen/meta/base/formats.py
@@ -1,8 +1,8 @@
 """
-The cretonne.formats defines all instruction formats.
+The cranelift.formats defines all instruction formats.
 
 Every instruction format has a corresponding `InstructionData` variant in the
-Rust representation of Cretonne IR, so all instruction formats must be defined
+Rust representation of Cranelift IR, so all instruction formats must be defined
 in this module.
 """
 from __future__ import absolute_import

--- a/lib/codegen/meta/base/immediates.py
+++ b/lib/codegen/meta/base/immediates.py
@@ -1,6 +1,6 @@
 """
-The `cretonne.immediates` module predefines all the Cretonne immediate operand
-types.
+The `cranelift.immediates` module predefines all the Cranelift immediate
+operand types.
 """
 from __future__ import absolute_import
 from cdsl.operands import ImmediateKind
@@ -8,7 +8,7 @@ from cdsl.operands import ImmediateKind
 #: A 64-bit immediate integer operand.
 #:
 #: This type of immediate integer can interact with SSA values with any
-#: :py:class:`cretonne.IntType` type.
+#: :py:class:`cranelift.IntType` type.
 imm64 = ImmediateKind('imm64', 'A 64-bit immediate integer.')
 
 #: An unsigned 8-bit immediate integer operand.
@@ -42,7 +42,7 @@ ieee64 = ImmediateKind('ieee64', 'A 64-bit immediate floating point number.')
 #: An immediate boolean operand.
 #:
 #: This type of immediate boolean can interact with SSA values with any
-#: :py:class:`cretonne.BoolType` type.
+#: :py:class:`cranelift.BoolType` type.
 boolean = ImmediateKind('bool', 'An immediate boolean.',
                         rust_type='bool')
 

--- a/lib/codegen/meta/base/instructions.py
+++ b/lib/codegen/meta/base/instructions.py
@@ -1,7 +1,7 @@
 """
-Cretonne base instruction set.
+Cranelift base instruction set.
 
-This module defines the basic Cretonne instruction set that all targets
+This module defines the basic Cranelift instruction set that all targets
 support.
 """
 from __future__ import absolute_import
@@ -1800,7 +1800,7 @@ fpromote = Instruction(
         Each lane in `x` is converted to the destination floating point format.
         This is an exact operation.
 
-        Cretonne currently only supports two floating point formats
+        Cranelift currently only supports two floating point formats
         - :type:`f32` and :type:`f64`. This may change in the future.
 
         The result type must have the same number of vector lanes as the input,
@@ -1816,7 +1816,7 @@ fdemote = Instruction(
         Each lane in `x` is converted to the destination floating point format
         by rounding to nearest, ties to even.
 
-        Cretonne currently only supports two floating point formats
+        Cranelift currently only supports two floating point formats
         - :type:`f32` and :type:`f64`. This may change in the future.
 
         The result type must have the same number of vector lanes as the input,

--- a/lib/codegen/meta/base/legalize.py
+++ b/lib/codegen/meta/base/legalize.py
@@ -1,7 +1,7 @@
 """
 Patterns for legalizing the `base` instruction set.
 
-The base Cretonne instruction set is 'fat', and many instructions don't have
+The base Cranelift instruction set is 'fat', and many instructions don't have
 legal representations in a given target ISA. This module defines legalization
 patterns that describe how base instructions can be transformed to other base
 instructions that are legal.

--- a/lib/codegen/meta/base/predicates.py
+++ b/lib/codegen/meta/base/predicates.py
@@ -1,5 +1,5 @@
 """
-Cretonne predicates that consider `Function` fields.
+Cranelift predicates that consider `Function` fields.
 """
 from cdsl.predicates import FieldPredicate
 from .formats import UnaryGlobalValue, InstructionFormat

--- a/lib/codegen/meta/base/settings.py
+++ b/lib/codegen/meta/base/settings.py
@@ -1,5 +1,5 @@
 """
-Cretonne shared settings.
+Cranelift shared settings.
 
 This module defines settings relevant for all code generators.
 """
@@ -20,10 +20,10 @@ opt_level = EnumSetting(
 
 enable_verifier = BoolSetting(
         """
-        Run the Cretonne IR verifier at strategic times during compilation.
+        Run the Cranelift IR verifier at strategic times during compilation.
 
         This makes compilation slower but catches many bugs. The verifier is
-        disabled by default, except when reading Cretonne IR from a text file.
+        disabled by default, except when reading Cranelift IR from a text file.
         """,
         default=True)
 
@@ -51,8 +51,8 @@ call_conv = EnumSetting(
         'probestack'
 )
 
-# Note that Cretonne doesn't currently need an is_pie flag, because PIE is just
-# PIC where symbols can't be pre-empted, which can be expressed with the
+# Note that Cranelift doesn't currently need an is_pie flag, because PIE is
+# just PIC where symbols can't be pre-empted, which can be expressed with the
 # `colocated` flag on external functions and global values.
 is_pic = BoolSetting("Enable Position-Independent Code generation")
 
@@ -126,7 +126,7 @@ baldrdash_prologue_words = NumSetting(
         in the epilogue.
 
         This setting configures the number of pointer-sized words pushed on the
-        stack when the Cretonne-generated code is entered. This includes the
+        stack when the Cranelift-generated code is entered. This includes the
         pushed return address on x86.
         """)
 

--- a/lib/codegen/meta/base/types.py
+++ b/lib/codegen/meta/base/types.py
@@ -1,5 +1,5 @@
 """
-The base.types module predefines all the Cretonne scalar types.
+The base.types module predefines all the Cranelift scalar types.
 """
 from __future__ import absolute_import
 from cdsl.types import IntType, FloatType, BoolType, FlagsType

--- a/lib/codegen/meta/build.py
+++ b/lib/codegen/meta/build.py
@@ -18,7 +18,7 @@ import gen_binemit
 def main():
     # type: () -> None
     parser = argparse.ArgumentParser(
-            description='Generate sources for Cretonne.')
+            description='Generate sources for Cranelift.')
     parser.add_argument('--out-dir', help='set output directory')
 
     args = parser.parse_args()

--- a/lib/codegen/meta/cdsl/__init__.py
+++ b/lib/codegen/meta/cdsl/__init__.py
@@ -1,7 +1,7 @@
 """
-Cretonne DSL classes.
+Cranelift DSL classes.
 
-This module defines the classes that are used to define Cretonne instructions
+This module defines the classes that are used to define Cranelift instructions
 and other entitties.
 """
 from __future__ import absolute_import

--- a/lib/codegen/meta/cdsl/ast.py
+++ b/lib/codegen/meta/cdsl/ast.py
@@ -2,7 +2,7 @@
 Abstract syntax trees.
 
 This module defines classes that can be used to create abstract syntax trees
-for patern matching an rewriting of cretonne instructions.
+for patern matching an rewriting of cranelift instructions.
 """
 from __future__ import absolute_import
 from . import instructions

--- a/lib/codegen/meta/cdsl/formats.py
+++ b/lib/codegen/meta/cdsl/formats.py
@@ -50,7 +50,7 @@ class InstructionFormat(object):
     of values.
 
     All instruction formats must be predefined in the
-    :py:mod:`cretonne.formats` module.
+    :py:mod:`cranelift.formats` module.
 
     :param kinds: List of `OperandKind` objects describing the operands.
     :param name: Instruction format name in CamelCase. This is used as a Rust

--- a/lib/codegen/meta/cdsl/operands.py
+++ b/lib/codegen/meta/cdsl/operands.py
@@ -67,7 +67,7 @@ VARIABLE_ARGS = OperandKind(
 
 
 # Instances of immediate operand types are provided in the
-# `cretonne.immediates` module.
+# `cranelift.immediates` module.
 class ImmediateKind(OperandKind):
     """
     The kind of an immediate instruction operand.
@@ -152,7 +152,7 @@ class ImmediateKind(OperandKind):
 
 
 # Instances of entity reference operand types are provided in the
-# `cretonne.entities` module.
+# `cranelift.entities` module.
 class EntityRefKind(OperandKind):
     """
     The kind of an entity reference instruction operand.

--- a/lib/codegen/meta/cdsl/predicates.py
+++ b/lib/codegen/meta/cdsl/predicates.py
@@ -1,5 +1,5 @@
 """
-Cretonne predicates.
+Cranelift predicates.
 
 A *predicate* is a function that computes a boolean result. The inputs to the
 function determine the kind of predicate:

--- a/lib/codegen/meta/cdsl/settings.py
+++ b/lib/codegen/meta/cdsl/settings.py
@@ -14,7 +14,7 @@ except ImportError:
 
 class Setting(object):
     """
-    A named setting variable that can be configured externally to Cretonne.
+    A named setting variable that can be configured externally to Cranelift.
 
     Settings are normally not named when they are created. They get their name
     from the `extract_names` method.

--- a/lib/codegen/meta/cdsl/types.py
+++ b/lib/codegen/meta/cdsl/types.py
@@ -1,4 +1,4 @@
-"""Cretonne ValueType hierarchy"""
+"""Cranelift ValueType hierarchy"""
 from __future__ import absolute_import
 import math
 

--- a/lib/codegen/meta/cdsl/typevar.py
+++ b/lib/codegen/meta/cdsl/typevar.py
@@ -1,7 +1,7 @@
 """
 Type variables for Parametric polymorphism.
 
-Cretonne instructions and instruction transformations can be specified to be
+Cranelift instructions and instruction transformations can be specified to be
 polymorphic by using type variables.
 """
 from __future__ import absolute_import

--- a/lib/codegen/meta/gen_legalizer.py
+++ b/lib/codegen/meta/gen_legalizer.py
@@ -1,7 +1,7 @@
 """
 Generate legalizer transformations.
 
-The transformations defined in the `cretonne.legalize` module are all of the
+The transformations defined in the `cranelift.legalize` module are all of the
 macro-expansion form where the input pattern is a single instruction. We
 generate a Rust function for each `XFormGroup` which takes a `Cursor` pointing
 at the instruction to be legalized. The expanded destination pattern replaces

--- a/lib/codegen/meta/isa/__init__.py
+++ b/lib/codegen/meta/isa/__init__.py
@@ -1,9 +1,9 @@
 """
-Cretonne target ISA definitions
+Cranelift target ISA definitions
 -------------------------------
 
 The :py:mod:`isa` package contains sub-packages for each target instruction set
-architecture supported by Cretonne.
+architecture supported by Cranelift.
 """
 from __future__ import absolute_import
 from cdsl.isa import TargetISA  # noqa
@@ -19,6 +19,6 @@ def all_isas():
     # type: () -> List[TargetISA]
     """
     Get a list of all the supported target ISAs. Each target ISA is represented
-    as a :py:class:`cretonne.TargetISA` instance.
+    as a :py:class:`cranelift.TargetISA` instance.
     """
     return [riscv.ISA, x86.ISA, arm32.ISA, arm64.ISA]

--- a/lib/codegen/meta/isa/x86/__init__.py
+++ b/lib/codegen/meta/isa/x86/__init__.py
@@ -6,7 +6,7 @@ This target ISA generates code for x86 CPUs with two separate CPU modes:
 
 `I32`
     32-bit x86 architecture, also known as 'IA-32', also sometimes referred
-    to as 'i386', however note that Cretonne depends on instructions not
+    to as 'i386', however note that Cranelift depends on instructions not
     in the original `i386`, such as SSE2, CMOVcc, and UD2.
 
 `I64`

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -34,7 +34,7 @@ except ImportError:
 
 # Opcode representation.
 #
-# Cretonne requires each recipe to have a single encoding size in bytes, and
+# Cranelift requires each recipe to have a single encoding size in bytes, and
 # x86 opcodes are variable length, so we use separate recipes for different
 # styles of opcodes and prefixes. The opcode format is indicated by the recipe
 # name prefix:
@@ -1600,7 +1600,7 @@ rcmp_sp = TailRecipe(
 #
 # 1. Guarantee that the test and branch get scheduled next to each other so
 #    macro fusion is guaranteed to be possible.
-# 2. Hide the status flags from Cretonne which doesn't currently model flags.
+# 2. Hide the status flags from Cranelift which doesn't currently model flags.
 #
 # The encoding bits affect both the test and the branch instruction:
 #

--- a/lib/codegen/meta/semantics/__init__.py
+++ b/lib/codegen/meta/semantics/__init__.py
@@ -1,4 +1,4 @@
-"""Definitions for the semantics segment of the Cretonne language."""
+"""Definitions for the semantics segment of the Cranelift language."""
 from cdsl.ti import TypeEnv, ti_rtl, get_type_env
 from cdsl.operands import ImmediateKind
 from cdsl.ast import Var

--- a/lib/codegen/meta/semantics/elaborate.py
+++ b/lib/codegen/meta/semantics/elaborate.py
@@ -1,7 +1,7 @@
 """
 Tools to elaborate a given Rtl with concrete types into its semantically
 equivalent primitive version. Its elaborated primitive version contains only
-primitive cretonne instructions, which map well to SMTLIB functions.
+primitive cranelift instructions, which map well to SMTLIB functions.
 """
 from .primitives import GROUP as PRIMITIVES, prim_to_bv, prim_from_bv
 from cdsl.xform import Rtl

--- a/lib/codegen/meta/semantics/primitives.py
+++ b/lib/codegen/meta/semantics/primitives.py
@@ -1,5 +1,5 @@
 """
-Cretonne primitive instruction set.
+Cranelift primitive instruction set.
 
 This module defines a primitive instruction set, in terms of which the base set
 is described. Most instructions in this set correspond 1-1 with an SMTLIB
@@ -26,9 +26,9 @@ y = Operand('x', BV, doc="A semantic value Y (same width as X)")
 a = Operand('a', BV, doc="A semantic value A (same width as X)")
 cond = Operand('b', TypeVar.singleton(b1), doc='A b1 value')
 
-real = Operand('real', Real, doc="A real cretonne value")
+real = Operand('real', Real, doc="A real cranelift value")
 fromReal = Operand('fromReal', Real.to_bitvec(),
-                   doc="A real cretonne value converted to a BV")
+                   doc="A real cranelift value converted to a BV")
 
 #
 # BV Conversion/Materialization

--- a/lib/codegen/src/binemit/memorysink.rs
+++ b/lib/codegen/src/binemit/memorysink.rs
@@ -1,6 +1,6 @@
 //! Code sink that writes binary machine code into contiguous memory.
 //!
-//! The `CodeSink` trait is the most general way of extracting binary machine code from Cretonne,
+//! The `CodeSink` trait is the most general way of extracting binary machine code from Cranelift,
 //! and it is implemented by things like the `test binemit` file test driver to generate
 //! hexadecimal machine code. The `CodeSink` has some undesirable performance properties because of
 //! the dual abstraction: `TargetIsa` is a trait object implemented by each supported ISA, so it
@@ -20,7 +20,7 @@ use std::ptr::write_unaligned;
 
 /// A `CodeSink` that writes binary machine code directly into memory.
 ///
-/// A `MemoryCodeSink` object should be used when emitting a Cretonne IR function into executable
+/// A `MemoryCodeSink` object should be used when emitting a Cranelift IR function into executable
 /// memory. It writes machine code directly to a raw pointer without any bounds checking, so make
 /// sure to allocate enough memory for the whole function. The number of bytes required is returned
 /// by the `Context::compile()` function.

--- a/lib/codegen/src/binemit/mod.rs
+++ b/lib/codegen/src/binemit/mod.rs
@@ -1,6 +1,6 @@
 //! Binary machine code emission.
 //!
-//! The `binemit` module contains code for translating Cretonne's intermediate representation into
+//! The `binemit` module contains code for translating Cranelift's intermediate representation into
 //! binary machine code.
 
 mod memorysink;
@@ -17,7 +17,7 @@ use std::fmt;
 
 /// Offset in bytes from the beginning of the function.
 ///
-/// Cretonne can be used as a cross compiler, so we don't want to use a type like `usize` which
+/// Cranelift can be used as a cross compiler, so we don't want to use a type like `usize` which
 /// depends on the *host* platform, not the *target* platform.
 pub type CodeOffset = u32;
 

--- a/lib/codegen/src/binemit/shrink.rs
+++ b/lib/codegen/src/binemit/shrink.rs
@@ -1,6 +1,6 @@
 //! Instruction shrinking.
 //!
-//! Sometimes there are multiple valid encodings for a given instruction. Cretonne often initially
+//! Sometimes there are multiple valid encodings for a given instruction. Cranelift often initially
 //! chooses the largest one, because this typically provides the register allocator the most
 //! flexibility. However, once register allocation is done, this is no longer important, and we
 //! can switch to smaller encodings when possible.

--- a/lib/codegen/src/context.rs
+++ b/lib/codegen/src/context.rs
@@ -1,4 +1,4 @@
-//! Cretonne compilation context and main entry point.
+//! Cranelift compilation context and main entry point.
 //!
 //! When compiling many small functions, it is important to avoid repeatedly allocating and
 //! deallocating the data structures needed for compilation. The `Context` struct is used to hold

--- a/lib/codegen/src/cursor.rs
+++ b/lib/codegen/src/cursor.rs
@@ -46,8 +46,8 @@ pub trait Cursor {
     /// This is intended to be used as a builder method:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb, SourceLoc};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb, SourceLoc};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function, srcloc: SourceLoc) {
     ///     let mut pos = FuncCursor::new(func).with_srcloc(srcloc);
     ///
@@ -76,8 +76,8 @@ pub trait Cursor {
     /// This is intended to be used as a builder method:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb, Inst};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb, Inst};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function, inst: Inst) {
     ///     let mut pos = FuncCursor::new(func).at_inst(inst);
     ///
@@ -99,8 +99,8 @@ pub trait Cursor {
     /// This is intended to be used as a builder method:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb, Inst};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb, Inst};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function, ebb: Ebb) {
     ///     let mut pos = FuncCursor::new(func).at_first_insertion_point(ebb);
     ///
@@ -120,8 +120,8 @@ pub trait Cursor {
     /// This is intended to be used as a builder method:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb, Inst};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb, Inst};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function, ebb: Ebb) {
     ///     let mut pos = FuncCursor::new(func).at_first_inst(ebb);
     ///
@@ -141,8 +141,8 @@ pub trait Cursor {
     /// This is intended to be used as a builder method:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb, Inst};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb, Inst};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function, ebb: Ebb) {
     ///     let mut pos = FuncCursor::new(func).at_last_inst(ebb);
     ///
@@ -162,8 +162,8 @@ pub trait Cursor {
     /// This is intended to be used as a builder method:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb, Inst};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb, Inst};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function, inst: Inst) {
     ///     let mut pos = FuncCursor::new(func).after_inst(inst);
     ///
@@ -183,8 +183,8 @@ pub trait Cursor {
     /// This is intended to be used as a builder method:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb, Inst};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb, Inst};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function, ebb: Ebb) {
     ///     let mut pos = FuncCursor::new(func).at_top(ebb);
     ///
@@ -204,8 +204,8 @@ pub trait Cursor {
     /// This is intended to be used as a builder method:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb, Inst};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb, Inst};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function, ebb: Ebb) {
     ///     let mut pos = FuncCursor::new(func).at_bottom(ebb);
     ///
@@ -311,8 +311,8 @@ pub trait Cursor {
     /// The `next_ebb()` method is intended for iterating over the EBBs in layout order:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function) {
     ///     let mut cursor = FuncCursor::new(func);
     ///     while let Some(ebb) = cursor.next_ebb() {
@@ -344,8 +344,8 @@ pub trait Cursor {
     /// The `prev_ebb()` method is intended for iterating over the EBBs in backwards layout order:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function) {
     ///     let mut cursor = FuncCursor::new(func);
     ///     while let Some(ebb) = cursor.prev_ebb() {
@@ -381,8 +381,8 @@ pub trait Cursor {
     /// this:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_ebb(func: &mut Function, ebb: Ebb) {
     ///     let mut cursor = FuncCursor::new(func).at_top(ebb);
     ///     while let Some(inst) = cursor.next_inst() {
@@ -395,8 +395,8 @@ pub trait Cursor {
     /// Iterating over all the instructions in a function looks like this:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_func(func: &mut Function) {
     ///     let mut cursor = FuncCursor::new(func);
     ///     while let Some(ebb) = cursor.next_ebb() {
@@ -451,8 +451,8 @@ pub trait Cursor {
     /// EBB like this:
     ///
     /// ```
-    /// # use cretonne_codegen::ir::{Function, Ebb};
-    /// # use cretonne_codegen::cursor::{Cursor, FuncCursor};
+    /// # use cranelift_codegen::ir::{Function, Ebb};
+    /// # use cranelift_codegen::cursor::{Cursor, FuncCursor};
     /// fn edit_ebb(func: &mut Function, ebb: Ebb) {
     ///     let mut cursor = FuncCursor::new(func).at_bottom(ebb);
     ///     while let Some(inst) = cursor.prev_inst() {

--- a/lib/codegen/src/dbg.rs
+++ b/lib/codegen/src/dbg.rs
@@ -1,12 +1,12 @@
 //! Debug tracing macros.
 //!
 //! This module defines the `dbg!` macro which works like `println!` except it writes to the
-//! Cretonne tracing output file if enabled.
+//! Cranelift tracing output file if enabled.
 //!
 //! Tracing can be enabled by setting the `CRETONNE_DBG` environment variable to something
 /// other than `0`.
 ///
-/// The output will appear in files named `cretonne.dbg.*`, where the suffix is named after the
+/// The output will appear in files named `cranelift.dbg.*`, where the suffix is named after the
 /// thread doing the logging.
 #[cfg(feature = "std")]
 use std::cell::RefCell;
@@ -92,7 +92,7 @@ pub fn writeln_with_format_args(args: fmt::Arguments) -> io::Result<()> {
 fn open_file() -> io::BufWriter<File> {
     let curthread = thread::current();
     let tmpstr;
-    let mut path = "cretonne.dbg.".to_owned();
+    let mut path = "cranelift.dbg.".to_owned();
     path.extend(
         match curthread.name() {
             Some(name) => name.chars(),

--- a/lib/codegen/src/ir/builder.rs
+++ b/lib/codegen/src/ir/builder.rs
@@ -1,6 +1,6 @@
-//! Cretonne instruction builder.
+//! Cranelift instruction builder.
 //!
-//! A `Builder` provides a convenient interface for inserting instructions into a Cretonne
+//! A `Builder` provides a convenient interface for inserting instructions into a Cranelift
 //! function. Many of its methods are generated from the meta language instruction definitions.
 
 use ir;

--- a/lib/codegen/src/ir/condcodes.rs
+++ b/lib/codegen/src/ir/condcodes.rs
@@ -1,4 +1,4 @@
-//! Condition codes for the Cretonne code generator.
+//! Condition codes for the Cranelift code generator.
 //!
 //! A condition code here is an enumerated type that determined how to compare two numbers. There
 //! are different rules for comparing integers and floating point numbers, so they use different

--- a/lib/codegen/src/ir/entities.rs
+++ b/lib/codegen/src/ir/entities.rs
@@ -1,6 +1,6 @@
-//! Cretonne IR entity references.
+//! Cranelift IR entity references.
 //!
-//! Instructions in Cretonne IR need to reference other entities in the function. This can be other
+//! Instructions in Cranelift IR need to reference other entities in the function. This can be other
 //! parts of the function like extended basic blocks or stack slots, or it can be external entities
 //! that are declared in the function preamble in the text format.
 //!

--- a/lib/codegen/src/ir/extfunc.rs
+++ b/lib/codegen/src/ir/extfunc.rs
@@ -1,6 +1,6 @@
 //! External function calls.
 //!
-//! To a Cretonne function, all functions are "external". Directly called functions must be
+//! To a Cranelift function, all functions are "external". Directly called functions must be
 //! declared in the preamble, and all function calls must have a signature.
 //!
 //! This module declares the data types used to represent external functions and call signatures.

--- a/lib/codegen/src/ir/extname.rs
+++ b/lib/codegen/src/ir/extname.rs
@@ -2,7 +2,7 @@
 //!
 //! These are identifiers for declaring entities defined outside the current
 //! function. The name of an external declaration doesn't have any meaning to
-//! Cretonne, which compiles functions independently.
+//! Cranelift, which compiles functions independently.
 
 use ir::LibCall;
 use std::cmp;
@@ -15,8 +15,8 @@ const TESTCASE_NAME_LENGTH: usize = 16;
 /// table, or a short sequence of ascii bytes so that test cases do not have
 /// to keep track of a sy mbol table.
 ///
-/// External names are primarily used as keys by code using Cretonne to map
-/// from a `cretonne_codegen::ir::FuncRef` or similar to additional associated
+/// External names are primarily used as keys by code using Cranelift to map
+/// from a `cranelift_codegen::ir::FuncRef` or similar to additional associated
 /// data.
 ///
 /// External names can also serve as a primitive testing and debugging tool.
@@ -24,7 +24,7 @@ const TESTCASE_NAME_LENGTH: usize = 16;
 /// functions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExternalName {
-    /// A name in a user-defined symbol table. Cretonne does not interpret
+    /// A name in a user-defined symbol table. Cranelift does not interpret
     /// these numbers in any way.
     User {
         /// Arbitrary.
@@ -51,7 +51,7 @@ impl ExternalName {
     /// # Examples
     ///
     /// ```rust
-    /// # use cretonne_codegen::ir::ExternalName;
+    /// # use cranelift_codegen::ir::ExternalName;
     /// // Create `ExternalName` from a string.
     /// let name = ExternalName::testcase("hello");
     /// assert_eq!(name.to_string(), "%hello");
@@ -72,7 +72,7 @@ impl ExternalName {
     ///
     /// # Examples
     /// ```rust
-    /// # use cretonne_codegen::ir::ExternalName;
+    /// # use cranelift_codegen::ir::ExternalName;
     /// // Create `ExternalName` from integer indicies
     /// let name = ExternalName::user(123, 456);
     /// assert_eq!(name.to_string(), "u123:456");

--- a/lib/codegen/src/ir/function.rs
+++ b/lib/codegen/src/ir/function.rs
@@ -68,7 +68,7 @@ pub struct Function {
     /// Source locations.
     ///
     /// Track the original source location for each instruction. The source locations are not
-    /// interpreted by Cretonne, only preserved.
+    /// interpreted by Cranelift, only preserved.
     pub srclocs: SourceLocs,
 }
 

--- a/lib/codegen/src/ir/globalvalue.rs
+++ b/lib/codegen/src/ir/globalvalue.rs
@@ -27,7 +27,7 @@ pub enum GlobalValueData {
         offset: Offset32,
     },
 
-    /// Value is identified by a symbolic name. Cretonne itself does not interpret this name;
+    /// Value is identified by a symbolic name. Cranelift itself does not interpret this name;
     /// it's used by embedders to link with other data structures.
     Sym {
         /// The symbolic name.

--- a/lib/codegen/src/ir/immediates.rs
+++ b/lib/codegen/src/ir/immediates.rs
@@ -1,7 +1,7 @@
-//! Immediate operands for Cretonne instructions
+//! Immediate operands for Cranelift instructions
 //!
-//! This module defines the types of immediate operands that can appear on Cretonne instructions.
-//! Each type here should have a corresponding definition in the `cretonne.immediates` Python
+//! This module defines the types of immediate operands that can appear on Cranelift instructions.
+//! Each type here should have a corresponding definition in the `cranelift.immediates` Python
 //! module in the meta language.
 
 use std::fmt::{self, Display, Formatter};

--- a/lib/codegen/src/ir/libcall.rs
+++ b/lib/codegen/src/ir/libcall.rs
@@ -11,9 +11,9 @@ use std::str::FromStr;
 
 /// The name of a runtime library routine.
 ///
-/// Runtime library calls are generated for Cretonne IR instructions that don't have an equivalent
+/// Runtime library calls are generated for Cranelift IR instructions that don't have an equivalent
 /// ISA instruction or an easy macro expansion. A `LibCall` is used as a well-known name to refer to
-/// the runtime library routine. This way, Cretonne doesn't have to know about the naming
+/// the runtime library routine. This way, Cranelift doesn't have to know about the naming
 /// convention in the embedding VM's runtime library.
 ///
 /// This list is likely to grow over time.

--- a/lib/codegen/src/ir/memflags.rs
+++ b/lib/codegen/src/ir/memflags.rs
@@ -51,10 +51,10 @@ impl MemFlags {
     /// Test if the `notrap` flag is set.
     ///
     /// Normally, trapping is part of the semantics of a load/store operation. If the platform
-    /// would cause a trap when accessing the effective address, the Cretonne memory operation is
+    /// would cause a trap when accessing the effective address, the Cranelift memory operation is
     /// also required to trap.
     ///
-    /// The `notrap` flag tells Cretonne that the memory is *accessible*, which means that
+    /// The `notrap` flag tells Cranelift that the memory is *accessible*, which means that
     /// accesses will not trap. This makes it possible to delete an unused load or a dead store
     /// instruction.
     pub fn notrap(self) -> bool {
@@ -68,7 +68,7 @@ impl MemFlags {
 
     /// Test if the `aligned` flag is set.
     ///
-    /// By default, Cretonne memory instructions work with any unaligned effective address. If the
+    /// By default, Cranelift memory instructions work with any unaligned effective address. If the
     /// `aligned` flag is set, the instruction is permitted to trap or return a wrong result if the
     /// effective address is misaligned.
     pub fn aligned(self) -> bool {

--- a/lib/codegen/src/ir/mod.rs
+++ b/lib/codegen/src/ir/mod.rs
@@ -1,4 +1,4 @@
-//! Representation of Cretonne IR functions.
+//! Representation of Cranelift IR functions.
 
 mod builder;
 pub mod condcodes;

--- a/lib/codegen/src/ir/progpoint.rs
+++ b/lib/codegen/src/ir/progpoint.rs
@@ -12,7 +12,7 @@ use std::u32;
 /// 1. An instruction or
 /// 2. An EBB header.
 ///
-/// This corresponds more or less to the lines in the textual form of Cretonne IR.
+/// This corresponds more or less to the lines in the textual form of Cranelift IR.
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct ProgramPoint(u32);
 

--- a/lib/codegen/src/ir/sourceloc.rs
+++ b/lib/codegen/src/ir/sourceloc.rs
@@ -1,13 +1,13 @@
 //! Source locations.
 //!
-//! Cretonne tracks the original source location of each instruction, and preserves the source
+//! Cranelift tracks the original source location of each instruction, and preserves the source
 //! location when instructions are transformed.
 
 use std::fmt;
 
 /// A source location.
 ///
-/// This is an opaque 32-bit number attached to each Cretonne IR instruction. Cretonne does not
+/// This is an opaque 32-bit number attached to each Cranelift IR instruction. Cranelift does not
 /// interpret source locations in any way, they are simply preserved from the input to the output.
 ///
 /// The default source location uses the all-ones bit pattern `!0`. It is used for instructions

--- a/lib/codegen/src/ir/stackslot.rs
+++ b/lib/codegen/src/ir/stackslot.rs
@@ -15,7 +15,7 @@ use std::vec::Vec;
 
 /// The size of an object on the stack, or the size of a stack frame.
 ///
-/// We don't use `usize` to represent object sizes on the target platform because Cretonne supports
+/// We don't use `usize` to represent object sizes on the target platform because Cranelift supports
 /// cross-compilation, and `usize` is a type that depends on the host platform, not the target
 /// platform.
 pub type StackSize = u32;

--- a/lib/codegen/src/ir/types.rs
+++ b/lib/codegen/src/ir/types.rs
@@ -1,4 +1,4 @@
-//! Common types for the Cretonne code generator.
+//! Common types for the Cranelift code generator.
 
 use std::default::Default;
 use std::fmt::{self, Debug, Display, Formatter};

--- a/lib/codegen/src/isa/mod.rs
+++ b/lib/codegen/src/isa/mod.rs
@@ -2,15 +2,15 @@
 //!
 //! The `isa` module provides a `TargetIsa` trait which provides the behavior specialization needed
 //! by the ISA-independent code generator. The sub-modules of this module provide definitions for
-//! the instruction sets that Cretonne can target. Each sub-module has it's own implementation of
+//! the instruction sets that Cranelift can target. Each sub-module has it's own implementation of
 //! `TargetIsa`.
 //!
 //! # Constructing a `TargetIsa` instance
 //!
 //! The target ISA is built from the following information:
 //!
-//! - The name of the target ISA as a string. Cretonne is a cross-compiler, so the ISA to target
-//!   can be selected dynamically. Individual ISAs can be left out when Cretonne is compiled, so a
+//! - The name of the target ISA as a string. Cranelift is a cross-compiler, so the ISA to target
+//!   can be selected dynamically. Individual ISAs can be left out when Cranelift is compiled, so a
 //!   string is used to identify the proper sub-module.
 //! - Values for settings that apply to all ISAs. This is represented by a `settings::Flags`
 //!   instance.
@@ -20,11 +20,11 @@
 //! appropriate for the requested ISA:
 //!
 //! ```
-//! # extern crate cretonne_codegen;
+//! # extern crate cranelift_codegen;
 //! # #[macro_use] extern crate target_lexicon;
 //! # fn main() {
-//! use cretonne_codegen::settings::{self, Configurable};
-//! use cretonne_codegen::isa;
+//! use cranelift_codegen::settings::{self, Configurable};
+//! use cranelift_codegen::isa;
 //! use std::str::FromStr;
 //! use target_lexicon::Triple;
 //!

--- a/lib/codegen/src/isa/x86/abi.rs
+++ b/lib/codegen/src/isa/x86/abi.rs
@@ -274,7 +274,7 @@ pub fn prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> CodegenRes
 pub fn baldrdash_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> CodegenResult<()> {
     debug_assert!(
         !isa.flags().probestack_enabled(),
-        "baldrdash does not expect cretonne to emit stack probes"
+        "baldrdash does not expect cranelift to emit stack probes"
     );
 
     // Baldrdash on 32-bit x86 always aligns its stack pointer to 16 bytes.
@@ -325,7 +325,7 @@ pub fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> C
     let csr_stack_size = ((csrs.iter(GPR).len() + 2) * word_size) as i32;
 
     // TODO: eventually use the 32 bytes (shadow store) as spill slot. This currently doesn't work
-    //       since cretonne does not support spill slots before incoming args
+    //       since cranelift does not support spill slots before incoming args
 
     func.create_stack_slot(ir::StackSlotData {
         kind: ir::StackSlotKind::IncomingArg,

--- a/lib/codegen/src/lib.rs
+++ b/lib/codegen/src/lib.rs
@@ -1,4 +1,4 @@
-//! Cretonne code generation library.
+//! Cranelift code generation library.
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
@@ -56,11 +56,11 @@ pub use legalizer::legalize_function;
 pub use verifier::verify_function;
 pub use write::write_function;
 
-/// Version number of the cretonne-codegen crate.
+/// Version number of the cranelift-codegen crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[macro_use]
-pub extern crate cretonne_entity as entity;
+pub extern crate cranelift_entity as entity;
 
 #[macro_use]
 pub mod dbg;

--- a/lib/codegen/src/print_errors.rs
+++ b/lib/codegen/src/print_errors.rs
@@ -65,7 +65,7 @@ fn pretty_function_error(
     }
 }
 
-/// Pretty-print a Cretonne error.
+/// Pretty-print a Cranelift error.
 pub fn pretty_error(func: &ir::Function, isa: Option<&TargetIsa>, err: CodegenError) -> String {
     if let CodegenError::Verifier(e) = err {
         pretty_verifier_error(func, isa, &e)

--- a/lib/codegen/src/regalloc/liverange.rs
+++ b/lib/codegen/src/regalloc/liverange.rs
@@ -41,7 +41,7 @@
 //!
 //! If one live range ends at an instruction that defines another live range, those two live ranges
 //! are not considered to interfere. This is because most ISAs allow instructions to reuse an input
-//! register for an output value. If Cretonne gets support for inline assembly, we will need to
+//! register for an output value. If Cranelift gets support for inline assembly, we will need to
 //! handle *early clobbers* which are output registers that are not allowed to alias any input
 //! registers.
 //!

--- a/lib/codegen/src/result.rs
+++ b/lib/codegen/src/result.rs
@@ -4,19 +4,19 @@ use verifier::VerifierError;
 
 /// A compilation error.
 ///
-/// When Cretonne fails to compile a function, it will return one of these error codes.
+/// When Cranelift fails to compile a function, it will return one of these error codes.
 #[derive(Fail, Debug, PartialEq, Eq)]
 pub enum CodegenError {
     /// An IR verifier error.
     ///
-    /// This always represents a bug, either in the code that generated IR for Cretonne, or a bug
-    /// in Cretonne itself.
+    /// This always represents a bug, either in the code that generated IR for Cranelift, or a bug
+    /// in Cranelift itself.
     #[fail(display = "Verifier error: {}", _0)]
     Verifier(#[cause] VerifierError),
 
     /// An implementation limit was exceeded.
     ///
-    /// Cretonne can compile very large and complicated functions, but the [implementation has
+    /// Cranelift can compile very large and complicated functions, but the [implementation has
     /// limits][limits] that cause compilation to fail when they are exceeded.
     ///
     /// [limits]: https://cretonne.readthedocs.io/en/latest/langref.html#implementation-limits

--- a/lib/codegen/src/settings.rs
+++ b/lib/codegen/src/settings.rs
@@ -11,7 +11,7 @@
 //!
 //! # Example
 //! ```
-//! use cretonne_codegen::settings::{self, Configurable};
+//! use cranelift_codegen::settings::{self, Configurable};
 //!
 //! let mut b = settings::builder();
 //! b.set("opt_level", "fastest");

--- a/lib/codegen/src/timing.rs
+++ b/lib/codegen/src/timing.rs
@@ -41,11 +41,11 @@ define_passes!{
     Pass, NUM_PASSES, DESCRIPTIONS;
 
     process_file: "Processing test file",
-    parse_text: "Parsing textual Cretonne IR",
+    parse_text: "Parsing textual Cranelift IR",
     wasm_translate_module: "Translate WASM module",
     wasm_translate_function: "Translate WASM function",
 
-    verifier: "Verify Cretonne IR",
+    verifier: "Verify Cranelift IR",
     verify_cssa: "Verify CSSA",
     verify_liveness: "Verify live ranges",
     verify_locations: "Verify value locations",

--- a/lib/codegen/src/verifier/cssa.rs
+++ b/lib/codegen/src/verifier/cssa.rs
@@ -11,7 +11,7 @@ use verifier::VerifierResult;
 
 /// Verify conventional SSA form for `func`.
 ///
-/// Conventional SSA form is represented in Cretonne with the help of virtual registers:
+/// Conventional SSA form is represented in Cranelift with the help of virtual registers:
 ///
 /// - Two values are said to be *PHI-related* if one is an EBB argument and the other is passed as
 ///   a branch argument in a location that matches the first value.

--- a/lib/codegen/src/write.rs
+++ b/lib/codegen/src/write.rs
@@ -1,7 +1,7 @@
-//! Converting Cretonne IR to text.
+//! Converting Cranelift IR to text.
 //!
 //! The `write` module provides the `write_function` function which converts an IR `Function` to an
-//! equivalent textual form. This textual form can be read back by the `cretonne-reader` crate.
+//! equivalent textual form. This textual form can be read back by the `cranelift-reader` crate.
 
 use ir::{DataFlowGraph, Ebb, Function, Inst, SigRef, Type, Value, ValueDef};
 use isa::{RegInfo, TargetIsa};

--- a/lib/entity/Cargo.toml
+++ b/lib/entity/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-authors = ["The Cretonne Project Developers"]
-name = "cretonne-entity"
+authors = ["The Cranelift Project Developers"]
+name = "cranelift-entity"
 version = "0.13.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cretonne.readthedocs.io/"
-repository = "https://github.com/cretonne/cretonne"
+repository = "https://github.com/CraneStation/cranelift"
 readme = "README.md"
 keywords = ["entity", "set", "map"]
 
@@ -15,4 +15,4 @@ std = []
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "cretonne/cretonne" }
+travis-ci = { repository = "CraneStation/cranelift" }

--- a/lib/entity/README.md
+++ b/lib/entity/README.md
@@ -1,2 +1,2 @@
-This crate contains array-based data structures used by the core Cretonne code
+This crate contains array-based data structures used by the core Cranelift code
 generator which use densely numbered entity references as mapping keys.

--- a/lib/entity/src/packed_option.rs
+++ b/lib/entity/src/packed_option.rs
@@ -1,6 +1,6 @@
 //! Compact representation of `Option<T>` for types with a reserved value.
 //!
-//! Small Cretonne types like the 32-bit entity references are often used in tables and linked
+//! Small Cranelift types like the 32-bit entity references are often used in tables and linked
 //! lists where an `Option<T>` is needed. Unfortunately, that would double the size of the tables
 //! because `Option<T>` is twice as big as `T`.
 //!

--- a/lib/faerie/Cargo.toml
+++ b/lib/faerie/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "cretonne-faerie"
+name = "cranelift-faerie"
 version = "0.13.0"
-authors = ["The Cretonne Project Developers"]
-description = "Emit Cretonne output to native object files with Faerie"
-repository = "https://github.com/cretonne/cretonne"
+authors = ["The Cranelift Project Developers"]
+description = "Emit Cranelift output to native object files with Faerie"
+repository = "https://github.com/CraneStation/cranelift"
 documentation = "https://cretonne.readthedocs.io/"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 
 [dependencies]
-cretonne-codegen = { path = "../codegen", version = "0.13.0" }
-cretonne-module = { path = "../module", version = "0.13.0" }
+cranelift-codegen = { path = "../codegen", version = "0.13.0" }
+cranelift-module = { path = "../module", version = "0.13.0" }
 faerie = "0.4.2"
 goblin = "0.0.15"
 failure = "0.1.1"
@@ -18,4 +18,4 @@ target-lexicon = "0.0.2"
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "cretonne/cretonne" }
+travis-ci = { repository = "CraneStation/cranelift" }

--- a/lib/faerie/README.md
+++ b/lib/faerie/README.md
@@ -1,4 +1,4 @@
 This crate contains a library that enables
-[Cretonne](https://crates.io/crates/cretonne)
+[Cranelift](https://crates.io/crates/cranelift)
 to emit native object (".o") files, using the
 [Faerie](https://crates.io/crates/faerie) library.

--- a/lib/faerie/src/backend.rs
+++ b/lib/faerie/src/backend.rs
@@ -1,10 +1,10 @@
 //! Defines `FaerieBackend`.
 
 use container;
-use cretonne_codegen::binemit::{Addend, CodeOffset, NullTrapSink, Reloc, RelocSink};
-use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::{self, binemit, ir};
-use cretonne_module::{
+use cranelift_codegen::binemit::{Addend, CodeOffset, NullTrapSink, Reloc, RelocSink};
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::{self, binemit, ir};
+use cranelift_module::{
     Backend, DataContext, DataDescription, Init, Linkage, ModuleError, ModuleNamespace,
     ModuleResult,
 };
@@ -34,16 +34,16 @@ pub struct FaerieBuilder {
 }
 
 impl FaerieBuilder {
-    /// Create a new `FaerieBuilder` using the given Cretonne target, that
+    /// Create a new `FaerieBuilder` using the given Cranelift target, that
     /// can be passed to
-    /// [`Module::new`](cretonne_module/struct.Module.html#method.new].
+    /// [`Module::new`](cranelift_module/struct.Module.html#method.new].
     ///
     /// Faerie output requires that TargetIsa have PIC (Position Independent Code) enabled.
     ///
     /// `collect_traps` setting determines whether trap information is collected in a
     /// `FaerieTrapManifest` available in the `FaerieProduct`.
     ///
-    /// The `libcall_names` function provides a way to translate `cretonne_codegen`'s `ir::LibCall`
+    /// The `libcall_names` function provides a way to translate `cranelift_codegen`'s `ir::LibCall`
     /// enum to symbols. LibCalls are inserted in the IR as part of the legalization for certain
     /// floating point instructions, and for stack probes. If you don't know what to use for this
     /// argument, use `FaerieBuilder::default_libcall_names()`.
@@ -68,10 +68,10 @@ impl FaerieBuilder {
 
     /// Default names for `ir::LibCall`s. A function by this name is imported into the object as
     /// part of the translation of a `ir::ExternalName::LibCall` variant. Calls to a LibCall should
-    /// only be inserted into the IR by the `cretonne_codegen` legalizer pass.
+    /// only be inserted into the IR by the `cranelift_codegen` legalizer pass.
     pub fn default_libcall_names() -> Box<Fn(ir::LibCall) -> String> {
         Box::new(move |libcall| match libcall {
-            ir::LibCall::Probestack => "__cretonne_probestack".to_owned(),
+            ir::LibCall::Probestack => "__cranelift_probestack".to_owned(),
             ir::LibCall::CeilF32 => "ceilf".to_owned(),
             ir::LibCall::CeilF64 => "ceil".to_owned(),
             ir::LibCall::FloorF32 => "floorf".to_owned(),
@@ -111,7 +111,7 @@ impl Backend for FaerieBackend {
     /// to memory and files.
     type Product = FaerieProduct;
 
-    /// Create a new `FaerieBackend` using the given Cretonne target.
+    /// Create a new `FaerieBackend` using the given Cranelift target.
     fn new(builder: FaerieBuilder) -> Self {
         Self {
             artifact: faerie::Artifact::new(builder.isa.triple().clone(), builder.name),
@@ -143,7 +143,7 @@ impl Backend for FaerieBackend {
     fn define_function(
         &mut self,
         name: &str,
-        ctx: &cretonne_codegen::Context,
+        ctx: &cranelift_codegen::Context,
         namespace: &ModuleNamespace<Self>,
         code_size: u32,
     ) -> ModuleResult<FaerieCompiledFunction> {
@@ -290,7 +290,7 @@ impl Backend for FaerieBackend {
 }
 
 /// This is the output of `Module`'s
-/// [`finish`](../cretonne_module/struct.Module.html#method.finish) function.
+/// [`finish`](../cranelift_module/struct.Module.html#method.finish) function.
 /// It provides functions for writing out the object file to memory or a file.
 pub struct FaerieProduct {
     /// Faerie artifact with all functions, data, and links from the module defined

--- a/lib/faerie/src/container.rs
+++ b/lib/faerie/src/container.rs
@@ -1,6 +1,6 @@
 //! Utilities for working with Faerie container formats.
 
-use cretonne_codegen::binemit::Reloc;
+use cranelift_codegen::binemit::Reloc;
 use target_lexicon::{Architecture, BinaryFormat, Triple};
 
 /// An object file format.
@@ -12,7 +12,7 @@ pub enum Format {
     MachO,
 }
 
-/// Translate from a Cretonne `Reloc` to a raw object-file-format-specific
+/// Translate from a Cranelift `Reloc` to a raw object-file-format-specific
 /// relocation code and relocation-implied addend.
 pub fn raw_relocation(reloc: Reloc, triple: &Triple) -> (u32, i64) {
     match triple.binary_format {
@@ -25,7 +25,7 @@ pub fn raw_relocation(reloc: Reloc, triple: &Triple) -> (u32, i64) {
                             Reloc::Abs4 => elf::reloc::R_X86_64_32,
                             Reloc::Abs8 => elf::reloc::R_X86_64_64,
                             Reloc::X86PCRel4 | Reloc::X86CallPCRel4 => elf::reloc::R_X86_64_PC32,
-                            // TODO: Get Cretonne to tell us when we can use
+                            // TODO: Get Cranelift to tell us when we can use
                             // R_X86_64_GOTPCRELX/R_X86_64_REX_GOTPCRELX.
                             Reloc::X86CallPLTRel4 => elf::reloc::R_X86_64_PLT32,
                             Reloc::X86GOTPCRel4 => elf::reloc::R_X86_64_GOTPCREL,

--- a/lib/faerie/src/lib.rs
+++ b/lib/faerie/src/lib.rs
@@ -1,4 +1,4 @@
-//! Top-level lib.rs for `cretonne_faerie`.
+//! Top-level lib.rs for `cranelift_faerie`.
 //!
 //! Users of this module should not have to depend on faerie directly.
 
@@ -14,8 +14,8 @@
     )
 )]
 
-extern crate cretonne_codegen;
-extern crate cretonne_module;
+extern crate cranelift_codegen;
+extern crate cranelift_module;
 extern crate faerie;
 extern crate failure;
 extern crate goblin;

--- a/lib/faerie/src/traps.rs
+++ b/lib/faerie/src/traps.rs
@@ -1,15 +1,15 @@
-//! Faerie trap manifests record every `TrapCode` that cretonne outputs during code generation,
+//! Faerie trap manifests record every `TrapCode` that cranelift outputs during code generation,
 //! for every function in the module. This data may be useful at runtime.
 
-use cretonne_codegen::{binemit, ir};
+use cranelift_codegen::{binemit, ir};
 
-/// Record of the arguments cretonne passes to `TrapSink::trap`
+/// Record of the arguments cranelift passes to `TrapSink::trap`
 pub struct FaerieTrapSite {
     /// Offset into function
     pub offset: binemit::CodeOffset,
-    /// Source location given to cretonne
+    /// Source location given to cranelift
     pub srcloc: ir::SourceLoc,
-    /// Trap code, as determined by cretonne
+    /// Trap code, as determined by cranelift
     pub code: ir::TrapCode,
 }
 

--- a/lib/filetests/Cargo.toml
+++ b/lib/filetests/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "cretonne-filetests"
-authors = ["The Cretonne Project Developers"]
+name = "cranelift-filetests"
+authors = ["The Cranelift Project Developers"]
 version = "0.13.0"
 description = "Test driver and implementations of the filetest commands"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cretonne.readthedocs.io/en/latest/testing.html#file-tests"
-repository = "https://github.com/cretonne/cretonne"
+repository = "https://github.com/CraneStation/cranelift"
 publish = false
 
 [dependencies]
-cretonne-codegen = { path = "../codegen", version = "0.13.0" }
-cretonne-reader = { path = "../reader", version = "0.13.0" }
+cranelift-codegen = { path = "../codegen", version = "0.13.0" }
+cranelift-reader = { path = "../reader", version = "0.13.0" }
 filecheck = "0.3.0"
 num_cpus = "1.8.0"

--- a/lib/filetests/src/concurrent.rs
+++ b/lib/filetests/src/concurrent.rs
@@ -3,7 +3,7 @@
 //! This module provides the `ConcurrentRunner` struct which uses a pool of threads to run tests
 //! concurrently.
 
-use cretonne_codegen::timing;
+use cranelift_codegen::timing;
 use num_cpus;
 use std::panic::catch_unwind;
 use std::path::{Path, PathBuf};

--- a/lib/filetests/src/lib.rs
+++ b/lib/filetests/src/lib.rs
@@ -18,12 +18,12 @@
 )]
 
 #[macro_use(dbg)]
-extern crate cretonne_codegen;
-extern crate cretonne_reader;
+extern crate cranelift_codegen;
+extern crate cranelift_reader;
 extern crate filecheck;
 extern crate num_cpus;
 
-use cretonne_reader::TestCommand;
+use cranelift_reader::TestCommand;
 use runner::TestRunner;
 use std::path::Path;
 use std::time;

--- a/lib/filetests/src/runone.rs
+++ b/lib/filetests/src/runone.rs
@@ -1,13 +1,13 @@
 //! Run the tests in a single test file.
 
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::print_errors::pretty_verifier_error;
-use cretonne_codegen::settings::Flags;
-use cretonne_codegen::timing;
-use cretonne_codegen::verify_function;
-use cretonne_reader::parse_test;
-use cretonne_reader::IsaSpec;
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::print_errors::pretty_verifier_error;
+use cranelift_codegen::settings::Flags;
+use cranelift_codegen::timing;
+use cranelift_codegen::verify_function;
+use cranelift_reader::parse_test;
+use cranelift_reader::IsaSpec;
 use std::borrow::Cow;
 use std::fs;
 use std::io::{self, Read};

--- a/lib/filetests/src/subtest.rs
+++ b/lib/filetests/src/subtest.rs
@@ -1,9 +1,9 @@
 //! `SubTest` trait.
 
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::settings::{Flags, FlagsOrIsa};
-use cretonne_reader::{Comment, Details};
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::settings::{Flags, FlagsOrIsa};
+use cranelift_reader::{Comment, Details};
 use filecheck::{Checker, CheckerBuilder, NO_VARIABLES};
 use std::borrow::Cow;
 

--- a/lib/filetests/src/test_binemit.rs
+++ b/lib/filetests/src/test_binemit.rs
@@ -3,14 +3,14 @@
 //! The `binemit` test command generates binary machine code for every instruction in the input
 //! functions and compares the results to the expected output.
 
-use cretonne_codegen::binemit;
-use cretonne_codegen::binemit::RegDiversions;
-use cretonne_codegen::dbg::DisplayList;
-use cretonne_codegen::ir;
-use cretonne_codegen::ir::entities::AnyEntity;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_codegen::settings::OptLevel;
-use cretonne_reader::TestCommand;
+use cranelift_codegen::binemit;
+use cranelift_codegen::binemit::RegDiversions;
+use cranelift_codegen::dbg::DisplayList;
+use cranelift_codegen::ir;
+use cranelift_codegen::ir::entities::AnyEntity;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_codegen::settings::OptLevel;
+use cranelift_reader::TestCommand;
 use match_directive::match_directive;
 use std::borrow::Cow;
 use std::collections::HashMap;

--- a/lib/filetests/src/test_cat.rs
+++ b/lib/filetests/src/test_cat.rs
@@ -1,7 +1,7 @@
 //! The `cat` subtest.
 
-use cretonne_codegen::ir::Function;
-use cretonne_reader::TestCommand;
+use cranelift_codegen::ir::Function;
+use cranelift_reader::TestCommand;
 use std::borrow::Cow;
 use subtest::{self, Context, SubTest, SubtestResult};
 

--- a/lib/filetests/src/test_compile.rs
+++ b/lib/filetests/src/test_compile.rs
@@ -2,10 +2,10 @@
 //!
 //! The `compile` test command runs each function through the full code generator pipeline
 
-use cretonne_codegen;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_codegen::{binemit, ir};
-use cretonne_reader::TestCommand;
+use cranelift_codegen;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_codegen::{binemit, ir};
+use cranelift_reader::TestCommand;
 use std::borrow::Cow;
 use subtest::{run_filecheck, Context, SubTest, SubtestResult};
 
@@ -35,7 +35,7 @@ impl SubTest for TestCompile {
 
     fn run(&self, func: Cow<ir::Function>, context: &Context) -> SubtestResult<()> {
         let isa = context.isa.expect("compile needs an ISA");
-        let mut comp_ctx = cretonne_codegen::Context::for_function(func.into_owned());
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
         let code_size = comp_ctx
             .compile(isa)

--- a/lib/filetests/src/test_dce.rs
+++ b/lib/filetests/src/test_dce.rs
@@ -5,10 +5,10 @@
 //!
 //! The resulting function is sent to `filecheck`.
 
-use cretonne_codegen;
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_reader::TestCommand;
+use cranelift_codegen;
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_reader::TestCommand;
 use std::borrow::Cow;
 use subtest::{run_filecheck, Context, SubTest, SubtestResult};
 
@@ -33,7 +33,7 @@ impl SubTest for TestDCE {
     }
 
     fn run(&self, func: Cow<Function>, context: &Context) -> SubtestResult<()> {
-        let mut comp_ctx = cretonne_codegen::Context::for_function(func.into_owned());
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
         comp_ctx.flowgraph();
         comp_ctx.compute_loop_analysis();

--- a/lib/filetests/src/test_domtree.rs
+++ b/lib/filetests/src/test_domtree.rs
@@ -12,11 +12,11 @@
 //! We verify that the dominator tree annotations are complete and correct.
 //!
 
-use cretonne_codegen::dominator_tree::{DominatorTree, DominatorTreePreorder};
-use cretonne_codegen::flowgraph::ControlFlowGraph;
-use cretonne_codegen::ir::entities::AnyEntity;
-use cretonne_codegen::ir::Function;
-use cretonne_reader::TestCommand;
+use cranelift_codegen::dominator_tree::{DominatorTree, DominatorTreePreorder};
+use cranelift_codegen::flowgraph::ControlFlowGraph;
+use cranelift_codegen::ir::entities::AnyEntity;
+use cranelift_codegen::ir::Function;
+use cranelift_reader::TestCommand;
 use match_directive::match_directive;
 use std::borrow::{Borrow, Cow};
 use std::collections::HashMap;

--- a/lib/filetests/src/test_legalizer.rs
+++ b/lib/filetests/src/test_legalizer.rs
@@ -3,10 +3,10 @@
 //! The `test legalizer` test command runs each function through `legalize_function()` and sends
 //! the result to filecheck.
 
-use cretonne_codegen;
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_reader::TestCommand;
+use cranelift_codegen;
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_reader::TestCommand;
 use std::borrow::Cow;
 use subtest::{run_filecheck, Context, SubTest, SubtestResult};
 
@@ -35,7 +35,7 @@ impl SubTest for TestLegalizer {
     }
 
     fn run(&self, func: Cow<Function>, context: &Context) -> SubtestResult<()> {
-        let mut comp_ctx = cretonne_codegen::Context::for_function(func.into_owned());
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
         let isa = context.isa.expect("legalizer needs an ISA");
 
         comp_ctx.compute_cfg();

--- a/lib/filetests/src/test_licm.rs
+++ b/lib/filetests/src/test_licm.rs
@@ -5,10 +5,10 @@
 //!
 //! The resulting function is sent to `filecheck`.
 
-use cretonne_codegen;
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_reader::TestCommand;
+use cranelift_codegen;
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_reader::TestCommand;
 use std::borrow::Cow;
 use subtest::{run_filecheck, Context, SubTest, SubtestResult};
 
@@ -33,7 +33,7 @@ impl SubTest for TestLICM {
     }
 
     fn run(&self, func: Cow<Function>, context: &Context) -> SubtestResult<()> {
-        let mut comp_ctx = cretonne_codegen::Context::for_function(func.into_owned());
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
         comp_ctx.flowgraph();
         comp_ctx.compute_loop_analysis();

--- a/lib/filetests/src/test_postopt.rs
+++ b/lib/filetests/src/test_postopt.rs
@@ -2,10 +2,10 @@
 //!
 //! The resulting function is sent to `filecheck`.
 
-use cretonne_codegen;
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_reader::TestCommand;
+use cranelift_codegen;
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_reader::TestCommand;
 use std::borrow::Cow;
 use subtest::{run_filecheck, Context, SubTest, SubtestResult};
 
@@ -30,7 +30,7 @@ impl SubTest for TestPostopt {
     }
 
     fn run(&self, func: Cow<Function>, context: &Context) -> SubtestResult<()> {
-        let mut comp_ctx = cretonne_codegen::Context::for_function(func.into_owned());
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
         let isa = context.isa.expect("postopt needs an ISA");
 
         comp_ctx.flowgraph();

--- a/lib/filetests/src/test_preopt.rs
+++ b/lib/filetests/src/test_preopt.rs
@@ -2,10 +2,10 @@
 //!
 //! The resulting function is sent to `filecheck`.
 
-use cretonne_codegen;
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_reader::TestCommand;
+use cranelift_codegen;
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_reader::TestCommand;
 use std::borrow::Cow;
 use subtest::{run_filecheck, Context, SubTest, SubtestResult};
 
@@ -30,7 +30,7 @@ impl SubTest for TestPreopt {
     }
 
     fn run(&self, func: Cow<Function>, context: &Context) -> SubtestResult<()> {
-        let mut comp_ctx = cretonne_codegen::Context::for_function(func.into_owned());
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
         let isa = context.isa.expect("preopt needs an ISA");
 
         comp_ctx.flowgraph();

--- a/lib/filetests/src/test_print_cfg.rs
+++ b/lib/filetests/src/test_print_cfg.rs
@@ -1,13 +1,13 @@
 //! The `print-cfg` sub-command.
 //!
-//! Read a series of Cretonne IR files and print their control flow graphs
+//! Read a series of Cranelift IR files and print their control flow graphs
 //! in graphviz format.
 
 use std::borrow::Cow;
 
-use cretonne_codegen::cfg_printer::CFGPrinter;
-use cretonne_codegen::ir::Function;
-use cretonne_reader::TestCommand;
+use cranelift_codegen::cfg_printer::CFGPrinter;
+use cranelift_codegen::ir::Function;
+use cranelift_reader::TestCommand;
 use subtest::{self, Context, SubTest, SubtestResult};
 
 /// Object implementing the `test print-cfg` sub-test.

--- a/lib/filetests/src/test_regalloc.rs
+++ b/lib/filetests/src/test_regalloc.rs
@@ -5,10 +5,10 @@
 //!
 //! The resulting function is sent to `filecheck`.
 
-use cretonne_codegen;
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_reader::TestCommand;
+use cranelift_codegen;
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_reader::TestCommand;
 use std::borrow::Cow;
 use subtest::{run_filecheck, Context, SubTest, SubtestResult};
 
@@ -38,7 +38,7 @@ impl SubTest for TestRegalloc {
 
     fn run(&self, func: Cow<Function>, context: &Context) -> SubtestResult<()> {
         let isa = context.isa.expect("register allocator needs an ISA");
-        let mut comp_ctx = cretonne_codegen::Context::for_function(func.into_owned());
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
         comp_ctx.compute_cfg();
         // TODO: Should we have an option to skip legalization?

--- a/lib/filetests/src/test_shrink.rs
+++ b/lib/filetests/src/test_shrink.rs
@@ -5,10 +5,10 @@
 //!
 //! The resulting function is sent to `filecheck`.
 
-use cretonne_codegen;
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_reader::TestCommand;
+use cranelift_codegen;
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_reader::TestCommand;
 use std::borrow::Cow;
 use subtest::{run_filecheck, Context, SubTest, SubtestResult};
 
@@ -34,7 +34,7 @@ impl SubTest for TestShrink {
 
     fn run(&self, func: Cow<Function>, context: &Context) -> SubtestResult<()> {
         let isa = context.isa.expect("shrink needs an ISA");
-        let mut comp_ctx = cretonne_codegen::Context::for_function(func.into_owned());
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
         comp_ctx
             .shrink_instructions(isa)

--- a/lib/filetests/src/test_simple_gvn.rs
+++ b/lib/filetests/src/test_simple_gvn.rs
@@ -5,10 +5,10 @@
 //!
 //! The resulting function is sent to `filecheck`.
 
-use cretonne_codegen;
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_reader::TestCommand;
+use cranelift_codegen;
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_reader::TestCommand;
 use std::borrow::Cow;
 use subtest::{run_filecheck, Context, SubTest, SubtestResult};
 
@@ -33,7 +33,7 @@ impl SubTest for TestSimpleGVN {
     }
 
     fn run(&self, func: Cow<Function>, context: &Context) -> SubtestResult<()> {
-        let mut comp_ctx = cretonne_codegen::Context::for_function(func.into_owned());
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
         comp_ctx.flowgraph();
         comp_ctx

--- a/lib/filetests/src/test_verifier.rs
+++ b/lib/filetests/src/test_verifier.rs
@@ -9,9 +9,9 @@
 //! This annotation means that the verifier is expected to given an error for the jump instruction
 //! containing the substring "jump to non-existent EBB".
 
-use cretonne_codegen::ir::Function;
-use cretonne_codegen::verify_function;
-use cretonne_reader::TestCommand;
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::verify_function;
+use cranelift_reader::TestCommand;
 use match_directive::match_directive;
 use std::borrow::{Borrow, Cow};
 use subtest::{Context, SubTest, SubtestResult};

--- a/lib/frontend/Cargo.toml
+++ b/lib/frontend/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-authors = ["The Cretonne Project Developers"]
-name = "cretonne-frontend"
+authors = ["The Cranelift Project Developers"]
+name = "cranelift-frontend"
 version = "0.13.0"
-description = "Cretonne IR builder helper"
+description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cretonne.readthedocs.io/"
-repository = "https://github.com/cretonne/cretonne"
+repository = "https://github.com/CraneStation/cranelift"
 readme = "README.md"
 
 [dependencies]
-cretonne-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
 
 [features]
 default = ["std"]
-std = ["cretonne-codegen/std"]
-core = ["cretonne-codegen/core"]
+std = ["cranelift-codegen/std"]
+core = ["cranelift-codegen/core"]
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "cretonne/cretonne" }
+travis-ci = { repository = "CraneStation/cranelift" }

--- a/lib/frontend/README.md
+++ b/lib/frontend/README.md
@@ -1,5 +1,5 @@
 This crate provides a straightforward way to create a
-[Cretonne](https://crates.io/crates/cretonne) IR function and fill it with
+[Cranelift](https://crates.io/crates/cranelift) IR function and fill it with
 instructions translated from another language. It contains an SSA construction
 module that provides convenient methods for translating non-SSA variables into
-SSA Cretonne IR values via `use_var` and `def_var` calls.
+SSA Cranelift IR values via `use_var` and `def_var` calls.

--- a/lib/frontend/src/frontend.rs
+++ b/lib/frontend/src/frontend.rs
@@ -1,19 +1,19 @@
-//! A frontend for building Cretonne IR from other languages.
-use cretonne_codegen::cursor::{Cursor, FuncCursor};
-use cretonne_codegen::entity::{EntityMap, EntityRef, EntitySet};
-use cretonne_codegen::ir;
-use cretonne_codegen::ir::function::DisplayFunction;
-use cretonne_codegen::ir::{
+//! A frontend for building Cranelift IR from other languages.
+use cranelift_codegen::cursor::{Cursor, FuncCursor};
+use cranelift_codegen::entity::{EntityMap, EntityRef, EntitySet};
+use cranelift_codegen::ir;
+use cranelift_codegen::ir::function::DisplayFunction;
+use cranelift_codegen::ir::{
     DataFlowGraph, Ebb, ExtFuncData, FuncRef, Function, GlobalValue, GlobalValueData, Heap,
     HeapData, Inst, InstBuilderBase, InstructionData, JumpTable, JumpTableData, SigRef, Signature,
     StackSlot, StackSlotData, Type, Value,
 };
-use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::packed_option::PackedOption;
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::packed_option::PackedOption;
 use ssa::{Block, SSABuilder, SideEffects};
 use std::fmt::Debug;
 
-/// Structure used for translating a series of functions into Cretonne IR.
+/// Structure used for translating a series of functions into Cranelift IR.
 ///
 /// In order to reduce memory reallocations when compiling multiple functions,
 /// `FunctionBuilderContext` holds various data structures which are cleared between
@@ -31,7 +31,7 @@ where
     types: EntityMap<Variable, Type>,
 }
 
-/// Temporary object used to build a single Cretonne IR `Function`.
+/// Temporary object used to build a single Cranelift IR `Function`.
 pub struct FunctionBuilder<'a, Variable: 'a>
 where
     Variable: EntityRef + Debug,
@@ -105,7 +105,7 @@ where
 }
 
 /// Implementation of the [`InstBuilder`](../codegen/ir/builder/trait.InstBuilder.html) that has
-/// one convenience method per Cretonne IR instruction.
+/// one convenience method per Cranelift IR instruction.
 pub struct FuncInstBuilder<'short, 'long: 'short, Variable: 'long>
 where
     Variable: EntityRef + Debug,
@@ -195,7 +195,7 @@ where
     }
 }
 
-/// This module allows you to create a function in Cretonne IR in a straightforward way, hiding
+/// This module allows you to create a function in Cranelift IR in a straightforward way, hiding
 /// all the complexity of its internal representation.
 ///
 /// The module is parametrized by one type which is the representation of variables in your
@@ -207,10 +207,10 @@ where
 /// - the last instruction of each block is a terminator instruction which has no natural successor,
 ///   and those instructions can only appear at the end of extended blocks.
 ///
-/// The parameters of Cretonne IR instructions are Cretonne IR values, which can only be created
-/// as results of other Cretonne IR instructions. To be able to create variables redefined multiple
+/// The parameters of Cranelift IR instructions are Cranelift IR values, which can only be created
+/// as results of other Cranelift IR instructions. To be able to create variables redefined multiple
 /// times in your program, use the `def_var` and `use_var` command, that will maintain the
-/// correspondence between your variables and Cretonne IR SSA values.
+/// correspondence between your variables and Cranelift IR SSA values.
 ///
 /// The first block for which you call `switch_to_block` will be assumed to be the beginning of
 /// the function.
@@ -224,7 +224,7 @@ where
 ///
 /// # Errors
 ///
-/// The functions below will panic in debug mode whenever you try to modify the Cretonne IR
+/// The functions below will panic in debug mode whenever you try to modify the Cranelift IR
 /// function in a way that violate the coherence of the code. For instance: switching to a new
 /// `Ebb` when you haven't filled the current one with a terminator instruction, inserting a
 /// return instruction with arguments that don't match the function's signature.
@@ -317,7 +317,7 @@ where
         self.func_ctx.types[var] = ty;
     }
 
-    /// Returns the Cretonne IR value corresponding to the utilization at the current program
+    /// Returns the Cranelift IR value corresponding to the utilization at the current program
     /// position of a previously defined user variable.
     pub fn use_var(&mut self, var: Variable) -> Value {
         let (val, side_effects) = {
@@ -481,8 +481,8 @@ where
 }
 
 /// All the functions documented in the previous block are write-only and help you build a valid
-/// Cretonne IR functions via multiple debug asserts. However, you might need to improve the
-/// performance of your translation perform more complex transformations to your Cretonne IR
+/// Cranelift IR functions via multiple debug asserts. However, you might need to improve the
+/// performance of your translation perform more complex transformations to your Cranelift IR
 /// function. The functions below help you inspect the function you're creating and modify it
 /// in ways that can be unsafe if used incorrectly.
 impl<'a, Variable> FunctionBuilder<'a, Variable>
@@ -610,12 +610,12 @@ where
 #[cfg(test)]
 mod tests {
 
-    use cretonne_codegen::entity::EntityRef;
-    use cretonne_codegen::ir::types::*;
-    use cretonne_codegen::ir::{AbiParam, ExternalName, Function, InstBuilder, Signature};
-    use cretonne_codegen::settings;
-    use cretonne_codegen::settings::CallConv;
-    use cretonne_codegen::verifier::verify_function;
+    use cranelift_codegen::entity::EntityRef;
+    use cranelift_codegen::ir::types::*;
+    use cranelift_codegen::ir::{AbiParam, ExternalName, Function, InstBuilder, Signature};
+    use cranelift_codegen::settings;
+    use cranelift_codegen::settings::CallConv;
+    use cranelift_codegen::verifier::verify_function;
     use frontend::{FunctionBuilder, FunctionBuilderContext};
     use Variable;
 

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -1,15 +1,15 @@
-//! Cretonne IR builder library.
+//! Cranelift IR builder library.
 //!
-//! Provides a straightforward way to create a Cretonne IR function and fill it with instructions
+//! Provides a straightforward way to create a Cranelift IR function and fill it with instructions
 //! translated from another language. Contains an SSA construction module that lets you translate
-//! your non-SSA variables into SSA Cretonne IR values via `use_var` and `def_var` calls.
+//! your non-SSA variables into SSA Cranelift IR values via `use_var` and `def_var` calls.
 //!
 //! To get started, create an [`FunctionBuilderContext`](struct.FunctionBuilderContext.html) and
 //! pass it as an argument to a [`FunctionBuilder`](struct.FunctionBuilder.html).
 //!
 //! # Example
 //!
-//! Here is a pseudo-program we want to transform into Cretonne IR:
+//! Here is a pseudo-program we want to transform into Cranelift IR:
 //!
 //! ```cton
 //! function(x) {
@@ -29,18 +29,18 @@
 //! }
 //! ```
 //!
-//! Here is how you build the corresponding Cretonne IR function using `FunctionBuilderContext`:
+//! Here is how you build the corresponding Cranelift IR function using `FunctionBuilderContext`:
 //!
 //! ```rust
-//! extern crate cretonne_codegen;
-//! extern crate cretonne_frontend;
+//! extern crate cranelift_codegen;
+//! extern crate cranelift_frontend;
 //!
-//! use cretonne_codegen::entity::EntityRef;
-//! use cretonne_codegen::ir::{ExternalName, Function, Signature, AbiParam, InstBuilder};
-//! use cretonne_codegen::ir::types::*;
-//! use cretonne_codegen::settings::{self, CallConv};
-//! use cretonne_frontend::{FunctionBuilderContext, FunctionBuilder, Variable};
-//! use cretonne_codegen::verifier::verify_function;
+//! use cranelift_codegen::entity::EntityRef;
+//! use cranelift_codegen::ir::{ExternalName, Function, Signature, AbiParam, InstBuilder};
+//! use cranelift_codegen::ir::types::*;
+//! use cranelift_codegen::settings::{self, CallConv};
+//! use cranelift_frontend::{FunctionBuilderContext, FunctionBuilder, Variable};
+//! use cranelift_codegen::verifier::verify_function;
 //!
 //! fn main() {
 //!     let mut sig = Signature::new(CallConv::SystemV);
@@ -141,7 +141,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
-extern crate cretonne_codegen;
+extern crate cranelift_codegen;
 
 pub use frontend::{FunctionBuilder, FunctionBuilderContext};
 pub use variable::Variable;

--- a/lib/frontend/src/ssa.rs
+++ b/lib/frontend/src/ssa.rs
@@ -5,14 +5,14 @@
 //! In: Jhala R., De Bosschere K. (eds) Compiler Construction. CC 2013.
 //! Lecture Notes in Computer Science, vol 7791. Springer, Berlin, Heidelberg
 
-use cretonne_codegen::cursor::{Cursor, FuncCursor};
-use cretonne_codegen::entity::{EntityMap, EntityRef, PrimaryMap};
-use cretonne_codegen::ir::immediates::{Ieee32, Ieee64};
-use cretonne_codegen::ir::instructions::BranchInfo;
-use cretonne_codegen::ir::types::{F32, F64};
-use cretonne_codegen::ir::{Ebb, Function, Inst, InstBuilder, Type, Value};
-use cretonne_codegen::packed_option::PackedOption;
-use cretonne_codegen::packed_option::ReservedValue;
+use cranelift_codegen::cursor::{Cursor, FuncCursor};
+use cranelift_codegen::entity::{EntityMap, EntityRef, PrimaryMap};
+use cranelift_codegen::ir::immediates::{Ieee32, Ieee64};
+use cranelift_codegen::ir::instructions::BranchInfo;
+use cranelift_codegen::ir::types::{F32, F64};
+use cranelift_codegen::ir::{Ebb, Function, Inst, InstBuilder, Type, Value};
+use cranelift_codegen::packed_option::PackedOption;
+use cranelift_codegen::packed_option::ReservedValue;
 use std::mem;
 use std::u32;
 use std::vec::Vec;
@@ -233,7 +233,7 @@ fn emit_zero(ty: Type, mut cur: FuncCursor) -> Value {
     }
 }
 /// The following methods are the API of the SSA builder. Here is how it should be used when
-/// translating to Cretonne IR:
+/// translating to Cranelift IR:
 ///
 /// - for each sequence of contiguous instructions (with no branches), create a corresponding
 ///   basic block with `declare_ebb_body_block` or `declare_ebb_header_block` depending on the
@@ -715,13 +715,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use cretonne_codegen::cursor::{Cursor, FuncCursor};
-    use cretonne_codegen::entity::EntityRef;
-    use cretonne_codegen::ir::instructions::BranchInfo;
-    use cretonne_codegen::ir::types::*;
-    use cretonne_codegen::ir::{Function, Inst, InstBuilder, JumpTableData, Opcode};
-    use cretonne_codegen::settings;
-    use cretonne_codegen::verify_function;
+    use cranelift_codegen::cursor::{Cursor, FuncCursor};
+    use cranelift_codegen::entity::EntityRef;
+    use cranelift_codegen::ir::instructions::BranchInfo;
+    use cranelift_codegen::ir::types::*;
+    use cranelift_codegen::ir::{Function, Inst, InstBuilder, JumpTableData, Opcode};
+    use cranelift_codegen::settings;
+    use cranelift_codegen::verify_function;
     use ssa::SSABuilder;
     use Variable;
 

--- a/lib/frontend/src/variable.rs
+++ b/lib/frontend/src/variable.rs
@@ -5,7 +5,7 @@
 //! their own index types to use them directly. Frontends which don't
 //! can use the `Variable` defined here.
 
-use cretonne_codegen::entity::EntityRef;
+use cranelift_codegen::entity::EntityRef;
 use std::u32;
 
 ///! An opaque reference to a variable.

--- a/lib/module/Cargo.toml
+++ b/lib/module/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name = "cretonne-module"
+name = "cranelift-module"
 version = "0.13.0"
-authors = ["The Cretonne Project Developers"]
-description = "Support for linking functions and data with Cretonne"
-repository = "https://github.com/cretonne/cretonne"
+authors = ["The Cranelift Project Developers"]
+description = "Support for linking functions and data with Cranelift"
+repository = "https://github.com/CraneStation/cranelift"
 documentation = "https://cretonne.readthedocs.io/"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 
 [dependencies]
-cretonne-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
-cretonne-entity = { path = "../entity", version = "0.13.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.13.0", default-features = false }
 hashmap_core = { version = "0.1.8", optional = true }
 failure = "0.1.1"
 
 [features]
 default = ["std"]
-std = ["cretonne-codegen/std", "cretonne-entity/std"]
-core = ["hashmap_core", "cretonne-codegen/core"]
+std = ["cranelift-codegen/std", "cranelift-entity/std"]
+core = ["hashmap_core", "cranelift-codegen/core"]
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "cretonne/cretonne" }
+travis-ci = { repository = "CraneStation/cranelift" }

--- a/lib/module/README.md
+++ b/lib/module/README.md
@@ -1,7 +1,7 @@
 This crate provides the `Module` trait, which provides an interface for
 multiple functions and data to be emitted with
-[Cretonne](https://crates.io/crates/cretonne) and then linked together.
+[Cranelift](https://crates.io/crates/cranelift) and then linked together.
 
-This crate is structured as an optional layer on top of cretonne-codegen.
+This crate is structured as an optional layer on top of cranelift-codegen.
 It provides additional functionality, such as linking, however users that
 require greater flexibility don't need to use it.

--- a/lib/module/src/backend.rs
+++ b/lib/module/src/backend.rs
@@ -1,8 +1,8 @@
 //! Defines the `Backend` trait.
 
-use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::Context;
-use cretonne_codegen::{binemit, ir};
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::Context;
+use cranelift_codegen::{binemit, ir};
 use std::marker;
 use DataContext;
 use Linkage;

--- a/lib/module/src/data_context.rs
+++ b/lib/module/src/data_context.rs
@@ -1,8 +1,8 @@
 //! Defines `DataContext`.
 
-use cretonne_codegen::binemit::{Addend, CodeOffset};
-use cretonne_codegen::entity::PrimaryMap;
-use cretonne_codegen::ir;
+use cranelift_codegen::binemit::{Addend, CodeOffset};
+use cranelift_codegen::entity::PrimaryMap;
+use cranelift_codegen::ir;
 use std::boxed::Box;
 use std::vec::Vec;
 
@@ -59,7 +59,7 @@ pub struct DataDescription {
     pub data_relocs: Vec<(CodeOffset, ir::GlobalValue, Addend)>,
 }
 
-/// This is to data objects what cretonne_codegen::Context is to functions.
+/// This is to data objects what cranelift_codegen::Context is to functions.
 pub struct DataContext {
     description: DataDescription,
 }
@@ -147,7 +147,7 @@ impl DataContext {
 
 #[cfg(test)]
 mod tests {
-    use cretonne_codegen::ir;
+    use cranelift_codegen::ir;
     use {DataContext, Init, Writability};
 
     #[test]

--- a/lib/module/src/lib.rs
+++ b/lib/module/src/lib.rs
@@ -1,4 +1,4 @@
-//! Top-level lib.rs for `cretonne_module`.
+//! Top-level lib.rs for `cranelift_module`.
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
@@ -21,9 +21,9 @@
 extern crate alloc;
 
 #[macro_use]
-extern crate cretonne_codegen;
+extern crate cranelift_codegen;
 #[macro_use]
-extern crate cretonne_entity;
+extern crate cranelift_entity;
 #[macro_use]
 extern crate failure;
 

--- a/lib/module/src/module.rs
+++ b/lib/module/src/module.rs
@@ -5,8 +5,8 @@
 // TODO: Factor out `ir::Function`'s `ext_funcs` and `global_values` into a struct
 // shared with `DataContext`?
 
-use cretonne_codegen::entity::{EntityRef, PrimaryMap};
-use cretonne_codegen::{binemit, ir, CodegenError, Context};
+use cranelift_codegen::entity::{EntityRef, PrimaryMap};
+use cranelift_codegen::{binemit, ir, CodegenError, Context};
 use data_context::DataContext;
 use std::borrow::ToOwned;
 use std::collections::HashMap;
@@ -131,7 +131,7 @@ pub enum ModuleError {
     /// Indicates an identifier was defined, but was declared as an import
     #[fail(display = "Invalid to define identifier declared as an import: {}", _0)]
     InvalidImportDefinition(String),
-    /// Wraps a `cretonne-codegen` error
+    /// Wraps a `cranelift-codegen` error
     #[fail(display = "Compilation error: {}", _0)]
     Compilation(CodegenError),
     /// Wraps a generic error from a backend

--- a/lib/native/Cargo.toml
+++ b/lib/native/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "cretonne-native"
+name = "cranelift-native"
 version = "0.13.0"
-authors = ["The Cretonne Project Developers"]
-description = "Support for targeting the host with Cretonne"
-repository = "https://github.com/cretonne/cretonne"
+authors = ["The Cranelift Project Developers"]
+description = "Support for targeting the host with Cranelift"
+repository = "https://github.com/CraneStation/cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 
 [dependencies]
-cretonne-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
 target-lexicon = { version = "0.0.2", default-features = false }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
@@ -16,12 +16,12 @@ raw-cpuid = "4"
 
 [features]
 default = ["std"]
-std = ["cretonne-codegen/std", "target-lexicon/std"]
+std = ["cranelift-codegen/std", "target-lexicon/std"]
 # when compiling with the "core" feature, nightly must be enabled
 # enabling the "nightly" feature for raw-cpuid allows avoiding
 # linking in a c-library.
-core = ["cretonne-codegen/core", "raw-cpuid/nightly"]
+core = ["cranelift-codegen/core", "raw-cpuid/nightly"]
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "cretonne/cretonne" }
+travis-ci = { repository = "CraneStation/cranelift" }

--- a/lib/native/README.md
+++ b/lib/native/README.md
@@ -1,3 +1,3 @@
 This crate performs autodetection of the host architecture, which can be used to
-configure [Cretonne](https://crates.io/crates/cretonne) to generate code
+configure [Cranelift](https://crates.io/crates/cranelift) to generate code
 specialized for the machine it's running on.

--- a/lib/native/src/lib.rs
+++ b/lib/native/src/lib.rs
@@ -1,5 +1,5 @@
 //! Performs autodetection of the host for the purposes of running
-//! Cretonne to generate code to run on the same machine.
+//! Cranelift to generate code to run on the same machine.
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces, unstable_features)]
@@ -14,13 +14,13 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate cretonne_codegen;
+extern crate cranelift_codegen;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 extern crate raw_cpuid;
 extern crate target_lexicon;
 
-use cretonne_codegen::isa;
-use cretonne_codegen::settings::{self, Configurable};
+use cranelift_codegen::isa;
+use cranelift_codegen::settings::{self, Configurable};
 use target_lexicon::Triple;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/lib/reader/Cargo.toml
+++ b/lib/reader/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-authors = ["The Cretonne Project Developers"]
-name = "cretonne-reader"
+authors = ["The Cranelift Project Developers"]
+name = "cranelift-reader"
 version = "0.13.0"
-description = "Cretonne textual IR reader"
+description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cretonne.readthedocs.io/"
-repository = "https://github.com/cretonne/cretonne"
+repository = "https://github.com/CraneStation/cranelift"
 readme = "README.md"
 
 [dependencies]
-cretonne-codegen = { path = "../codegen", version = "0.13.0" }
+cranelift-codegen = { path = "../codegen", version = "0.13.0" }
 target-lexicon = "0.0.2"
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "cretonne/cretonne" }
+travis-ci = { repository = "CraneStation/cranelift" }

--- a/lib/reader/README.md
+++ b/lib/reader/README.md
@@ -1,3 +1,3 @@
 This crate library supports reading .cton files. This functionality is needed
-for testing [Cretonne](https://crates.io/crates/cretonne), but is not essential
+for testing [Cranelift](https://crates.io/crates/cranelift), but is not essential
 for a JIT compiler.

--- a/lib/reader/src/isaspec.rs
+++ b/lib/reader/src/isaspec.rs
@@ -6,8 +6,8 @@
 //! If a test case file contains `isa` commands, the tests will only be run against the specified
 //! ISAs. If the file contains no `isa` commands, the tests will be run against all supported ISAs.
 
-use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::settings::{Configurable, Flags, SetError};
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::settings::{Configurable, Flags, SetError};
 use error::{Location, ParseResult};
 use testcommand::TestOption;
 

--- a/lib/reader/src/lexer.rs
+++ b/lib/reader/src/lexer.rs
@@ -1,7 +1,7 @@
 //! Lexical analysis for .cton files.
 
-use cretonne_codegen::ir::types;
-use cretonne_codegen::ir::{Ebb, Value};
+use cranelift_codegen::ir::types;
+use cranelift_codegen::ir::{Ebb, Value};
 use error::Location;
 #[allow(unused_imports, deprecated)]
 use std::ascii::AsciiExt;
@@ -479,8 +479,8 @@ impl<'a> Lexer<'a> {
 mod tests {
     use super::trailing_digits;
     use super::*;
-    use cretonne_codegen::ir::types;
-    use cretonne_codegen::ir::{Ebb, Value};
+    use cranelift_codegen::ir::types;
+    use cranelift_codegen::ir::{Ebb, Value};
     use error::Location;
 
     #[test]

--- a/lib/reader/src/lib.rs
+++ b/lib/reader/src/lib.rs
@@ -1,7 +1,7 @@
-//! Cretonne file reader library.
+//! Cranelift file reader library.
 //!
-//! The `cretonne_reader` library supports reading .cton files. This functionality is needed for
-//! testing Cretonne, but is not essential for a JIT compiler.
+//! The `cranelift_reader` library supports reading .cton files. This functionality is needed for
+//! testing Cranelift, but is not essential for a JIT compiler.
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces, unstable_features)]
@@ -15,7 +15,7 @@
     )
 )]
 
-extern crate cretonne_codegen;
+extern crate cranelift_codegen;
 extern crate target_lexicon;
 
 pub use error::{Location, ParseError, ParseResult};

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -1,21 +1,21 @@
 //! Parser for .cton files.
 
-use cretonne_codegen::entity::EntityRef;
-use cretonne_codegen::ir;
-use cretonne_codegen::ir::entities::AnyEntity;
-use cretonne_codegen::ir::immediates::{Ieee32, Ieee64, Imm64, Offset32, Uimm32};
-use cretonne_codegen::ir::instructions::{InstructionData, InstructionFormat, VariableArgs};
-use cretonne_codegen::ir::types::VOID;
-use cretonne_codegen::ir::{
+use cranelift_codegen::entity::EntityRef;
+use cranelift_codegen::ir;
+use cranelift_codegen::ir::entities::AnyEntity;
+use cranelift_codegen::ir::immediates::{Ieee32, Ieee64, Imm64, Offset32, Uimm32};
+use cranelift_codegen::ir::instructions::{InstructionData, InstructionFormat, VariableArgs};
+use cranelift_codegen::ir::types::VOID;
+use cranelift_codegen::ir::{
     AbiParam, ArgumentExtension, ArgumentLoc, Ebb, ExtFuncData, ExternalName, FuncRef, Function,
     GlobalValue, GlobalValueData, Heap, HeapBase, HeapData, HeapStyle, JumpTable, JumpTableData,
     MemFlags, Opcode, SigRef, Signature, StackSlot, StackSlotData, StackSlotKind, Type, Value,
     ValueLoc,
 };
-use cretonne_codegen::isa::{self, Encoding, RegUnit, TargetIsa};
-use cretonne_codegen::packed_option::ReservedValue;
-use cretonne_codegen::settings::CallConv;
-use cretonne_codegen::{settings, timing};
+use cranelift_codegen::isa::{self, Encoding, RegUnit, TargetIsa};
+use cranelift_codegen::packed_option::ReservedValue;
+use cranelift_codegen::settings::CallConv;
+use cranelift_codegen::{settings, timing};
 use error::{Location, ParseError, ParseResult};
 use isaspec;
 use lexer::{LexError, Lexer, LocatedError, LocatedToken, Token};
@@ -2291,11 +2291,11 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cretonne_codegen::ir::entities::AnyEntity;
-    use cretonne_codegen::ir::types;
-    use cretonne_codegen::ir::StackSlotKind;
-    use cretonne_codegen::ir::{ArgumentExtension, ArgumentPurpose};
-    use cretonne_codegen::settings::CallConv;
+    use cranelift_codegen::ir::entities::AnyEntity;
+    use cranelift_codegen::ir::types;
+    use cranelift_codegen::ir::StackSlotKind;
+    use cranelift_codegen::ir::{ArgumentExtension, ArgumentPurpose};
+    use cranelift_codegen::settings::CallConv;
     use error::ParseError;
     use isaspec::IsaSpec;
     use testfile::{Comment, Details};

--- a/lib/reader/src/sourcemap.rs
+++ b/lib/reader/src/sourcemap.rs
@@ -6,8 +6,8 @@
 //! The `SourceMap` struct defined in this module makes this mapping available
 //! to parser clients.
 
-use cretonne_codegen::ir::entities::AnyEntity;
-use cretonne_codegen::ir::{Ebb, FuncRef, GlobalValue, Heap, JumpTable, SigRef, StackSlot, Value};
+use cranelift_codegen::ir::entities::AnyEntity;
+use cranelift_codegen::ir::{Ebb, FuncRef, GlobalValue, Heap, JumpTable, SigRef, StackSlot, Value};
 use error::{Location, ParseResult};
 use lexer::split_entity_name;
 use std::collections::HashMap;

--- a/lib/reader/src/testfile.rs
+++ b/lib/reader/src/testfile.rs
@@ -4,8 +4,8 @@
 //! file-based test case.
 //!
 
-use cretonne_codegen::ir::entities::AnyEntity;
-use cretonne_codegen::ir::Function;
+use cranelift_codegen::ir::entities::AnyEntity;
+use cranelift_codegen::ir::Function;
 use error::Location;
 use isaspec::IsaSpec;
 use sourcemap::SourceMap;

--- a/lib/simplejit/Cargo.toml
+++ b/lib/simplejit/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "cretonne-simplejit"
+name = "cranelift-simplejit"
 version = "0.13.0"
-authors = ["The Cretonne Project Developers"]
-description = "A simple JIT library backed by Cretonne"
-repository = "https://github.com/cretonne/cretonne"
+authors = ["The Cranelift Project Developers"]
+description = "A simple JIT library backed by Cranelift"
+repository = "https://github.com/CraneStation/cranelift"
 documentation = "https://cretonne.readthedocs.io/"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 
 [dependencies]
-cretonne-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
-cretonne-module = { path = "../module", version = "0.13.0", default-features = false }
-cretonne-native = { path = "../native", version = "0.13.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
+cranelift-module = { path = "../module", version = "0.13.0", default-features = false }
+cranelift-native = { path = "../native", version = "0.13.0", default-features = false }
 region = "0.3.0"
 libc = { version = "0.2.40", default-features = false }
 errno = "0.2.3"
@@ -22,9 +22,9 @@ winapi = { version = "0.3", features = ["winbase", "memoryapi"] }
 
 [features]
 default = ["std"]
-std = ["libc/use_std", "cretonne-codegen/std", "cretonne-module/std", "cretonne-native/std", "target-lexicon/std"]
-core = ["cretonne-codegen/core", "cretonne-module/core", "cretonne-native/core"]
+std = ["libc/use_std", "cranelift-codegen/std", "cranelift-module/std", "cranelift-native/std", "target-lexicon/std"]
+core = ["cranelift-codegen/core", "cranelift-module/core", "cranelift-native/core"]
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "cretonne/cretonne" }
+travis-ci = { repository = "CraneStation/cranelift" }

--- a/lib/simplejit/README.md
+++ b/lib/simplejit/README.md
@@ -1,4 +1,4 @@
 This crate provides a simple JIT library that uses
-[Cretonne](https://crates.io/crates/cretonne).
+[Cranelift](https://crates.io/crates/cranelift).
 
 This crate is extremely experimental.

--- a/lib/simplejit/src/backend.rs
+++ b/lib/simplejit/src/backend.rs
@@ -1,13 +1,13 @@
 //! Defines `SimpleJITBackend`.
 
-use cretonne_codegen::binemit::{Addend, CodeOffset, NullTrapSink, Reloc, RelocSink};
-use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::{self, ir, settings};
-use cretonne_module::{
+use cranelift_codegen::binemit::{Addend, CodeOffset, NullTrapSink, Reloc, RelocSink};
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::{self, ir, settings};
+use cranelift_module::{
     Backend, DataContext, DataDescription, Init, Linkage, ModuleNamespace, ModuleResult,
     Writability,
 };
-use cretonne_native;
+use cranelift_native;
 use libc;
 use memory::Memory;
 use std::ffi::CString;
@@ -24,7 +24,7 @@ pub struct SimpleJITBuilder {
 impl SimpleJITBuilder {
     /// Create a new `SimpleJITBuilder`.
     pub fn new() -> Self {
-        let (flag_builder, isa_builder) = cretonne_native::builders().unwrap_or_else(|_| {
+        let (flag_builder, isa_builder) = cranelift_native::builders().unwrap_or_else(|_| {
             panic!("host machine is not a supported target");
         });
         let isa = isa_builder.finish(settings::Flags::new(flag_builder));
@@ -117,7 +117,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
     fn define_function(
         &mut self,
         _name: &str,
-        ctx: &cretonne_codegen::Context,
+        ctx: &cranelift_codegen::Context,
         _namespace: &ModuleNamespace<Self>,
         code_size: u32,
     ) -> ModuleResult<Self::CompiledFunction> {

--- a/lib/simplejit/src/lib.rs
+++ b/lib/simplejit/src/lib.rs
@@ -1,4 +1,4 @@
-//! Top-level lib.rs for `cretonne_simplejit`.
+//! Top-level lib.rs for `cranelift_simplejit`.
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces, unstable_features)]
@@ -12,9 +12,9 @@
     )
 )]
 
-extern crate cretonne_codegen;
-extern crate cretonne_module;
-extern crate cretonne_native;
+extern crate cranelift_codegen;
+extern crate cranelift_module;
+extern crate cranelift_native;
 extern crate errno;
 extern crate libc;
 extern crate region;

--- a/lib/umbrella/Cargo.toml
+++ b/lib/umbrella/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-authors = ["The Cretonne Project Developers"]
-name = "cretonne"
+authors = ["The Cranelift Project Developers"]
+name = "cranelift"
 version = "0.13.0"
-description = "Umbrella for commonly-used cretonne crates"
+description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cretonne.readthedocs.io/"
-repository = "https://github.com/cretonne/cretonne"
+repository = "https://github.com/CraneStation/cranelift"
 readme = "README.md"
 keywords = ["compile", "compiler", "jit"]
 
 [dependencies]
-cretonne-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
-cretonne-frontend = { path = "../frontend", version = "0.13.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
+cranelift-frontend = { path = "../frontend", version = "0.13.0", default-features = false }
 
 [features]
 default = ["std"]
-std = ["cretonne-codegen/std", "cretonne-frontend/std"]
-core = ["cretonne-codegen/core", "cretonne-frontend/core"]
+std = ["cranelift-codegen/std", "cranelift-frontend/std"]
+core = ["cranelift-codegen/core", "cranelift-frontend/core"]
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "cretonne/cretonne" }
+travis-ci = { repository = "cranelift/cranelift" }

--- a/lib/umbrella/README.md
+++ b/lib/umbrella/README.md
@@ -1,3 +1,3 @@
 This is an umbrella crate which contains no code of its own, but pulls in
-other cretonne library crates to provide a convenient one-line dependency,
+other cranelift library crates to provide a convenient one-line dependency,
 and a prelude, for common use cases.

--- a/lib/umbrella/src/lib.rs
+++ b/lib/umbrella/src/lib.rs
@@ -1,4 +1,4 @@
-//! Cretonne umbrella crate, providing a convenient one-line dependency.
+//! Cranelift umbrella crate, providing a convenient one-line dependency.
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces, unstable_features)]
@@ -13,11 +13,11 @@
 )]
 
 /// Provide these crates, renamed to reduce stutter.
-pub extern crate cretonne_codegen as codegen;
-pub extern crate cretonne_frontend as frontend;
+pub extern crate cranelift_codegen as codegen;
+pub extern crate cranelift_frontend as frontend;
 
-/// A prelude providing convenient access to commonly-used cretonne features. Use
-/// as `use cretonne::prelude::*`.
+/// A prelude providing convenient access to commonly-used cranelift features. Use
+/// as `use cranelift::prelude::*`.
 pub mod prelude {
     pub use codegen;
     pub use codegen::entity::EntityRef;

--- a/lib/wasm/Cargo.toml
+++ b/lib/wasm/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "cretonne-wasm"
+name = "cranelift-wasm"
 version = "0.13.0"
-authors = ["The Cretonne Project Developers"]
-description = "Translator from WebAssembly to Cretonne IR"
-repository = "https://github.com/cretonne/cretonne"
+authors = ["The Cranelift Project Developers"]
+description = "Translator from WebAssembly to Cranelift IR"
+repository = "https://github.com/CraneStation/cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 keywords = ["webassembly", "wasm"]
 
 [dependencies]
 wasmparser = { version = "0.17.0", default-features = false }
-cretonne-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
-cretonne-frontend = { path = "../frontend", version = "0.13.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.13.0", default-features = false }
+cranelift-frontend = { path = "../frontend", version = "0.13.0", default-features = false }
 hashmap_core = { version = "0.1.8", optional = true }
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }
@@ -22,9 +22,9 @@ wabt = "0.4"
 
 [features]
 default = ["std"]
-std = ["cretonne-codegen/std", "cretonne-frontend/std", "wasmparser/std", "target-lexicon/std"]
-core = ["hashmap_core", "cretonne-codegen/core", "cretonne-frontend/core", "wasmparser/core"]
+std = ["cranelift-codegen/std", "cranelift-frontend/std", "wasmparser/std", "target-lexicon/std"]
+core = ["hashmap_core", "cranelift-codegen/core", "cranelift-frontend/core", "wasmparser/core"]
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "cretonne/cretonne" }
+travis-ci = { repository = "CraneStation/cranelift" }

--- a/lib/wasm/README.md
+++ b/lib/wasm/README.md
@@ -1,2 +1,2 @@
 This crate performs the translation from a wasm module in binary format to the
-in-memory form of the [Cretonne](https://crates.io/crates/cretonne) IR.
+in-memory form of the [Cranelift](https://crates.io/crates/cranelift) IR.

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -1,9 +1,9 @@
 //! "Dummy" environment for testing wasm translation.
 
-use cretonne_codegen::cursor::FuncCursor;
-use cretonne_codegen::ir::types::*;
-use cretonne_codegen::ir::{self, InstBuilder};
-use cretonne_codegen::settings;
+use cranelift_codegen::cursor::FuncCursor;
+use cranelift_codegen::ir::types::*;
+use cranelift_codegen::ir::{self, InstBuilder};
+use cranelift_codegen::settings;
 use environ::{FuncEnvironment, GlobalVariable, ModuleEnvironment, WasmResult};
 use func_translator::FuncTranslator;
 use std::string::String;

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -1,8 +1,8 @@
-//! All the runtime support necessary for the wasm to cretonne translation is formalized by the
+//! All the runtime support necessary for the wasm to cranelift translation is formalized by the
 //! traits `FunctionEnvironment` and `ModuleEnvironment`.
-use cretonne_codegen::cursor::FuncCursor;
-use cretonne_codegen::ir::{self, InstBuilder};
-use cretonne_codegen::settings::Flags;
+use cranelift_codegen::cursor::FuncCursor;
+use cranelift_codegen::ir::{self, InstBuilder};
+use cranelift_codegen::settings::Flags;
 use std::vec::Vec;
 use target_lexicon::Triple;
 use translation_utils::{
@@ -51,7 +51,7 @@ pub enum WasmError {
 
     /// An implementation limit was exceeded.
     ///
-    /// Cretonne can compile very large and complicated functions, but the [implementation has
+    /// Cranelift can compile very large and complicated functions, but the [implementation has
     /// limits][limits] that cause compilation to fail when they are exceeded.
     ///
     /// [limits]: https://cretonne.readthedocs.io/en/latest/langref.html#implementation-limits
@@ -72,7 +72,7 @@ pub type WasmResult<T> = Result<T, WasmError>;
 
 /// Environment affecting the translation of a single WebAssembly function.
 ///
-/// A `FuncEnvironment` trait object is required to translate a WebAssembly function to Cretonne
+/// A `FuncEnvironment` trait object is required to translate a WebAssembly function to Cranelift
 /// IR. The function environment provides information about the WebAssembly module as well as the
 /// runtime environment.
 pub trait FuncEnvironment {
@@ -82,7 +82,7 @@ pub trait FuncEnvironment {
     /// Get the flags for the current compilation.
     fn flags(&self) -> &Flags;
 
-    /// Get the Cretonne integer type to use for native pointers.
+    /// Get the Cranelift integer type to use for native pointers.
     ///
     /// This returns `I64` for 64-bit architectures and `I32` for 32-bit architectures.
     fn native_pointer(&self) -> ir::Type {
@@ -204,7 +204,7 @@ pub trait FuncEnvironment {
 
 /// An object satisfying the `ModuleEnvironment` trait can be passed as argument to the
 /// [`translate_module`](fn.translate_module.html) function. These methods should not be called
-/// by the user, they are only for `cretonne-wasm` internal use.
+/// by the user, they are only for `cranelift-wasm` internal use.
 pub trait ModuleEnvironment<'data> {
     /// Get the flags for the current compilation.
     fn flags(&self) -> &Flags;

--- a/lib/wasm/src/func_translator.rs
+++ b/lib/wasm/src/func_translator.rs
@@ -1,21 +1,21 @@
-//! Stand-alone WebAssembly to Cretonne IR translator.
+//! Stand-alone WebAssembly to Cranelift IR translator.
 //!
 //! This module defines the `FuncTranslator` type which can translate a single WebAssembly
-//! function to Cretonne IR guided by a `FuncEnvironment` which provides information about the
+//! function to Cranelift IR guided by a `FuncEnvironment` which provides information about the
 //! WebAssembly module and the runtime environment.
 
 use code_translator::translate_operator;
-use cretonne_codegen::entity::EntityRef;
-use cretonne_codegen::ir::{self, Ebb, InstBuilder};
-use cretonne_codegen::timing;
-use cretonne_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
+use cranelift_codegen::entity::EntityRef;
+use cranelift_codegen::ir::{self, Ebb, InstBuilder};
+use cranelift_codegen::timing;
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
 use environ::{FuncEnvironment, WasmError, WasmResult};
 use state::TranslationState;
 use wasmparser::{self, BinaryReader};
 
-/// WebAssembly to Cretonne IR function translator.
+/// WebAssembly to Cranelift IR function translator.
 ///
-/// A `FuncTranslator` is used to translate a binary WebAssembly function into Cretonne IR guided
+/// A `FuncTranslator` is used to translate a binary WebAssembly function into Cranelift IR guided
 /// by a `FuncEnvironment` object. A single translator instance can be reused to translate multiple
 /// functions which will reduce heap allocation traffic.
 pub struct FuncTranslator {
@@ -45,7 +45,7 @@ impl FuncTranslator {
     ///
     /// [wasm]: https://webassembly.github.io/spec/binary/modules.html#code-section
     ///
-    /// The Cretonne IR function `func` should be completely empty except for the `func.signature`
+    /// The Cranelift IR function `func` should be completely empty except for the `func.signature`
     /// and `func.name` fields. The signature may contain special-purpose arguments which are not
     /// regarded as WebAssembly local variables. Any signature arguments marked as
     /// `ArgumentPurpose::Normal` are made accessible as WebAssembly local variables.
@@ -226,7 +226,7 @@ fn parse_function_body<FE: FuncEnvironment + ?Sized>(
 fn cur_srcloc(reader: &BinaryReader) -> ir::SourceLoc {
     // We record source locations as byte code offsets relative to the beginning of the function.
     // This will wrap around of a single function's byte code is larger than 4 GB, but a) the
-    // WebAssembly format doesn't allow for that, and b) that would hit other Cretonne
+    // WebAssembly format doesn't allow for that, and b) that would hit other Cranelift
     // implementation limits anyway.
     ir::SourceLoc::new(reader.current_position() as u32)
 }
@@ -234,8 +234,8 @@ fn cur_srcloc(reader: &BinaryReader) -> ir::SourceLoc {
 #[cfg(test)]
 mod tests {
     use super::FuncTranslator;
-    use cretonne_codegen::ir::types::I32;
-    use cretonne_codegen::{ir, Context};
+    use cranelift_codegen::ir::types::I32;
+    use cranelift_codegen::{ir, Context};
     use environ::{DummyEnvironment, FuncEnvironment};
     use target_lexicon::Triple;
 

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -1,5 +1,5 @@
 //! Performs translation from a wasm module in binary format to the in-memory form
-//! of Cretonne IR. More particularly, it translates the code of all the functions bodies and
+//! of Cranelift IR. More particularly, it translates the code of all the functions bodies and
 //! interacts with an environment implementing the
 //! [`ModuleEnvironment`](trait.ModuleEnvironment.html)
 //! trait to deal with tables, globals and linear memory.
@@ -25,8 +25,8 @@
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[macro_use(dbg)]
-extern crate cretonne_codegen;
-extern crate cretonne_frontend;
+extern crate cranelift_codegen;
+extern crate cranelift_frontend;
 extern crate target_lexicon;
 extern crate wasmparser;
 

--- a/lib/wasm/src/module_translator.rs
+++ b/lib/wasm/src/module_translator.rs
@@ -1,6 +1,6 @@
 //! Translation skeleton that traverses the whole WebAssembly module and call helper functions
 //! to deal with each part of it.
-use cretonne_codegen::timing;
+use cranelift_codegen::timing;
 use environ::{ModuleEnvironment, WasmError, WasmResult};
 use sections_translator::{
     parse_data_section, parse_elements_section, parse_export_section, parse_function_section,
@@ -9,7 +9,7 @@ use sections_translator::{
 };
 use wasmparser::{Parser, ParserInput, ParserState, SectionCode, WasmDecoder};
 
-/// Translate a sequence of bytes forming a valid Wasm binary into a list of valid Cretonne IR
+/// Translate a sequence of bytes forming a valid Wasm binary into a list of valid Cranelift IR
 /// [`Function`](../codegen/ir/function/struct.Function.html).
 /// Returns the functions and also the mappings for imported functions and signature between the
 /// indexes in the wasm module and the indexes inside each functions.

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -7,7 +7,7 @@
 //! The special case of the initialize expressions for table elements offsets or global variables
 //! is handled, according to the semantics of WebAssembly, to only specific expressions that are
 //! interpreted on the fly.
-use cretonne_codegen::ir::{self, AbiParam, Signature};
+use cranelift_codegen::ir::{self, AbiParam, Signature};
 use environ::{ModuleEnvironment, WasmError, WasmResult};
 use std::str::from_utf8;
 use std::vec::Vec;

--- a/lib/wasm/src/state.rs
+++ b/lib/wasm/src/state.rs
@@ -3,7 +3,7 @@
 //! The `TranslationState` struct defined in this module is used to keep track of the WebAssembly
 //! value and control stacks during the translation of a single function.
 
-use cretonne_codegen::ir::{self, Ebb, Inst, Value};
+use cranelift_codegen::ir::{self, Ebb, Inst, Value};
 use environ::{FuncEnvironment, GlobalVariable};
 use std::collections::HashMap;
 use std::vec::Vec;

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -1,5 +1,5 @@
 //! Helper functions and structures for the translation.
-use cretonne_codegen::ir;
+use cranelift_codegen::ir;
 use std::u32;
 use wasmparser;
 
@@ -71,7 +71,7 @@ pub struct Memory {
     pub shared: bool,
 }
 
-/// Helper function translating wasmparser types to Cretonne types when possible.
+/// Helper function translating wasmparser types to Cranelift types when possible.
 pub fn type_to_type(ty: wasmparser::Type) -> Result<ir::Type, ()> {
     match ty {
         wasmparser::Type::I32 => Ok(ir::types::I32),
@@ -82,17 +82,17 @@ pub fn type_to_type(ty: wasmparser::Type) -> Result<ir::Type, ()> {
     }
 }
 
-/// Turns a `wasmparser` `f32` into a `Cretonne` one.
+/// Turns a `wasmparser` `f32` into a `Cranelift` one.
 pub fn f32_translation(x: wasmparser::Ieee32) -> ir::immediates::Ieee32 {
     ir::immediates::Ieee32::with_bits(x.bits())
 }
 
-/// Turns a `wasmparser` `f64` into a `Cretonne` one.
+/// Turns a `wasmparser` `f64` into a `Cranelift` one.
 pub fn f64_translation(x: wasmparser::Ieee64) -> ir::immediates::Ieee64 {
     ir::immediates::Ieee64::with_bits(x.bits())
 }
 
-/// Translate a `wasmparser` type into its `Cretonne` equivalent, when possible
+/// Translate a `wasmparser` type into its `Cranelift` equivalent, when possible
 pub fn num_return_values(ty: wasmparser::Type) -> usize {
     match ty {
         wasmparser::Type::EmptyBlockType => 0,

--- a/lib/wasm/tests/wasm_testsuite.rs
+++ b/lib/wasm/tests/wasm_testsuite.rs
@@ -1,13 +1,13 @@
-extern crate cretonne_codegen;
-extern crate cretonne_wasm;
+extern crate cranelift_codegen;
+extern crate cranelift_wasm;
 #[macro_use]
 extern crate target_lexicon;
 extern crate wabt;
 
-use cretonne_codegen::print_errors::pretty_verifier_error;
-use cretonne_codegen::settings::{self, Configurable, Flags};
-use cretonne_codegen::verifier;
-use cretonne_wasm::{translate_module, DummyEnvironment};
+use cranelift_codegen::print_errors::pretty_verifier_error;
+use cranelift_codegen::settings::{self, Configurable, Flags};
+use cranelift_codegen::verifier;
+use cranelift_wasm::{translate_module, DummyEnvironment};
 use std::fs;
 use std::fs::File;
 use std::io;

--- a/misc/vim/syntax/cton.vim
+++ b/misc/vim/syntax/cton.vim
@@ -1,5 +1,5 @@
 " Vim syntax file
-" Language:     Cretonne
+" Language:     Cranelift
 " Maintainer:   Jakob Stoklund Olesen <stoklund@2pi.dk
 " Last Change:  Jun 16, 2017
 

--- a/publish-all.sh
+++ b/publish-all.sh
@@ -3,18 +3,18 @@ set -euo pipefail
 topdir=$(dirname "$0")
 cd "$topdir"
 
-# All the cretonne-* crates have the same version number
+# All the cranelift-* crates have the same version number
 version="0.13.0"
 
 # Update all of the Cargo.toml files.
 #
-# The main Cargo.toml in the top-level directory is the cretonne-tools crate which we don't publish.
+# The main Cargo.toml in the top-level directory is the cranelift-tools crate which we don't publish.
 echo "Updating crate versions to $version"
 for crate in . lib/*; do
     # Update the version number of this crate to $version.
     sed -i.bk -e "s/^version = .*/version = \"$version\"/" "$crate/Cargo.toml"
-    # Update the required version number of any cretonne* dependencies.
-    sed -i.bk -e "/^cretonne/s/version = \"[^\"]*\"/version = \"$version\"/" "$crate/Cargo.toml"
+    # Update the required version number of any cranelift* dependencies.
+    sed -i.bk -e "/^cranelift/s/version = \"[^\"]*\"/version = \"$version\"/" "$crate/Cargo.toml"
 done
 
 # Update our local Cargo.lock (not checked in).
@@ -31,4 +31,4 @@ for crate in entity codegen frontend native reader wasm module simplejit faerie 
     echo cargo publish --manifest-path "lib/$crate/Cargo.toml"
 done
 echo
-echo Then, go to https://github.com/cretonne/cretonne/releases/ and define a new release.
+echo Then, go to https://github.com/CraneStation/cranelift/releases/ and define a new release.

--- a/rustc.rst
+++ b/rustc.rst
@@ -1,16 +1,16 @@
 =================
-Cretonne in Rustc
+Cranelift in Rustc
 =================
 
-One goal for Cretonne is to be usable as a backend suitable for compiling Rust
+One goal for Cranelift is to be usable as a backend suitable for compiling Rust
 in debug mode. This mode doesn't require a lot of mid-level optimization, and it
 does want very fast compile times, and this matches up fairly well with what we
-expect Cretonne's initial strengths and weaknesses will be. Cretonne is being
+expect Cranelift's initial strengths and weaknesses will be. Cranelift is being
 designed to take aggressive advantage of multiple cores, and to be very efficient
 with its use of memory.
 
 Another goal is a "pretty good" backend. The idea here is to do the work to get
-MIR-level inlining enabled, do some basic optimizations in Cretonne to capture the
+MIR-level inlining enabled, do some basic optimizations in Cranelift to capture the
 low-hanging fruit, and then use that along with good low-level optimizations to
 produce code which has a chance of being decently fast, with quite fast compile
 times. It obviously wouldn't compete with LLVM-based release builds in terms of
@@ -22,7 +22,7 @@ enabled a Rust compiler written entirely in Rust, and enabled faster Rust compil
 times for important use cases.
 
 With all that said, there is a potential goal beyond that, which is to build a
-full optimizing release-capable backend. We can't predict how far Cretonne will go
+full optimizing release-capable backend. We can't predict how far Cranelift will go
 yet, but we do have some crazy ideas about what such a thing might look like,
 including:
 
@@ -44,8 +44,8 @@ including:
   less manual effort.
 
 - Build an optimizer IR without the constraints of fast-debug-build compilation.
-  Cretonne's base IR is focused on Codegen, so a full-strength optimizer would either
-  use an IR layer on top of it (possibly using Cretonne's flexible EntityMap system),
+  Cranelift's base IR is focused on Codegen, so a full-strength optimizer would either
+  use an IR layer on top of it (possibly using Cranelift's flexible EntityMap system),
   or possibly an independent IR that could be translated to/from the base IR. Either
   way, this overall architecture would keep the optimizer out of the way of the
   non-optimizing build path, which keeps that path fast and simple, and gives the

--- a/spidermonkey.rst
+++ b/spidermonkey.rst
@@ -1,9 +1,9 @@
 ========================
-Cretonne in SpiderMonkey
+Cranelift in SpiderMonkey
 ========================
 
 `SpiderMonkey <https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey>`_ is the
-JavaScript and WebAssembly engine in Firefox. Cretonne is designed to be used in SpiderMonkey with
+JavaScript and WebAssembly engine in Firefox. Cranelift is designed to be used in SpiderMonkey with
 the goal of enabling better code generation for ARM's 32-bit and 64-bit architectures, and building
 a framework for improved low-level code optimizations in the future.
 
@@ -17,11 +17,11 @@ allocation.
 .. image:: media/spidermonkey1.png
     :align: center
     :width: 80%
-    :alt: Cretonne in SpiderMonkey phase 1
+    :alt: Cranelift in SpiderMonkey phase 1
 
-In phase 1, Cretonne aims to replace the IonMonkey-based tier 2 compiler for WebAssembly only. It
+In phase 1, Cranelift aims to replace the IonMonkey-based tier 2 compiler for WebAssembly only. It
 will still be orchestrated by the BaldrMonkey engine and compile WebAssembly modules on multiple
-threads. Cretonne translates binary wasm functions directly into its own intermediate
+threads. Cranelift translates binary wasm functions directly into its own intermediate
 representation, and it generates binary machine code without depending on SpiderMonkey's macro
 assembler.
 
@@ -38,7 +38,7 @@ intermediate representations to do that:
 .. image:: media/spidermonkey2.png
     :align: center
     :width: 80%
-    :alt: Cretonne in SpiderMonkey phase 2
+    :alt: Cranelift in SpiderMonkey phase 2
 
-Cretonne has its own register allocator, so the LIR representation can be skipped when using
-Cretonne as a backend for IonMonkey.
+Cranelift has its own register allocator, so the LIR representation can be skipped when using
+Cranelift as a backend for IonMonkey.

--- a/src/cat.rs
+++ b/src/cat.rs
@@ -1,9 +1,9 @@
 //! The `cat` sub-command.
 //!
-//! Read a sequence of Cretonne IR files and print them again to stdout. This has the effect of
+//! Read a sequence of Cranelift IR files and print them again to stdout. This has the effect of
 //! normalizing formatting and removing comments.
 
-use cretonne_reader::parse_functions;
+use cranelift_reader::parse_functions;
 use utils::read_to_string;
 use CommandResult;
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,11 +1,11 @@
-//! CLI tool to read Cretonne IR files and compile them into native code.
+//! CLI tool to read Cranelift IR files and compile them into native code.
 
-use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::print_errors::pretty_error;
-use cretonne_codegen::settings::FlagsOrIsa;
-use cretonne_codegen::Context;
-use cretonne_codegen::{binemit, ir};
-use cretonne_reader::parse_test;
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::print_errors::pretty_error;
+use cranelift_codegen::settings::FlagsOrIsa;
+use cranelift_codegen::Context;
+use cranelift_codegen::{binemit, ir};
+use cranelift_reader::parse_test;
 use std::path::Path;
 use std::path::PathBuf;
 use utils::{parse_sets_and_triple, read_to_string};

--- a/src/cton-util.rs
+++ b/src/cton-util.rs
@@ -10,9 +10,9 @@
 
 #[macro_use]
 extern crate cfg_if;
-extern crate cretonne_codegen;
-extern crate cretonne_filetests;
-extern crate cretonne_reader;
+extern crate cranelift_codegen;
+extern crate cranelift_filetests;
+extern crate cranelift_reader;
 extern crate docopt;
 extern crate filecheck;
 #[macro_use]
@@ -23,14 +23,14 @@ extern crate term;
 
 cfg_if! {
     if #[cfg(feature = "wasm")] {
-        extern crate cretonne_wasm;
+        extern crate cranelift_wasm;
         extern crate wabt;
         mod wasm;
     }
 }
 extern crate target_lexicon;
 
-use cretonne_codegen::{timing, VERSION};
+use cranelift_codegen::{timing, VERSION};
 use docopt::Docopt;
 use std::io::{self, Write};
 use std::process;
@@ -42,7 +42,7 @@ mod rsfilecheck;
 mod utils;
 
 const USAGE: &str = "
-Cretonne code generator utility
+Cranelift code generator utility
 
 Usage:
     cton-util test [-vT] <file>...
@@ -58,17 +58,17 @@ Options:
     -T, --time-passes
                     print pass timing report
     -t, --just-decode
-                    just decode WebAssembly to Cretonne IR
+                    just decode WebAssembly to Cranelift IR
     -s, --print-size
                     prints generated code size
     -c, --check-translation
-                    just checks the correctness of Cretonne IR translated from WebAssembly
-    -p, --print     print the resulting Cretonne IR
+                    just checks the correctness of Cranelift IR translated from WebAssembly
+    -p, --print     print the resulting Cranelift IR
     -h, --help      print this help message
-    --set=<set>     configure Cretonne settings
+    --set=<set>     configure Cranelift settings
     --target=<triple>
-                    specify the Cretonne target
-    --version       print the Cretonne version
+                    specify the Cranelift target
+    --version       print the Cranelift version
 
 ";
 
@@ -100,14 +100,14 @@ fn cton_util() -> CommandResult {
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {
             d.help(true)
-                .version(Some(format!("Cretonne {}", VERSION)))
+                .version(Some(format!("Cranelift {}", VERSION)))
                 .deserialize()
         })
         .unwrap_or_else(|e| e.exit());
 
     // Find the sub-command to execute.
     let result = if args.cmd_test {
-        cretonne_filetests::run(args.flag_verbose, &args.arg_file).map(|_time| ())
+        cranelift_filetests::run(args.flag_verbose, &args.arg_file).map(|_time| ())
     } else if args.cmd_cat {
         cat::run(&args.arg_file)
     } else if args.cmd_filecheck {

--- a/src/print_cfg.rs
+++ b/src/print_cfg.rs
@@ -1,10 +1,10 @@
 //! The `print-cfg` sub-command.
 //!
-//! Read a series of Cretonne IR files and print their control flow graphs
+//! Read a series of Cranelift IR files and print their control flow graphs
 //! in graphviz format.
 
-use cretonne_codegen::cfg_printer::CFGPrinter;
-use cretonne_reader::parse_functions;
+use cranelift_codegen::cfg_printer::CFGPrinter;
+use cranelift_reader::parse_functions;
 use utils::read_to_string;
 use CommandResult;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,9 @@
 //! Utility functions.
 
-use cretonne_codegen::isa;
-use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::settings::{self, FlagsOrIsa};
-use cretonne_reader::{parse_options, Location};
+use cranelift_codegen::isa;
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::settings::{self, FlagsOrIsa};
+use cranelift_reader::{parse_options, Location};
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::Path;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,13 +1,13 @@
-//! CLI tool to use the functions provided by the [cretonne-wasm](../cretonne_wasm/index.html)
+//! CLI tool to use the functions provided by the [cranelift-wasm](../cranelift_wasm/index.html)
 //! crate.
 //!
-//! Reads Wasm binary files, translates the functions' code to Cretonne IR.
+//! Reads Wasm binary files, translates the functions' code to Cranelift IR.
 #![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments, cyclomatic_complexity))]
 
-use cretonne_codegen::Context;
-use cretonne_codegen::print_errors::{pretty_error, pretty_verifier_error};
-use cretonne_codegen::settings::FlagsOrIsa;
-use cretonne_wasm::{translate_module, DummyEnvironment, ModuleEnvironment};
+use cranelift_codegen::Context;
+use cranelift_codegen::print_errors::{pretty_error, pretty_verifier_error};
+use cranelift_codegen::settings::FlagsOrIsa;
+use cranelift_wasm::{translate_module, DummyEnvironment, ModuleEnvironment};
 use std::error::Error;
 use std::path::Path;
 use std::path::PathBuf;

--- a/test-all.sh
+++ b/test-all.sh
@@ -64,7 +64,7 @@ banner "Rust unit tests"
 cargo test --all
 
 # Make sure the documentation builds.
-banner "Rust documentation: $topdir/target/doc/cretonne/index.html"
+banner "Rust documentation: $topdir/target/doc/cranelift/index.html"
 cargo doc
 
 # Run clippy if we have it.

--- a/tests/filetests.rs
+++ b/tests/filetests.rs
@@ -1,7 +1,7 @@
-extern crate cretonne_filetests;
+extern crate cranelift_filetests;
 
 #[test]
 fn filetests() {
     // Run all the filetests in the following directories.
-    cretonne_filetests::run(false, &["filetests".into(), "docs".into()]).expect("test harness");
+    cranelift_filetests::run(false, &["filetests".into(), "docs".into()]).expect("test harness");
 }


### PR DESCRIPTION
A few sed scripts: one to rename "retonne" to "ranelift", one to rename "github.com/cranelift" to "github.com/CraneStation", manual changes for travis-ci, and manual reverts here and there where external changes are required to happen first.