### PR TITLE
Implement wasm saturating conversions

### DIFF
--- a/filetests/wasm/conversions.clif
+++ b/filetests/wasm/conversions.clif
@@ -69,6 +69,54 @@ ebb0(v0: f64):
     return v1
 }
 
+function %i32_trunc_s_sat_f32(f32) -> i32 {
+ebb0(v0: f32):
+    v1 = fcvt_to_sint_sat.i32 v0
+    return v1
+}
+
+function %i32_trunc_u_sat_f32(f32) -> i32 {
+ebb0(v0: f32):
+    v1 = fcvt_to_uint_sat.i32 v0
+    return v1
+}
+
+function %i32_trunc_s_sat_f64(f64) -> i32 {
+ebb0(v0: f64):
+    v1 = fcvt_to_sint_sat.i32 v0
+    return v1
+}
+
+function %i32_trunc_u_sat_f64(f64) -> i32 {
+ebb0(v0: f64):
+    v1 = fcvt_to_uint_sat.i32 v0
+    return v1
+}
+
+function %i64_trunc_s_sat_f32(f32) -> i64 {
+ebb0(v0: f32):
+    v1 = fcvt_to_sint_sat.i64 v0
+    return v1
+}
+
+function %i64_trunc_u_sat_f32(f32) -> i64 {
+ebb0(v0: f32):
+    v1 = fcvt_to_uint_sat.i64 v0
+    return v1
+}
+
+function %i64_trunc_s_sat_f64(f64) -> i64 {
+ebb0(v0: f64):
+    v1 = fcvt_to_sint_sat.i64 v0
+    return v1
+}
+
+function %i64_trunc_u_sat_f64(f64) -> i64 {
+ebb0(v0: f64):
+    v1 = fcvt_to_uint_sat.i64 v0
+    return v1
+}
+
 function %f32_trunc_f64(f64) -> f32 {
 ebb0(v0: f64):
     v1 = fdemote.f32 v0

--- a/lib/codegen/meta-python/base/instructions.py
+++ b/lib/codegen/meta-python/base/instructions.py
@@ -1879,6 +1879,14 @@ fcvt_to_uint = Instruction(
         """,
         ins=x, outs=a, can_trap=True)
 
+fcvt_to_uint_sat = Instruction(
+        'fcvt_to_uint_sat', r"""
+        Convert floating point to unsigned integer as fcvt_to_uint does, but
+        saturates the input instead of trapping. NaN and negative values are
+        converted to 0.
+        """,
+        ins=x, outs=a)
+
 fcvt_to_sint = Instruction(
         'fcvt_to_sint', r"""
         Convert floating point to signed integer.
@@ -1890,6 +1898,13 @@ fcvt_to_sint = Instruction(
         The result type must have the same number of vector lanes as the input.
         """,
         ins=x, outs=a, can_trap=True)
+
+fcvt_to_sint_sat = Instruction(
+        'fcvt_to_sint_sat', r"""
+        Convert floating point to signed integer as fcvt_to_sint does, but
+        saturates the input instead of trapping. NaN values are converted to 0.
+        """,
+        ins=x, outs=a)
 
 x = Operand('x', Int)
 a = Operand('a', FloatTo)

--- a/lib/codegen/meta-python/isa/x86/legalize.py
+++ b/lib/codegen/meta-python/isa/x86/legalize.py
@@ -94,9 +94,11 @@ x86_expand.custom_legalize(insts.fmax, 'expand_minmax')
 
 # Conversions from unsigned need special handling.
 x86_expand.custom_legalize(insts.fcvt_from_uint, 'expand_fcvt_from_uint')
-# Conversions from float to int can trap.
+# Conversions from float to int can trap and modify the control flow graph.
 x86_expand.custom_legalize(insts.fcvt_to_sint, 'expand_fcvt_to_sint')
 x86_expand.custom_legalize(insts.fcvt_to_uint, 'expand_fcvt_to_uint')
+x86_expand.custom_legalize(insts.fcvt_to_sint_sat, 'expand_fcvt_to_sint_sat')
+x86_expand.custom_legalize(insts.fcvt_to_uint_sat, 'expand_fcvt_to_uint_sat')
 
 # Count leading and trailing zeroes, for baseline x86_64
 c_minus_one = Var('c_minus_one')

--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -631,17 +631,21 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let val = state.pop1();
             state.push1(builder.ins().fcvt_to_uint(I32, val));
         }
-        Operator::I64TruncSSatF64
-        | Operator::I64TruncSSatF32
-        | Operator::I32TruncSSatF64
-        | Operator::I32TruncSSatF32
-        | Operator::I64TruncUSatF64
-        | Operator::I64TruncUSatF32
-        | Operator::I32TruncUSatF64
-        | Operator::I32TruncUSatF32 => {
-            return Err(WasmError::Unsupported(
-                "proposed saturating conversion operators",
-            ));
+        Operator::I64TruncSSatF64 | Operator::I64TruncSSatF32 => {
+            let val = state.pop1();
+            state.push1(builder.ins().fcvt_to_sint_sat(I64, val));
+        }
+        Operator::I32TruncSSatF64 | Operator::I32TruncSSatF32 => {
+            let val = state.pop1();
+            state.push1(builder.ins().fcvt_to_sint_sat(I32, val));
+        }
+        Operator::I64TruncUSatF64 | Operator::I64TruncUSatF32 => {
+            let val = state.pop1();
+            state.push1(builder.ins().fcvt_to_uint_sat(I64, val));
+        }
+        Operator::I32TruncUSatF64 | Operator::I32TruncUSatF32 => {
+            let val = state.pop1();
+            state.push1(builder.ins().fcvt_to_uint_sat(I32, val));
         }
         Operator::F32ReinterpretI32 => {
             let val = state.pop1();


### PR DESCRIPTION
I initially thought I could factor the code more, since the behavior doesn't seem to change much with respect to the non-saturating ops. In fact, this is different enough that a different function is justified for the signed comparison; for the unsigned one, we could maybe use a boolean toggle to decide if we want a saturating operation or not. Will investigate more.

Still a work in progress; I need to test it against Baldrdash to make sure it is correct. 