### PR TITLE
Remove the build time and directory from cranelift-codegen-meta's output

### DIFF
--- a/lib/codegen/build.rs
+++ b/lib/codegen/build.rs
@@ -24,11 +24,7 @@ use meta::isa::Isa;
 use std::env;
 use std::process;
 
-use std::time::Instant;
-
 fn main() {
-    let start_time = Instant::now();
-
     let out_dir = env::var("OUT_DIR").expect("The OUT_DIR environment variable must be set");
     let target_triple = env::var("TARGET").expect("The TARGET environment variable must be set");
     let cranelift_targets = env::var("CRANELIFT_TARGETS").ok();
@@ -96,15 +92,6 @@ fn main() {
             process::exit(1);
         }
     }
-
-    println!(
-        "cargo:warning=Cranelift meta-build step took {:?}",
-        Instant::now() - start_time
-    );
-    println!(
-        "cargo:warning=Meta-build script generated files in {}",
-        out_dir
-    );
 }
 
 fn identify_python() -> &'static str {


### PR DESCRIPTION
This makes its output non-deterministic, making it friendlier for compilation caching tools such as [sccache](https://github.com/mozilla/sccache).

Printing out the build directory is nice to do, as Cargo tends to keep a few versions around under the target directory and it's useful to know which one is for the current build, but I wasn't able to find a better way to do that.

This is my current theory as to what's causing the significant build time regressions in mozilla-central reported here: https://bugzilla.mozilla.org/show_bug.cgi?id=1506511