### PR TITLE
Update the minimum supported Rust version to 1.29.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@
 
 language: rust
 rust:
-    - stable
-    # The version of rust in the latest Ubuntu LTS, currently Bionic.
-    - 1.25.0
+    # The oldest version we currently support. See
+    # CONTRIBUTING.md#rustc-version-support for details.
+    - 1.29.0
     - beta
     - nightly
 matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,17 +75,14 @@ which may be convenient when there are multiple versions installed.
 
 ### Rustc version support
 
-Our current policy is to support the version of Rustc that ships with the
-latest Ubuntu LTS release, as well as the current stable version. This means
-we don't use some of the very latest released Rust features.
+Cranelift supports stable Rust, and follows the
+[Rust Update Policy for Firefox].
 
 Some of the developer scripts depend on nightly Rust, for example to run
 clippy and other tools, however we avoid depending on these for the main
 build.
 
-That said, if there are any new Rust features that would be particularly
-valuable to use, please bring them up, as we may be able to find ways to
-accommodate them.
+[Rust Update Policy for Firefox]: https://wiki.mozilla.org/Rust_Update_Policy_for_Firefox#Schedule
 
 ### Python
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ into executable machine code.
 [![Documentation Status](https://readthedocs.org/projects/cranelift/badge/?version=latest)](https://cranelift.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://travis-ci.org/CraneStation/cranelift.svg?branch=master)](https://travis-ci.org/CraneStation/cranelift)
 [![Gitter chat](https://badges.gitter.im/CraneStation/CraneStation.svg)](https://gitter.im/CraneStation/Lobby)
-![Minimum rustc 1.25](https://img.shields.io/badge/rustc-1.25+-red.svg)
+![Minimum rustc 1.29](https://img.shields.io/badge/rustc-1.29+-red.svg)
 
 For more information, see [the
 documentation](https://cranelift.readthedocs.io/en/latest/?badge=latest).
@@ -47,11 +47,8 @@ needed before it would be ready for a production use case.
 
 Cranelift's APIs are not yet stable.
 
-Cranelift currently supports Rust 1.25.0 and later. We intend to always
-support the latest *stable* Rust. And, we currently support the version
-of Rust in the latest Ubuntu LTS, although whether we will always do so
-is not yet determined. Cranelift requires Python 2.7 or Python 3 to
-build.
+Cranelift currently requires Rust 1.29 or later, and Python 2.7 or 3
+to build.
 
 Planned uses
 ------------

--- a/lib/bforest/src/node.rs
+++ b/lib/bforest/src/node.rs
@@ -105,7 +105,7 @@ impl<F: Forest> NodeData<F> {
                 let size = usize::from(size);
                 // TODO: We could probably use `get_unchecked()` here since `size` is always in
                 // range.
-                (&keys[0..size], &tree[0..size + 1])
+                (&keys[0..size], &tree[0..=size])
             }
             _ => panic!("Expected inner node"),
         }
@@ -175,10 +175,10 @@ impl<F: Forest> NodeData<F> {
                 debug_assert!(sz <= keys.len());
                 debug_assert!(index <= sz, "Can't insert at {} with {} keys", index, sz);
 
-                if let Some(ks) = keys.get_mut(0..sz + 1) {
+                if let Some(ks) = keys.get_mut(0..=sz) {
                     *size = (sz + 1) as u8;
                     slice_insert(ks, index, key);
-                    slice_insert(&mut tree[1..sz + 2], index, node);
+                    slice_insert(&mut tree[1..=sz + 1], index, node);
                     true
                 } else {
                     false
@@ -203,10 +203,10 @@ impl<F: Forest> NodeData<F> {
                 debug_assert!(sz <= keys.len());
                 debug_assert!(index <= sz);
 
-                if let Some(ks) = keys.get_mut(0..sz + 1) {
+                if let Some(ks) = keys.get_mut(0..=sz) {
                     *size = (sz + 1) as u8;
                     slice_insert(ks, index, key);
-                    slice_insert(&mut vals[0..sz + 1], index, value);
+                    slice_insert(&mut vals[0..=sz], index, value);
                     true
                 } else {
                     false

--- a/lib/codegen/src/context.rs
+++ b/lib/codegen/src/context.rs
@@ -101,14 +101,7 @@ impl Context {
         let code_size = self.compile(isa)?;
         let old_len = mem.len();
         mem.resize(old_len + code_size as usize, 0);
-        unsafe {
-            self.emit_to_memory(
-                isa,
-                mem.as_mut_ptr().offset(old_len as isize),
-                relocs,
-                traps,
-            )
-        };
+        unsafe { self.emit_to_memory(isa, mem.as_mut_ptr().add(old_len), relocs, traps) };
         Ok(())
     }
 

--- a/lib/codegen/src/ir/dfg.rs
+++ b/lib/codegen/src/ir/dfg.rs
@@ -127,7 +127,7 @@ fn maybe_resolve_aliases(values: &PrimaryMap<Value, ValueData>, value: Value) ->
     let mut v = value;
 
     // Note that values may be empty here.
-    for _ in 0..values.len() + 1 {
+    for _ in 0..=values.len() {
         if let ValueData::Alias { original, .. } = values[v] {
             v = original;
         } else {

--- a/lib/codegen/src/lib.rs
+++ b/lib/codegen/src/lib.rs
@@ -8,8 +8,6 @@
     plugin(clippy(conf_file = "../../clippy.toml"))
 )]
 #![cfg_attr(feature="cargo-clippy", allow(
-// This requires Rust 1.27 or later.
-                duration_subsec,
 // Produces only a false positive:
                 while_let_loop,
 // Produces many false positives, but did produce some valid lints, now fixed:

--- a/lib/codegen/src/timing.rs
+++ b/lib/codegen/src/timing.rs
@@ -154,7 +154,7 @@ mod details {
                 fn fmtdur(mut dur: Duration, f: &mut fmt::Formatter) -> fmt::Result {
                     // Round to nearest ms by adding 500us.
                     dur += Duration::new(0, 500_000);
-                    let ms = dur.subsec_nanos() / 1_000_000;
+                    let ms = dur.subsec_millis();
                     write!(f, "{:4}.{:03} ", dur.as_secs(), ms)
                 }
 

--- a/lib/entity/src/list.rs
+++ b/lib/entity/src/list.rs
@@ -234,7 +234,7 @@ impl<T: EntityRef> EntityList<T> {
 
         let block = pool.alloc(sclass_for_length(len));
         pool.data[block] = T::new(len);
-        pool.data[block + 1..block + len + 1].copy_from_slice(slice);
+        pool.data[block + 1..=block + len].copy_from_slice(slice);
 
         Self {
             index: (block + 1) as u32,

--- a/lib/faerie/Cargo.toml
+++ b/lib/faerie/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 cranelift-codegen = { path = "../codegen", version = "0.22.0" }
 cranelift-module = { path = "../module", version = "0.22.0" }
 faerie = "0.5.0"
-goblin = "0.0.17"
+goblin = "0.0.19"
 failure = "0.1.2"
 target-lexicon = "0.0.3"
 

--- a/lib/filetests/src/lib.rs
+++ b/lib/filetests/src/lib.rs
@@ -10,11 +10,7 @@
     unstable_features
 )]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "cargo-clippy",
-    allow(
-          type_complexity,
-          // This requires Rust 1.27 or later.
-          duration_subsec))]
+#![cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
 #![cfg_attr(
     feature = "cargo-clippy",
     warn(

--- a/lib/filetests/src/runner.rs
+++ b/lib/filetests/src/runner.rs
@@ -47,13 +47,7 @@ impl Display for QueueEntry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let p = self.path.to_string_lossy();
         match self.state {
-            State::Done(Ok(dur)) => write!(
-                f,
-                "{}.{:03} {}",
-                dur.as_secs(),
-                dur.subsec_nanos() / 1_000_000,
-                p
-            ),
+            State::Done(Ok(dur)) => write!(f, "{}.{:03} {}", dur.as_secs(), dur.subsec_millis(), p),
             State::Done(Err(ref e)) => write!(f, "FAIL {}: {}", p, e),
             _ => write!(f, "{}", p),
         }

--- a/lib/simplejit/Cargo.toml
+++ b/lib/simplejit/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 cranelift-codegen = { path = "../codegen", version = "0.22.0", default-features = false }
 cranelift-module = { path = "../module", version = "0.22.0", default-features = false }
 cranelift-native = { path = "../native", version = "0.22.0", default-features = false }
-region = "0.3.0"
+region = "1.0.0"
 libc = { version = "0.2.42", default-features = false }
 errno = "0.2.4"
 target-lexicon = { version = "0.0.3", default-features = false }

--- a/lib/simplejit/src/memory.rs
+++ b/lib/simplejit/src/memory.rs
@@ -100,7 +100,7 @@ impl Memory {
     pub fn allocate(&mut self, size: usize) -> Result<*mut u8, String> {
         if size <= self.current.len - self.position {
             // TODO: Ensure overflow is not possible.
-            let ptr = unsafe { self.current.ptr.offset(self.position as isize) };
+            let ptr = unsafe { self.current.ptr.add(self.position) };
             self.position += size;
             return Ok(ptr);
         }


### PR DESCRIPTION
We no longer need the Ubuntu LTS restriction, so now the only only
constraint I'm aware of is Firefox's policy. Fortunately, that tracks
the latest stable delayed by only two weeks. So this puts is at
Rust 1.29 now.

If anyone is aware of other important constraints that we should follow,
please bring them up!