### PR TITLE
Fix error not reported if at least one other error expected.

### DIFF
--- a/filetests/isa/riscv/verify-encoding.clif
+++ b/filetests/isa/riscv/verify-encoding.clif
@@ -7,7 +7,7 @@ function %RV32I(i32 link [%x1]) -> i32 link [%x1] {
 ebb0(v9999: i32):
     ; iconst.i32 needs legalizing, so it should throw a
     [R#0,-]         v1 = iconst.i32 0xf0f0f0f0f0 ; error: Instruction failed to re-encode
-    return v9999
+    [Iret#19]       return v9999
 }
 
 function %RV32I(i32 link [%x1]) -> i32 link [%x1] {
@@ -17,5 +17,5 @@ ebb0(v9999: i32):
     v1 = iconst.i32 1
     v2 = iconst.i32 2
     [R#0,-]         v3 = iadd v1, v2 ; error: encoding R#00 should be R#0c
-    return v9999
+    [Iret#19]       return v9999
 }

--- a/filetests/verifier/type_check.clif
+++ b/filetests/verifier/type_check.clif
@@ -82,6 +82,7 @@ function %jump_args() {
         v0 = iconst.i16 10
         v3 = iconst.i64 20
         jump ebb1(v0, v3) ; error: arg 0 (v0) has type i16, expected i64
+                          ; error: arg 1 (v3) has type i64, expected i16
     ebb1(v10: i64, v11: i16):
         return
 }
@@ -91,6 +92,7 @@ function %jump_args2() {
         v0 = iconst.i16 10
         v3 = iconst.i64 20
         brz v0, ebb1(v0, v3) ; error: arg 0 (v0) has type i16, expected i64
+                             ; error: arg 1 (v3) has type i64, expected i16
         jump ebb1(v3, v0)
     ebb1(v10: i64, v11: i16):
         return

--- a/lib/codegen/src/verifier/mod.rs
+++ b/lib/codegen/src/verifier/mod.rs
@@ -1384,7 +1384,12 @@ impl<'a> Verifier<'a> {
 
     /// If the verifier has been set up with an ISA, make sure that the recorded encoding for the
     /// instruction (if any) matches how the ISA would encode it.
-    fn verify_encoding(&self, inst: Inst, verify_need: &mut bool, errors: &mut VerifierErrors) -> VerifierStepResult<()> {
+    fn verify_encoding(
+        &self,
+        inst: Inst,
+        verify_need: &mut bool,
+        errors: &mut VerifierErrors,
+    ) -> VerifierStepResult<()> {
         // When the encodings table is empty, we don't require any instructions to be encoded.
         //
         // Once some instructions are encoded, we require all side-effecting instructions to have a
@@ -1437,7 +1442,7 @@ impl<'a> Verifier<'a> {
                         .write_fmt(format_args!("{}", isa.encoding_info().display(enc)))
                         .unwrap();
                 }
-                
+
                 *verify_need = false;
 
                 return nonfatal!(

--- a/lib/filetests/src/test_verifier.rs
+++ b/lib/filetests/src/test_verifier.rs
@@ -78,6 +78,10 @@ impl SubTest for TestVerifier {
                     }
                 }
 
+                for err in errors {
+                    write!(msg, "unexpected error {}", err).unwrap();
+                }
+
                 if msg.is_empty() {
                     Ok(())
                 } else {

--- a/lib/filetests/src/test_verifier.rs
+++ b/lib/filetests/src/test_verifier.rs
@@ -66,7 +66,7 @@ impl SubTest for TestVerifier {
                 for expect in expected {
                     let pos = errors
                         .iter()
-                        .position(|err| err.message.contains(expect.1) && err.location == expect.0);
+                        .position(|err| err.location == expect.0 && err.message.contains(expect.1));
 
                     match pos {
                         None => {
@@ -78,6 +78,7 @@ impl SubTest for TestVerifier {
                     }
                 }
 
+                // report remaining errors
                 for err in errors {
                     write!(msg, "unexpected error {}", err).unwrap();
                 }

--- a/src/clif-util.rs
+++ b/src/clif-util.rs
@@ -15,13 +15,13 @@ extern crate cfg_if;
 extern crate capstone;
 extern crate clap;
 extern crate cranelift_codegen;
-extern crate cranelift_entity;
 extern crate cranelift_filetests;
 extern crate cranelift_reader;
 extern crate pretty_env_logger;
 
 cfg_if! {
     if #[cfg(feature = "wasm")] {
+        extern crate cranelift_entity;
         extern crate cranelift_wasm;
         extern crate term;
         extern crate wabt;


### PR DESCRIPTION
In filetests, if multiple errors were reported in a function but only one of them was expected, no fail was reported. This fixes it.

Additionally, now that errors are correctly checked, some tests had to be fixed because more than one error were reported.