### PR TITLE
Add safe heap_load and heap_store instructions.

### DIFF
--- a/lib/codegen/meta-python/base/formats.py
+++ b/lib/codegen/meta-python/base/formats.py
@@ -73,6 +73,10 @@ HeapAddr = InstructionFormat(heap, VALUE, uimm32)
 # Accessing a WebAssembly table.
 TableAddr = InstructionFormat(table, VALUE, offset32)
 
+# Safe heap_load/heap_store
+HeapLoad = InstructionFormat(heap, VALUE, offset32)
+HeapStore = InstructionFormat(heap, VALUE, VALUE, offset32)
+
 RegMove = InstructionFormat(VALUE, ('src', regunit), ('dst', regunit))
 CopySpecial = InstructionFormat(('src', regunit), ('dst', regunit))
 RegSpill = InstructionFormat(

--- a/lib/codegen/meta-python/base/formats.py
+++ b/lib/codegen/meta-python/base/formats.py
@@ -68,14 +68,11 @@ StackLoad = InstructionFormat(stack_slot, offset32)
 StackStore = InstructionFormat(VALUE, stack_slot, offset32)
 
 # Accessing a WebAssembly heap.
-HeapAddr = InstructionFormat(heap, VALUE, uimm32)
+UnaryHeap = InstructionFormat(heap, VALUE, uimm32)
+BinaryHeap = InstructionFormat(heap, VALUE, VALUE, uimm32)
 
 # Accessing a WebAssembly table.
 TableAddr = InstructionFormat(table, VALUE, offset32)
-
-# Safe heap_load/heap_store
-HeapLoad = InstructionFormat(heap, VALUE, offset32)
-HeapStore = InstructionFormat(heap, VALUE, VALUE, offset32)
 
 RegMove = InstructionFormat(VALUE, ('src', regunit), ('dst', regunit))
 CopySpecial = InstructionFormat(('src', regunit), ('dst', regunit))

--- a/lib/codegen/meta-python/base/instructions.py
+++ b/lib/codegen/meta-python/base/instructions.py
@@ -630,9 +630,10 @@ heap_load = Instruction(
         This is a polymorphic instruction that can load any value type which
         has a memory representation.
 
-        1. If ``p + Offset + sizeof a`` is not greater than the heap bound, return
-           the value at ``p + Offset``.
-        2. If ``p + Offset + sizeof a`` is greater than the heap bound, generate a trap.
+        1. If ``p + Offset + sizeof a`` is not greater than the heap bound,
+           return the value at ``p + Offset``.
+        2. If ``p + Offset + sizeof a`` is greater than the heap bound, 
+           generate a trap.
         """,
         ins=(H, p, Offset), outs=a, can_load=True)
 
@@ -648,9 +649,10 @@ heap_store = Instruction(
         This is a polymorphic instruction that can store any value type which
         has a memory representation.
 
-        1. If ``p + Offset + sizeof x`` is not greater than the heap bound, return
-           the value at ``p + Offset``.
-        2. If ``p + Offset + sizeof x`` is greater than the heap bound, generate a trap.
+        1. If ``p + Offset + sizeof x`` is not greater than the heap bound,
+           return the value at ``p + Offset``.
+        2. If ``p + Offset + sizeof x`` is greater than the heap bound,
+           generate a trap.
         """,
         ins=(H, x, p, Offset), can_store=True)
 

--- a/lib/codegen/meta-python/base/instructions.py
+++ b/lib/codegen/meta-python/base/instructions.py
@@ -609,6 +609,50 @@ table_addr = Instruction(
         """,
         ins=(T, p, Offset), outs=addr)
 
+#
+# Heap accesses for safe-subset of cranelift ir.
+#
+
+H = Operand('H', entities.heap)
+HeapOffset = TypeVar('HeapOffset', 'An unsigned heap offset', ints=(32, 64))
+x = Operand('x', Mem, doc='Value to be stored')
+a = Operand('a', Mem, doc='Value loaded')
+p = Operand('p', HeapOffset)
+Offset = Operand('Offset', offset32, 'Byte offset from element address')
+
+heap_load = Instruction(
+        'heap_load', r"""
+        Safely load from a cranelift heap.
+
+        Verify that ``p + Offset .. p + Offset + sizeof a`` is
+        is in bounds of the specified heap and load a value from there.
+
+        This is a polymorphic instruction that can load any value type which
+        has a memory representation.
+
+        1. If ``p + Offset + sizeof a`` is not greater than the heap bound, return
+           the value at ``p + Offset``.
+        2. If ``p + Offset + sizeof a`` is greater than the heap bound, generate a trap.
+        """,
+        ins=(H, p, Offset), outs=a, can_load=True)
+
+heap_store = Instruction(
+        'heap_store', r"""
+        Store ``x`` to memory at ``p + Offset``.
+
+        Safely store in a cranelift heap.
+
+        Verify that ``p + Offset .. p + Offset + sizeof x`` is
+        is in bounds of the specified heap and store a value there.
+
+        This is a polymorphic instruction that can store any value type which
+        has a memory representation.
+
+        1. If ``p + Offset + sizeof x`` is not greater than the heap bound, return
+           the value at ``p + Offset``.
+        2. If ``p + Offset + sizeof x`` is greater than the heap bound, generate a trap.
+        """,
+        ins=(H, x, p, Offset), can_store=True)
 
 #
 # Materializing constants.

--- a/lib/codegen/meta-python/base/instructions.py
+++ b/lib/codegen/meta-python/base/instructions.py
@@ -632,7 +632,7 @@ heap_load = Instruction(
 
         1. If ``p + Offset + sizeof a`` is not greater than the heap bound,
            return the value at ``p + Offset``.
-        2. If ``p + Offset + sizeof a`` is greater than the heap bound, 
+        2. If ``p + Offset + sizeof a`` is greater than the heap bound,
            generate a trap.
         """,
         ins=(H, p, Offset), outs=a, can_load=True)

--- a/lib/codegen/meta-python/base/instructions.py
+++ b/lib/codegen/meta-python/base/instructions.py
@@ -618,7 +618,7 @@ HeapOffset = TypeVar('HeapOffset', 'An unsigned heap offset', ints=(32, 64))
 x = Operand('x', Mem, doc='Value to be stored')
 a = Operand('a', Mem, doc='Value loaded')
 p = Operand('p', HeapOffset)
-Offset = Operand('Offset', offset32, 'Byte offset from element address')
+Offset = Operand('Offset', uimm32, 'Byte offset from element address')
 
 heap_load = Instruction(
         'heap_load', r"""

--- a/lib/codegen/meta-python/base/legalize.py
+++ b/lib/codegen/meta-python/base/legalize.py
@@ -94,6 +94,10 @@ expand.custom_legalize(insts.f64const, 'expand_fconst')
 expand.custom_legalize(insts.stack_load, 'expand_stack_load')
 expand.custom_legalize(insts.stack_store, 'expand_stack_store')
 
+# CUstom expansions for heap_load/heap_store
+expand.custom_legalize(insts.heap_load, 'expand_heap_load')
+expand.custom_legalize(insts.heap_store, 'expand_heap_store')
+
 x = Var('x')
 y = Var('y')
 z = Var('z')

--- a/lib/codegen/src/ir/entities.rs
+++ b/lib/codegen/src/ir/entities.rs
@@ -20,7 +20,7 @@
 //! format.
 
 use std::fmt;
-use std::u32;
+use std::{u32, u8};
 
 /// An opaque reference to an extended basic block in a function.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -156,7 +156,7 @@ impl SigRef {
 
 /// A reference to a heap.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Heap(u32);
+pub struct Heap(u8);
 entity_impl!(Heap, "heap");
 
 impl Heap {
@@ -164,8 +164,8 @@ impl Heap {
     ///
     /// This method is for use by the parser.
     pub fn with_number(n: u32) -> Option<Self> {
-        if n < u32::MAX {
-            Some(Heap(n))
+        if n < u8::MAX as u32 {
+            Some(Heap(n as u8))
         } else {
             None
         }

--- a/lib/codegen/src/legalizer/heap.rs
+++ b/lib/codegen/src/legalizer/heap.rs
@@ -18,7 +18,7 @@ pub fn expand_heap_addr(
 ) {
     // Unpack the instruction.
     let (heap, offset, access_size) = match func.dfg[inst] {
-        ir::InstructionData::HeapAddr {
+        ir::InstructionData::UnaryHeap {
             opcode,
             heap,
             arg,

--- a/lib/codegen/src/verifier/mod.rs
+++ b/lib/codegen/src/verifier/mod.rs
@@ -632,7 +632,7 @@ impl<'a> Verifier<'a> {
             UnaryGlobalValue { global_value, .. } => {
                 self.verify_global_value(inst, global_value, errors)?;
             }
-            HeapAddr { heap, .. } | HeapLoad { heap, .. } | HeapStore { heap, .. } => {
+            UnaryHeap { heap, .. } | BinaryHeap { heap, .. } => {
                 self.verify_heap(inst, heap, errors)?;
             }
             TableAddr { table, .. } => {
@@ -1413,7 +1413,12 @@ impl<'a> Verifier<'a> {
                     _ => {}
                 }
             }
-            ir::InstructionData::HeapAddr { heap, arg, .. } => {
+            ir::InstructionData::UnaryHeap { heap, arg, .. }
+            | ir::InstructionData::BinaryHeap {
+                heap,
+                args: [arg, _],
+                ..
+            } => {
                 let index_type = self.func.dfg.value_type(arg);
                 let heap_index_type = self.func.heaps[heap].index_type;
                 if index_type != heap_index_type {

--- a/lib/codegen/src/verifier/mod.rs
+++ b/lib/codegen/src/verifier/mod.rs
@@ -632,7 +632,7 @@ impl<'a> Verifier<'a> {
             UnaryGlobalValue { global_value, .. } => {
                 self.verify_global_value(inst, global_value, errors)?;
             }
-            HeapAddr { heap, .. } => {
+            HeapAddr { heap, .. } | HeapLoad { heap, .. } | HeapStore { heap, .. } => {
                 self.verify_heap(inst, heap, errors)?;
             }
             TableAddr { table, .. } => {

--- a/lib/codegen/src/write.rs
+++ b/lib/codegen/src/write.rs
@@ -483,14 +483,11 @@ pub fn write_operands(
             offset,
             ..
         } => write!(w, " {}, {}{}", arg, stack_slot, offset),
-        HeapAddr { heap, arg, imm, .. } => write!(w, " {}, {}, {}", heap, arg, imm),
+        UnaryHeap { heap, arg, imm, .. } => write!(w, " {}, {}, {}", heap, arg, imm),
+        BinaryHeap {
+            heap, args, imm, ..
+        } => write!(w, " {}, {}, {}, {}", heap, args[0], args[1], imm),
         TableAddr { table, arg, .. } => write!(w, " {}, {}", table, arg),
-        HeapLoad {
-            heap, arg, offset, ..
-        } => write!(w, " {}, {}, {}", heap, arg, offset),
-        HeapStore {
-            heap, args, offset, ..
-        } => write!(w, " {}, {}, {}, {}", heap, args[0], args[1], offset),
         Load {
             flags, arg, offset, ..
         } => write!(w, "{} {}{}", flags, arg, offset),

--- a/lib/codegen/src/write.rs
+++ b/lib/codegen/src/write.rs
@@ -485,6 +485,12 @@ pub fn write_operands(
         } => write!(w, " {}, {}{}", arg, stack_slot, offset),
         HeapAddr { heap, arg, imm, .. } => write!(w, " {}, {}, {}", heap, arg, imm),
         TableAddr { table, arg, .. } => write!(w, " {}, {}", table, arg),
+        HeapLoad {
+            heap, arg, offset, ..
+        } => write!(w, " {}, {}, {}", heap, arg, offset),
+        HeapStore {
+            heap, args, offset, ..
+        } => write!(w, " {}, {}, {}, {}", heap, args[0], args[1], offset),
         Load {
             flags, arg, offset, ..
         } => write!(w, "{} {}{}", flags, arg, offset),

--- a/lib/entity/src/lib.rs
+++ b/lib/entity/src/lib.rs
@@ -88,7 +88,8 @@ macro_rules! entity_impl {
         impl $crate::EntityRef for $entity {
             fn new(index: usize) -> Self {
                 debug_assert!(index < ($crate::__core::u32::MAX as usize));
-                $entity(index as u32)
+                #[allow(trivial_numeric_casts)]
+                $entity(index as _)
             }
 
             fn index(self) -> usize {
@@ -98,7 +99,8 @@ macro_rules! entity_impl {
 
         impl $crate::packed_option::ReservedValue for $entity {
             fn reserved_value() -> $entity {
-                $entity($crate::__core::u32::MAX)
+                #[allow(trivial_numeric_casts)]
+                $entity($crate::__core::u32::MAX as _)
             }
         }
     };

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -2416,6 +2416,36 @@ impl<'a> Parser<'a> {
                     offset,
                 }
             }
+            InstructionFormat::HeapLoad => {
+                let heap = self.match_heap("expected heap identifier")?;
+                ctx.check_heap(heap, self.loc)?;
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let arg = self.match_value("expected SSA value heap address")?;
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let offset = self.optional_offset32()?;
+                InstructionData::HeapLoad {
+                    opcode,
+                    heap,
+                    arg,
+                    offset,
+                }
+            }
+            InstructionFormat::HeapStore => {
+                let heap = self.match_heap("expected heap identifier")?;
+                ctx.check_heap(heap, self.loc)?;
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let arg = self.match_value("expected SSA value operand")?;
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let addr = self.match_value("expected SSA value address")?;
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let offset = self.optional_offset32()?;
+                InstructionData::HeapStore {
+                    opcode,
+                    heap,
+                    args: [arg, addr],
+                    offset,
+                }
+            }
             InstructionFormat::Load => {
                 let flags = self.optional_memflags();
                 let addr = self.match_value("expected SSA value address")?;

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -2388,17 +2388,33 @@ impl<'a> Parser<'a> {
                     offset,
                 }
             }
-            InstructionFormat::HeapAddr => {
+            InstructionFormat::UnaryHeap => {
                 let heap = self.match_heap("expected heap identifier")?;
                 ctx.check_heap(heap, self.loc)?;
                 self.match_token(Token::Comma, "expected ',' between operands")?;
                 let arg = self.match_value("expected SSA value heap address")?;
                 self.match_token(Token::Comma, "expected ',' between operands")?;
-                let imm = self.match_uimm32("expected 32-bit integer size")?;
-                InstructionData::HeapAddr {
+                let imm = self.match_uimm32("expected 32-bit integer")?;
+                InstructionData::UnaryHeap {
                     opcode,
                     heap,
                     arg,
+                    imm,
+                }
+            }
+            InstructionFormat::BinaryHeap => {
+                let heap = self.match_heap("expected heap identifier")?;
+                ctx.check_heap(heap, self.loc)?;
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let arg = self.match_value("expected SSA value operand")?;
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let addr = self.match_value("expected SSA value address")?;
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let imm = self.match_uimm32("expected 32-bit integer")?;
+                InstructionData::BinaryHeap {
+                    opcode,
+                    heap,
+                    args: [arg, addr],
                     imm,
                 }
             }
@@ -2413,36 +2429,6 @@ impl<'a> Parser<'a> {
                     opcode,
                     table,
                     arg,
-                    offset,
-                }
-            }
-            InstructionFormat::HeapLoad => {
-                let heap = self.match_heap("expected heap identifier")?;
-                ctx.check_heap(heap, self.loc)?;
-                self.match_token(Token::Comma, "expected ',' between operands")?;
-                let arg = self.match_value("expected SSA value heap address")?;
-                self.match_token(Token::Comma, "expected ',' between operands")?;
-                let offset = self.optional_offset32()?;
-                InstructionData::HeapLoad {
-                    opcode,
-                    heap,
-                    arg,
-                    offset,
-                }
-            }
-            InstructionFormat::HeapStore => {
-                let heap = self.match_heap("expected heap identifier")?;
-                ctx.check_heap(heap, self.loc)?;
-                self.match_token(Token::Comma, "expected ',' between operands")?;
-                let arg = self.match_value("expected SSA value operand")?;
-                self.match_token(Token::Comma, "expected ',' between operands")?;
-                let addr = self.match_value("expected SSA value address")?;
-                self.match_token(Token::Comma, "expected ',' between operands")?;
-                let offset = self.optional_offset32()?;
-                InstructionData::HeapStore {
-                    opcode,
-                    heap,
-                    args: [arg, addr],
                     offset,
                 }
             }

--- a/lib/serde/src/serde_clif_json.rs
+++ b/lib/serde/src/serde_clif_json.rs
@@ -198,6 +198,18 @@ pub enum SerInstData {
         table: String,
         offset: String,
     },
+    HeapLoad {
+        opcode: String,
+        arg: String,
+        heap: String,
+        offset: String,
+    },
+    HeapStore {
+        opcode: String,
+        args: [String; 2],
+        heap: String,
+        offset: String,
+    },
     RegMove {
         opcode: String,
         arg: String,
@@ -632,6 +644,28 @@ pub fn get_inst_data(inst_index: Inst, func: &Function) -> SerInstData {
             opcode: opcode.to_string(),
             arg: arg.to_string(),
             table: table.to_string(),
+            offset: offset.to_string(),
+        },
+        InstructionData::HeapLoad {
+            opcode,
+            arg,
+            heap,
+            offset,
+        } => SerInstData::HeapLoad {
+            opcode: opcode.to_string(),
+            arg: arg.to_string(),
+            heap: heap.to_string(),
+            offset: offset.to_string(),
+        },
+        InstructionData::HeapStore {
+            opcode,
+            args,
+            heap,
+            offset,
+        } => SerInstData::HeapStore {
+            opcode: opcode.to_string(),
+            args: [args[0].to_string(), args[1].to_string()],
+            heap: heap.to_string(),
             offset: offset.to_string(),
         },
         InstructionData::RegMove {

--- a/lib/serde/src/serde_clif_json.rs
+++ b/lib/serde/src/serde_clif_json.rs
@@ -186,9 +186,15 @@ pub enum SerInstData {
         stack_slot: String,
         offset: String,
     },
-    HeapAddr {
+    UnaryHeap {
         opcode: String,
         arg: String,
+        heap: String,
+        imm: String,
+    },
+    BinaryHeap {
+        opcode: String,
+        args: [String; 2],
         heap: String,
         imm: String,
     },
@@ -196,18 +202,6 @@ pub enum SerInstData {
         opcode: String,
         arg: String,
         table: String,
-        offset: String,
-    },
-    HeapLoad {
-        opcode: String,
-        arg: String,
-        heap: String,
-        offset: String,
-    },
-    HeapStore {
-        opcode: String,
-        args: [String; 2],
-        heap: String,
         offset: String,
     },
     RegMove {
@@ -624,14 +618,25 @@ pub fn get_inst_data(inst_index: Inst, func: &Function) -> SerInstData {
             stack_slot: stack_slot.to_string(),
             offset: offset.to_string(),
         },
-        InstructionData::HeapAddr {
+        InstructionData::UnaryHeap {
             opcode,
             arg,
             heap,
             imm,
-        } => SerInstData::HeapAddr {
+        } => SerInstData::UnaryHeap {
             opcode: opcode.to_string(),
             arg: arg.to_string(),
+            heap: heap.to_string(),
+            imm: imm.to_string(),
+        },
+        InstructionData::BinaryHeap {
+            opcode,
+            args,
+            heap,
+            imm,
+        } => SerInstData::BinaryHeap {
+            opcode: opcode.to_string(),
+            args: [args[0].to_string(), args[1].to_string()],
             heap: heap.to_string(),
             imm: imm.to_string(),
         },
@@ -644,28 +649,6 @@ pub fn get_inst_data(inst_index: Inst, func: &Function) -> SerInstData {
             opcode: opcode.to_string(),
             arg: arg.to_string(),
             table: table.to_string(),
-            offset: offset.to_string(),
-        },
-        InstructionData::HeapLoad {
-            opcode,
-            arg,
-            heap,
-            offset,
-        } => SerInstData::HeapLoad {
-            opcode: opcode.to_string(),
-            arg: arg.to_string(),
-            heap: heap.to_string(),
-            offset: offset.to_string(),
-        },
-        InstructionData::HeapStore {
-            opcode,
-            args,
-            heap,
-            offset,
-        } => SerInstData::HeapStore {
-            opcode: opcode.to_string(),
-            args: [args[0].to_string(), args[1].to_string()],
-            heap: heap.to_string(),
             offset: offset.to_string(),
         },
         InstructionData::RegMove {

--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -985,7 +985,7 @@ fn translate_unreachable_operator(
 /// Translate a load instruction.
 fn translate_load<FE: FuncEnvironment + ?Sized>(
     offset: u32,
-    opcode: ir::Opcode,
+    _opcode: ir::Opcode,
     result_ty: Type,
     builder: &mut FunctionBuilder,
     state: &mut TranslationState,
@@ -994,16 +994,17 @@ fn translate_load<FE: FuncEnvironment + ?Sized>(
     let addr32 = state.pop1();
     // We don't yet support multiple linear memories.
     let heap = state.get_heap(builder.func, 0, environ);
-    let (load, dfg) = builder
-        .ins()
-        .UnaryHeap(opcode, result_ty, heap, offset.into(), addr32);
+    let (load, dfg) =
+        builder
+            .ins()
+            .UnaryHeap(ir::Opcode::HeapLoad, result_ty, heap, offset.into(), addr32);
     state.push1(dfg.first_result(load));
 }
 
 /// Translate a store instruction.
 fn translate_store<FE: FuncEnvironment + ?Sized>(
     offset: u32,
-    opcode: ir::Opcode,
+    _opcode: ir::Opcode,
     builder: &mut FunctionBuilder,
     state: &mut TranslationState,
     environ: &mut FE,
@@ -1013,9 +1014,14 @@ fn translate_store<FE: FuncEnvironment + ?Sized>(
 
     // We don't yet support multiple linear memories.
     let heap = state.get_heap(builder.func, 0, environ);
-    builder
-        .ins()
-        .BinaryHeap(opcode, val_ty, heap, offset.into(), val, addr32);
+    builder.ins().BinaryHeap(
+        ir::Opcode::HeapStore,
+        val_ty,
+        heap,
+        offset.into(),
+        val,
+        addr32,
+    );
 }
 
 fn translate_icmp(cc: IntCC, builder: &mut FunctionBuilder, state: &mut TranslationState) {


### PR DESCRIPTION
This pr starts implementing the safe-subset of cranelift IR specified by #589.