### PR TITLE
Use `Display` rather than having an explicit `name()` function for types.

### DIFF
--- a/lib/codegen/meta/src/cdsl/types.rs
+++ b/lib/codegen/meta/src/cdsl/types.rs
@@ -79,16 +79,6 @@ impl ValueType {
         self.width() / 8
     }
 
-    /// Get the name of this type.
-    pub fn name(&self) -> String {
-        match *self {
-            ValueType::BV(ref b) => b.name(),
-            ValueType::Lane(l) => l.name(),
-            ValueType::Special(s) => s.name(),
-            ValueType::Vector(ref v) => v.name(),
-        }
-    }
-
     /// Find the unique number associated with this type.
     pub fn number(&self) -> Option<u8> {
         match *self {
@@ -101,7 +91,7 @@ impl ValueType {
 
     /// Return the name of this type for generated Rust source files.
     pub fn _rust_name(&self) -> String {
-        format!("{}{}", _RUST_NAME_PREFIX, self.name().to_uppercase())
+        format!("{}{}", _RUST_NAME_PREFIX, self.to_string().to_uppercase())
     }
 
     /// Return true iff:
@@ -119,7 +109,12 @@ impl ValueType {
 
 impl fmt::Display for ValueType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.name())
+        match *self {
+            ValueType::BV(ref b) => b.fmt(f),
+            ValueType::Lane(l) => l.fmt(f),
+            ValueType::Special(s) => s.fmt(f),
+            ValueType::Vector(ref v) => v.fmt(f),
+        }
     }
 }
 
@@ -193,15 +188,6 @@ impl LaneType {
         }
     }
 
-    /// Get the name of this lane type.
-    pub fn name(self) -> String {
-        match self {
-            LaneType::BoolType(_) => format!("b{}", self.lane_bits()),
-            LaneType::FloatType(_) => format!("f{}", self.lane_bits()),
-            LaneType::IntType(_) => format!("i{}", self.lane_bits()),
-        }
-    }
-
     /// Find the unique number associated with this lane type.
     pub fn number(self) -> u8 {
         LANE_BASE + match self {
@@ -216,6 +202,16 @@ impl LaneType {
             LaneType::IntType(base_types::Int::I64) => 8,
             LaneType::FloatType(base_types::Float::F32) => 9,
             LaneType::FloatType(base_types::Float::F64) => 10,
+        }
+    }
+}
+
+impl fmt::Display for LaneType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            LaneType::BoolType(_) => write!(f, "b{}", self.lane_bits()),
+            LaneType::FloatType(_) => write!(f, "f{}", self.lane_bits()),
+            LaneType::IntType(_) => write!(f, "i{}", self.lane_bits()),
         }
     }
 }
@@ -309,7 +305,7 @@ impl VectorType {
         format!(
             "A SIMD vector with {} lanes containing a `{}` each.",
             self.lane_count(),
-            self.base.name()
+            self.base
         )
     }
 
@@ -321,11 +317,6 @@ impl VectorType {
     /// Return the number of lanes.
     pub fn lane_count(&self) -> u64 {
         self.lanes
-    }
-
-    /// Get the name of this vector type.
-    pub fn name(&self) -> String {
-        format!("{}x{}", self.base.name(), self.lane_count())
     }
 
     /// Find the unique number associated with this vector type.
@@ -340,12 +331,18 @@ impl VectorType {
     }
 }
 
+impl fmt::Display for VectorType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}x{}", self.base, self.lane_count())
+    }
+}
+
 impl fmt::Debug for VectorType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "VectorType(base={}, lanes={})",
-            self.base.name(),
+            self.base,
             self.lane_count()
         )
     }
@@ -371,10 +368,11 @@ impl BVType {
     pub fn lane_bits(&self) -> u64 {
         self.bits
     }
+}
 
-    /// Get the name of this bitvector type.
-    pub fn name(&self) -> String {
-        format!("bv{}", self.bits)
+impl fmt::Display for BVType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "bv{}", self.bits)
     }
 }
 
@@ -414,19 +412,20 @@ impl SpecialType {
         }
     }
 
-    /// Get the name of this special type.
-    pub fn name(self) -> String {
-        match self {
-            SpecialType::Flag(base_types::Flag::IFlags) => "iflags".to_string(),
-            SpecialType::Flag(base_types::Flag::FFlags) => "fflags".to_string(),
-        }
-    }
-
     /// Find the unique number associated with this special type.
     pub fn number(self) -> u8 {
         match self {
             SpecialType::Flag(base_types::Flag::IFlags) => 1,
             SpecialType::Flag(base_types::Flag::FFlags) => 2,
+        }
+    }
+}
+
+impl fmt::Display for SpecialType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SpecialType::Flag(base_types::Flag::IFlags) => write!(f, "iflags"),
+            SpecialType::Flag(base_types::Flag::FFlags) => write!(f, "fflags"),
         }
     }
 }
@@ -437,7 +436,7 @@ impl fmt::Debug for SpecialType {
             f,
             "{}",
             match *self {
-                SpecialType::Flag(_) => format!("FlagsType({})", self.name()),
+                SpecialType::Flag(_) => format!("FlagsType({})", self),
             }
         )
     }

--- a/lib/codegen/meta/src/gen_types.rs
+++ b/lib/codegen/meta/src/gen_types.rs
@@ -13,7 +13,7 @@ use srcgen;
 
 /// Emit a constant definition of a single value type.
 fn emit_type(ty: &cdsl_types::ValueType, fmt: &mut srcgen::Formatter) -> Result<(), error::Error> {
-    let name = ty.name().to_uppercase();
+    let name = ty.to_string().to_uppercase();
     let number = ty.number().ok_or_else(|| {
         error::Error::with_msg(format!(
             "Could not emit type `{}` which has no number.",


### PR DESCRIPTION
This is more idiomatic Rust.