### PR TITLE
Some little clif-util things

### DIFF
--- a/lib/filetests/src/lib.rs
+++ b/lib/filetests/src/lib.rs
@@ -88,7 +88,7 @@ pub fn run_passes(verbose: bool, passes: &[String], target: &str, file: &String)
     let mut runner = TestRunner::new(verbose);
 
     let path = Path::new(file);
-    if path.is_file() {
+    if path == Path::new("-") || path.is_file() {
         runner.push_test(path);
     } else {
         runner.push_dir(path);

--- a/src/clif-util.rs
+++ b/src/clif-util.rs
@@ -47,17 +47,17 @@ pub type CommandResult = Result<(), String>;
 
 fn add_input_file_arg<'a>() -> clap::Arg<'a, 'a> {
     Arg::with_name("file")
-        .required(true)
+        .default_value("-")
         .multiple(true)
         .value_name("file")
-        .help("Specify file(s) to be used for test")
+        .help("Specify file(s) to be used for test. Defaults to reading from stdin.")
 }
 
 fn add_single_input_file_arg<'a>() -> clap::Arg<'a, 'a> {
     Arg::with_name("single-file")
-        .required(true)
+        .default_value("-")
         .value_name("single-file")
-        .help("Specify a file to be used")
+        .help("Specify a file to be used. Defaults to reading from stdin.")
 }
 
 fn add_pass_arg<'a>() -> clap::Arg<'a, 'a> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,17 +12,29 @@ use target_lexicon::Triple;
 
 /// Read an entire file into a string.
 pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
-    let mut file = File::open(path)?;
     let mut buffer = String::new();
-    file.read_to_string(&mut buffer)?;
+    if path.as_ref() == Path::new("-") {
+        let stdin = io::stdin();
+        let mut stdin = stdin.lock();
+        stdin.read_to_string(&mut buffer)?;
+    } else {
+        let mut file = File::open(path)?;
+        file.read_to_string(&mut buffer)?;
+    }
     Ok(buffer)
 }
 
 /// Read an entire file into a vector of bytes.
 pub fn read_to_end<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
-    let mut file = File::open(path)?;
     let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer)?;
+    if path.as_ref() == Path::new("-") {
+        let stdin = io::stdin();
+        let mut stdin = stdin.lock();
+        stdin.read_to_end(&mut buffer)?;
+    } else {
+        let mut file = File::open(path)?;
+        file.read_to_end(&mut buffer)?;
+    }
     Ok(buffer)
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -72,13 +72,13 @@ fn handle_module(
     fisa: FlagsOrIsa,
 ) -> Result<(), String> {
     let mut terminal = term::stdout().unwrap();
-    terminal.fg(term::color::YELLOW).unwrap();
+    let _ = terminal.fg(term::color::YELLOW);
     vprint!(flag_verbose, "Handling: ");
-    terminal.reset().unwrap();
+    let _ = terminal.reset();
     vprintln!(flag_verbose, "\"{}\"", name);
-    terminal.fg(term::color::MAGENTA).unwrap();
+    let _ = terminal.fg(term::color::MAGENTA);
     vprint!(flag_verbose, "Translating... ");
-    terminal.reset().unwrap();
+    let _ = terminal.reset();
 
     let mut module_binary =
         read_to_end(path.clone()).map_err(|err| String::from(err.description()))?;
@@ -103,9 +103,9 @@ fn handle_module(
         DummyEnvironment::with_triple_flags(isa.triple().clone(), fisa.flags.clone());
     translate_module(&module_binary, &mut dummy_environ).map_err(|e| e.to_string())?;
 
-    terminal.fg(term::color::GREEN).unwrap();
+    let _ = terminal.fg(term::color::GREEN);
     vprintln!(flag_verbose, "ok");
-    terminal.reset().unwrap();
+    let _ = terminal.reset();
 
     if flag_just_decode {
         if !flag_print {
@@ -131,17 +131,17 @@ fn handle_module(
             println!("{}", context.func.display(None));
             vprintln!(flag_verbose, "");
         }
-        terminal.reset().unwrap();
+        let _ = terminal.reset();
         return Ok(());
     }
 
-    terminal.fg(term::color::MAGENTA).unwrap();
+    let _ = terminal.fg(term::color::MAGENTA);
     if flag_check_translation {
         vprint!(flag_verbose, "Checking... ");
     } else {
         vprint!(flag_verbose, "Compiling... ");
     }
-    terminal.reset().unwrap();
+    let _ = terminal.reset();
 
     if flag_print_size {
         vprintln!(flag_verbose, "");
@@ -201,8 +201,8 @@ fn handle_module(
         println!("Total module bytecode size: {} bytes", total_bytecode_size);
     }
 
-    terminal.fg(term::color::GREEN).unwrap();
+    let _ = terminal.fg(term::color::GREEN);
     vprintln!(flag_verbose, "ok");
-    terminal.reset().unwrap();
+    let _ = terminal.reset();
     Ok(())
 }


### PR DESCRIPTION
Not sure how to write a test for this, or if that is necessary, but these commands work now, when they did not before:

```
$ cargo run --bin clif-util -- compile --target x86_64-unknown-linux-gnu < filetests/wasm/control.clif
$ cargo run --bin clif-util -- wasm --target x86_64-unknown-linux-gnu < ~/path/to/test.wasm 
```