### PR TITLE
Add more content to cranelift-entity's README.md.

### DIFF
--- a/lib/entity/README.md
+++ b/lib/entity/README.md
@@ -18,9 +18,9 @@ a map it's not intended for is diagnosed with a type error.
 Another is that this crate has two core map types, `PrimaryMap` and
 `EntityMap`, which serve complementary purposes. A `PrimaryMap` creates its
 own keys when elements are inserted, while an `EntityMap` reuses the keys
-values of a `PrimaryMap` and serves a supplementary purpose. `EntityMap`'s
-values must implement `Default` and all elements in an `EntityMap` initially
-have the value of `default()`.
+values of a `PrimaryMap`, conceptually storing additional data in the same
+index space. `EntityMap`'s values must implement `Default` and all elements
+in an `EntityMap` initially have the value of `default()`.
 
 A common way to implement `Default` is to wrap a type in `Option`, however
 this crate also provides the `PackedOption` utility which can use less memory

--- a/lib/entity/README.md
+++ b/lib/entity/README.md
@@ -11,7 +11,7 @@ unique keys (eg. slotmap's versioning).
 Another major difference is that this crate protects against using a key from
 one map to access an element in another. Where `SlotMap` and `Slab` have a
 value type parameter, `PrimaryMap` has a key type parameter and a value type
-parameter. The crante also provides the `entity_impl` macro which makes it
+parameter. The crate also provides the `entity_impl` macro which makes it
 easy to declare new unique types for use as keys. Any attempt to use a key in
 a map it's not intended for is diagnosed with a type error.
 

--- a/lib/entity/README.md
+++ b/lib/entity/README.md
@@ -4,7 +4,7 @@ generator which use densely numbered entity references as mapping keys.
 One major difference between this crate and crates like [slotmap], [slab],
 and [generational-arena] is that this crate currently provides no way to delete
 entities. This limits its use to situations where deleting isn't important,
-however it also makes it more efficient, because it doesn't need extra
+however this also makes it more efficient, because it doesn't need extra
 bookkeeping state to reuse the storage for deleted objects, or to ensure that
 new objects always have unique keys (eg. slotmap's versioning).
 

--- a/lib/entity/README.md
+++ b/lib/entity/README.md
@@ -1,17 +1,17 @@
 This crate contains array-based data structures used by the core Cranelift code
 generator which use densely numbered entity references as mapping keys.
 
-One major difference between this crate and crates like [slotmap] and [slab]
-is that this crate currently provides no way to delete entities. This limits
-its use to situations where deleting isn't important, however it also makes
-it more efficient, because it doesn't need extra bookkeeping state to reuse
-the storage for deleted objects, or to ensure that new objects always have
-unique keys (eg. slotmap's versioning).
+One major difference between this crate and crates like [slotmap], [slab],
+and [generational-arena] is that this crate currently provides no way to delete
+entities. This limits its use to situations where deleting isn't important,
+however it also makes it more efficient, because it doesn't need extra
+bookkeeping state to reuse the storage for deleted objects, or to ensure that
+new objects always have unique keys (eg. slotmap's versioning).
 
 Another major difference is that this crate protects against using a key from
-one map to access an element in another. Where `SlotMap` and `Slab` have a
-value type parameter, `PrimaryMap` has a key type parameter and a value type
-parameter. The crate also provides the `entity_impl` macro which makes it
+one map to access an element in another. Where `SlotMap`, `Slab`, and `Arena`
+have a value type parameter, `PrimaryMap` has a key type parameter and a value
+type parameter. The crate also provides the `entity_impl` macro which makes it
 easy to declare new unique types for use as keys. Any attempt to use a key in
 a map it's not intended for is diagnosed with a type error.
 
@@ -36,3 +36,4 @@ Additional utilities provided by this crate include:
 
 [slotmap]: https://crates.io/crates/slotmap
 [slab]: https://crates.io/crates/slab
+[generational-arena]: https://crates.io/crates/generational-arena

--- a/lib/entity/README.md
+++ b/lib/entity/README.md
@@ -6,7 +6,8 @@ and [generational-arena] is that this crate currently provides no way to delete
 entities. This limits its use to situations where deleting isn't important,
 however this also makes it more efficient, because it doesn't need extra
 bookkeeping state to reuse the storage for deleted objects, or to ensure that
-new objects always have unique keys (eg. slotmap's versioning).
+new objects always have unique keys (eg. slotmap's and generational-arena's
+versioning).
 
 Another major difference is that this crate protects against using a key from
 one map to access an element in another. Where `SlotMap`, `Slab`, and `Arena`

--- a/lib/entity/README.md
+++ b/lib/entity/README.md
@@ -1,2 +1,38 @@
 This crate contains array-based data structures used by the core Cranelift code
 generator which use densely numbered entity references as mapping keys.
+
+One major difference between this crate and crates like [slotmap] and [slab]
+is that this crate currently provides no way to delete entities. This limits
+its use to situations where deleting isn't important, however it also makes
+it more efficient, because it doesn't need extra bookkeeping state to reuse
+the storage for deleted objects, or to ensure that new objects always have
+unique keys (eg. slotmap's versioning).
+
+Another major difference is that this crate protects against using a key from
+one map to access an element in another. Where `SlotMap` and `Slab` have a
+value type parameter, `PrimaryMap` has a key type parameter and a value type
+parameter. The crante also provides the `entity_impl` macro which makes it
+easy to declare new unique types for use as keys. Any attempt to use a key in
+a map it's not intended for is diagnosed with a type error.
+
+Another is that this crate has two core map types, `PrimaryMap` and
+`EntityMap`, which serve complementary purposes. A `PrimaryMap` creates its
+own keys when elements are inserted, while an `EntityMap` reuses the keys
+values of a `PrimaryMap` and serves a supplementary purpose. `EntityMap`'s
+values must implement `Default` and all elements in an `EntityMap` initially
+have the value of `default()`.
+
+A common way to implement `Default` is to wrap a type in `Option`, however
+this crate also provides the `PackedOption` utility which can use less memory
+in some cases.
+
+Additional utilities provided by this crate include:
+ - `EntityList`, for allocating many small arrays (such as instruction operand
+    lists in a compiler code generator).
+ - `SparseMap`: an alternative to `EntityMap` which can use less memory
+   in some situations.
+ - `EntitySet`: a specialized form of `EntityMap` using a bitvector to
+   record which entities are members of the set.
+
+[slotmap]: https://crates.io/crates/slotmap
+[slab]: https://crates.io/crates/slab


### PR DESCRIPTION
Summarize what cranelift-entity provides, and how it differs from
similar systems such as slotmap, which was recently highlighted in the
RustConf 2018 Closing Keynote.