### PR TITLE
Remove the concept of non-dense jump tables.

### DIFF
--- a/docs/ir.rst
+++ b/docs/ir.rst
@@ -360,13 +360,12 @@ instruction in the EBB.
 .. autoinst:: brff
 .. autoinst:: br_table
 
-.. inst:: JT = jump_table EBB0, EBB1, ..., EBBn
+.. inst:: JT = jump_table [EBB0, EBB1, ..., EBBn]
 
     Declare a jump table in the :term:`function preamble`.
 
     This declares a jump table for use by the :inst:`br_table` indirect branch
-    instruction. Entries in the table are either EBB names, or ``0`` which
-    indicates an absent entry.
+    instruction. Entries in the table are EBB names.
 
     The EBBs listed must belong to the current function, and they can't have
     any arguments.

--- a/filetests/isa/x86/binary64.clif
+++ b/filetests/isa/x86/binary64.clif
@@ -1405,7 +1405,7 @@ ebb0:
 
 ; Tests for i64 jump table instructions.
 function %I64_JT(i64 [%rdi]) {
-    jt0 = jump_table ebb1, ebb2, ebb3
+    jt0 = jump_table [ebb1, ebb2, ebb3]
 
 ebb0(v0: i64 [%rdi]):
     ; Note: The next two lines will need to change whenever instructions are

--- a/filetests/isa/x86/legalize-br-table.clif
+++ b/filetests/isa/x86/legalize-br-table.clif
@@ -4,7 +4,7 @@ target x86_64
 
 function u0:0(i64) system_v {
     ss0 = explicit_slot 1
-    jt0 = jump_table ebb1
+    jt0 = jump_table [ebb1]
 
 ebb0(v0: i64):
     v1 = stack_addr.i64 ss0

--- a/filetests/parser/branch.clif
+++ b/filetests/parser/branch.clif
@@ -81,8 +81,8 @@ ebb1(v92: i32, v93: f32):
 ; nextln: }
 
 function %jumptable(i32) {
-    jt200 = jump_table 0, 0
-    jt2 = jump_table 0, 0, ebb10, ebb40, ebb20, ebb30
+    jt200 = jump_table []
+    jt2 = jump_table [ebb10, ebb40, ebb20, ebb30]
 
 ebb10(v3: i32):
     br_table v3, ebb50, jt2
@@ -97,8 +97,8 @@ ebb50:
     trap user1    
 }
 ; sameln: function %jumptable(i32) fast {
-; check:      jt2 = jump_table 0, 0, ebb10, ebb40, ebb20, ebb30
-; check:      jt200 = jump_table 0
+; check:      jt2 = jump_table [ebb10, ebb40, ebb20, ebb30]
+; check:      jt200 = jump_table []
 ; check:  ebb10(v3: i32):
 ; nextln:     br_table v3, ebb50, jt2
 ; nextln: 

--- a/filetests/verifier/type_check.clif
+++ b/filetests/verifier/type_check.clif
@@ -68,7 +68,7 @@ function %fn_call_incorrect_arg_type(i64) {
 ; TODO: Should we instead just verify that jump tables contain no EBBs that take arguments? This
 ; error doesn't occur if no instruction uses the jump table.
 function %jump_table_args() {
-    jt1 = jump_table ebb1
+    jt1 = jump_table [ebb1]
     ebb0:
         v0 = iconst.i32 0
         br_table v0, ebb2, jt1 ; error: takes no arguments, but had target ebb1 with 1 arguments

--- a/filetests/wasm/control.clif
+++ b/filetests/wasm/control.clif
@@ -48,7 +48,7 @@ ebb0:
 }
 
 function %br_table(i32) {
-jt0 = jump_table ebb3, ebb1, 0, ebb2
+jt0 = jump_table [ebb3, ebb1, ebb2]
 
 ebb0(v0: i32):
     br_table v0, ebb4, jt0

--- a/lib/codegen/src/binemit/mod.rs
+++ b/lib/codegen/src/binemit/mod.rs
@@ -132,14 +132,9 @@ where
     // output jump tables
     for (jt, jt_data) in func.jump_tables.iter() {
         let jt_offset = func.jt_offsets[jt];
-        for idx in 0..jt_data.len() {
-            match jt_data.get_entry(idx) {
-                Some(ebb) => {
-                    let rel_offset: i32 = func.offsets[ebb] as i32 - jt_offset as i32;
-                    sink.put4(rel_offset as u32)
-                }
-                None => sink.put4(0),
-            }
+        for ebb in jt_data.iter() {
+            let rel_offset: i32 = func.offsets[*ebb] as i32 - jt_offset as i32;
+            sink.put4(rel_offset as u32)
         }
     }
 }

--- a/lib/codegen/src/dominator_tree.rs
+++ b/lib/codegen/src/dominator_tree.rs
@@ -347,8 +347,8 @@ impl DominatorTree {
             match func.dfg.analyze_branch(inst) {
                 BranchInfo::SingleDest(succ, _) => self.push_if_unseen(succ),
                 BranchInfo::Table(jt, dest) => {
-                    for (_, succ) in func.jump_tables[jt].entries() {
-                        self.push_if_unseen(succ);
+                    for succ in func.jump_tables[jt].iter() {
+                        self.push_if_unseen(*succ);
                     }
                     if let Some(dest) = dest {
                         self.push_if_unseen(dest);

--- a/lib/codegen/src/flowgraph.rs
+++ b/lib/codegen/src/flowgraph.rs
@@ -129,8 +129,8 @@ impl ControlFlowGraph {
                     if let Some(dest) = dest {
                         self.add_edge(ebb, inst, dest);
                     }
-                    for (_, dest) in func.jump_tables[jt].entries() {
-                        self.add_edge(ebb, inst, dest);
+                    for dest in func.jump_tables[jt].iter() {
+                        self.add_edge(ebb, inst, *dest);
                     }
                 }
                 BranchInfo::NotABranch => {}

--- a/lib/codegen/src/ir/function.rs
+++ b/lib/codegen/src/ir/function.rs
@@ -122,11 +122,6 @@ impl Function {
         self.jump_tables.push(data)
     }
 
-    /// Inserts an entry in a previously declared jump table.
-    pub fn insert_jump_table_entry(&mut self, jt: JumpTable, index: usize, ebb: Ebb) {
-        self.jump_tables[jt].set_entry(index, ebb);
-    }
-
     /// Creates a stack slot in the function, to be used by `stack_load`, `stack_store` and
     /// `stack_addr` instructions.
     pub fn create_stack_slot(&mut self, data: StackSlotData) -> StackSlot {

--- a/lib/codegen/src/ir/jumptable.rs
+++ b/lib/codegen/src/ir/jumptable.rs
@@ -4,39 +4,29 @@
 //! The actual table of destinations is stored in a `JumpTableData` struct defined in this module.
 
 use ir::entities::Ebb;
-use packed_option::PackedOption;
 use std::fmt::{self, Display, Formatter};
-use std::iter;
-use std::slice;
+use std::slice::{Iter, IterMut};
 use std::vec::Vec;
 
 /// Contents of a jump table.
 ///
-/// All jump tables use 0-based indexing and are expected to be densely populated. They don't need
-/// to be completely populated, though. Individual entries can be missing.
+/// All jump tables use 0-based indexing and densely populated.
 #[derive(Clone)]
 pub struct JumpTableData {
-    // Table entries, using `None` as a placeholder for missing entries.
-    table: Vec<PackedOption<Ebb>>,
-
-    // How many `None` holes in table?
-    holes: usize,
+    // Table entries.
+    table: Vec<Ebb>,
 }
 
 impl JumpTableData {
     /// Create a new empty jump table.
     pub fn new() -> Self {
-        Self {
-            table: Vec::new(),
-            holes: 0,
-        }
+        Self { table: Vec::new() }
     }
 
     /// Create a new empty jump table with the specified capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             table: Vec::with_capacity(capacity),
-            holes: 0,
         }
     }
 
@@ -45,100 +35,48 @@ impl JumpTableData {
         self.table.len()
     }
 
-    /// Boolean that is false if the table has missing entries.
-    pub fn fully_dense(&self) -> bool {
-        self.holes == 0
-    }
-
-    /// Set a table entry.
-    ///
-    /// The table will grow as needed to fit `idx`.
-    pub fn set_entry(&mut self, idx: usize, dest: Ebb) {
-        // Resize table to fit `idx`.
-        if idx >= self.table.len() {
-            self.holes += idx - self.table.len();
-            self.table.resize(idx + 1, None.into());
-        } else if self.table[idx].is_none() {
-            // We're filling in an existing hole.
-            self.holes -= 1;
-        }
-        self.table[idx] = dest.into();
-    }
-
     /// Append a table entry.
     pub fn push_entry(&mut self, dest: Ebb) {
-        self.table.push(dest.into())
-    }
-
-    /// Clear a table entry.
-    ///
-    /// The `br_table` instruction will fall through if given an index corresponding to a cleared
-    /// table entry.
-    pub fn clear_entry(&mut self, idx: usize) {
-        if idx < self.table.len() && self.table[idx].is_some() {
-            self.holes += 1;
-            self.table[idx] = None.into();
-        }
-    }
-
-    /// Get the entry for `idx`, or `None`.
-    pub fn get_entry(&self, idx: usize) -> Option<Ebb> {
-        self.table.get(idx).and_then(|e| e.expand())
-    }
-
-    /// Enumerate over all `(idx, dest)` pairs in the table in order.
-    ///
-    /// This returns an iterator that skips any empty slots in the table.
-    pub fn entries(&self) -> Entries {
-        Entries(self.table.iter().cloned().enumerate())
+        self.table.push(dest)
     }
 
     /// Checks if any of the entries branch to `ebb`.
     pub fn branches_to(&self, ebb: Ebb) -> bool {
-        self.table
-            .iter()
-            .any(|target_ebb| target_ebb.expand() == Some(ebb))
+        self.table.iter().any(|target_ebb| *target_ebb == ebb)
+    }
+
+    /// Access the whole table as a slice.
+    pub fn as_slice(&self) -> &[Ebb] {
+        self.table.as_slice()
     }
 
     /// Access the whole table as a mutable slice.
-    pub fn as_mut_slice(&mut self) -> &mut [PackedOption<Ebb>] {
+    pub fn as_mut_slice(&mut self) -> &mut [Ebb] {
         self.table.as_mut_slice()
     }
-}
 
-/// Enumerate `(idx, dest)` pairs in order.
-pub struct Entries<'a>(iter::Enumerate<iter::Cloned<slice::Iter<'a, PackedOption<Ebb>>>>);
+    /// Returns an iterator over the table.
+    pub fn iter(&self) -> Iter<Ebb> {
+        self.table.iter()
+    }
 
-impl<'a> Iterator for Entries<'a> {
-    type Item = (usize, Ebb);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Some((idx, dest)) = self.0.next() {
-                if let Some(ebb) = dest.expand() {
-                    return Some((idx, ebb));
-                }
-            } else {
-                return None;
-            }
-        }
+    /// Returns an iterator that allows modifying each value.
+    pub fn iter_mut(&mut self) -> IterMut<Ebb> {
+        self.table.iter_mut()
     }
 }
 
 impl Display for JumpTableData {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        match self.table.first().and_then(|e| e.expand()) {
-            None => write!(fmt, "jump_table 0")?,
-            Some(first) => write!(fmt, "jump_table {}", first)?,
+        write!(fmt, "jump_table [")?;
+        match self.table.first() {
+            None => (),
+            Some(first) => write!(fmt, "{}", first)?,
         }
-
-        for dest in self.table.iter().skip(1).map(|e| e.expand()) {
-            match dest {
-                None => write!(fmt, ", 0")?,
-                Some(ebb) => write!(fmt, ", {}", ebb)?,
-            }
+        for ebb in self.table.iter().skip(1) {
+            write!(fmt, ", {}", ebb)?;
         }
-        Ok(())
+        write!(fmt, "]")
     }
 }
 
@@ -148,18 +86,17 @@ mod tests {
     use entity::EntityRef;
     use ir::Ebb;
     use std::string::ToString;
-    use std::vec::Vec;
 
     #[test]
     fn empty() {
         let jt = JumpTableData::new();
 
-        assert_eq!(jt.get_entry(0), None);
-        assert_eq!(jt.get_entry(10), None);
+        assert_eq!(jt.as_slice().get(0), None);
+        assert_eq!(jt.as_slice().get(10), None);
 
-        assert_eq!(jt.to_string(), "jump_table 0");
+        assert_eq!(jt.to_string(), "jump_table []");
 
-        let v: Vec<(usize, Ebb)> = jt.entries().collect();
+        let v = jt.as_slice();
         assert_eq!(v, []);
     }
 
@@ -170,16 +107,13 @@ mod tests {
 
         let mut jt = JumpTableData::new();
 
-        jt.set_entry(0, e1);
-        jt.set_entry(0, e2);
-        jt.set_entry(10, e1);
+        jt.push_entry(e1);
+        jt.push_entry(e2);
+        jt.push_entry(e1);
 
-        assert_eq!(
-            jt.to_string(),
-            "jump_table ebb2, 0, 0, 0, 0, 0, 0, 0, 0, 0, ebb1"
-        );
+        assert_eq!(jt.to_string(), "jump_table [ebb1, ebb2, ebb1]");
 
-        let v: Vec<(usize, Ebb)> = jt.entries().collect();
-        assert_eq!(v, [(0, e2), (10, e1)]);
+        let v = jt.as_slice();
+        assert_eq!(v, [e1, e2, e1]);
     }
 }

--- a/lib/codegen/src/regalloc/coloring.rs
+++ b/lib/codegen/src/regalloc/coloring.rs
@@ -907,8 +907,8 @@ impl<'a> Context<'a> {
                         .cur
                         .func
                         .jump_tables[jt]
-                        .entries()
-                        .any(|(_, ebb)| lr.is_livein(ebb, ctx)))
+                        .iter()
+                        .any(|ebb| lr.is_livein(*ebb, ctx)))
             }
         }
     }

--- a/lib/codegen/src/verifier/flags.rs
+++ b/lib/codegen/src/verifier/flags.rs
@@ -141,8 +141,8 @@ impl<'a> FlagsVerifier<'a> {
                             merge(&mut live_val, val, inst, errors)?;
                         }
                     }
-                    for (_, dest) in self.func.jump_tables[jt].entries() {
-                        if let Some(val) = self.livein[dest].expand() {
+                    for dest in self.func.jump_tables[jt].iter() {
+                        if let Some(val) = self.livein[*dest].expand() {
                             merge(&mut live_val, val, inst, errors)?;
                         }
                     }

--- a/lib/codegen/src/verifier/locations.rs
+++ b/lib/codegen/src/verifier/locations.rs
@@ -347,8 +347,8 @@ impl<'a> LocationVerifier<'a> {
                             );
                         }
                     }
-                    for (_, ebb) in self.func.jump_tables[jt].entries() {
-                        if lr.is_livein(ebb, liveness.context(&self.func.layout)) {
+                    for ebb in self.func.jump_tables[jt].iter() {
+                        if lr.is_livein(*ebb, liveness.context(&self.func.layout)) {
                             return fatal!(
                                 errors,
                                 inst,

--- a/lib/codegen/src/verifier/mod.rs
+++ b/lib/codegen/src/verifier/mod.rs
@@ -1229,8 +1229,8 @@ impl<'a> Verifier<'a> {
                         );
                     }
                 }
-                for (_, ebb) in self.func.jump_tables[table].entries() {
-                    let arg_count = self.func.dfg.num_ebb_params(ebb);
+                for ebb in self.func.jump_tables[table].iter() {
+                    let arg_count = self.func.dfg.num_ebb_params(*ebb);
                     if arg_count != 0 {
                         return nonfatal!(
                             errors,

--- a/lib/filetests/src/test_binemit.rs
+++ b/lib/filetests/src/test_binemit.rs
@@ -291,14 +291,9 @@ impl SubTest for TestBinEmit {
 
         for (jt, jt_data) in func.jump_tables.iter() {
             let jt_offset = func.jt_offsets[jt];
-            for idx in 0..jt_data.len() {
-                match jt_data.get_entry(idx) {
-                    Some(ebb) => {
-                        let rel_offset: i32 = func.offsets[ebb] as i32 - jt_offset as i32;
-                        sink.put4(rel_offset as u32)
-                    }
-                    None => sink.put4(0),
-                }
+            for ebb in jt_data.iter() {
+                let rel_offset: i32 = func.offsets[*ebb] as i32 - jt_offset as i32;
+                sink.put4(rel_offset as u32)
             }
         }
 

--- a/lib/frontend/src/frontend.rs
+++ b/lib/frontend/src/frontend.rs
@@ -152,12 +152,11 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
                             .jump_tables
                             .get(table)
                             .expect("you are referencing an undeclared jump table")
-                            .entries()
-                            .map(|(_, ebb)| ebb)
-                            .filter(|dest_ebb| unique.insert(*dest_ebb))
+                            .iter()
+                            .filter(|&dest_ebb| unique.insert(*dest_ebb))
                         {
                             self.builder.func_ctx.ssa.declare_ebb_predecessor(
-                                dest_ebb,
+                                *dest_ebb,
                                 self.builder.position.basic_block.unwrap(),
                                 inst,
                             )
@@ -334,11 +333,6 @@ impl<'a> FunctionBuilder<'a> {
     /// Creates a jump table in the function, to be used by `br_table` instructions.
     pub fn create_jump_table(&mut self, data: JumpTableData) -> JumpTable {
         self.func.create_jump_table(data)
-    }
-
-    /// Inserts an entry in a previously declared jump table.
-    pub fn insert_jump_table_entry(&mut self, jt: JumpTable, index: usize, ebb: Ebb) {
-        self.func.insert_jump_table_entry(jt, index, ebb)
     }
 
     /// Creates a stack slot in the function, to be used by `stack_load`, `stack_store` and

--- a/lib/frontend/src/ssa.rs
+++ b/lib/frontend/src/ssa.rs
@@ -672,8 +672,8 @@ impl SSABuilder {
                 }
 
                 for old_dest in func.jump_tables[jt].as_mut_slice() {
-                    if *old_dest == PackedOption::from(dest_ebb) {
-                        *old_dest = PackedOption::from(middle_ebb);
+                    if *old_dest == dest_ebb {
+                        *old_dest = middle_ebb;
                     }
                 }
                 let mut cur = FuncCursor::new(func).at_bottom(middle_ebb);
@@ -1005,7 +1005,7 @@ mod tests {
         // Here is the pseudo-program we want to translate:
         //
         // function %f {
-        // jt = jump_table ebb2, 0, ebb1
+        // jt = jump_table [ebb2, ebb1]
         // ebb0:
         //    x = 1;
         //    br_table x, ebb2, jt
@@ -1039,9 +1039,9 @@ mod tests {
         };
         ssa.def_var(x_var, x1, block0);
 
-        // jt = jump_table ebb2, 0, ebb1
+        // jt = jump_table [ebb2, ebb1]
         jump_table.push_entry(ebb2);
-        jump_table.set_entry(2, ebb1);
+        jump_table.push_entry(ebb1);
         let jt = func.create_jump_table(jump_table);
 
         // ebb0:

--- a/lib/frontend/src/switch.rs
+++ b/lib/frontend/src/switch.rs
@@ -244,7 +244,7 @@ mod tests {
         let func = setup!(0, [0, 1,]);
         assert_eq!(
             func,
-            "    jt0 = jump_table ebb1, ebb2
+            "    jt0 = jump_table [ebb1, ebb2]
 
 ebb0:
     v0 = iconst.i8 0
@@ -280,8 +280,8 @@ ebb3:
         let func = setup!(0, [0, 1, 5, 7, 10, 11, 12,]);
         assert_eq!(
             func,
-            "    jt0 = jump_table ebb1, ebb2
-    jt1 = jump_table ebb5, ebb6, ebb7
+            "    jt0 = jump_table [ebb1, ebb2]
+    jt1 = jump_table [ebb5, ebb6, ebb7]
 
 ebb0:
     v0 = iconst.i8 0

--- a/lib/reader/src/sourcemap.rs
+++ b/lib/reader/src/sourcemap.rs
@@ -218,7 +218,7 @@ mod tests {
         let tf = parse_test(
             "function %detail() {
                                ss10 = incoming_arg 13
-                               jt10 = jump_table ebb0
+                               jt10 = jump_table [ebb0]
                              ebb0(v4: i32, v7: i32):
                                v10 = iadd v4, v7
                              }",


### PR DESCRIPTION
WebAssembly doesn't have non-dense jump tables, and higher-level users
are better served by the facilities in lib/frontend/src/switch.rs for
working with non-dense switches.

This eliminates the concept of "absent" jump table entries, which
were represented as "0" in the text format.

Also, jump table contents are now enclosed in `[` and `]`, so that
we can unambiguously display empty jump tables. Previously, empty jump
tables were displayed as if they had a single absent entry.