### PR TITLE
[SimpleJIT] When finalizing multiple functions, make them all executable at the end.

### DIFF
--- a/lib/faerie/src/backend.rs
+++ b/lib/faerie/src/backend.rs
@@ -281,6 +281,10 @@ impl Backend for FaerieBackend {
         // Nothing to do.
     }
 
+    fn publish(&mut self) {
+        // Nothing to do.
+    }
+
     fn finish(self) -> FaerieProduct {
         FaerieProduct {
             artifact: self.artifact,

--- a/lib/module/src/backend.rs
+++ b/lib/module/src/backend.rs
@@ -104,6 +104,9 @@ where
         namespace: &ModuleNamespace<Self>,
     ) -> Self::FinalizedData;
 
+    /// "Publish" all finalized functions and data objects to their ultimate destinations.
+    fn publish(&mut self);
+
     /// Consume this `Backend` and return a result. Some implementations may
     /// provide additional functionality through this result.
     fn finish(self) -> Self::Product;

--- a/lib/module/src/module.rs
+++ b/lib/module/src/module.rs
@@ -584,6 +584,7 @@ where
             )
         };
         self.contents.functions[func].finalized = true;
+        self.backend.publish();
         output
     }
 
@@ -611,6 +612,7 @@ where
             )
         };
         self.contents.data_objects[data].finalized = true;
+        self.backend.publish();
         output
     }
 
@@ -630,6 +632,9 @@ where
                 );
             }
         }
+        for info in self.contents.functions.values_mut() {
+            info.finalized = true;
+        }
         for info in self.contents.data_objects.values() {
             if info.decl.linkage.is_definable() && !info.finalized {
                 self.backend.finalize_data(
@@ -642,12 +647,16 @@ where
                 );
             }
         }
+        for info in self.contents.data_objects.values_mut() {
+            info.finalized = true;
+        }
     }
 
     /// Consume the module and return the resulting `Product`. Some `Backend`
     /// implementations may provide additional functionality available after
     /// a `Module` is complete.
-    pub fn finish(self) -> B::Product {
+    pub fn finish(mut self) -> B::Product {
+        self.backend.publish();
         self.backend.finish()
     }
 }

--- a/lib/simplejit/src/backend.rs
+++ b/lib/simplejit/src/backend.rs
@@ -337,8 +337,6 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
             }
         }
 
-        // Now that we're done patching, make the memory executable.
-        self.code_memory.set_executable();
         func.code
     }
 
@@ -399,8 +397,13 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
             }
         }
 
-        self.readonly_memory.set_readonly();
         (data.storage, data.size)
+    }
+
+    fn publish(&mut self) {
+        // Now that we're done patching, prepare the memory for execution!
+        self.readonly_memory.set_readonly();
+        self.code_memory.set_executable();
     }
 
     /// SimpleJIT emits code and data into memory as it processes them, so it


### PR DESCRIPTION
Add `publish()` function to cranelift-module's `Backend` trait, which
allows `finalize_all()` to defer making memory executable until it
has finished all of the patching it needs to do.

Fixes #468.