### PR TITLE
Remove `Module`'s `finalize_function` and `finalize_data`.

### DIFF
--- a/lib/simplejit/examples/simplejit-minimal.rs
+++ b/lib/simplejit/examples/simplejit-minimal.rs
@@ -67,7 +67,7 @@ fn main() {
     module.clear_context(&mut ctx);
 
     // Perform linking.
-    module.finalize_all();
+    module.finalize_definitions();
 
     // Get a raw pointer to the generated code.
     let code_b = module.get_finalized_function(func_b);

--- a/lib/simplejit/tests/basic.rs
+++ b/lib/simplejit/tests/basic.rs
@@ -57,13 +57,12 @@ fn define_simple_function(module: &mut Module<SimpleJITBackend>) -> FuncId {
 }
 
 #[test]
-#[should_panic(expected = "function can't be finalized twice")]
-fn panic_on_double_finalize() {
+fn double_finalize() {
     let mut module: Module<SimpleJITBackend> = Module::new(SimpleJITBuilder::new());
 
     let func_id = define_simple_function(&mut module);
-    module.finalize_function(func_id);
-    module.finalize_function(func_id);
+    module.finalize_definitions();
+    module.finalize_definitions();
 }
 
 #[test]
@@ -72,6 +71,6 @@ fn panic_on_define_after_finalize() {
     let mut module: Module<SimpleJITBackend> = Module::new(SimpleJITBuilder::new());
 
     let func_id = define_simple_function(&mut module);
-    module.finalize_function(func_id);
+    module.finalize_definitions();
     define_simple_function(&mut module);
 }

--- a/lib/simplejit/tests/basic.rs
+++ b/lib/simplejit/tests/basic.rs
@@ -62,6 +62,9 @@ fn double_finalize() {
 
     let func_id = define_simple_function(&mut module);
     module.finalize_definitions();
+
+    // Calling `finalize_definitions` a second time without any new definitions
+    // should have no effect.
     module.finalize_definitions();
 }
 


### PR DESCRIPTION
Remove the ability to finalize individiual functions and data objects,
and instead just provide a way to finalize everything that's been
defined but not yet finalized. This allows SimpleJIT to share an
allocation between multiple functions without having to worry about
individual functions being finalized and needing to be published
without the other functions in the same allocation.

Users of the return values of `Module`'s `finalize_function` and
`finalize_data` should now use `get_finalized_function` and
`get_finalized_data` to obtain these values.

Fixes #468.