### PR TITLE
Make the verifier output even prettier

### DIFF
--- a/filetests/verifier/defs_dominates_uses.clif
+++ b/filetests/verifier/defs_dominates_uses.clif
@@ -4,13 +4,13 @@ test verifier
 
 function %non_dominating(i32) -> i32 system_v {
 ebb0(v0: i32):
-    v1 = iadd.i32 v2, v0   ; error: uses value from non-dominating
+    v1 = iadd.i32 v2, v0   ; error: uses value v2 from non-dominating
     v2 = iadd.i32 v1, v0
     return v2
 }
 
 function %inst_uses_its_own_values(i32) -> i32 system_v {
 ebb0(v0: i32):
-    v1 = iadd.i32 v1, v0   ; error: uses value from itself
+    v1 = iadd.i32 v1, v0   ; error: uses value v1 from itself
     return v1
 }

--- a/lib/codegen/src/print_errors.rs
+++ b/lib/codegen/src/print_errors.rs
@@ -23,6 +23,7 @@ pub fn pretty_verifier_error<'a>(
 ) -> String {
     let mut errors = errors.0;
     let mut w = String::new();
+    let num_errors = errors.len();
 
     decorate_function(
         &mut PrettyVerifierError(func_w.unwrap_or_else(|| Box::new(PlainWriter)), &mut errors),
@@ -30,6 +31,14 @@ pub fn pretty_verifier_error<'a>(
         func,
         isa,
     ).unwrap();
+
+    writeln!(
+        w,
+        "\n; {} verifier error{} detected (see above). Compilation aborted.",
+        num_errors,
+        if num_errors == 1 { "" } else { "s" }
+    ).unwrap();
+
     w
 }
 

--- a/lib/codegen/src/verifier/mod.rs
+++ b/lib/codegen/src/verifier/mod.rs
@@ -867,14 +867,7 @@ impl<'a> Verifier<'a> {
                         );
                     }
                     if def_inst == loc_inst {
-                        return fatal!(
-                            errors,
-                            loc_inst,
-                            "uses value {} from itself {},  {}",
-                            v,
-                            def_inst,
-                            loc_inst
-                        );
+                        return fatal!(errors, loc_inst, "uses value {} from itself", v);
                     }
                 }
             }

--- a/lib/codegen/src/verifier/mod.rs
+++ b/lib/codegen/src/verifier/mod.rs
@@ -861,7 +861,8 @@ impl<'a> Verifier<'a> {
                         return fatal!(
                             errors,
                             loc_inst,
-                            "uses value from non-dominating {}",
+                            "uses value {} from non-dominating {}",
+                            v,
                             def_inst
                         );
                     }
@@ -869,7 +870,8 @@ impl<'a> Verifier<'a> {
                         return fatal!(
                             errors,
                             loc_inst,
-                            "uses value from itself {},  {}",
+                            "uses value {} from itself {},  {}",
+                            v,
                             def_inst,
                             loc_inst
                         );

--- a/lib/filetests/src/test_verifier.rs
+++ b/lib/filetests/src/test_verifier.rs
@@ -62,7 +62,7 @@ impl SubTest for TestVerifier {
                 let mut errors = errors.0;
                 let mut msg = String::new();
 
-                // for each expected error, find a suitable match
+                // For each expected error, find a suitable match.
                 for expect in expected {
                     let pos = errors
                         .iter()
@@ -70,7 +70,7 @@ impl SubTest for TestVerifier {
 
                     match pos {
                         None => {
-                            write!(msg, "expected error {}", expect.0).unwrap();
+                            writeln!(msg, "  expected error {}: {}", expect.0, expect.1).unwrap();
                         }
                         Some(pos) => {
                             errors.swap_remove(pos);
@@ -78,9 +78,9 @@ impl SubTest for TestVerifier {
                     }
                 }
 
-                // report remaining errors
+                // Report remaining errors.
                 for err in errors {
-                    write!(msg, "unexpected error {}", err).unwrap();
+                    writeln!(msg, "unexpected error {}", err).unwrap();
                 }
 
                 if msg.is_empty() {


### PR DESCRIPTION
This tidies up several aspects of the verifier output. It fixes the length of the arrow to match the length of the subject, for example where it previously printed:

```
    gv2 = load.i32 notrap aligned gv1
;   ^~~~ verifier gv2: base gv1 has type i32, which is not the pointer type i64
```
it now prints:
```
    gv2 = load.i32 notrap aligned gv1
;   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
; error: gv2: base gv1 has type i32, which is not the pointer type i64
```

And, it tacks on a
```
; 1 verifier error detected (see above). Compilation aborted.
```
at the end, which is helpful because sometimes one gets a big IR dump and it's not immediately obvious why.