### PR TITLE
use iterative rather than recursive method for following aliases

### DIFF
--- a/lib/codegen/src/write.rs
+++ b/lib/codegen/src/write.rs
@@ -283,10 +283,21 @@ fn write_value_aliases(
     target: Value,
     indent: usize,
 ) -> fmt::Result {
+    let mut todo_stack = vec![];
+
     for &a in &aliases[target] {
         writeln!(w, "{1:0$}{2} -> {3}", indent, "", a, target)?;
-        write_value_aliases(w, aliases, a, indent)?;
+        todo_stack.push(a);
     }
+
+    while !todo_stack.is_empty() {
+        let target = todo_stack.pop().unwrap();
+        for &a in &aliases[target] {
+            writeln!(w, "{1:0$}{2} -> {3}", indent, "", a, target)?;
+            todo_stack.push(a);
+        }
+    }
+
     Ok(())
 }
 

--- a/lib/entity/src/map.rs
+++ b/lib/entity/src/map.rs
@@ -84,12 +84,12 @@ where
         Keys::with_len(self.elems.len())
     }
 
-    /// Iterate over all the keys in this map.
+    /// Iterate over all the values in this map.
     pub fn values(&self) -> slice::Iter<V> {
         self.elems.iter()
     }
 
-    /// Iterate over all the keys in this map, mutable edition.
+    /// Iterate over all the values in this map, mutable edition.
     pub fn values_mut(&mut self) -> slice::IterMut<V> {
         self.elems.iter_mut()
     }


### PR DESCRIPTION
* this avoids consuming stack via plain recursive calls

addresses #550 

I feel like there's probably a more idiomatic way to do this, but factoring out the for loop seemed like it'd have to be verbose b/c of borrowing the vec.

Should there be a unit test for this fn or is the write::tests::aliases test enough?