### PR TITLE
Update to the new wasmparser and port to the new readers API.

### DIFF
--- a/lib/wasm/Cargo.toml
+++ b/lib/wasm/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["webassembly", "wasm"]
 
 [dependencies]
-wasmparser = { version = "0.19.1", default-features = false }
+wasmparser = { version = "0.21.4", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.22.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.22.0", default-features = false }
 cranelift-frontend = { path = "../frontend", version = "0.22.0", default-features = false }

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -3,6 +3,7 @@
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::{self, InstBuilder};
 use cranelift_codegen::isa::TargetFrontendConfig;
+use std::convert::From;
 use std::vec::Vec;
 use translation_utils::{
     FuncIndex, Global, GlobalIndex, Memory, MemoryIndex, SignatureIndex, Table, TableIndex,
@@ -62,9 +63,9 @@ pub enum WasmError {
     ImplLimitExceeded,
 }
 
-impl WasmError {
+impl From<BinaryReaderError> for WasmError {
     /// Convert from a `BinaryReaderError` to a `WasmError`.
-    pub fn from_binary_reader_error(e: BinaryReaderError) -> Self {
+    fn from(e: BinaryReaderError) -> Self {
         let BinaryReaderError { message, offset } = e;
         WasmError::InvalidWebAssembly { message, offset }
     }

--- a/lib/wasm/src/func_translator.rs
+++ b/lib/wasm/src/func_translator.rs
@@ -9,7 +9,7 @@ use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir::{self, Ebb, InstBuilder};
 use cranelift_codegen::timing;
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
-use environ::{FuncEnvironment, ReturnMode, WasmError, WasmResult};
+use environ::{FuncEnvironment, ReturnMode, WasmResult};
 use state::TranslationState;
 use wasmparser::{self, BinaryReader};
 
@@ -135,16 +135,12 @@ fn parse_local_decls(
     num_params: usize,
 ) -> WasmResult<()> {
     let mut next_local = num_params;
-    let local_count = reader
-        .read_local_count()
-        .map_err(WasmError::from_binary_reader_error)?;
+    let local_count = reader.read_local_count()?;
 
     let mut locals_total = 0;
     for _ in 0..local_count {
         builder.set_srcloc(cur_srcloc(reader));
-        let (count, ty) = reader
-            .read_local_decl(&mut locals_total)
-            .map_err(WasmError::from_binary_reader_error)?;
+        let (count, ty) = reader.read_local_decl(&mut locals_total)?;
         declare_locals(builder, count, ty, &mut next_local);
     }
 
@@ -195,9 +191,7 @@ fn parse_function_body<FE: FuncEnvironment + ?Sized>(
     // Keep going until the final `End` operator which pops the outermost block.
     while !state.control_stack.is_empty() {
         builder.set_srcloc(cur_srcloc(&reader));
-        let op = reader
-            .read_operator()
-            .map_err(WasmError::from_binary_reader_error)?;
+        let op = reader.read_operator()?;
         translate_operator(op, builder, state, environ)?;
     }
 

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -76,6 +76,7 @@ mod std {
 
     pub use self::alloc::string;
     pub use self::alloc::vec;
+    pub use core::convert;
     pub use core::fmt;
     pub use core::option;
     pub use core::{cmp, i32, str, u32};

--- a/lib/wasm/src/module_translator.rs
+++ b/lib/wasm/src/module_translator.rs
@@ -1,119 +1,143 @@
 //! Translation skeleton that traverses the whole WebAssembly module and call helper functions
 //! to deal with each part of it.
 use cranelift_codegen::timing;
-use environ::{ModuleEnvironment, WasmError, WasmResult};
+use environ::{ModuleEnvironment, WasmResult};
 use sections_translator::{
     parse_code_section, parse_data_section, parse_element_section, parse_export_section,
-    parse_function_section, parse_function_signatures, parse_global_section, parse_import_section,
-    parse_memory_section, parse_start_section, parse_table_section,
+    parse_function_section, parse_global_section, parse_import_section, parse_memory_section,
+    parse_start_section, parse_table_section, parse_type_section,
 };
-use wasmparser::{Parser, ParserInput, ParserState, SectionCode, WasmDecoder};
+use wasmparser::{ModuleReader, SectionCode};
 
 /// Translate a sequence of bytes forming a valid Wasm binary into a list of valid Cranelift IR
 /// [`Function`](../codegen/ir/function/struct.Function.html).
-/// Returns the functions and also the mappings for imported functions and signature between the
-/// indexes in the wasm module and the indexes inside each functions.
 pub fn translate_module<'data>(
     data: &'data [u8],
     environ: &mut ModuleEnvironment<'data>,
 ) -> WasmResult<()> {
     let _tt = timing::wasm_translate_module();
-    let mut parser = Parser::new(data);
-    match *parser.read() {
-        ParserState::BeginWasm { .. } => {}
-        ParserState::Error(e) => {
-            return Err(WasmError::from_binary_reader_error(e));
+    let mut reader = ModuleReader::new(data)?;
+
+    reader.skip_custom_sections()?;
+    if reader.eof() {
+        return Ok(());
+    }
+    let mut section = reader.read()?;
+
+    if let SectionCode::Type = section.code {
+        let types = section.get_type_section_reader()?;
+        parse_type_section(types, environ)?;
+
+        reader.skip_custom_sections()?;
+        if reader.eof() {
+            return Ok(());
         }
-        ref s => panic!("modules should begin properly: {:?}", s),
+        section = reader.read()?;
     }
-    let mut next_input = ParserInput::Default;
-    loop {
-        match *parser.read_with_input(next_input) {
-            ParserState::BeginSection {
-                code: SectionCode::Type,
-                ..
-            } => {
-                parse_function_signatures(&mut parser, environ)?;
-                next_input = ParserInput::Default;
-            }
-            ParserState::BeginSection {
-                code: SectionCode::Import,
-                ..
-            } => {
-                parse_import_section(&mut parser, environ)?;
-                next_input = ParserInput::Default;
-            }
-            ParserState::BeginSection {
-                code: SectionCode::Function,
-                ..
-            } => {
-                parse_function_section(&mut parser, environ)?;
-                next_input = ParserInput::Default;
-            }
-            ParserState::BeginSection {
-                code: SectionCode::Table,
-                ..
-            } => {
-                parse_table_section(&mut parser, environ)?;
-            }
-            ParserState::BeginSection {
-                code: SectionCode::Memory,
-                ..
-            } => {
-                parse_memory_section(&mut parser, environ)?;
-                next_input = ParserInput::Default;
-            }
-            ParserState::BeginSection {
-                code: SectionCode::Global,
-                ..
-            } => {
-                parse_global_section(&mut parser, environ)?;
-                next_input = ParserInput::Default;
-            }
-            ParserState::BeginSection {
-                code: SectionCode::Export,
-                ..
-            } => {
-                parse_export_section(&mut parser, environ)?;
-                next_input = ParserInput::Default;
-            }
-            ParserState::BeginSection {
-                code: SectionCode::Start,
-                ..
-            } => {
-                parse_start_section(&mut parser, environ)?;
-                next_input = ParserInput::Default;
-            }
-            ParserState::BeginSection {
-                code: SectionCode::Element,
-                ..
-            } => {
-                parse_element_section(&mut parser, environ)?;
-                next_input = ParserInput::Default;
-            }
-            ParserState::BeginSection {
-                code: SectionCode::Code,
-                ..
-            } => parse_code_section(&mut parser, environ)?,
-            ParserState::EndSection => {
-                next_input = ParserInput::Default;
-            }
-            ParserState::EndWasm => return Ok(()),
-            ParserState::BeginSection {
-                code: SectionCode::Data,
-                ..
-            } => {
-                parse_data_section(&mut parser, environ)?;
-            }
-            ParserState::BeginSection {
-                code: SectionCode::Custom { .. },
-                ..
-            } => {
-                // Ignore unknown custom sections.
-                next_input = ParserInput::SkipSection;
-            }
-            ParserState::Error(e) => return Err(WasmError::from_binary_reader_error(e)),
-            _ => panic!("wrong content in the preamble"),
-        };
+
+    if let SectionCode::Import = section.code {
+        let imports = section.get_import_section_reader()?;
+        parse_import_section(imports, environ)?;
+
+        reader.skip_custom_sections()?;
+        if reader.eof() {
+            return Ok(());
+        }
+        section = reader.read()?;
     }
+
+    if let SectionCode::Function = section.code {
+        let functions = section.get_function_section_reader()?;
+        parse_function_section(functions, environ)?;
+
+        reader.skip_custom_sections()?;
+        if reader.eof() {
+            return Ok(());
+        }
+        section = reader.read()?;
+    }
+
+    if let SectionCode::Table = section.code {
+        let tables = section.get_table_section_reader()?;
+        parse_table_section(tables, environ)?;
+
+        reader.skip_custom_sections()?;
+        if reader.eof() {
+            return Ok(());
+        }
+        section = reader.read()?;
+    }
+
+    if let SectionCode::Memory = section.code {
+        let memories = section.get_memory_section_reader()?;
+        parse_memory_section(memories, environ)?;
+
+        reader.skip_custom_sections()?;
+        if reader.eof() {
+            return Ok(());
+        }
+        section = reader.read()?;
+    }
+
+    if let SectionCode::Global = section.code {
+        let globals = section.get_global_section_reader()?;
+        parse_global_section(globals, environ)?;
+
+        reader.skip_custom_sections()?;
+        if reader.eof() {
+            return Ok(());
+        }
+        section = reader.read()?;
+    }
+
+    if let SectionCode::Export = section.code {
+        let exports = section.get_export_section_reader()?;
+        parse_export_section(exports, environ)?;
+
+        reader.skip_custom_sections()?;
+        if reader.eof() {
+            return Ok(());
+        }
+        section = reader.read()?;
+    }
+
+    if let SectionCode::Start = section.code {
+        let start = section.get_start_section_content()?;
+        parse_start_section(start, environ)?;
+
+        reader.skip_custom_sections()?;
+        if reader.eof() {
+            return Ok(());
+        }
+        section = reader.read()?;
+    }
+
+    if let SectionCode::Element = section.code {
+        let elements = section.get_element_section_reader()?;
+        parse_element_section(elements, environ)?;
+
+        reader.skip_custom_sections()?;
+        if reader.eof() {
+            return Ok(());
+        }
+        section = reader.read()?;
+    }
+
+    if let SectionCode::Code = section.code {
+        let code = section.get_code_section_reader()?;
+        parse_code_section(code, environ)?;
+
+        reader.skip_custom_sections()?;
+        if reader.eof() {
+            return Ok(());
+        }
+        section = reader.read()?;
+    }
+
+    if let SectionCode::Data = section.code {
+        let data = section.get_data_section_reader()?;
+        parse_data_section(data, environ)?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
The new wasmparser API provides dedicated reader types for each section
type, which significantly simplifies the code.

This also changes WasmError::from_binary_reader_error into a From
trait so that we don't have to do .map_err(from_binary_reader_error)
throughout the code.