### PR TITLE
Fixed trivially_copy_pass_by_ref warnings

### DIFF
--- a/lib/codegen/src/flowgraph.rs
+++ b/lib/codegen/src/flowgraph.rs
@@ -123,11 +123,11 @@ impl ControlFlowGraph {
         for inst in func.layout.ebb_insts(ebb) {
             match func.dfg.analyze_branch(inst) {
                 BranchInfo::SingleDest(dest, _) => {
-                    self.add_edge(BasicBlock::new(ebb, inst), dest);
+                    self.add_edge(ebb, inst, dest);
                 }
                 BranchInfo::Table(jt) => {
                     for (_, dest) in func.jump_tables[jt].entries() {
-                        self.add_edge(BasicBlock::new(ebb, inst), dest);
+                        self.add_edge(ebb, inst, dest);
                     }
                 }
                 BranchInfo::NotABranch => {}
@@ -160,13 +160,13 @@ impl ControlFlowGraph {
         self.compute_ebb(func, ebb);
     }
 
-    fn add_edge(&mut self, from: BasicBlock, to: Ebb) {
-        self.data[from.ebb]
+    fn add_edge(&mut self, from: Ebb, from_inst: Inst, to: Ebb) {
+        self.data[from]
             .successors
             .insert(to, &mut self.succ_forest, &());
         self.data[to]
             .predecessors
-            .insert(from.inst, from.ebb, &mut self.pred_forest, &());
+            .insert(from_inst, from, &mut self.pred_forest, &());
     }
 
     /// Get an iterator over the CFG predecessors to `ebb`.

--- a/lib/codegen/src/ir/instructions.rs
+++ b/lib/codegen/src/ir/instructions.rs
@@ -447,7 +447,7 @@ impl ValueTypeSet {
     /// Is `scalar` part of the base type set?
     ///
     /// Note that the base type set does not have to be included in the type set proper.
-    fn is_base_type(&self, scalar: Type) -> bool {
+    fn is_base_type(self, scalar: Type) -> bool {
         let l2b = scalar.log2_lane_bits();
         if scalar.is_int() {
             self.ints.contains(l2b)
@@ -461,7 +461,7 @@ impl ValueTypeSet {
     }
 
     /// Does `typ` belong to this set?
-    pub fn contains(&self, typ: Type) -> bool {
+    pub fn contains(self, typ: Type) -> bool {
         let l2l = typ.log2_lane_count();
         self.lanes.contains(l2l) && self.is_base_type(typ.lane_type())
     }
@@ -469,7 +469,7 @@ impl ValueTypeSet {
     /// Get an example member of this type set.
     ///
     /// This is used for error messages to avoid suggesting invalid types.
-    pub fn example(&self) -> Type {
+    pub fn example(self) -> Type {
         let t = if self.ints.max().unwrap_or(0) > 5 {
             types::I32
         } else if self.floats.max().unwrap_or(0) > 5 {

--- a/lib/codegen/src/ir/valueloc.rs
+++ b/lib/codegen/src/ir/valueloc.rs
@@ -26,8 +26,8 @@ impl Default for ValueLoc {
 
 impl ValueLoc {
     /// Is this an assigned location? (That is, not `Unassigned`).
-    pub fn is_assigned(&self) -> bool {
-        match *self {
+    pub fn is_assigned(self) -> bool {
+        match self {
             ValueLoc::Unassigned => false,
             _ => true,
         }
@@ -111,24 +111,24 @@ impl Default for ArgumentLoc {
 
 impl ArgumentLoc {
     /// Is this an assigned location? (That is, not `Unassigned`).
-    pub fn is_assigned(&self) -> bool {
-        match *self {
+    pub fn is_assigned(self) -> bool {
+        match self {
             ArgumentLoc::Unassigned => false,
             _ => true,
         }
     }
 
     /// Is this a register location?
-    pub fn is_reg(&self) -> bool {
-        match *self {
+    pub fn is_reg(self) -> bool {
+        match self {
             ArgumentLoc::Reg(_) => true,
             _ => false,
         }
     }
 
     /// Is this a stack location?
-    pub fn is_stack(&self) -> bool {
-        match *self {
+    pub fn is_stack(self) -> bool {
+        match self {
             ArgumentLoc::Stack(_) => true,
             _ => false,
         }

--- a/lib/codegen/src/settings.rs
+++ b/lib/codegen/src/settings.rs
@@ -59,9 +59,9 @@ impl Builder {
     }
 
     /// Extract contents of builder once everything is configured.
-    pub fn state_for(&self, name: &str) -> &[u8] {
+    pub fn state_for(self, name: &str) -> Box<[u8]> {
         assert_eq!(name, self.template.name);
-        &self.bytes[..]
+        self.bytes
     }
 
     /// Set the value of a single bit.
@@ -301,8 +301,8 @@ pub mod detail {
     impl Detail {
         /// Check if a detail is a Detail::Preset. Useful because the Descriptor
         /// offset field has a different meaning when the detail is a preset.
-        pub fn is_preset(&self) -> bool {
-            match *self {
+        pub fn is_preset(self) -> bool {
+            match self {
                 Detail::Preset => true,
                 _ => false,
             }


### PR DESCRIPTION
Th only one I couldn't figure out how to fix was `congruence_class`.
https://github.com/CraneStation/cranelift/blob/01de6842b1a3230db645a00f4ecf0176b5fdc65f/lib/codegen/src/regalloc/virtregs.rs#L100-L106