### PR TITLE
FunctionBuilder no longer Variable-parametric (and updated doc)

### DIFF
--- a/lib/frontend/src/frontend.rs
+++ b/lib/frontend/src/frontend.rs
@@ -1,6 +1,6 @@
 //! A frontend for building Cranelift IR from other languages.
 use cranelift_codegen::cursor::{Cursor, FuncCursor};
-use cranelift_codegen::entity::{EntityMap, EntityRef, EntitySet};
+use cranelift_codegen::entity::{EntityMap, EntitySet};
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::function::DisplayFunction;
 use cranelift_codegen::ir::{
@@ -11,7 +11,7 @@ use cranelift_codegen::ir::{
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::packed_option::PackedOption;
 use ssa::{Block, SSABuilder, SideEffects};
-use std::fmt::Debug;
+use variable::Variable;
 
 /// Structure used for translating a series of functions into Cranelift IR.
 ///
@@ -22,20 +22,14 @@ use std::fmt::Debug;
 /// The `Variable` parameter can be any index-like type that can be made to
 /// implement `EntityRef`. For frontends that don't have an obvious type to
 /// use here, `variable::Variable` can be used.
-pub struct FunctionBuilderContext<Variable>
-where
-    Variable: EntityRef + Debug,
-{
+pub struct FunctionBuilderContext {
     ssa: SSABuilder<Variable>,
     ebbs: EntityMap<Ebb, EbbData>,
     types: EntityMap<Variable, Type>,
 }
 
 /// Temporary object used to build a single Cranelift IR `Function`.
-pub struct FunctionBuilder<'a, Variable: 'a>
-where
-    Variable: EntityRef + Debug,
-{
+pub struct FunctionBuilder<'a> {
     /// The function currently being built.
     /// This field is public so the function can be re-borrowed.
     pub func: &'a mut Function,
@@ -43,7 +37,7 @@ where
     /// Source location to assign to all new instructions.
     srcloc: ir::SourceLoc,
 
-    func_ctx: &'a mut FunctionBuilderContext<Variable>,
+    func_ctx: &'a mut FunctionBuilderContext,
     position: Position,
 }
 
@@ -79,10 +73,7 @@ impl Position {
     }
 }
 
-impl<Variable> FunctionBuilderContext<Variable>
-where
-    Variable: EntityRef + Debug,
-{
+impl FunctionBuilderContext {
     /// Creates a FunctionBuilderContext structure. The structure is automatically cleared after
     /// each [`FunctionBuilder`](struct.FunctionBuilder.html) completes translating a function.
     pub fn new() -> Self {
@@ -106,30 +97,18 @@ where
 
 /// Implementation of the [`InstBuilder`](../codegen/ir/builder/trait.InstBuilder.html) that has
 /// one convenience method per Cranelift IR instruction.
-pub struct FuncInstBuilder<'short, 'long: 'short, Variable: 'long>
-where
-    Variable: EntityRef + Debug,
-{
-    builder: &'short mut FunctionBuilder<'long, Variable>,
+pub struct FuncInstBuilder<'short, 'long: 'short> {
+    builder: &'short mut FunctionBuilder<'long>,
     ebb: Ebb,
 }
 
-impl<'short, 'long, Variable> FuncInstBuilder<'short, 'long, Variable>
-where
-    Variable: EntityRef + Debug,
-{
-    fn new<'s, 'l>(
-        builder: &'s mut FunctionBuilder<'l, Variable>,
-        ebb: Ebb,
-    ) -> FuncInstBuilder<'s, 'l, Variable> {
+impl<'short, 'long> FuncInstBuilder<'short, 'long> {
+    fn new<'s, 'l>(builder: &'s mut FunctionBuilder<'l>, ebb: Ebb) -> FuncInstBuilder<'s, 'l> {
         FuncInstBuilder { builder, ebb }
     }
 }
 
-impl<'short, 'long, Variable> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long, Variable>
-where
-    Variable: EntityRef + Debug,
-{
+impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
     fn data_flow_graph(&self) -> &DataFlowGraph {
         &self.builder.func.dfg
     }
@@ -228,16 +207,13 @@ where
 /// function in a way that violate the coherence of the code. For instance: switching to a new
 /// `Ebb` when you haven't filled the current one with a terminator instruction, inserting a
 /// return instruction with arguments that don't match the function's signature.
-impl<'a, Variable> FunctionBuilder<'a, Variable>
-where
-    Variable: EntityRef + Debug,
-{
+impl<'a> FunctionBuilder<'a> {
     /// Creates a new FunctionBuilder structure that will operate on a `Function` using a
     /// `FunctionBuilderContext`.
     pub fn new(
         func: &'a mut Function,
-        func_ctx: &'a mut FunctionBuilderContext<Variable>,
-    ) -> FunctionBuilder<'a, Variable> {
+        func_ctx: &'a mut FunctionBuilderContext,
+    ) -> FunctionBuilder<'a> {
         debug_assert!(func_ctx.is_empty());
         FunctionBuilder {
             func,
@@ -392,7 +368,7 @@ where
 
     /// Returns an object with the [`InstBuilder`](../codegen/ir/builder/trait.InstBuilder.html)
     /// trait that allows to conveniently append an instruction to the current `Ebb` being built.
-    pub fn ins<'short>(&'short mut self) -> FuncInstBuilder<'short, 'a, Variable> {
+    pub fn ins<'short>(&'short mut self) -> FuncInstBuilder<'short, 'a> {
         let ebb = self.position.ebb.unwrap();
         FuncInstBuilder::new(self, ebb)
     }
@@ -485,10 +461,7 @@ where
 /// performance of your translation perform more complex transformations to your Cranelift IR
 /// function. The functions below help you inspect the function you're creating and modify it
 /// in ways that can be unsafe if used incorrectly.
-impl<'a, Variable> FunctionBuilder<'a, Variable>
-where
-    Variable: EntityRef + Debug,
-{
+impl<'a> FunctionBuilder<'a> {
     /// Retrieves all the parameters for an `Ebb` currently inferred from the jump instructions
     /// inserted that target it and the SSA construction.
     pub fn ebb_params(&self, ebb: Ebb) -> &[Value] {
@@ -572,10 +545,7 @@ where
 }
 
 // Helper functions
-impl<'a, Variable> FunctionBuilder<'a, Variable>
-where
-    Variable: EntityRef + Debug,
-{
+impl<'a> FunctionBuilder<'a> {
     fn move_to_next_basic_block(&mut self) {
         self.position.basic_block = PackedOption::from(
             self.func_ctx
@@ -623,10 +593,10 @@ mod tests {
         sig.returns.push(AbiParam::new(I32));
         sig.params.push(AbiParam::new(I32));
 
-        let mut fn_ctx = FunctionBuilderContext::<Variable>::new();
+        let mut fn_ctx = FunctionBuilderContext::new();
         let mut func = Function::with_name_signature(ExternalName::testcase("sample"), sig);
         {
-            let mut builder = FunctionBuilder::<Variable>::new(&mut func, &mut fn_ctx);
+            let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
 
             let block0 = builder.create_ebb();
             let block1 = builder.create_ebb();

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -80,10 +80,10 @@
 //!     let mut sig = Signature::new(CallConv::SystemV);
 //!     sig.returns.push(AbiParam::new(I32));
 //!     sig.params.push(AbiParam::new(I32));
-//!     let mut fn_builder_ctx = FunctionBuilderContext::<Variable>::new();
+//!     let mut fn_builder_ctx = FunctionBuilderContext::new();
 //!     let mut func = Function::with_name_signature(ExternalName::user(0, 0), sig);
 //!     {
-//!         let mut builder = FunctionBuilder::<Variable>::new(&mut func, &mut fn_builder_ctx);
+//!         let mut builder = FunctionBuilder::new(&mut func, &mut fn_builder_ctx);
 //!
 //!         let block0 = builder.create_ebb();
 //!         let block1 = builder.create_ebb();

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -6,35 +6,38 @@
 //! To get started, create an [`FunctionBuilderContext`](struct.FunctionBuilderContext.html) and
 //! pass it as an argument to a [`FunctionBuilder`](struct.FunctionBuilder.html).
 //!
-//! # Source Language Variables and Cranelift IR values
+//! # Mutable variables and Cranelift IR values
 //!
 //! The most interesting feature of this API is that it provides a single way to deal with all your
 //! variable problems. Indeed, the [`FunctionBuilder`](struct.FunctionBuilder.html) struct has a
-//! type parameter `Variable` that should be instantiated with the type of your Source Language
-//! Variables (SLV). Then, through calling the functions
+//! type parameter `Variable` that should be instantiated with the type of your source language
+//! variables. Then, through calling the functions
 //! [`declare_var`](struct.FunctionBuilder.html#method.declare_var),
 //! [`def_var`](struct.FunctionBuilder.html#method.def_var) and
 //! [`use_var`](struct.FunctionBuilder.html#method.use_var), the
 //! [`FunctionBuilder`](struct.FunctionBuilder.html) will create for you all the Cranelift IR
-//! values corresponding to your SLVs.
+//! values corresponding to your variables.
 //!
-//! If a SLV is immutable (defined only once), then it will get mapped to one and only Cranelift IR
-//! value. If a SLV is mutable ([`def_var`](struct.FunctionBuilder.html#method.def_var) multiple
-//! times), then internally a [`SSA`](https://en.wikipedia.org/wiki/Static_single_assignment_form)
-//! construction algorithm will automatically create multiple Cranelift IR values that will be
-//! returned to you by [`use_var`](struct.FunctionBuilder.html#method.use_var) depending on where
-//! you want to use your SLV.
+//! This API has been designed to help you translate your mutable variables into
+//! [`SSA`](https://en.wikipedia.org/wiki/Static_single_assignment_form) form.
+//! [`use_var`](struct.FunctionBuilder.html#method.use_var) will returns the Cranelift IR value
+//! that corresponds to your mutable variable at a precise point in the program. However, you know
+//! beforehand that one of your variables is defined only once, for instance if it is the result
+//! of an intermediate expression in an expression-based language, then you can translate it
+//! directly by the Cranelift IR value returned by the instruction builder. Using the
+//! [`use_var`](struct.FunctionBuilder.html#method.use_var) API for such an immutable variable
+//! would also work but with a slight additional overhead (the SSA algorithm does not know
+//! beforehand if a variable is immutable or not).
 //!
-//! The morality is that you should use these three functions to handle all your SLVs, even those
-//! that are not present in the source code but artefacts of the translation. For instance, if your
-//! source language is expression-based, then you will need to introduce artifical SLVs to store
-//! intermediate results of the computation of your expressions. Hence The `Variable` type that you
+//!
+//! The moral is that you should use these three functions to handle all your mutable variables, even those
+//! that are not present in the source code but artefacts of the translation. Hence The `Variable` type that you
 //! would pass to [`FunctionBuilder`](struct.FunctionBuilder.html) could look like this
 //!
 //! ```
 //! enum Variable {
 //!     OriginalSourceVariable(String),
-//!     IntermediateExpressionVariable(u32)
+//!     TranslationArtefact(u32)
 //! }
 //! ```
 //!

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -10,8 +10,8 @@
 //!
 //! The most interesting feature of this API is that it provides a single way to deal with all your
 //! variable problems. Indeed, the [`FunctionBuilder`](struct.FunctionBuilder.html) struct has a
-//! type parameter `Variable` that should be instantiated with the type of your source language
-//! variables. Then, through calling the functions
+//! type `Variable` that should be an index of your source language variables. Then, through
+//! calling the functions
 //! [`declare_var`](struct.FunctionBuilder.html#method.declare_var),
 //! [`def_var`](struct.FunctionBuilder.html#method.def_var) and
 //! [`use_var`](struct.FunctionBuilder.html#method.use_var), the
@@ -29,17 +29,13 @@
 //! would also work but with a slight additional overhead (the SSA algorithm does not know
 //! beforehand if a variable is immutable or not).
 //!
-//!
-//! The moral is that you should use these three functions to handle all your mutable variables, even those
-//! that are not present in the source code but artefacts of the translation. Hence The `Variable` type that you
-//! would pass to [`FunctionBuilder`](struct.FunctionBuilder.html) could look like this
-//!
-//! ```
-//! enum Variable {
-//!     OriginalSourceVariable(String),
-//!     TranslationArtefact(u32)
-//! }
-//! ```
+//! The moral is that you should use these three functions to handle all your mutable variables,
+//! even those that are not present in the source code but artefacts of the translation. It is up
+//! to you to keep a mapping between the mutable variables of your language and their `Variable`
+//! index that is used by Cranelift. Caution: as the `Variable` is used by Cranelift to index an
+//! array containing information about your mutable variables, when you create a new `Variable`
+//! with [`Variable::new(var_index)`] you should make sure that `var_index` is provided by a
+//! counter incremented by 1 each time you encounter a new mutable variable.
 //!
 //! # Example
 //!

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -1,11 +1,42 @@
 //! Cranelift IR builder library.
 //!
 //! Provides a straightforward way to create a Cranelift IR function and fill it with instructions
-//! translated from another language. Contains an SSA construction module that lets you translate
-//! your non-SSA variables into SSA Cranelift IR values via `use_var` and `def_var` calls.
+//! corresponding to your source program written in another language.
 //!
 //! To get started, create an [`FunctionBuilderContext`](struct.FunctionBuilderContext.html) and
 //! pass it as an argument to a [`FunctionBuilder`](struct.FunctionBuilder.html).
+//!
+//! # Source Language Variables and Cranelift IR values
+//!
+//! The most interesting feature of this API is that it provides a single way to deal with all your
+//! variable problems. Indeed, the [`FunctionBuilder`](struct.FunctionBuilder.html) struct has a
+//! type parameter `Variable` that should be instantiated with the type of your Source Language
+//! Variables (SLV). Then, through calling the functions
+//! [`declare_var`](struct.FunctionBuilder.html#method.declare_var),
+//! [`def_var`](struct.FunctionBuilder.html#method.def_var) and
+//! [`use_var`](struct.FunctionBuilder.html#method.use_var), the
+//! [`FunctionBuilder`](struct.FunctionBuilder.html) will create for you all the Cranelift IR
+//! values corresponding to your SLVs.
+//!
+//! If a SLV is immutable (defined only once), then it will get mapped to one and only Cranelift IR
+//! value. If a SLV is mutable ([`def_var`](struct.FunctionBuilder.html#method.def_var) multiple
+//! times), then internally a [`SSA`](https://en.wikipedia.org/wiki/Static_single_assignment_form)
+//! construction algorithm will automatically create multiple Cranelift IR values that will be
+//! returned to you by [`use_var`](struct.FunctionBuilder.html#method.use_var) depending on where
+//! you want to use your SLV.
+//!
+//! The morality is that you should use these three functions to handle all your SLVs, even those
+//! that are not present in the source code but artefacts of the translation. For instance, if your
+//! source language is expression-based, then you will need to introduce artifical SLVs to store
+//! intermediate results of the computation of your expressions. Hence The `Variable` type that you
+//! would pass to [`FunctionBuilder`](struct.FunctionBuilder.html) could look like this
+//!
+//! ```
+//! enum Variable {
+//!     OriginalSourceVariable(String),
+//!     IntermediateExpressionVariable(u32)
+//! }
+//! ```
 //!
 //! # Example
 //!

--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -42,7 +42,7 @@ use wasmparser::{MemoryImmediate, Operator};
 /// a return.
 pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
     op: Operator,
-    builder: &mut FunctionBuilder<Variable>,
+    builder: &mut FunctionBuilder,
     state: &mut TranslationState,
     environ: &mut FE,
 ) -> WasmResult<()> {
@@ -897,7 +897,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
 /// portion so the translation state muts be updated accordingly.
 fn translate_unreachable_operator(
     op: &Operator,
-    builder: &mut FunctionBuilder<Variable>,
+    builder: &mut FunctionBuilder,
     state: &mut TranslationState,
 ) {
     match *op {
@@ -981,7 +981,7 @@ fn get_heap_addr(
     addr32: ir::Value,
     offset: u32,
     addr_ty: Type,
-    builder: &mut FunctionBuilder<Variable>,
+    builder: &mut FunctionBuilder,
 ) -> (ir::Value, i32) {
     use std::cmp::min;
 
@@ -1017,7 +1017,7 @@ fn translate_load<FE: FuncEnvironment + ?Sized>(
     offset: u32,
     opcode: ir::Opcode,
     result_ty: Type,
-    builder: &mut FunctionBuilder<Variable>,
+    builder: &mut FunctionBuilder,
     state: &mut TranslationState,
     environ: &mut FE,
 ) {
@@ -1039,7 +1039,7 @@ fn translate_load<FE: FuncEnvironment + ?Sized>(
 fn translate_store<FE: FuncEnvironment + ?Sized>(
     offset: u32,
     opcode: ir::Opcode,
-    builder: &mut FunctionBuilder<Variable>,
+    builder: &mut FunctionBuilder,
     state: &mut TranslationState,
     environ: &mut FE,
 ) {
@@ -1056,21 +1056,13 @@ fn translate_store<FE: FuncEnvironment + ?Sized>(
         .Store(opcode, val_ty, flags, offset.into(), val, base);
 }
 
-fn translate_icmp(
-    cc: IntCC,
-    builder: &mut FunctionBuilder<Variable>,
-    state: &mut TranslationState,
-) {
+fn translate_icmp(cc: IntCC, builder: &mut FunctionBuilder, state: &mut TranslationState) {
     let (arg0, arg1) = state.pop2();
     let val = builder.ins().icmp(cc, arg0, arg1);
     state.push1(builder.ins().bint(I32, val));
 }
 
-fn translate_fcmp(
-    cc: FloatCC,
-    builder: &mut FunctionBuilder<Variable>,
-    state: &mut TranslationState,
-) {
+fn translate_fcmp(cc: FloatCC, builder: &mut FunctionBuilder, state: &mut TranslationState) {
     let (arg0, arg1) = state.pop2();
     let val = builder.ins().fcmp(cc, arg0, arg1);
     state.push1(builder.ins().bint(I32, val));
@@ -1078,7 +1070,7 @@ fn translate_fcmp(
 
 fn translate_br_if(
     relative_depth: u32,
-    builder: &mut FunctionBuilder<Variable>,
+    builder: &mut FunctionBuilder,
     state: &mut TranslationState,
 ) {
     let val = state.pop1();

--- a/lib/wasm/src/func_translator.rs
+++ b/lib/wasm/src/func_translator.rs
@@ -19,7 +19,7 @@ use wasmparser::{self, BinaryReader};
 /// by a `FuncEnvironment` object. A single translator instance can be reused to translate multiple
 /// functions which will reduce heap allocation traffic.
 pub struct FuncTranslator {
-    func_ctx: FunctionBuilderContext<Variable>,
+    func_ctx: FunctionBuilderContext,
     state: TranslationState,
 }
 
@@ -105,7 +105,7 @@ impl FuncTranslator {
 /// Declare local variables for the signature parameters that correspond to WebAssembly locals.
 ///
 /// Return the number of local variables declared.
-fn declare_wasm_parameters(builder: &mut FunctionBuilder<Variable>, entry_block: Ebb) -> usize {
+fn declare_wasm_parameters(builder: &mut FunctionBuilder, entry_block: Ebb) -> usize {
     let sig_len = builder.func.signature.params.len();
     let mut next_local = 0;
     for i in 0..sig_len {
@@ -131,7 +131,7 @@ fn declare_wasm_parameters(builder: &mut FunctionBuilder<Variable>, entry_block:
 /// Declare local variables, starting from `num_params`.
 fn parse_local_decls(
     reader: &mut BinaryReader,
-    builder: &mut FunctionBuilder<Variable>,
+    builder: &mut FunctionBuilder,
     num_params: usize,
 ) -> WasmResult<()> {
     let mut next_local = num_params;
@@ -155,7 +155,7 @@ fn parse_local_decls(
 ///
 /// Fail of too many locals are declared in the function, or if the type is not valid for a local.
 fn declare_locals(
-    builder: &mut FunctionBuilder<Variable>,
+    builder: &mut FunctionBuilder,
     count: u32,
     wasm_type: wasmparser::Type,
     next_local: &mut usize,
@@ -185,7 +185,7 @@ fn declare_locals(
 /// arguments and locals are declared in the builder.
 fn parse_function_body<FE: FuncEnvironment + ?Sized>(
     mut reader: BinaryReader,
-    builder: &mut FunctionBuilder<Variable>,
+    builder: &mut FunctionBuilder,
     state: &mut TranslationState,
     environ: &mut FE,
 ) -> WasmResult<()> {


### PR DESCRIPTION
Following some reports of confusion over how to translate SSA or non-SSA "variables", improved the doc so explain better how the builder API handles them.