### PR TITLE
clif-util: fix `clif-util pass` subcommand arguments

### DIFF
--- a/src/clif-util.rs
+++ b/src/clif-util.rs
@@ -55,9 +55,9 @@ fn add_input_file_arg<'a>() -> clap::Arg<'a, 'a> {
 
 fn add_single_input_file_arg<'a>() -> clap::Arg<'a, 'a> {
     Arg::with_name("single-file")
-        .default_value("-")
+        .required(true)
         .value_name("single-file")
-        .help("Specify a file to be used. Defaults to reading from stdin.")
+        .help("Specify a file to be used. Use '-' for stdin.")
 }
 
 fn add_pass_arg<'a>() -> clap::Arg<'a, 'a> {


### PR DESCRIPTION
Because of the way that the `pass` subcommand orders its arguments, the positional "single-file" input cannot be optional with a default value, because it is followed by required positional arguments. If it were optional, that would result in argument ambiguity where `clap` cannot tell if the optional positional argument is supplied, or if the given argument is the next required positional argument.

Before this commit:

```
$ cargo run --bin clif-util -- pass ./filetests/dce/basic.clif dce
   Compiling cranelift-tools v0.21.0 (file:///Users/fitzgen/src/cranelift)
    Finished dev [unoptimized + debuginfo] target(s) in 4.38s
     Running `target/debug/clif-util pass ./filetests/dce/basic.clif dce`
thread 'main' panicked at 'Found positional argument which is not required with a lower index than a required positional argument: "single-file" index 1', /Users/fitzgen/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.32.0/src/app/parser.rs:612:21
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

After this commit:

```
$ cargo run --bin clif-util -- pass ./filetests/dce/basic.clif dce
   Compiling cranelift-filetests v0.21.0 (file:///Users/fitzgen/src/cranelift/lib/filetests)
   Compiling cranelift-tools v0.21.0 (file:///Users/fitzgen/src/cranelift)
    Finished dev [unoptimized + debuginfo] target(s) in 5.96s
     Running `target/debug/clif-util pass ./filetests/dce/basic.clif dce`
1 tests
```

r? @sunfishcode 