### PR TITLE
Put TargetIsa's emit_inst under a "testing_hooks" feature.

### DIFF
--- a/lib/codegen/Cargo.toml
+++ b/lib/codegen/Cargo.toml
@@ -34,6 +34,9 @@ cranelift-codegen-meta = { path = "meta", version = "0.22.0" }
 default = ["std"]
 std = ["cranelift-entity/std", "cranelift-bforest/std", "target-lexicon/std"]
 core = ["hashmap_core"]
+# This enables some additional functions useful for writing tests, but which
+# can significantly increase the size of the library.
+testing_hooks = []
 
 [badges]
 maintenance = { status = "experimental" }

--- a/lib/codegen/src/isa/arm32/mod.rs
+++ b/lib/codegen/src/isa/arm32/mod.rs
@@ -7,7 +7,9 @@ mod registers;
 pub mod settings;
 
 use super::super::settings as shared_settings;
-use binemit::{emit_function, CodeSink, MemoryCodeSink};
+#[cfg(feature = "testing_hooks")]
+use binemit::CodeSink;
+use binemit::{emit_function, MemoryCodeSink};
 use ir;
 use isa::enc_tables::{self as shared_enc_tables, lookup_enclist, Encodings};
 use isa::Builder as IsaBuilder;
@@ -111,6 +113,7 @@ impl TargetIsa for Isa {
         abi::allocatable_registers(func)
     }
 
+    #[cfg(feature = "testing_hooks")]
     fn emit_inst(
         &self,
         func: &ir::Function,

--- a/lib/codegen/src/isa/arm64/mod.rs
+++ b/lib/codegen/src/isa/arm64/mod.rs
@@ -7,7 +7,9 @@ mod registers;
 pub mod settings;
 
 use super::super::settings as shared_settings;
-use binemit::{emit_function, CodeSink, MemoryCodeSink};
+#[cfg(feature = "testing_hooks")]
+use binemit::CodeSink;
+use binemit::{emit_function, MemoryCodeSink};
 use ir;
 use isa::enc_tables::{lookup_enclist, Encodings};
 use isa::Builder as IsaBuilder;
@@ -98,6 +100,7 @@ impl TargetIsa for Isa {
         abi::allocatable_registers(func)
     }
 
+    #[cfg(feature = "testing_hooks")]
     fn emit_inst(
         &self,
         func: &ir::Function,

--- a/lib/codegen/src/isa/mod.rs
+++ b/lib/codegen/src/isa/mod.rs
@@ -307,6 +307,9 @@ pub trait TargetIsa: fmt::Display {
     ///
     /// Note that this will call `put*` methods on the `sink` trait object via its vtable which
     /// is not the fastest way of emitting code.
+    ///
+    /// This function is under the "testing_hooks" feature, and is only suitable for use by
+    /// test harnesses. It increases code size, and is inefficient.
     #[cfg(feature = "testing_hooks")]
     fn emit_inst(
         &self,
@@ -317,7 +320,5 @@ pub trait TargetIsa: fmt::Display {
     );
 
     /// Emit a whole function into memory.
-    ///
-    /// This is more performant than calling `emit_inst` for each instruction.
     fn emit_function_to_memory(&self, func: &ir::Function, sink: &mut binemit::MemoryCodeSink);
 }

--- a/lib/codegen/src/isa/mod.rs
+++ b/lib/codegen/src/isa/mod.rs
@@ -307,6 +307,7 @@ pub trait TargetIsa: fmt::Display {
     ///
     /// Note that this will call `put*` methods on the `sink` trait object via its vtable which
     /// is not the fastest way of emitting code.
+    #[cfg(feature = "testing_hooks")]
     fn emit_inst(
         &self,
         func: &ir::Function,

--- a/lib/codegen/src/isa/riscv/mod.rs
+++ b/lib/codegen/src/isa/riscv/mod.rs
@@ -7,7 +7,9 @@ mod registers;
 pub mod settings;
 
 use super::super::settings as shared_settings;
-use binemit::{emit_function, CodeSink, MemoryCodeSink};
+#[cfg(feature = "testing_hooks")]
+use binemit::CodeSink;
+use binemit::{emit_function, MemoryCodeSink};
 use ir;
 use isa::enc_tables::{self as shared_enc_tables, lookup_enclist, Encodings};
 use isa::Builder as IsaBuilder;
@@ -105,6 +107,7 @@ impl TargetIsa for Isa {
         abi::allocatable_registers(func, &self.isa_flags)
     }
 
+    #[cfg(feature = "testing_hooks")]
     fn emit_inst(
         &self,
         func: &ir::Function,

--- a/lib/codegen/src/isa/x86/mod.rs
+++ b/lib/codegen/src/isa/x86/mod.rs
@@ -7,7 +7,9 @@ mod registers;
 pub mod settings;
 
 use super::super::settings as shared_settings;
-use binemit::{emit_function, CodeSink, MemoryCodeSink};
+#[cfg(feature = "testing_hooks")]
+use binemit::CodeSink;
+use binemit::{emit_function, MemoryCodeSink};
 use ir;
 use isa::enc_tables::{self as shared_enc_tables, lookup_enclist, Encodings};
 use isa::Builder as IsaBuilder;
@@ -115,6 +117,7 @@ impl TargetIsa for Isa {
         abi::allocatable_registers(func, &self.triple)
     }
 
+    #[cfg(feature = "testing_hooks")]
     fn emit_inst(
         &self,
         func: &ir::Function,

--- a/lib/filetests/Cargo.toml
+++ b/lib/filetests/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/CraneStation/cranelift"
 publish = false
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.22.0" }
+cranelift-codegen = { path = "../codegen", version = "0.22.0", features = ["testing_hooks"] }
 cranelift-reader = { path = "../reader", version = "0.22.0" }
 file-per-thread-logger = "0.1.1"
 filecheck = "0.4.0"


### PR DESCRIPTION
In practice, TargetIsa's emit_inst pulls in its own instantiation
of the target-specific `emit_inst` functions, which can be quite
large, and LTO doesn't eliminate them because they're held live
by TargetIsa's vtable.

Fortunately, this function is only used by tests, so we can put
it behind a feature flag.

Fixes #530.