### PR TITLE
Optimize load/store with an iadd_imm operand.

### DIFF
--- a/filetests/postopt/fold_offset_into_address.clif
+++ b/filetests/postopt/fold_offset_into_address.clif
@@ -1,0 +1,18 @@
+test postopt
+target x86_64
+
+; Fold the immediate of an iadd_imm into an address offset.
+
+function u0:0(i64 vmctx) -> i64 {
+ebb0(v0: i64):
+                     v1 = iadd_imm.i64 v0, 16
+[RexOp1ldDisp8#808b] v2 = load.i64 notrap aligned v1
+[Op1ret#c3]          return v2
+}
+
+; sameln: function u0:0(i64 vmctx) -> i64 fast {
+; nextln: ebb0(v0: i64):
+; nextln:                                     v1 = iadd_imm v0, 16
+; nextln: [RexOp1ldDisp8#808b]                v2 = load.i64 notrap aligned v0+16
+; nextln: [Op1ret#c3]                         return v2
+; nextln: }

--- a/lib/codegen/src/ir/immediates.rs
+++ b/lib/codegen/src/ir/immediates.rs
@@ -224,6 +224,16 @@ impl Offset32 {
             None
         }
     }
+
+    /// Add in the signed number `x` if possible.
+    pub fn try_add_i64(self, x: i64) -> Option<Self> {
+        let casted = x as i32;
+        if casted as i64 == x {
+            self.0.checked_add(casted).map(Self::new)
+        } else {
+            None
+        }
+    }
 }
 
 impl Into<i32> for Offset32 {


### PR DESCRIPTION
Fold the immediate into the load/store offset when possible.

I'm hoping to avoid doing too many special-case pattern matches like this, as I'm looking forward to developing a more comprehensive pattern-matching system, but it does make sense to do a few simple and common ones for now.