### PR TITLE
Make regalloc visit fallthrough_return instructions.

### DIFF
--- a/filetests/regalloc/fallthrough-return.clif
+++ b/filetests/regalloc/fallthrough-return.clif
@@ -1,0 +1,23 @@
+test regalloc
+target x86_64
+
+; Test that fallthrough returns are visited by reload and coloring.
+
+function %foo() -> f64 {
+  fn0 = %bar()
+
+ebb0:
+  v0 = f64const 0.0
+  call fn0()
+  fallthrough_return v0
+}
+; check: fill v0
+
+function %foo() -> f64 {
+  fn0 = %bar() -> f64, f64
+
+ebb0:
+  v0, v1 = call fn0()
+  fallthrough_return v1
+}
+; check: regmove v1, %xmm1 -> %xmm0

--- a/lib/codegen/meta-python/base/instructions.py
+++ b/lib/codegen/meta-python/base/instructions.py
@@ -844,7 +844,7 @@ vsplit = Instruction(
         the lanes from ``x``. The result may be two scalars if ``x`` only had
         two lanes.
         """,
-        ins=x, outs=(lo, hi))
+        ins=x, outs=(lo, hi), is_ghost=True)
 
 Any128 = TypeVar(
         'Any128', 'Any scalar or vector type with as most 128 lanes',
@@ -864,7 +864,7 @@ vconcat = Instruction(
 
         It is possible to form a vector by concatenating two scalars.
         """,
-        ins=(x, y), outs=a)
+        ins=(x, y), outs=a, is_ghost=True)
 
 c = Operand('c', TxN.as_bool(), doc='Controlling vector')
 x = Operand('x', TxN, doc='Value to use where `c` is true')
@@ -2009,7 +2009,7 @@ isplit = Instruction(
         Returns the low half of `x` and the high half of `x` as two independent
         values.
         """,
-        ins=x, outs=(lo, hi))
+        ins=x, outs=(lo, hi), is_ghost=True)
 
 
 NarrowInt = TypeVar(
@@ -2029,6 +2029,6 @@ iconcat = Instruction(
         the same number of lanes as the inputs, but the lanes are twice the
         size.
         """,
-        ins=(lo, hi), outs=a)
+        ins=(lo, hi), outs=a, is_ghost=True)
 
 GROUP.close()

--- a/lib/codegen/meta-python/cdsl/instructions.py
+++ b/lib/codegen/meta-python/cdsl/instructions.py
@@ -92,6 +92,7 @@ class Instruction(object):
     :param is_indirect_branch: This is an indirect branch instruction.
     :param is_call: This is a call instruction.
     :param is_return: This is a return instruction.
+    :param is_ghost: This is a ghost instruction.
     :param can_trap: This instruction can trap.
     :param can_load: This instruction can load from memory.
     :param can_store: This instruction can store to memory.
@@ -108,6 +109,7 @@ class Instruction(object):
             'True for all indirect branch or jump instructions.',
             'is_call': 'Is this a call instruction?',
             'is_return': 'Is this a return instruction?',
+            'is_ghost': 'Is this a ghost instruction?',
             'can_load': 'Can this instruction read from memory?',
             'can_store': 'Can this instruction write to memory?',
             'can_trap': 'Can this instruction cause a trap?',

--- a/lib/codegen/meta-python/cdsl/instructions.py
+++ b/lib/codegen/meta-python/cdsl/instructions.py
@@ -92,7 +92,8 @@ class Instruction(object):
     :param is_indirect_branch: This is an indirect branch instruction.
     :param is_call: This is a call instruction.
     :param is_return: This is a return instruction.
-    :param is_ghost: This is a ghost instruction.
+    :param is_ghost: This is a ghost instruction, which has no encoding and no
+                     other register allocation constraints.
     :param can_trap: This instruction can trap.
     :param can_load: This instruction can load from memory.
     :param can_store: This instruction can store to memory.

--- a/lib/codegen/src/regalloc/coloring.rs
+++ b/lib/codegen/src/regalloc/coloring.rs
@@ -166,6 +166,8 @@ impl<'a> Context<'a> {
         while let Some(inst) = self.cur.next_inst() {
             self.cur.use_srcloc(inst);
             if !self.cur.func.dfg[inst].opcode().is_ghost() {
+                // This is an instruction which either has an encoding or carries ABI-related
+                // register allocation constraints.
                 let enc = self.cur.func.encodings[inst];
                 let constraints = self.encinfo.operand_constraints(enc);
                 if self.visit_inst(inst, constraints, tracker, &mut regs) {
@@ -175,7 +177,7 @@ impl<'a> Context<'a> {
                     self.cur.goto_inst(inst);
                 }
             } else {
-                // This is a ghost instruction with no encoding.
+                // This is a ghost instruction with no encoding and no extra constraints.
                 let (_throughs, kills) = tracker.process_ghost(inst);
                 self.process_ghost_kills(kills, &mut regs);
             }

--- a/lib/codegen/src/regalloc/reload.rs
+++ b/lib/codegen/src/regalloc/reload.rs
@@ -125,8 +125,8 @@ impl<'a> Context<'a> {
 
         // visit_ebb_header() places us at the first interesting instruction in the EBB.
         while let Some(inst) = self.cur.current_inst() {
-            let encoding = self.cur.func.encodings[inst];
-            if encoding.is_legal() {
+            if !self.cur.func.dfg[inst].opcode().is_ghost() {
+                let encoding = self.cur.func.encodings[inst];
                 self.visit_inst(ebb, inst, encoding, tracker);
                 tracker.drop_dead(inst);
             } else {
@@ -200,10 +200,7 @@ impl<'a> Context<'a> {
         self.cur.use_srcloc(inst);
 
         // Get the operand constraints for `inst` that we are trying to satisfy.
-        let constraints = self
-            .encinfo
-            .operand_constraints(encoding)
-            .expect("Missing instruction encoding");
+        let constraints = self.encinfo.operand_constraints(encoding);
 
         // Identify reload candidates.
         debug_assert!(self.candidates.is_empty());
@@ -240,27 +237,32 @@ impl<'a> Context<'a> {
         // v2 = spill v7
         //
         // That way, we don't need to rewrite all future uses of v2.
-        for (lv, op) in defs.iter().zip(constraints.outs) {
-            if lv.affinity.is_stack() && op.kind != ConstraintKind::Stack {
-                if let InstructionData::Unary {
-                    opcode: Opcode::Copy,
-                    arg,
-                } = self.cur.func.dfg[inst]
-                {
-                    self.cur.func.dfg.replace(inst).spill(arg);
-                    let ok = self.cur.func.update_encoding(inst, self.cur.isa).is_ok();
-                    debug_assert!(ok);
-                } else {
-                    let value_type = self.cur.func.dfg.value_type(lv.value);
-                    let reg = self.cur.func.dfg.replace_result(lv.value, value_type);
-                    self.liveness.create_dead(reg, inst, Affinity::new(op));
-                    self.insert_spill(ebb, lv.value, reg);
+        if let Some(constraints) = constraints {
+            for (lv, op) in defs.iter().zip(constraints.outs) {
+                if lv.affinity.is_stack() && op.kind != ConstraintKind::Stack {
+                    if let InstructionData::Unary {
+                        opcode: Opcode::Copy,
+                        arg,
+                    } = self.cur.func.dfg[inst]
+                    {
+                        self.cur.func.dfg.replace(inst).spill(arg);
+                        let ok = self.cur.func.update_encoding(inst, self.cur.isa).is_ok();
+                        debug_assert!(ok);
+                    } else {
+                        let value_type = self.cur.func.dfg.value_type(lv.value);
+                        let reg = self.cur.func.dfg.replace_result(lv.value, value_type);
+                        self.liveness.create_dead(reg, inst, Affinity::new(op));
+                        self.insert_spill(ebb, lv.value, reg);
+                    }
                 }
             }
         }
 
         // Same thing for spilled call return values.
-        let retvals = &defs[constraints.outs.len()..];
+        let retvals = &defs[self.cur.func.dfg[inst]
+                                .opcode()
+                                .constraints()
+                                .fixed_results()..];
         if !retvals.is_empty() {
             let sig = self
                 .cur
@@ -342,21 +344,26 @@ impl<'a> Context<'a> {
     // Find reload candidates for `inst` and add them to `self.candidates`.
     //
     // These are uses of spilled values where the operand constraint requires a register.
-    fn find_candidates(&mut self, inst: Inst, constraints: &RecipeConstraints) {
+    fn find_candidates(&mut self, inst: Inst, constraints: Option<&RecipeConstraints>) {
         let args = self.cur.func.dfg.inst_args(inst);
 
-        for (argidx, (op, &arg)) in constraints.ins.iter().zip(args).enumerate() {
-            if op.kind != ConstraintKind::Stack && self.liveness[arg].affinity.is_stack() {
-                self.candidates.push(ReloadCandidate {
-                    argidx,
-                    value: arg,
-                    regclass: op.regclass,
-                })
+        if let Some(constraints) = constraints {
+            for (argidx, (op, &arg)) in constraints.ins.iter().zip(args).enumerate() {
+                if op.kind != ConstraintKind::Stack && self.liveness[arg].affinity.is_stack() {
+                    self.candidates.push(ReloadCandidate {
+                        argidx,
+                        value: arg,
+                        regclass: op.regclass,
+                    })
+                }
             }
         }
 
         // If we only have the fixed arguments, we're done now.
-        let offset = constraints.ins.len();
+        let offset = self.cur.func.dfg[inst]
+            .opcode()
+            .constraints()
+            .fixed_value_arguments();
         if args.len() == offset {
             return;
         }

--- a/lib/codegen/src/regalloc/reload.rs
+++ b/lib/codegen/src/regalloc/reload.rs
@@ -126,10 +126,14 @@ impl<'a> Context<'a> {
         // visit_ebb_header() places us at the first interesting instruction in the EBB.
         while let Some(inst) = self.cur.current_inst() {
             if !self.cur.func.dfg[inst].opcode().is_ghost() {
+                // This instruction either has an encoding or has ABI constraints, so visit it to
+                // insert spills and fills as needed.
                 let encoding = self.cur.func.encodings[inst];
                 self.visit_inst(ebb, inst, encoding, tracker);
                 tracker.drop_dead(inst);
             } else {
+                // This is a ghost instruction with no encoding and no extra constraints, so we can
+                // just skip over it.
                 self.cur.next_inst();
             }
         }

--- a/lib/codegen/src/verifier/mod.rs
+++ b/lib/codegen/src/verifier/mod.rs
@@ -1550,6 +1550,15 @@ impl<'a> Verifier<'a> {
 
         let encoding = self.func.encodings[inst];
         if encoding.is_legal() {
+            if self.func.dfg[inst].opcode().is_ghost() {
+                return nonfatal!(
+                    errors,
+                    inst,
+                    "Ghost instruction has an encoding: {}",
+                    isa.encoding_info().display(encoding)
+                );
+            }
+
             let mut encodings = isa
                 .legal_encodings(
                     &self.func,


### PR DESCRIPTION
Add an explicit "is_ghost" property to selected instructions, and use
that to determine whether reload and coloring should visit instructions.
This allows them to visit fallthrough_return instructions and insert
fills and register moves as needed.