### PR TITLE
Use types to represent wasm global/table/memory/signature indices

### DIFF
--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -403,13 +403,13 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::MemoryGrow { reserved } => {
             // The WebAssembly MVP only supports one linear memory, but we expect the reserved
             // argument to be a memory index.
-            let heap_index = reserved as MemoryIndex;
+            let heap_index = MemoryIndex::new(reserved as usize);
             let heap = state.get_heap(builder.func, reserved, environ);
             let val = state.pop1();
             state.push1(environ.translate_memory_grow(builder.cursor(), heap_index, heap, val)?)
         }
         Operator::MemorySize { reserved } => {
-            let heap_index = reserved as MemoryIndex;
+            let heap_index = MemoryIndex::new(reserved as usize);
             let heap = state.get_heap(builder.func, reserved, environ);
             state.push1(environ.translate_memory_size(builder.cursor(), heap_index, heap)?);
         }

--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -382,7 +382,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 builder.cursor(),
                 TableIndex::new(table_index as usize),
                 table,
-                index as SignatureIndex,
+                SignatureIndex::new(index as usize),
                 sigref,
                 callee,
                 state.peekn(num_args),

--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -380,7 +380,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let callee = state.pop1();
             let call = environ.translate_call_indirect(
                 builder.cursor(),
-                table_index as TableIndex,
+                TableIndex::new(table_index as usize),
                 table,
                 index as SignatureIndex,
                 sigref,

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -51,7 +51,7 @@ pub struct DummyModuleInfo {
     pub flags: settings::Flags,
 
     /// Signatures as provided by `declare_signature`.
-    pub signatures: Vec<ir::Signature>,
+    pub signatures: PrimaryMap<SignatureIndex, ir::Signature>,
 
     /// Module and field names of imported functions as provided by `declare_func_import`.
     pub imported_funcs: Vec<(String, String)>,
@@ -63,13 +63,13 @@ pub struct DummyModuleInfo {
     pub function_bodies: PrimaryMap<DefinedFuncIndex, ir::Function>,
 
     /// Tables as provided by `declare_table`.
-    pub tables: Vec<Exportable<Table>>,
+    pub tables: PrimaryMap<TableIndex, Exportable<Table>>,
 
     /// Memories as provided by `declare_memory`.
-    pub memories: Vec<Exportable<Memory>>,
+    pub memories: PrimaryMap<MemoryIndex, Exportable<Memory>>,
 
     /// Globals as provided by `declare_global`.
-    pub globals: Vec<Exportable<Global>>,
+    pub globals: PrimaryMap<GlobalIndex, Exportable<Global>>,
 
     /// The start function.
     pub start_func: Option<FuncIndex>,
@@ -81,13 +81,13 @@ impl DummyModuleInfo {
         Self {
             triple,
             flags,
-            signatures: Vec::new(),
+            signatures: PrimaryMap::new(),
             imported_funcs: Vec::new(),
             functions: PrimaryMap::new(),
             function_bodies: PrimaryMap::new(),
-            tables: Vec::new(),
-            memories: Vec::new(),
-            globals: Vec::new(),
+            tables: PrimaryMap::new(),
+            memories: PrimaryMap::new(),
+            globals: PrimaryMap::new(),
             start_func: None,
         }
     }
@@ -159,7 +159,7 @@ impl<'dummy_environment> DummyFuncEnvironment<'dummy_environment> {
     // Create a signature for `sigidx` amended with a `vmctx` argument after the standard wasm
     // arguments.
     fn vmctx_sig(&self, sigidx: SignatureIndex) -> ir::Signature {
-        let mut sig = self.mod_info.signatures[sigidx.index()].clone();
+        let mut sig = self.mod_info.signatures[sigidx].clone();
         sig.params.push(ir::AbiParam::special(
             self.pointer_type(),
             ir::ArgumentPurpose::VMContext,
@@ -188,7 +188,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         });
         GlobalVariable::Memory {
             gv: iadd,
-            ty: self.mod_info.globals[index.index()].entity.ty,
+            ty: self.mod_info.globals[index].entity.ty,
         }
     }
 
@@ -358,7 +358,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     }
 
     fn get_signature(&self, sig_index: SignatureIndex) -> &ir::Signature {
-        &self.info.signatures[sig_index.index()]
+        &self.info.signatures[sig_index]
     }
 
     fn declare_func_import(
@@ -395,7 +395,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     }
 
     fn get_global(&self, global_index: GlobalIndex) -> &Global {
-        &self.info.globals[global_index.index()].entity
+        &self.info.globals[global_index].entity
     }
 
     fn declare_table(&mut self, table: Table) {
@@ -430,19 +430,19 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     }
 
     fn declare_table_export(&mut self, table_index: TableIndex, name: &'data str) {
-        self.info.tables[table_index.index()]
+        self.info.tables[table_index]
             .export_names
             .push(String::from(name));
     }
 
     fn declare_memory_export(&mut self, memory_index: MemoryIndex, name: &'data str) {
-        self.info.memories[memory_index.index()]
+        self.info.memories[memory_index]
             .export_names
             .push(String::from(name));
     }
 
     fn declare_global_export(&mut self, global_index: GlobalIndex, name: &'data str) {
-        self.info.globals[global_index.index()]
+        self.info.globals[global_index]
             .export_names
             .push(String::from(name));
     }

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -436,7 +436,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     }
 
     fn declare_memory_export(&mut self, memory_index: MemoryIndex, name: &'data str) {
-        self.info.memories[memory_index]
+        self.info.memories[memory_index.index()]
             .export_names
             .push(String::from(name));
     }

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -430,7 +430,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     }
 
     fn declare_table_export(&mut self, table_index: TableIndex, name: &'data str) {
-        self.info.tables[table_index]
+        self.info.tables[table_index.index()]
             .export_names
             .push(String::from(name));
     }

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -179,7 +179,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
 
     fn make_global(&mut self, func: &mut ir::Function, index: GlobalIndex) -> GlobalVariable {
         // Just create a dummy `vmctx` global.
-        let offset = ((index * 8) as i64 + 8).into();
+        let offset = ((index.index() * 8) as i64 + 8).into();
         let vmctx = func.create_global_value(ir::GlobalValueData::VMContext {});
         let iadd = func.create_global_value(ir::GlobalValueData::IAddImm {
             base: vmctx,
@@ -188,7 +188,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         });
         GlobalVariable::Memory {
             gv: iadd,
-            ty: self.mod_info.globals[index].entity.ty,
+            ty: self.mod_info.globals[index.index()].entity.ty,
         }
     }
 
@@ -395,7 +395,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     }
 
     fn get_global(&self, global_index: GlobalIndex) -> &Global {
-        &self.info.globals[global_index].entity
+        &self.info.globals[global_index.index()].entity
     }
 
     fn declare_table(&mut self, table: Table) {
@@ -442,7 +442,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     }
 
     fn declare_global_export(&mut self, global_index: GlobalIndex, name: &'data str) {
-        self.info.globals[global_index]
+        self.info.globals[global_index.index()]
             .export_names
             .push(String::from(name));
     }

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -159,7 +159,7 @@ impl<'dummy_environment> DummyFuncEnvironment<'dummy_environment> {
     // Create a signature for `sigidx` amended with a `vmctx` argument after the standard wasm
     // arguments.
     fn vmctx_sig(&self, sigidx: SignatureIndex) -> ir::Signature {
-        let mut sig = self.mod_info.signatures[sigidx].clone();
+        let mut sig = self.mod_info.signatures[sigidx.index()].clone();
         sig.params.push(ir::AbiParam::special(
             self.pointer_type(),
             ir::ArgumentPurpose::VMContext,
@@ -358,7 +358,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     }
 
     fn get_signature(&self, sig_index: SignatureIndex) -> &ir::Signature {
-        &self.info.signatures[sig_index]
+        &self.info.signatures[sig_index.index()]
     }
 
     fn declare_func_import(

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -157,7 +157,9 @@ pub fn parse_export_section<'data>(
                     ExternalKind::Table => {
                         environ.declare_table_export(TableIndex::new(func_index.index()), name)
                     }
-                    ExternalKind::Memory => environ.declare_memory_export(func_index.index(), name),
+                    ExternalKind::Memory => {
+                        environ.declare_memory_export(MemoryIndex::new(func_index.index()), name)
+                    }
                     ExternalKind::Global => {
                         environ.declare_global_export(GlobalIndex::new(func_index.index()), name)
                     }
@@ -316,7 +318,7 @@ pub fn parse_data_section<'data>(
                 ref s => panic!("unexpected section content: {:?}", s),
             };
             environ.declare_data_initialization(
-                memory_index as MemoryIndex,
+                MemoryIndex::new(memory_index as usize),
                 base,
                 running_offset,
                 data,

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -158,7 +158,9 @@ pub fn parse_export_section<'data>(
                         environ.declare_table_export(TableIndex::new(func_index.index()), name)
                     }
                     ExternalKind::Memory => environ.declare_memory_export(func_index.index(), name),
-                    ExternalKind::Global => environ.declare_global_export(func_index.index(), name),
+                    ExternalKind::Global => {
+                        environ.declare_global_export(GlobalIndex::new(func_index.index()), name)
+                    }
                 }
             }
             ParserState::EndSection => break,
@@ -237,7 +239,7 @@ pub fn parse_global_section(
                 GlobalInit::F64Const(value.bits())
             }
             ParserState::InitExpressionOperator(Operator::GetGlobal { global_index }) => {
-                GlobalInit::GlobalRef(global_index as GlobalIndex)
+                GlobalInit::GlobalRef(GlobalIndex::new(global_index as usize))
             }
             ParserState::Error(e) => return Err(WasmError::from_binary_reader_error(e)),
             ref s => panic!("unexpected section content: {:?}", s),
@@ -283,9 +285,12 @@ pub fn parse_data_section<'data>(
                 (None, value as u32 as usize)
             }
             ParserState::InitExpressionOperator(Operator::GetGlobal { global_index }) => {
-                match environ.get_global(global_index as GlobalIndex).initializer {
+                match environ
+                    .get_global(GlobalIndex::new(global_index as usize))
+                    .initializer
+                {
                     GlobalInit::I32Const(value) => (None, value as u32 as usize),
-                    GlobalInit::Import() => (Some(global_index as GlobalIndex), 0),
+                    GlobalInit::Import() => (Some(GlobalIndex::new(global_index as usize)), 0),
                     _ => panic!("should not happen"),
                 }
             }
@@ -371,9 +376,12 @@ pub fn parse_elements_section(
                 (None, value as u32 as usize)
             }
             ParserState::InitExpressionOperator(Operator::GetGlobal { global_index }) => {
-                match environ.get_global(global_index as GlobalIndex).initializer {
+                match environ
+                    .get_global(GlobalIndex::new(global_index as usize))
+                    .initializer
+                {
                     GlobalInit::I32Const(value) => (None, value as u32 as usize),
-                    GlobalInit::Import() => (Some(global_index as GlobalIndex), 0),
+                    GlobalInit::Import() => (Some(GlobalIndex::new(global_index as usize)), 0),
                     _ => panic!("should not happen"),
                 }
             }

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -72,7 +72,11 @@ pub fn parse_import_section<'data>(
                 // becomes a concern here.
                 let module_name = from_utf8(module).unwrap();
                 let field_name = from_utf8(field).unwrap();
-                environ.declare_func_import(sig as SignatureIndex, module_name, field_name);
+                environ.declare_func_import(
+                    SignatureIndex::new(sig as usize),
+                    module_name,
+                    field_name,
+                );
             }
             ParserState::ImportSectionEntry {
                 ty:
@@ -125,7 +129,7 @@ pub fn parse_function_section(
     loop {
         match *parser.read() {
             ParserState::FunctionSectionEntry(sigindex) => {
-                environ.declare_func_type(sigindex as SignatureIndex);
+                environ.declare_func_type(SignatureIndex::new(sigindex as usize));
             }
             ParserState::EndSection => break,
             ParserState::Error(e) => return Err(WasmError::from_binary_reader_error(e)),

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -155,17 +155,19 @@ pub fn parse_export_section<'data>(
                 // assume valid UTF-8 and use `from_utf8_unchecked` if performance
                 // becomes a concern here.
                 let name = from_utf8(field).unwrap();
-                let func_index = FuncIndex::new(index as usize);
+                let index = index as usize;
                 match *kind {
-                    ExternalKind::Function => environ.declare_func_export(func_index, name),
+                    ExternalKind::Function => {
+                        environ.declare_func_export(FuncIndex::new(index), name)
+                    }
                     ExternalKind::Table => {
-                        environ.declare_table_export(TableIndex::new(func_index.index()), name)
+                        environ.declare_table_export(TableIndex::new(index), name)
                     }
                     ExternalKind::Memory => {
-                        environ.declare_memory_export(MemoryIndex::new(func_index.index()), name)
+                        environ.declare_memory_export(MemoryIndex::new(index), name)
                     }
                     ExternalKind::Global => {
-                        environ.declare_global_export(GlobalIndex::new(func_index.index()), name)
+                        environ.declare_global_export(GlobalIndex::new(index), name)
                     }
                 }
             }

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -154,7 +154,9 @@ pub fn parse_export_section<'data>(
                 let func_index = FuncIndex::new(index as usize);
                 match *kind {
                     ExternalKind::Function => environ.declare_func_export(func_index, name),
-                    ExternalKind::Table => environ.declare_table_export(func_index.index(), name),
+                    ExternalKind::Table => {
+                        environ.declare_table_export(TableIndex::new(func_index.index()), name)
+                    }
                     ExternalKind::Memory => environ.declare_memory_export(func_index.index(), name),
                     ExternalKind::Global => environ.declare_global_export(func_index.index(), name),
                 }
@@ -352,7 +354,9 @@ pub fn parse_elements_section(
 ) -> WasmResult<()> {
     loop {
         let table_index = match *parser.read() {
-            ParserState::BeginElementSectionEntry(table_index) => table_index as TableIndex,
+            ParserState::BeginElementSectionEntry(table_index) => {
+                TableIndex::new(table_index as usize)
+            }
             ParserState::EndSection => break,
             ParserState::Error(e) => return Err(WasmError::from_binary_reader_error(e)),
             ref s => panic!("unexpected section content: {:?}", s),

--- a/lib/wasm/src/state.rs
+++ b/lib/wasm/src/state.rs
@@ -302,7 +302,7 @@ impl TranslationState {
         index: u32,
         environ: &mut FE,
     ) -> ir::Heap {
-        let index = index as MemoryIndex;
+        let index = MemoryIndex::new(index as usize);
         *self
             .heaps
             .entry(index)

--- a/lib/wasm/src/state.rs
+++ b/lib/wasm/src/state.rs
@@ -334,7 +334,7 @@ impl TranslationState {
         index: u32,
         environ: &mut FE,
     ) -> (ir::SigRef, usize) {
-        let index = index as SignatureIndex;
+        let index = SignatureIndex::new(index as usize);
         *self.signatures.entry(index).or_insert_with(|| {
             let sig = environ.make_indirect_sig(func, index);
             (sig, normal_args(&func.dfg.signatures[sig]))

--- a/lib/wasm/src/state.rs
+++ b/lib/wasm/src/state.rs
@@ -287,7 +287,7 @@ impl TranslationState {
         index: u32,
         environ: &mut FE,
     ) -> GlobalVariable {
-        let index = index as GlobalIndex;
+        let index = GlobalIndex::new(index as usize);
         *self
             .globals
             .entry(index)

--- a/lib/wasm/src/state.rs
+++ b/lib/wasm/src/state.rs
@@ -317,7 +317,7 @@ impl TranslationState {
         index: u32,
         environ: &mut FE,
     ) -> ir::Table {
-        let index = index as TableIndex;
+        let index = TableIndex::new(index as usize);
         *self
             .tables
             .entry(index)

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -18,8 +18,11 @@ entity_impl!(DefinedFuncIndex);
 pub struct TableIndex(u32);
 entity_impl!(TableIndex);
 
-/// Index of a global variable (imported or defined) inside the WebAssembly module.
-pub type GlobalIndex = usize;
+/// Index type of a global variable (imported or defined) inside the WebAssembly module.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct GlobalIndex(u32);
+entity_impl!(GlobalIndex);
+
 /// Index of a linear memory (imported or defined) inside the WebAssembly module.
 pub type MemoryIndex = usize;
 /// Index of a signature (imported or defined) inside the WebAssembly module.

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -28,8 +28,10 @@ entity_impl!(GlobalIndex);
 pub struct MemoryIndex(u32);
 entity_impl!(MemoryIndex);
 
-/// Index of a signature (imported or defined) inside the WebAssembly module.
-pub type SignatureIndex = usize;
+/// Index type of a signature (imported or defined) inside the WebAssembly module.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct SignatureIndex(u32);
+entity_impl!(SignatureIndex);
 
 /// WebAssembly global.
 #[derive(Debug, Clone, Copy)]

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -13,8 +13,11 @@ entity_impl!(FuncIndex);
 pub struct DefinedFuncIndex(u32);
 entity_impl!(DefinedFuncIndex);
 
-/// Index of a table (imported or defined) inside the WebAssembly module.
-pub type TableIndex = usize;
+/// Index type of a table (imported or defined) inside the WebAssembly module.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct TableIndex(u32);
+entity_impl!(TableIndex);
+
 /// Index of a global variable (imported or defined) inside the WebAssembly module.
 pub type GlobalIndex = usize;
 /// Index of a linear memory (imported or defined) inside the WebAssembly module.

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -23,8 +23,11 @@ entity_impl!(TableIndex);
 pub struct GlobalIndex(u32);
 entity_impl!(GlobalIndex);
 
-/// Index of a linear memory (imported or defined) inside the WebAssembly module.
-pub type MemoryIndex = usize;
+/// Index type of a linear memory (imported or defined) inside the WebAssembly module.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct MemoryIndex(u32);
+entity_impl!(MemoryIndex);
+
 /// Index of a signature (imported or defined) inside the WebAssembly module.
 pub type SignatureIndex = usize;
 


### PR DESCRIPTION
fix #489 