### PR TITLE
Remove reserved_reg functionality.

### DIFF
--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -689,15 +689,12 @@ trap when accessed.
 
     Declare a static heap in the preamble.
 
-    :arg Base: Global value holding the heap's base address or
-            ``reserved_reg``.
+    :arg Base: Global value holding the heap's base address.
     :arg MinBytes: Guaranteed minimum heap size in bytes. Accesses below this
             size will never trap.
     :arg BoundBytes: Fixed heap bound in bytes. This defines the amount of
             address space reserved for the heap, not including the guard pages.
     :arg GuardBytes: Size of the guard pages in bytes.
-
-The ``reserved_reg`` option is not yet implemented.
 
 Dynamic heaps
 ~~~~~~~~~~~~~
@@ -710,14 +707,11 @@ is resized. The bound of a dynamic heap is stored in a global value.
 
     Declare a dynamic heap in the preamble.
 
-    :arg Base: Global value holding the heap's base address or
-            ``reserved_reg``.
+    :arg Base: Global value holding the heap's base address.
     :arg MinBytes: Guaranteed minimum heap size in bytes. Accesses below this
             size will never trap.
     :arg BoundGV: Global value containing the current heap bound in bytes.
     :arg GuardBytes: Size of the guard pages in bytes.
-
-The ``reserved_reg`` option is not yet implemented.
 
 Heap examples
 ~~~~~~~~~~~~~

--- a/filetests/parser/memory.clif
+++ b/filetests/parser/memory.clif
@@ -52,11 +52,11 @@ ebb0:
 
 ; Declare static heaps.
 function %sheap(i32, i64 vmctx) -> i64 {
-    heap1 = static reserved_reg, min 0x1_0000, bound 0x1_0000_0000, guard 0x8000_0000
+    heap1 = static gv5, min 0x1_0000, bound 0x1_0000_0000, guard 0x8000_0000
     heap2 = static gv5, guard 0x1000, bound 0x1_0000
     gv5 = vmctx+64
 
-    ; check: heap1 = static reserved_reg, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    ; check: heap1 = static gv5, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
     ; check: heap2 = static gv5, min 0, bound 0x0001_0000, guard 4096
 ebb0(v1: i32, v2: i64):
     v3 = heap_addr.i64 heap1, v1, 0
@@ -66,12 +66,12 @@ ebb0(v1: i32, v2: i64):
 
 ; Declare dynamic heaps.
 function %dheap(i32, i64 vmctx) -> i64 {
-    heap1 = dynamic reserved_reg, min 0x1_0000, bound gv6, guard 0x8000_0000
+    heap1 = dynamic gv5, min 0x1_0000, bound gv6, guard 0x8000_0000
     heap2 = dynamic gv5, bound gv6, guard 0x1000
     gv5 = vmctx+64
     gv6 = vmctx+72
 
-    ; check: heap1 = dynamic reserved_reg, min 0x0001_0000, bound gv6, guard 0x8000_0000
+    ; check: heap1 = dynamic gv5, min 0x0001_0000, bound gv6, guard 0x8000_0000
     ; check: heap2 = dynamic gv5, min 0, bound gv6, guard 4096
 ebb0(v1: i32, v2: i64):
     v3 = heap_addr.i64 heap2, v1, 0

--- a/lib/codegen/src/ir/heap.rs
+++ b/lib/codegen/src/ir/heap.rs
@@ -7,8 +7,8 @@ use std::fmt;
 /// Information about a heap declaration.
 #[derive(Clone)]
 pub struct HeapData {
-    /// Method for determining the heap base address.
-    pub base: HeapBase,
+    /// The address of the start of the heap's storage.
+    pub base: GlobalValue,
 
     /// Guaranteed minimum heap size in bytes. Heap accesses before `min_size` don't need bounds
     /// checking.
@@ -19,18 +19,6 @@ pub struct HeapData {
 
     /// Heap style, with additional style-specific info.
     pub style: HeapStyle,
-}
-
-/// Method for determining the base address of a heap.
-#[derive(Clone)]
-pub enum HeapBase {
-    /// The heap base lives in a reserved register.
-    ///
-    /// This feature is not yet implemented.
-    ReservedReg,
-
-    /// The heap base is a global value.
-    GlobalValue(GlobalValue),
 }
 
 /// Style of heap including style-specific information.
@@ -57,12 +45,7 @@ impl fmt::Display for HeapData {
             HeapStyle::Static { .. } => "static",
         })?;
 
-        match self.base {
-            HeapBase::ReservedReg => write!(f, " reserved_reg")?,
-            HeapBase::GlobalValue(gv) => write!(f, " {}", gv)?,
-        }
-
-        write!(f, ", min {}", self.min_size)?;
+        write!(f, " {}, min {}", self.base, self.min_size)?;
         match self.style {
             HeapStyle::Dynamic { bound_gv } => write!(f, ", bound {}", bound_gv)?,
             HeapStyle::Static { bound } => write!(f, ", bound {}", bound)?,

--- a/lib/codegen/src/ir/mod.rs
+++ b/lib/codegen/src/ir/mod.rs
@@ -31,7 +31,7 @@ pub use ir::extfunc::{AbiParam, ArgumentExtension, ArgumentPurpose, ExtFuncData,
 pub use ir::extname::ExternalName;
 pub use ir::function::Function;
 pub use ir::globalvalue::GlobalValueData;
-pub use ir::heap::{HeapBase, HeapData, HeapStyle};
+pub use ir::heap::{HeapData, HeapStyle};
 pub use ir::instructions::{InstructionData, Opcode, ValueList, ValueListPool, VariableArgs};
 pub use ir::jumptable::JumpTableData;
 pub use ir::layout::Layout;

--- a/lib/codegen/src/legalizer/heap.rs
+++ b/lib/codegen/src/legalizer/heap.rs
@@ -154,11 +154,7 @@ fn offset_addr(
     }
 
     // Add the heap base address base
-    match pos.func.heaps[heap].base {
-        ir::HeapBase::ReservedReg => unimplemented!(),
-        ir::HeapBase::GlobalValue(base_gv) => {
-            let base = pos.ins().global_value(addr_ty, base_gv);
-            pos.func.dfg.replace(inst).iadd(base, offset);
-        }
-    }
+    let base_gv = pos.func.heaps[heap].base;
+    let base = pos.ins().global_value(addr_ty, base_gv);
+    pos.func.dfg.replace(inst).iadd(base, offset);
 }

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -8,9 +8,8 @@ use cranelift_codegen::ir::instructions::{InstructionData, InstructionFormat, Va
 use cranelift_codegen::ir::types::VOID;
 use cranelift_codegen::ir::{
     AbiParam, ArgumentExtension, ArgumentLoc, Ebb, ExtFuncData, ExternalName, FuncRef, Function,
-    GlobalValue, GlobalValueData, Heap, HeapBase, HeapData, HeapStyle, JumpTable, JumpTableData,
-    MemFlags, Opcode, SigRef, Signature, StackSlot, StackSlotData, StackSlotKind, Type, Value,
-    ValueLoc,
+    GlobalValue, GlobalValueData, Heap, HeapData, HeapStyle, JumpTable, JumpTableData, MemFlags,
+    Opcode, SigRef, Signature, StackSlot, StackSlotData, StackSlotKind, Type, Value, ValueLoc,
 };
 use cranelift_codegen::isa::{self, Encoding, RegUnit, TargetIsa};
 use cranelift_codegen::packed_option::ReservedValue;
@@ -165,7 +164,7 @@ impl<'a> Context<'a> {
     fn add_heap(&mut self, heap: Heap, data: HeapData, loc: Location) -> ParseResult<()> {
         while self.function.heaps.next_key().index() <= heap.index() {
             self.function.create_heap(HeapData {
-                base: HeapBase::ReservedReg,
+                base: GlobalValue::new(0),
                 min_size: Imm64::new(0),
                 guard_size: Imm64::new(0),
                 style: HeapStyle::Static {
@@ -1117,8 +1116,7 @@ impl<'a> Parser<'a> {
     // heap-decl ::= * Heap(heap) "=" heap-desc
     // heap-desc ::= heap-style heap-base { "," heap-attr }
     // heap-style ::= "static" | "dynamic"
-    // heap-base ::= "reserved_reg"
-    //             | GlobalValue(base)
+    // heap-base ::= GlobalValue(base)
     // heap-attr ::= "min" Imm64(bytes)
     //             | "max" Imm64(bytes)
     //             | "guard" Imm64(bytes)
@@ -1130,17 +1128,12 @@ impl<'a> Parser<'a> {
         let style_name = self.match_any_identifier("expected 'static' or 'dynamic'")?;
 
         // heap-desc ::= heap-style * heap-base { "," heap-attr }
-        // heap-base ::= * "reserved_reg"
-        //             | * GlobalValue(base)
+        // heap-base ::= * GlobalValue(base)
         let base = match self.token() {
-            Some(Token::Identifier("reserved_reg")) => HeapBase::ReservedReg,
-            Some(Token::GlobalValue(base_num)) => {
-                let base_gv = match GlobalValue::with_number(base_num) {
-                    Some(gv) => gv,
-                    None => return err!(self.loc, "invalid global value number for heap base"),
-                };
-                HeapBase::GlobalValue(base_gv)
-            }
+            Some(Token::GlobalValue(base_num)) => match GlobalValue::with_number(base_num) {
+                Some(gv) => gv,
+                None => return err!(self.loc, "invalid global value number for heap base"),
+            },
             _ => return err!(self.loc, "expected heap base"),
         };
         self.consume();

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -164,7 +164,7 @@ impl<'a> Context<'a> {
     fn add_heap(&mut self, heap: Heap, data: HeapData, loc: Location) -> ParseResult<()> {
         while self.function.heaps.next_key().index() <= heap.index() {
             self.function.create_heap(HeapData {
-                base: GlobalValue::new(0),
+                base: GlobalValue::reserved_value(),
                 min_size: Imm64::new(0),
                 guard_size: Imm64::new(0),
                 style: HeapStyle::Static {

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -172,7 +172,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         let gv = func.create_global_value(ir::GlobalValueData::VMContext { offset: 0.into() });
 
         func.create_heap(ir::HeapData {
-            base: ir::HeapBase::GlobalValue(gv),
+            base: gv,
             min_size: 0.into(),
             guard_size: 0x8000_0000.into(),
             style: ir::HeapStyle::Static {


### PR DESCRIPTION
This wasn't implemented, and if we need it in the future, it seems like
it would be better to extend the concept of global values to cover this.

This is also related to #346, adding a table concept, as it would be
extra complexity to support reserved-reg for tables as well.