### PR TITLE
Enhance Verifier error reporting

### DIFF
--- a/filetests/verifier/type_check.clif
+++ b/filetests/verifier/type_check.clif
@@ -44,7 +44,7 @@ function %type_mismatch_controlling_variable() {
 function %fn_call_too_few_args() {
     fn2 = %great_fn(i32, f32)
     ebb0:
-        call fn2() ; error: mismatched argument count, got 0, expected 2
+        call fn2() ; error: mismatched argument count for `call fn2()`: got 0, expected 2
         return
 }
 
@@ -53,7 +53,7 @@ function %fn_call_too_many_args() {
     ebb0:
         v0 = iconst.i64 56
         v1 = f32const 0.0
-        call fn5(v0, v1) ; error: mismatched argument count, got 2, expected 0
+        call fn5(v0, v1) ; error: mismatched argument count for `call fn5(v0, v1)`: got 2, expected 0
         return
 }
 

--- a/lib/codegen/src/verifier/mod.rs
+++ b/lib/codegen/src/verifier/mod.rs
@@ -820,7 +820,8 @@ impl<'a> Verifier<'a> {
         if i != variable_args.len() {
             return err!(
                 inst,
-                "mismatched argument count, got {}, expected {}",
+                "mismatched argument count for `{}`: got {}, expected {}",
+                self.func.dfg.display_inst(inst, None),
                 variable_args.len(),
                 i
             );

--- a/lib/filetests/src/runone.rs
+++ b/lib/filetests/src/runone.rs
@@ -135,5 +135,5 @@ fn run_one_test<'a>(
     }
 
     test.run(func, context)
-        .map_err(|e| format!("{}: {}", name, e))
+        .map_err(|e| format!("{}:\n{}", name, e))
 }


### PR DESCRIPTION
- if the error location isn't an instruction, the error wasn't printed *and* the instructions were not printed either.
- added hints in the mismatched argument count error reporting by showing which instruction is involved.
- random fixing of new line displaying to have consistent indent when a function is printed by the verifier pretty printer.