### PR TITLE
Fixes #600: Add a SIB byte when encoding a non-indexed load/store

### DIFF
--- a/filetests/isa/x86/binary64.clif
+++ b/filetests/isa/x86/binary64.clif
@@ -1440,3 +1440,131 @@ ebb2:
 ebb3:
     trap user0
 }
+
+function %r12_r13_loads() {
+ebb0:
+    [-,%r12]            v1 = iconst.i64 0x0123_4567_89ab_cdef
+    [-,%r13]            v2 = iconst.i64 0xfedc_ba98_7654_3210
+    [-,%rax]            v3 = iconst.i64 0x1
+
+    ;; Simple GPR load.
+    ; asm: movq (%r12), %rdx
+    [-,%rdx]            v4 = load.i64 notrap v1 ; bin: 49 8b 14 24
+    ; asm: movq (%r13), %rdx
+    [-,%rdx]            v5 = load.i64 notrap v2 ; bin: 49 8b 55 00
+
+    ;; Load with disp8.
+    ; asm: movq 0x1(%r12), %rdx
+    [-,%rdx]            v6 = load.i64 notrap v1+1 ; bin: 49 8b 54 24 01
+    ; asm: movq 0x1(%r13), %rdx
+    [-,%rdx]            v7 = load.i64 notrap v2+1 ; bin: 49 8b 55 01
+
+    ;; Load with disp32.
+    ; asm: movq 0x100(%r12), %rdx
+    [-,%rdx]            v8 = load.i64 notrap v1+256 ; bin: 49 8b 94 24 00000100
+    ; asm: movq 0x100(%r13), %rdx
+    [-,%rdx]            v9 = load.i64 notrap v2+256 ; bin: 49 8b 95 00000100
+
+    ;; Load for base+index.
+    ; asm: movq (%r12, %rax, 1), %rdx
+    [-,%rdx]            v10 = load_complex.i64 notrap v1+v3 ; bin: 49 8b 14 04
+    ; asm: movq (%r13, %rax, 1), %rdx
+    [-,%rdx]            v11 = load_complex.i64 notrap v2+v3 ; bin: 49 8b 54 05 00
+
+    ;; Now for FP values.
+    ; asm: movss (%r12), %xmm0
+    [-,%xmm0]            v12 = load.f32 notrap v1 ; bin: f3 41 0f 10 04 24
+    ; asm: movss (%r13), %xmm0
+    [-,%xmm0]            v13 = load.f32 notrap v2 ; bin: f3 41 0f 10 45 00
+
+    ;; Load with disp8.
+    ; asm: movss 0x1(%r12), %xmm0
+    [-,%xmm0]            v14 = load.f32 notrap v1+1 ; bin: f3 41 0f 10 44 24 01
+    ; asm: movss 0x1(%r13), %xmm0
+    [-,%xmm0]            v15 = load.f32 notrap v2+1 ; bin: f3 41 0f 10 45 01
+
+    ;; Load with disp32.
+    ; asm: movss 0x100(%r12), %xmm0
+    [-,%xmm0]            v16 = load.f32 notrap v1+256 ; bin: f3 41 0f 10 84 24 00000100
+    ; asm: movss 0x100(%r13), %xmm0
+    [-,%xmm0]            v17 = load.f32 notrap v2+256 ; bin: f3 41 0f 10 85 00000100
+
+    ;; Load for base+index.
+    ; asm: movss (%r12, %rax, 1), %xmm0
+    [-,%xmm0]            v18 = load_complex.f32 notrap v1+v3 ; bin: f3 41 0f 10 04 04
+    ; asm: movss (%r13, %rax, 1), %xmm0
+    [-,%xmm0]            v19 = load_complex.f32 notrap v2+v3 ; bin: f3 41 0f 10 44 05 00
+
+    return
+}
+
+function %r12_r13_stores() {
+ebb0:
+    [-,%r12]            v1 = iconst.i64 0x0123_4567_89ab_cdef
+    [-,%r13]            v2 = iconst.i64 0xfedc_ba98_7654_3210
+    [-,%rax]            v3 = iconst.i64 0x1
+    [-,%xmm0]           v4 = f32const 0x1.0
+
+    ;; Simple GPR load.
+    ; asm: movq %rax, (%r12)
+    store notrap v3, v1; bin: 49 89 04 24
+    ; asm: movq (%r13), %rdx
+    store notrap v3, v2; bin: 49 89 45 00
+
+    ; asm: movq %rax, 0x1(%r12)
+    store notrap v3, v1+1; bin: 49 89 44 24 01
+    ; asm: movq %rax, 0x1(%r13)
+    store notrap v3, v2+1; bin: 49 89 45 01
+
+    ; asm: movq %rax, 0x100(%r12)
+    store notrap v3, v1+256; bin: 49 89 84 24 00000100
+    ; asm: movq %rax, 0x100(%r13)
+    store notrap v3, v2+256; bin: 49 89 85 00000100
+
+    ; asm: movq %rax, (%r12, %rax, 1)
+    store_complex notrap v3, v1+v3; bin: 49 89 04 04
+    ; asm: movq %rax, (%r13, %rax, 1)
+    store_complex notrap v3, v2+v3; bin: 49 89 44 05 00
+
+    ; asm: movb %al, (%r12)
+    istore8 notrap v3, v1; bin: 41 88 04 24
+    ; asm: movb %al, (%r13)
+    istore8 notrap v3, v2; bin: 41 88 45 00
+
+    ; asm: movb %al, 0x1(%r12)
+    istore8 notrap v3, v1+1; bin: 41 88 44 24 01
+    ; asm: movb %al, 0x1(%r13)
+    istore8 notrap v3, v2+1; bin: 41 88 45 01
+
+    ; asm: movb %al, 0x100(%r12)
+    istore8 notrap v3, v1+256; bin: 41 88 84 24 00000100
+    ; asm: movb %al, 0x100(%r13)
+    istore8 notrap v3, v2+256; bin: 41 88 85 00000100
+
+    ; asm: movb %al, (%r12, %rax, 1)
+    istore8_complex notrap v3, v1+v3; bin: 41 88 04 04
+    ; asm: movb %al, (%r13, %rax, 1)
+    istore8_complex notrap v3, v2+v3; bin: 41 88 44 05 00
+
+    ; asm: movss %xmm0, (%r12)
+    store notrap v4, v1; bin: f3 41 0f 11 04 24
+    ; asm: movss %xmm0, (%r13)
+    store notrap v4, v2; bin: f3 41 0f 11 45 00
+
+    ; asm: movss %xmm0, 0x1(%r12)
+    store notrap v4, v1+1; bin: f3 41 0f 11 44 24 01
+    ; asm: movss %xmm0, 0x1(%r13)
+    store notrap v4, v2+1; bin: f3 41 0f 11 45 01
+
+    ; asm: movss %xmm0, 0x100(%r12)
+    store notrap v4, v1+256; bin: f3 41 0f 11 84 24 00000100
+    ; asm: movss %xmm0, 0x100(%r13)
+    store notrap v4, v2+256; bin: f3 41 0f 11 85 00000100
+
+    ; asm: movss %xmm0, (%r12, %rax, 1)
+    store_complex notrap v4, v1+v3; bin: f3 41 0f 11 04 04
+    ; asm: movss %xmm0, (%r13, %rax, 1)
+    store_complex notrap v4, v2+v3; bin: f3 41 0f 11 44 05 00
+
+    return
+}

--- a/lib/codegen/meta-python/isa/x86/recipes.py
+++ b/lib/codegen/meta-python/isa/x86/recipes.py
@@ -806,13 +806,16 @@ st = TailRecipe(
         'st', Store, base_size=1, ins=(GPR, GPR), outs=(),
         instp=IsEqual(Store.offset, 0),
         clobbers_flags=False,
-        compute_size="size_plus_maybe_offset_for_in_reg_1",
+        compute_size="size_plus_maybe_sib_or_offset_for_in_reg_1",
         emit='''
         if !flags.notrap() {
             sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
         }
         PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
-        if needs_offset(in_reg1) {
+        if needs_sib_byte(in_reg1) {
+            modrm_sib(in_reg0, sink);
+            sib_noindex(in_reg1, sink);
+        } else if needs_offset(in_reg1) {
             modrm_disp8(in_reg1, in_reg0, sink);
             sink.put1(0);
         } else {
@@ -833,6 +836,7 @@ stWithIndex = TailRecipe(
         sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
     }
     PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+    // The else branch always inserts an SIB byte.
     if needs_offset(in_reg1) {
         modrm_sib_disp8(in_reg0, sink);
         sib(0, in_reg2, in_reg1, sink);
@@ -872,6 +876,7 @@ stWithIndex_abcd = TailRecipe(
         sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
     }
     PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+    // The else branch always inserts an SIB byte.
     if needs_offset(in_reg1) {
         modrm_sib_disp8(in_reg0, sink);
         sib(0, in_reg2, in_reg1, sink);
@@ -887,13 +892,16 @@ fst = TailRecipe(
         'fst', Store, base_size=1, ins=(FPR, GPR), outs=(),
         instp=IsEqual(Store.offset, 0),
         clobbers_flags=False,
-        compute_size="size_plus_maybe_offset_for_in_reg_1",
+        compute_size="size_plus_maybe_sib_or_offset_for_in_reg_1",
         emit='''
         if !flags.notrap() {
             sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
         }
         PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
-        if needs_offset(in_reg1) {
+        if needs_sib_byte(in_reg1) {
+            modrm_sib(in_reg0, sink);
+            sib_noindex(in_reg1, sink);
+        } else if needs_offset(in_reg1) {
             modrm_disp8(in_reg1, in_reg0, sink);
             sink.put1(0);
         } else {
@@ -912,6 +920,7 @@ fstWithIndex = TailRecipe(
             sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
         }
         PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+        // The else branch always inserts an SIB byte.
         if needs_offset(in_reg1) {
             modrm_sib_disp8(in_reg0, sink);
             sib(0, in_reg2, in_reg1, sink);
@@ -1210,13 +1219,16 @@ ld = TailRecipe(
         'ld', Load, base_size=1, ins=(GPR), outs=(GPR),
         instp=IsEqual(Load.offset, 0),
         clobbers_flags=False,
-        compute_size="size_plus_maybe_offset_for_in_reg_0",
+        compute_size="size_plus_maybe_sib_or_offset_for_in_reg_0",
         emit='''
         if !flags.notrap() {
             sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
         }
         PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
-        if needs_offset(in_reg0) {
+        if needs_sib_byte(in_reg0) {
+            modrm_sib(out_reg0, sink);
+            sib_noindex(in_reg0, sink);
+        } else if needs_offset(in_reg0) {
             modrm_disp8(in_reg0, out_reg0, sink);
             sink.put1(0);
         } else {
@@ -1237,6 +1249,7 @@ ldWithIndex = TailRecipe(
         sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
     }
     PUT_OP(bits, rex3(in_reg0, out_reg0, in_reg1), sink);
+    // The else branch always inserts an SIB byte.
     if needs_offset(in_reg0) {
         modrm_sib_disp8(out_reg0, sink);
         sib(0, in_reg1, in_reg0, sink);
@@ -1252,13 +1265,16 @@ fld = TailRecipe(
         'fld', Load, base_size=1, ins=(GPR), outs=(FPR),
         instp=IsEqual(Load.offset, 0),
         clobbers_flags=False,
-        compute_size="size_plus_maybe_offset_for_in_reg_0",
+        compute_size="size_plus_maybe_sib_or_offset_for_in_reg_0",
         emit='''
         if !flags.notrap() {
             sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
         }
         PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
-        if needs_offset(in_reg0) {
+        if needs_sib_byte(in_reg0) {
+            modrm_sib(out_reg0, sink);
+            sib_noindex(in_reg0, sink);
+        } else if needs_offset(in_reg0) {
             modrm_disp8(in_reg0, out_reg0, sink);
             sink.put1(0);
         } else {
@@ -1279,6 +1295,7 @@ fldWithIndex = TailRecipe(
         sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
     }
     PUT_OP(bits, rex3(in_reg0, out_reg0, in_reg1), sink);
+    // The else branch always inserts an SIB byte.
     if needs_offset(in_reg0) {
         modrm_sib_disp8(out_reg0, sink);
         sib(0, in_reg1, in_reg0, sink);

--- a/lib/codegen/src/isa/x86/enc_tables.rs
+++ b/lib/codegen/src/isa/x86/enc_tables.rs
@@ -23,6 +23,9 @@ pub fn needs_sib_byte(reg: RegUnit) -> bool {
 pub fn needs_offset(reg: RegUnit) -> bool {
     reg == RU::r13 as RegUnit || reg == RU::rbp as RegUnit
 }
+pub fn needs_sib_byte_or_offset(reg: RegUnit) -> bool {
+    needs_sib_byte(reg) || needs_offset(reg)
+}
 
 fn additional_size_if(
     op_index: usize,
@@ -70,6 +73,22 @@ fn size_plus_maybe_sib_for_in_reg_1(
     func: &Function,
 ) -> u8 {
     sizing.base_size + additional_size_if(1, inst, divert, func, needs_sib_byte)
+}
+fn size_plus_maybe_sib_or_offset_for_in_reg_0(
+    sizing: &RecipeSizing,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    sizing.base_size + additional_size_if(0, inst, divert, func, needs_sib_byte_or_offset)
+}
+fn size_plus_maybe_sib_or_offset_for_in_reg_1(
+    sizing: &RecipeSizing,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    sizing.base_size + additional_size_if(1, inst, divert, func, needs_sib_byte_or_offset)
 }
 
 /// Expand the `sdiv` and `srem` instructions using `x86_sdivmodx`.

--- a/lib/codegen/src/write.rs
+++ b/lib/codegen/src/write.rs
@@ -14,6 +14,16 @@ use std::vec::Vec;
 
 /// A `FuncWriter` used to decorate functions during printing.
 pub trait FuncWriter {
+    /// Write the extended basic block header for the current function.
+    fn write_ebb_header(
+        &mut self,
+        w: &mut Write,
+        func: &Function,
+        isa: Option<&TargetIsa>,
+        ebb: Ebb,
+        indent: usize,
+    ) -> fmt::Result;
+
     /// Write the given `inst` to `w`.
     fn write_instruction(
         &mut self,
@@ -22,7 +32,7 @@ pub trait FuncWriter {
         aliases: &SecondaryMap<Value, Vec<Value>>,
         isa: Option<&TargetIsa>,
         inst: Inst,
-        ident: usize,
+        indent: usize,
     ) -> fmt::Result;
 
     /// Write the preamble to `w`. By default, this uses `write_entity_definition`.
@@ -107,6 +117,17 @@ impl FuncWriter for PlainWriter {
         indent: usize,
     ) -> fmt::Result {
         write_instruction(w, func, aliases, isa, inst, indent)
+    }
+
+    fn write_ebb_header(
+        &mut self,
+        w: &mut Write,
+        func: &Function,
+        isa: Option<&TargetIsa>,
+        ebb: Ebb,
+        indent: usize,
+    ) -> fmt::Result {
+        write_ebb_header(w, func, isa, ebb, indent)
     }
 }
 
@@ -227,7 +248,7 @@ fn decorate_ebb<FW: FuncWriter>(
         36
     };
 
-    write_ebb_header(w, func, isa, ebb, indent)?;
+    func_w.write_ebb_header(w, func, isa, ebb, indent)?;
     for a in func.dfg.ebb_params(ebb).iter().cloned() {
         write_value_aliases(w, aliases, a, indent)?;
     }


### PR DESCRIPTION
Memory access instructions which took the GPR_ZERO_DEREF_SAFE register
class (that was removed in #552 ) should check for the need of either an
offset (r13/rbp) or the SIB byte (r12/rsp). Some load/store instructions
would already take an index, thus already contain the SIB byte in this
case (see instructions which have a comment telling that the else branch
already contains an SIB byte). Non-indexed memory accesses lacked the
SIB byte check, which this patch adds.