### PR TITLE
Update the reload pass to replace copies with fill/spill instructions

### DIFF
--- a/filetests/regalloc/reload.clif
+++ b/filetests/regalloc/reload.clif
@@ -17,3 +17,30 @@ ebb0:
     ; check: $(reload=$V) = fill v0
     ; check: return $reload
 }
+
+; Check that copies where the arg has been spilled are replaced with fills.
+;
+; RV32E has 6 registers for function arguments so the 7th, v6, will be placed
+; on the stack.
+function %spilled_copy_arg(i32, i32, i32, i32, i32, i32, i32) -> i32 {
+
+ebb0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
+    ; not: copy
+    ; check: v10 = fill v6
+    v10 = copy v6
+    return v10
+}
+
+; Check that copies where the result has been spilled are replaced with spills.
+;
+; v1 is live across a call so it will be spilled.
+function %spilled_copy_result(i32) -> i32 {
+    fn0 = %foo(i32)
+
+ebb0(v0: i32):
+    ; not: copy
+    ; check: v1 = spill v0
+    v1 = copy v0
+    call fn0(v1)
+    return v1
+}


### PR DESCRIPTION
This fixes #245. 