### PR TITLE
Bump wabt version to 0.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clap = "2.32.0"
 serde = "1.0.8"
 term = "0.5.1"
 capstone = { version = "0.5.0", optional = true }
-wabt = { version = "0.5", optional = true }
+wabt = { version = "0.6", optional = true }
 target-lexicon = "0.0.3"
 pretty_env_logger = "0.2.4"
 file-per-thread-logger = "0.1.1"

--- a/lib/wasm/Cargo.toml
+++ b/lib/wasm/Cargo.toml
@@ -21,7 +21,7 @@ target-lexicon = { version = "0.0.3", default-features = false }
 log = { version = "0.4.4", default-features = false, features = ["release_max_level_warn"] }
 
 [dev-dependencies]
-wabt = "0.5.0"
+wabt = "0.6.0"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
After upgrading, errors with outdated `cmake` should gone.