### PR TITLE
Renamings

### DIFF
--- a/lib/codegen/src/ir/instructions.rs
+++ b/lib/codegen/src/ir/instructions.rs
@@ -335,8 +335,8 @@ pub struct OpcodeConstraints {
     typeset_offset: u8,
 
     /// Offset into `OPERAND_CONSTRAINT` table of the descriptors for this opcode. The first
-    /// `fixed_results()` entries describe the result constraints, then follows constraints for the
-    /// fixed `Value` input operands. (`fixed_value_arguments()` of them).
+    /// `num_fixed_results()` entries describe the result constraints, then follows constraints for the
+    /// fixed `Value` input operands. (`num_fixed_value_arguments()` of them).
     constraint_offset: u16,
 }
 
@@ -360,7 +360,7 @@ impl OpcodeConstraints {
 
     /// Get the number of *fixed* result values produced by this opcode.
     /// This does not include `variable_args` produced by calls.
-    pub fn fixed_results(self) -> usize {
+    pub fn num_fixed_results(self) -> usize {
         (self.flags & 0x7) as usize
     }
 
@@ -371,7 +371,7 @@ impl OpcodeConstraints {
     /// The number of fixed input values is usually implied by the instruction format, but
     /// instruction formats that use a `ValueList` put both fixed and variable arguments in the
     /// list. This method returns the *minimum* number of values required in the value list.
-    pub fn fixed_value_arguments(self) -> usize {
+    pub fn num_fixed_value_arguments(self) -> usize {
         ((self.flags >> 5) & 0x7) as usize
     }
 
@@ -394,7 +394,7 @@ impl OpcodeConstraints {
     /// Get the value type of result number `n`, having resolved the controlling type variable to
     /// `ctrl_type`.
     pub fn result_type(self, n: usize, ctrl_type: Type) -> Type {
-        debug_assert!(n < self.fixed_results(), "Invalid result index");
+        debug_assert!(n < self.num_fixed_results(), "Invalid result index");
         if let ResolvedConstraint::Bound(t) =
             OPERAND_CONSTRAINTS[self.constraint_offset() + n].resolve(ctrl_type)
         {
@@ -411,10 +411,10 @@ impl OpcodeConstraints {
     /// `ValueTypeSet`. This is represented with the `ArgumentConstraint::Free` variant.
     pub fn value_argument_constraint(self, n: usize, ctrl_type: Type) -> ResolvedConstraint {
         debug_assert!(
-            n < self.fixed_value_arguments(),
+            n < self.num_fixed_value_arguments(),
             "Invalid value argument index"
         );
-        let offset = self.constraint_offset() + self.fixed_results();
+        let offset = self.constraint_offset() + self.num_fixed_results();
         OPERAND_CONSTRAINTS[offset + n].resolve(ctrl_type)
     }
 
@@ -603,8 +603,8 @@ mod tests {
         let a = Opcode::Iadd.constraints();
         assert!(a.use_typevar_operand());
         assert!(!a.requires_typevar_operand());
-        assert_eq!(a.fixed_results(), 1);
-        assert_eq!(a.fixed_value_arguments(), 2);
+        assert_eq!(a.num_fixed_results(), 1);
+        assert_eq!(a.num_fixed_value_arguments(), 2);
         assert_eq!(a.result_type(0, types::I32), types::I32);
         assert_eq!(a.result_type(0, types::I8), types::I8);
         assert_eq!(
@@ -619,8 +619,8 @@ mod tests {
         let b = Opcode::Bitcast.constraints();
         assert!(!b.use_typevar_operand());
         assert!(!b.requires_typevar_operand());
-        assert_eq!(b.fixed_results(), 1);
-        assert_eq!(b.fixed_value_arguments(), 1);
+        assert_eq!(b.num_fixed_results(), 1);
+        assert_eq!(b.num_fixed_value_arguments(), 1);
         assert_eq!(b.result_type(0, types::I32), types::I32);
         assert_eq!(b.result_type(0, types::I8), types::I8);
         match b.value_argument_constraint(0, types::I32) {
@@ -629,18 +629,18 @@ mod tests {
         }
 
         let c = Opcode::Call.constraints();
-        assert_eq!(c.fixed_results(), 0);
-        assert_eq!(c.fixed_value_arguments(), 0);
+        assert_eq!(c.num_fixed_results(), 0);
+        assert_eq!(c.num_fixed_value_arguments(), 0);
 
         let i = Opcode::CallIndirect.constraints();
-        assert_eq!(i.fixed_results(), 0);
-        assert_eq!(i.fixed_value_arguments(), 1);
+        assert_eq!(i.num_fixed_results(), 0);
+        assert_eq!(i.num_fixed_value_arguments(), 1);
 
         let cmp = Opcode::Icmp.constraints();
         assert!(cmp.use_typevar_operand());
         assert!(cmp.requires_typevar_operand());
-        assert_eq!(cmp.fixed_results(), 1);
-        assert_eq!(cmp.fixed_value_arguments(), 2);
+        assert_eq!(cmp.num_fixed_results(), 1);
+        assert_eq!(cmp.num_fixed_value_arguments(), 2);
     }
 
     #[test]

--- a/lib/codegen/src/legalizer/boundary.rs
+++ b/lib/codegen/src/legalizer/boundary.rs
@@ -201,8 +201,14 @@ where
 
     // We theoretically allow for call instructions that return a number of fixed results before
     // the call return values. In practice, it doesn't happen.
-    let fixed_results = pos.func.dfg[call].opcode().constraints().fixed_results();
-    debug_assert_eq!(fixed_results, 0, "Fixed results on calls not supported");
+    debug_assert_eq!(
+        pos.func.dfg[call]
+            .opcode()
+            .constraints()
+            .num_fixed_results(),
+        0,
+        "Fixed results on calls not supported"
+    );
 
     let results = pos.func.dfg.detach_results(call);
     let mut next_res = 0;
@@ -440,11 +446,11 @@ fn legalize_inst_arguments<ArgType>(
     // The value list contains all arguments to the instruction, including the callee on an
     // indirect call which isn't part of the call arguments that must match the ABI signature.
     // Figure out how many fixed values are at the front of the list. We won't touch those.
-    let fixed_values = pos.func.dfg[inst]
+    let num_fixed_values = pos.func.dfg[inst]
         .opcode()
         .constraints()
-        .fixed_value_arguments();
-    let have_args = vlist.len(&pos.func.dfg.value_lists) - fixed_values;
+        .num_fixed_value_arguments();
+    let have_args = vlist.len(&pos.func.dfg.value_lists) - num_fixed_values;
 
     // Grow the value list to the right size and shift all the existing arguments to the right.
     // This lets us write the new argument values into the list without overwriting the old
@@ -472,11 +478,11 @@ fn legalize_inst_arguments<ArgType>(
     //   [FFFFNNNNNNNNNNNNNNNNNNNN]
     //
     vlist.grow_at(
-        fixed_values,
+        num_fixed_values,
         abi_args - have_args,
         &mut pos.func.dfg.value_lists,
     );
-    let old_arg_offset = fixed_values + abi_args - have_args;
+    let old_arg_offset = num_fixed_values + abi_args - have_args;
 
     let mut abi_arg = 0;
     for old_arg in 0..have_args {
@@ -487,7 +493,7 @@ fn legalize_inst_arguments<ArgType>(
             let abi_type = get_abi_type(func, abi_arg);
             if func.dfg.value_type(arg) == abi_type.value_type {
                 // This is the argument type we need.
-                vlist.as_mut_slice(&mut func.dfg.value_lists)[fixed_values + abi_arg] = arg;
+                vlist.as_mut_slice(&mut func.dfg.value_lists)[num_fixed_values + abi_arg] = arg;
                 abi_arg += 1;
                 Ok(())
             } else {

--- a/lib/codegen/src/regalloc/reload.rs
+++ b/lib/codegen/src/regalloc/reload.rs
@@ -266,7 +266,7 @@ impl<'a> Context<'a> {
         let retvals = &defs[self.cur.func.dfg[inst]
                                 .opcode()
                                 .constraints()
-                                .fixed_results()..];
+                                .num_fixed_results()..];
         if !retvals.is_empty() {
             let sig = self
                 .cur
@@ -367,7 +367,7 @@ impl<'a> Context<'a> {
         let offset = self.cur.func.dfg[inst]
             .opcode()
             .constraints()
-            .fixed_value_arguments();
+            .num_fixed_value_arguments();
         if args.len() == offset {
             return;
         }

--- a/lib/codegen/src/regalloc/spilling.rs
+++ b/lib/codegen/src/regalloc/spilling.rs
@@ -376,10 +376,10 @@ impl<'a> Context<'a> {
 
     // Collect register uses from the ABI input constraints.
     fn collect_abi_reg_uses(&mut self, inst: Inst, sig: SigRef) {
-        let fixed_args = self.cur.func.dfg[inst]
+        let num_fixed_args = self.cur.func.dfg[inst]
             .opcode()
             .constraints()
-            .fixed_value_arguments();
+            .num_fixed_value_arguments();
         let args = self.cur.func.dfg.inst_variable_args(inst);
         for (idx, (abi, &arg)) in self.cur.func.dfg.signatures[sig]
             .params
@@ -396,7 +396,7 @@ impl<'a> Context<'a> {
                     ),
                     Affinity::Unassigned => panic!("Missing affinity for {}", arg),
                 };
-                let mut reguse = RegUse::new(arg, fixed_args + idx, rci);
+                let mut reguse = RegUse::new(arg, num_fixed_args + idx, rci);
                 reguse.fixed = true;
                 reguse.spilled = spilled;
                 self.reg_uses.push(reguse);

--- a/lib/codegen/src/verifier/mod.rs
+++ b/lib/codegen/src/verifier/mod.rs
@@ -524,12 +524,12 @@ impl<'a> Verifier<'a> {
             );
         }
 
-        let fixed_results = inst_data.opcode().constraints().fixed_results();
+        let num_fixed_results = inst_data.opcode().constraints().num_fixed_results();
         // var_results is 0 if we aren't a call instruction
         let var_results = dfg
             .call_signature(inst)
             .map_or(0, |sig| dfg.signatures[sig].returns.len());
-        let total_results = fixed_results + var_results;
+        let total_results = num_fixed_results + var_results;
 
         // All result values for multi-valued instructions are created
         let got_results = dfg.inst_results(inst).len();

--- a/lib/simplejit/src/backend.rs
+++ b/lib/simplejit/src/backend.rs
@@ -187,7 +187,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
                 .open(format!("/tmp/perf-{}.map", ::std::process::id()))
                 .unwrap();
 
-            writeln!(map_file, "{:x} {:x} {}", ptr as usize, code_size, name);
+            let _ = writeln!(map_file, "{:x} {:x} {}", ptr as usize, code_size, name);
         }
 
         let mut reloc_sink = SimpleJITRelocSink::new();


### PR DESCRIPTION
This removes one warning seen when compiling on Linux, and renames `fixed_results / fixed_value_arguments` to the same names prefixed with `num_` to make clear they return a number (and not a slice/array of what they describe).