### PR TITLE
Port typevar and InstructionList from meta-python

### DIFF
--- a/lib/codegen/meta/Cargo.toml
+++ b/lib/codegen/meta/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 
 [dependencies]
 cranelift-entity = { path = "../../entity", version = "0.23.0" }
+indexmap = "1.0.2"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/lib/codegen/meta/src/base/instructions.rs
+++ b/lib/codegen/meta/src/base/instructions.rs
@@ -1,0 +1,2 @@
+//! This module predefines all the Cranelift instructions.
+

--- a/lib/codegen/meta/src/base/instructions.rs
+++ b/lib/codegen/meta/src/base/instructions.rs
@@ -1,2 +1,1 @@
 //! This module predefines all the Cranelift instructions.
-

--- a/lib/codegen/meta/src/base/mod.rs
+++ b/lib/codegen/meta/src/base/mod.rs
@@ -1,4 +1,4 @@
 //! Definitions for the base Cranelift language.
 
-pub mod types;
 pub mod instructions;
+pub mod types;

--- a/lib/codegen/meta/src/base/mod.rs
+++ b/lib/codegen/meta/src/base/mod.rs
@@ -1,3 +1,4 @@
 //! Definitions for the base Cranelift language.
 
 pub mod types;
+pub mod instructions;

--- a/lib/codegen/meta/src/base/types.rs
+++ b/lib/codegen/meta/src/base/types.rs
@@ -113,7 +113,7 @@ impl Iterator for FloatIterator {
 /// A type representing CPU flags.
 ///
 /// Flags can't be stored in memory.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Flag {
     /// CPU flags from an integer comparison.
     IFlags,

--- a/lib/codegen/meta/src/cdsl/instructions.rs
+++ b/lib/codegen/meta/src/cdsl/instructions.rs
@@ -6,9 +6,7 @@ pub struct InstructionList {
 
 impl InstructionList {
     pub fn new() -> Self {
-        Self {
-            groups: Vec::new(),
-        }
+        Self { groups: Vec::new() }
     }
 
     pub fn group(&mut self, name: &'static str, f: impl FnOnce(&mut InstructionGroup)) {
@@ -96,12 +94,8 @@ impl InstructionBuilder {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Constraint {
-    WiderOrEq {
-        ty: [ValueType; 2],
-    },
-    TypesEqual {
-        ty: [ValueType; 2],
-    },
+    WiderOrEq { ty: [ValueType; 2] },
+    TypesEqual { ty: [ValueType; 2] },
 }
 
 impl Constraint {

--- a/lib/codegen/meta/src/cdsl/instructions.rs
+++ b/lib/codegen/meta/src/cdsl/instructions.rs
@@ -1,0 +1,118 @@
+use super::types::ValueType;
+
+pub struct InstructionList {
+    groups: Vec<InstructionGroup>,
+}
+
+impl InstructionList {
+    pub fn new() -> Self {
+        Self {
+            groups: Vec::new(),
+        }
+    }
+
+    pub fn group(&mut self, name: &'static str, f: impl FnOnce(&mut InstructionGroup)) {
+        let mut group = InstructionGroup::new(name);
+        f(&mut group);
+        self.groups.push(group);
+    }
+}
+
+pub struct InstructionGroup {
+    name: &'static str,
+    insts: Vec<Instruction>,
+}
+
+impl InstructionGroup {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            insts: Vec::new(),
+        }
+    }
+
+    pub fn add(&mut self, inst: Instruction) {
+        self.insts.push(inst);
+    }
+}
+
+pub struct Instruction {
+    name: &'static str,
+    doc: &'static str,
+    ins: &'static [()],
+    outs: &'static [()],
+    constraints: &'static [Constraint],
+}
+
+pub struct InstructionBuilder {
+    name: &'static str,
+    doc: &'static str,
+    ins: &'static [()],
+    outs: &'static [()],
+    constraints: &'static [Constraint],
+}
+
+impl InstructionBuilder {
+    pub fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            doc: "",
+            ins: &[],
+            outs: &[],
+            constraints: &[],
+        }
+    }
+
+    pub fn doc(mut self, doc: &'static str) -> Self {
+        self.doc = doc;
+        self
+    }
+
+    pub fn ins(mut self, ins: &'static [()]) -> Self {
+        self.ins = ins;
+        self
+    }
+
+    pub fn outs(mut self, outs: &'static [()]) -> Self {
+        self.outs = outs;
+        self
+    }
+
+    pub fn constraints(mut self, constraints: &'static [Constraint]) -> Self {
+        self.constraints = constraints;
+        self
+    }
+
+    pub fn build(self) -> Instruction {
+        Instruction {
+            name: self.name,
+            doc: self.doc,
+            ins: self.ins,
+            outs: self.outs,
+            constraints: self.constraints,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Constraint {
+    WiderOrEq {
+        ty: [ValueType; 2],
+    },
+    TypesEqual {
+        ty: [ValueType; 2],
+    },
+}
+
+impl Constraint {
+    pub fn eval(&self) {
+        match self {
+            Constraint::WiderOrEq { ty: [ty0, ty1] } => {
+                assert!(ty0.width() >= ty1.width());
+            }
+            Constraint::TypesEqual { ty: [ty0, ty1] } => {
+                assert_eq!(ty0, ty1);
+            }
+        }
+    }
+}

--- a/lib/codegen/meta/src/cdsl/mod.rs
+++ b/lib/codegen/meta/src/cdsl/mod.rs
@@ -3,10 +3,10 @@
 //! This module defines the classes that are used to define Cranelift
 //! instructions and other entities.
 
+pub mod instructions;
 pub mod isa;
 pub mod regs;
 pub mod types;
-pub mod instructions;
 pub mod typevar;
 
 /// Convert the string `s` to CamelCase.

--- a/lib/codegen/meta/src/cdsl/mod.rs
+++ b/lib/codegen/meta/src/cdsl/mod.rs
@@ -6,6 +6,8 @@
 pub mod isa;
 pub mod regs;
 pub mod types;
+pub mod instructions;
+pub mod typevar;
 
 /// Convert the string `s` to CamelCase.
 fn _camel_case(s: &str) -> String {

--- a/lib/codegen/meta/src/cdsl/types.rs
+++ b/lib/codegen/meta/src/cdsl/types.rs
@@ -27,7 +27,7 @@ static _RUST_NAME_PREFIX: &'static str = "ir::types::";
 ///
 /// All SSA values have a type that is described by an instance of `ValueType`
 /// or one of its subclasses.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ValueType {
     BV(BVType),
     Lane(LaneType),
@@ -147,7 +147,7 @@ impl From<VectorType> for ValueType {
 }
 
 /// A concrete scalar type that can appear as a vector lane too.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum LaneType {
     BoolType(base_types::Bool),
     FloatType(base_types::Float),
@@ -289,6 +289,7 @@ impl Iterator for LaneTypeIterator {
 ///
 /// A vector type has a lane type which is an instance of `LaneType`,
 /// and a positive number of lanes.
+#[derive(PartialEq, Eq)]
 pub struct VectorType {
     base: LaneType,
     lanes: u64,
@@ -349,6 +350,7 @@ impl fmt::Debug for VectorType {
 }
 
 /// A flat bitvector type. Used for semantics description only.
+#[derive(PartialEq, Eq)]
 pub struct BVType {
     bits: u64,
 }
@@ -385,7 +387,7 @@ impl fmt::Debug for BVType {
 /// A concrete scalar type that is neither a vector nor a lane type.
 ///
 /// Special types cannot be used to form vectors.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SpecialType {
     Flag(base_types::Flag),
 }

--- a/lib/codegen/meta/src/cdsl/typevar.rs
+++ b/lib/codegen/meta/src/cdsl/typevar.rs
@@ -1,0 +1,347 @@
+use super::types::{
+    ValueType,
+    SpecialType,
+};
+use std::ops::Range;
+use indexmap::IndexSet;
+
+const MAX_LANES: usize = 256;
+const MAX_BITS: usize = 64;
+const MAX_BITVEC: usize = MAX_BITS * MAX_LANES;
+
+pub enum Interval {
+    All,
+    Range(Range<usize>),
+}
+
+#[derive(Clone, Debug)]
+struct IntervalIter {
+    next: usize,
+    range: Range<usize>,
+}
+
+impl IntervalIter {
+    fn empty() -> Self {
+        Self {
+            next: 0,
+            range: (0..0),
+        }
+    }
+}
+
+impl Iterator for IntervalIter {
+    type Item = usize;
+    fn next(&mut self) -> Option<usize> {
+        let next = self.next;
+        if next <= self.range.end && next > 0 {
+            self.next *= 2;
+            Some(next)
+        } else {
+            None
+        }
+    }
+}
+
+impl Interval {
+    fn decode(interval: Option<Interval>, full_range: Range<usize>, default: Option<usize>) -> Range<usize> {
+        match interval {
+            Some(Interval::All) => full_range,
+            Some(Interval::Range(range)) => range,
+            None => match default {
+                Some(default) => (default..default),
+                None => (0..0)
+            }
+        }
+    }
+
+    fn to_iter(range: Range<usize>) -> IntervalIter {
+        if let (0, 0) = (range.start, range.end) {
+            return IntervalIter::empty();
+        }
+
+        let (start, end) = (range.start, range.end);
+
+        assert!(start.is_power_of_two());
+        assert!(end.is_power_of_two());
+        assert!(start <= end);
+
+        IntervalIter {
+            next: start,
+            range,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum SpecialSpec {
+    All,
+    List(Vec<SpecialType>),
+}
+
+impl SpecialSpec {
+    fn to_set(spec: Option<SpecialSpec>) -> IndexSet<SpecialType> {
+        match spec {
+            Some(SpecialSpec::All) => ValueType::all_special_types().collect(),
+            Some(SpecialSpec::List(vec)) => vec.into_iter().collect(),
+            None => IndexSet::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeSet {
+    lanes: IndexSet<usize>,
+    ints: IndexSet<usize>,
+    floats: IndexSet<usize>,
+    bools: IndexSet<usize>,
+    bitvecs: IndexSet<usize>,
+    specials: IndexSet<SpecialType>,
+}
+
+impl TypeSet {
+    pub fn build() -> TypeSetBuilder {
+        Default::default()
+    }
+
+    pub fn intersect(&self, other: &TypeSet) -> TypeSet {
+        TypeSet {
+            lanes: &self.lanes & &other.lanes,
+            ints: &self.ints & &other.ints,
+            floats: &self.floats & &other.floats,
+            bools: &self.bools & &other.bools,
+            bitvecs: &self.bitvecs & &other.bitvecs,
+            specials: &self.specials & &other.specials,
+        }
+    }
+
+    pub fn is_subset(&self, other: &TypeSet) -> bool {
+        self.lanes.is_subset(&other.lanes)
+        && self.ints.is_subset(&other.ints)
+        && self.floats.is_subset(&other.floats)
+        && self.bools.is_subset(&other.bools)
+        && self.bitvecs.is_subset(&other.bitvecs)
+        && self.specials.is_subset(&other.specials)
+    }
+
+    pub fn as_bool(&self) -> TypeSet {
+        let mut new = self.clone();
+        new.ints.clear();
+        new.floats.clear();
+        new.bitvecs.clear();
+
+        if self.lanes.difference(&[1usize].to_vec().into_iter().collect::<IndexSet<usize>>()).count() > 0 {
+            new.bools = self.ints
+                .union(&self.floats)
+                .map(|i| *i)
+                .collect::<IndexSet<usize>>()
+                .union(&self.bools)
+                .map(|i| *i)
+                .collect::<IndexSet<usize>>();
+        }
+
+        if self.lanes.contains(&1) {
+            new.bools.insert(1);
+        }
+
+        new
+    }
+
+
+}
+
+#[derive(Default)]
+pub struct TypeSetBuilder {
+    lanes: Option<Interval>,
+    ints: Option<Interval>,
+    floats: Option<Interval>,
+    bools: Option<Interval>,
+    bitvecs: Option<Interval>,
+    specials: Option<SpecialSpec>,
+}
+
+impl TypeSetBuilder {
+    pub fn lanes(mut self, interval: Interval) -> Self {
+        self.lanes = Some(interval);
+        self
+    }
+
+    pub fn ints(mut self, interval: Interval) -> Self {
+        self.ints = Some(interval);
+        self
+    }
+
+    pub fn floats(mut self, interval: Interval) -> Self {
+        self.floats = Some(interval);
+        self
+    }
+
+    pub fn bools(mut self, interval: Interval) -> Self {
+        self.bools = Some(interval);
+        self
+    }
+
+    pub fn bitvecs(mut self, interval: Interval) -> Self {
+        self.bitvecs = Some(interval);
+        self
+    }
+
+    pub fn specials(mut self, specials: SpecialSpec) -> Self {
+        self.specials = Some(specials);
+        self
+    }
+
+    pub fn finish(self) -> TypeSet {
+        TypeSet {
+            lanes: Interval::to_iter(Interval::decode(self.lanes, 1..MAX_LANES, Some(1))).collect(),
+            ints: Interval::to_iter(Interval::decode(self.ints, 8..MAX_BITS, None)).collect(),
+            floats: Interval::to_iter(Interval::decode(self.floats, 32..64, None)).collect(),
+            bools: Interval::to_iter(Interval::decode(self.bools, 1..MAX_BITS, None))
+                .filter(|&bits| {
+                    bits == 1 || (bits >= 8 && bits <= MAX_BITS && bits.is_power_of_two())
+                }).collect(),
+            bitvecs: Interval::to_iter(Interval::decode(self.bitvecs, 1..MAX_BITVEC, None)).collect(),
+            specials: SpecialSpec::to_set(self.specials),
+        }
+    }
+
+}
+
+pub struct TypeVar {
+    name: String,
+    doc: &'static str,
+    type_set: TypeSet,
+    base: Option<Box<TypeVar>>,
+    derived_func: Option<&'static str>,
+}
+
+impl TypeVar {
+    pub fn build(name: impl Into<String>) -> TypeVarBuilder {
+        TypeVarBuilder {
+            name: name.into(),
+            doc: "",
+            type_set_builder: TypeSet::build(),
+            derived_func: None,
+            scalars: true,
+            simd: None,
+            base: None,
+        }
+    }
+}
+
+pub struct TypeVarBuilder {
+    name: String,
+    doc: &'static str,
+    base: Option<Box<TypeVar>>,
+    type_set_builder: TypeSetBuilder,
+    derived_func: Option<&'static str>,
+    scalars: bool,
+    simd: Option<Interval>
+}
+
+impl TypeVarBuilder {
+    pub fn doc(mut self, doc: &'static str) -> Self {
+        self.doc = doc;
+        self
+    }
+
+    pub fn ints(mut self, interval: Interval) -> Self {
+        self.type_set_builder = self.type_set_builder.ints(interval);
+        self
+    }
+
+    pub fn floats(mut self, interval: Interval) -> Self {
+        self.type_set_builder = self.type_set_builder.floats(interval);
+        self
+    }
+
+    pub fn bools(mut self, interval: Interval) -> Self {
+        self.type_set_builder = self.type_set_builder.bools(interval);
+        self
+    }
+
+    pub fn scalars(mut self, b: bool) -> Self {
+        self.scalars = b;
+        self
+    }
+
+    pub fn simd(mut self, interval: Interval) -> Self {
+        self.simd = Some(interval);
+        self
+    }
+
+    pub fn bitvecs(mut self, interval: Interval) -> Self {
+        self.type_set_builder = self.type_set_builder.bitvecs(interval);
+        self
+    }
+
+    pub fn base(mut self, base: TypeVar, derived_func: &'static str) -> Self {
+        self.name = format!("{}({})", derived_func, base.name);
+        self.base = Some(Box::new(base));
+        self.derived_func = Some(derived_func);
+        self
+    }
+
+    pub fn specials(mut self, specials: SpecialSpec) -> Self {
+        self.type_set_builder = self.type_set_builder.specials(specials);
+        self
+    }
+
+    pub fn finish(self) -> TypeVar {
+        let min_lanes = if self.scalars { 1 } else { 2 };
+        let type_set = self.type_set_builder
+            .lanes(Interval::Range(Interval::decode(self.simd, min_lanes..MAX_LANES, Some(1))))
+            .finish();
+
+        TypeVar {
+            name: self.name,
+            doc: self.doc,
+            type_set,
+            derived_func: self.derived_func,
+            base: self.base,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_set_works() {
+        let set = TypeSet::build()
+            .ints(Interval::Range(8..32))
+            .finish();
+        
+        assert_eq!(set.lanes, indexset!{1});
+        assert_eq!(set.ints, indexset!{8, 16, 32});
+
+        let set = TypeSet::build()
+            .ints(Interval::All)
+            .finish();
+
+        assert_eq!(set.lanes, indexset!{1});
+        assert_eq!(set.ints, indexset!{8, 16, 32, 64});
+
+        let set = TypeSet::build()
+            .floats(Interval::All)
+            .finish();
+        
+        assert_eq!(set.lanes, indexset!{1});
+        assert_eq!(set.floats, indexset!{32, 64});
+
+        let set = TypeSet::build()
+            .bools(Interval::All)
+            .finish();
+        
+        assert_eq!(set.lanes, indexset!{1});
+        assert_eq!(set.bools, indexset!{1, 8, 16, 32, 64});
+
+        let set = TypeSet::build()
+            .lanes(Interval::All)
+            .ints(Interval::All)
+            .finish();
+        
+        assert_eq!(set.lanes, indexset!{1, 2, 4, 8, 16, 32, 64, 128, 256});
+        assert_eq!(set.ints, indexset!{8, 16, 32, 64}); 
+    }
+}

--- a/lib/codegen/meta/src/gen_instr.rs
+++ b/lib/codegen/meta/src/gen_instr.rs
@@ -1,7 +1,7 @@
 //! Generate sources with instruction info.
-//! 
+//!
 //! This generates the `opcodes.rs` file which is included in
-//! `lib/codegen/ir/instructions.rs`. The file provides definitions of 
+//! `lib/codegen/ir/instructions.rs`. The file provides definitions of
 //! `InstructionFormat`, `InstructionData`, `Opcode`, `OPCODE_FORMAT`,
 //! `opcode_name`, `OPCODE_HASH_TABLE`, `OPCODE_CONSTRAINTS`, `TYPE_SETS`,
 //! and `OPERAND_CONSTRAINTS`.
@@ -11,17 +11,17 @@ use srcgen::Formatter;
 
 /// Generate an instruction format enumeration.
 fn gen_formats(fmt: &mut Formatter) -> Result<(), error::Error> {
-    fmt.doc_comment("
+    fmt.doc_comment(
+        "
         An instruction format
 
         Every opcode has a corresponding instruction format
         which is represented by both the `InstructionFormat`
         and the `InstructionData` enums.
-    ");
+    ",
+    );
     fmt.line("#[derive(Copy, Clone, PartialEq, Eq, Debug)]");
-    fmt.indent_with("pub enum InstructionFormat {", "}", |fmt| {
-
-    });
+    fmt.indent_with("pub enum InstructionFormat {", "}", |fmt| {});
 
     Ok(())
 }

--- a/lib/codegen/meta/src/gen_instr.rs
+++ b/lib/codegen/meta/src/gen_instr.rs
@@ -1,0 +1,37 @@
+//! Generate sources with instruction info.
+//! 
+//! This generates the `opcodes.rs` file which is included in
+//! `lib/codegen/ir/instructions.rs`. The file provides definitions of 
+//! `InstructionFormat`, `InstructionData`, `Opcode`, `OPCODE_FORMAT`,
+//! `opcode_name`, `OPCODE_HASH_TABLE`, `OPCODE_CONSTRAINTS`, `TYPE_SETS`,
+//! and `OPERAND_CONSTRAINTS`.
+
+use error;
+use srcgen::Formatter;
+
+/// Generate an instruction format enumeration.
+fn gen_formats(fmt: &mut Formatter) -> Result<(), error::Error> {
+    fmt.doc_comment("
+        An instruction format
+
+        Every opcode has a corresponding instruction format
+        which is represented by both the `InstructionFormat`
+        and the `InstructionData` enums.
+    ");
+    fmt.line("#[derive(Copy, Clone, PartialEq, Eq, Debug)]");
+    fmt.indent_with("pub enum InstructionFormat {", "}", |fmt| {
+
+    });
+
+    Ok(())
+}
+
+pub fn generate(filename: &str, out_dir: &str) -> Result<(), error::Error> {
+    let mut fmt = Formatter::new();
+
+    gen_formats(&mut fmt)?;
+
+    fmt.update_file(filename, out_dir)?;
+
+    Ok(())
+}

--- a/lib/codegen/meta/src/lib.rs
+++ b/lib/codegen/meta/src/lib.rs
@@ -4,9 +4,9 @@ extern crate cranelift_entity;
 extern crate indexmap;
 
 pub mod error;
+pub mod gen_instr;
 pub mod gen_registers;
 pub mod gen_types;
-pub mod gen_instr;
 pub mod isa;
 
 mod base;

--- a/lib/codegen/meta/src/lib.rs
+++ b/lib/codegen/meta/src/lib.rs
@@ -1,9 +1,12 @@
 #[macro_use]
 extern crate cranelift_entity;
+#[macro_use]
+extern crate indexmap;
 
 pub mod error;
 pub mod gen_registers;
 pub mod gen_types;
+pub mod gen_instr;
 pub mod isa;
 
 mod base;

--- a/lib/codegen/meta/src/srcgen.rs
+++ b/lib/codegen/meta/src/srcgen.rs
@@ -45,7 +45,12 @@ impl Formatter {
         ret
     }
 
-    pub fn indent_with<T>(&mut self, start: &str, end: &str, f: impl FnOnce(&mut Formatter) -> T) -> T {
+    pub fn indent_with<T>(
+        &mut self,
+        start: &str,
+        end: &str,
+        f: impl FnOnce(&mut Formatter) -> T,
+    ) -> T {
         self.line(start);
         let ret = self.indent(f);
         self.line(end);

--- a/lib/codegen/meta/src/srcgen.rs
+++ b/lib/codegen/meta/src/srcgen.rs
@@ -45,6 +45,13 @@ impl Formatter {
         ret
     }
 
+    pub fn indent_with<T>(&mut self, start: &str, end: &str, f: impl FnOnce(&mut Formatter) -> T) -> T {
+        self.line(start);
+        let ret = self.indent(f);
+        self.line(end);
+        ret
+    }
+
     /// Get the current whitespace indentation in the form of a String.
     fn get_indent(&self) -> String {
         if self.indent == 0 {


### PR DESCRIPTION
This ports more of meta-python over to meta. Right now, the added code isn't used, but it will be soon, once the instructions start getting moved over.