### PR TITLE
Misc refactorings when looking at the wasm code

### DIFF
--- a/lib/codegen/src/dominator_tree.rs
+++ b/lib/codegen/src/dominator_tree.rs
@@ -271,7 +271,7 @@ impl DominatorTree {
         //
         // There are two ways of viewing the CFG as a graph:
         //
-        // 1. Each EBB is a node, with outgoing edges for all the branches in the EBB>
+        // 1. Each EBB is a node, with outgoing edges for all the branches in the EBB.
         // 2. Each basic block is a node, with outgoing edges for the single branch at the end of
         //    the BB. (An EBB is a linear sequence of basic blocks).
         //

--- a/lib/codegen/src/preopt.rs
+++ b/lib/codegen/src/preopt.rs
@@ -517,25 +517,19 @@ fn simplify(pos: &mut FuncCursor, inst: Inst) {
             ..
         } => {
             // Fold away a redundant `bint`.
-            let maybe = {
+            let condition_def = {
                 let args = pos.func.dfg.inst_args(inst);
-                if let ValueDef::Result(def_inst, _) = pos.func.dfg.value_def(args[0]) {
-                    if let InstructionData::Unary {
-                        opcode: Opcode::Bint,
-                        arg: bool_val,
-                    } = pos.func.dfg[def_inst]
-                    {
-                        Some(bool_val)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
+                pos.func.dfg.value_def(args[0])
             };
-            if let Some(bool_val) = maybe {
-                let args = pos.func.dfg.inst_args_mut(inst);
-                args[0] = bool_val;
+            if let ValueDef::Result(def_inst, _) = condition_def {
+                if let InstructionData::Unary {
+                    opcode: Opcode::Bint,
+                    arg: bool_val,
+                } = pos.func.dfg[def_inst]
+                {
+                    let args = pos.func.dfg.inst_args_mut(inst);
+                    args[0] = bool_val;
+                }
             }
         }
         _ => {}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -141,8 +141,8 @@ fn handle_module(
 
     let num_func_imports = dummy_environ.get_num_func_imports();
     let mut total_module_code_size = 0;
+    let mut context = Context::new();
     for (def_index, func) in dummy_environ.info.function_bodies.iter().enumerate() {
-        let mut context = Context::new();
         context.func = func.clone();
 
         let func_index = num_func_imports + def_index;
@@ -180,6 +180,8 @@ fn handle_module(
             println!("{}", context.func.display(fisa.isa));
             vprintln!(flag_verbose, "");
         }
+
+        context.clear();
     }
 
     if !flag_check_translation && flag_print_size {


### PR DESCRIPTION
Sorry this is in a form of potpourri. These are small fixes to comments or small refactorings which make the code easier to understand, in my opinion:

- fixed typo in dominator_tree.
- simplify some control flow in preopt by playing with block expression to avoid mutable borrow of an immutably borrowed value (which justified the previous code).
- simplify to the module translator to avoid duplicate code for data sections.
- reuse and clear the Context in wasm.rs. After all, that's the first thing the comment of Context recommends to do :) And it improves the testing of the re-usability of Context.