### PR TITLE
Updating Sphinx link and install

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Building the documentation
 --------------------------
 
 To build the Cranelift documentation, you need the [Sphinx documentation
-generator](https://www.sphinx-doc.org/):
+generator](http://www.sphinx-doc.org/) as well as Python 3::
 
     $ pip install sphinx sphinx-autobuild sphinx_rtd_theme
     $ cd cranelift/docs


### PR DESCRIPTION
Trying to build the documentation and needed to install python 3 so I updated it and the old https link was not working because Sphinx's settings were not correct so the link had to be changed to http.