### PR TITLE
Improved imports

### DIFF
--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -55,6 +55,9 @@ pub struct DummyModuleInfo {
     /// Module and field names of imported globals as provided by `declare_global_import`.
     pub imported_globals: Vec<(String, String)>,
 
+    /// Module and field names of imported tables as provided by `declare_table_import`.
+    pub imported_tables: Vec<(String, String)>,
+
     /// Functions, imported and local.
     pub functions: PrimaryMap<FuncIndex, Exportable<SignatureIndex>>,
 
@@ -82,6 +85,7 @@ impl DummyModuleInfo {
             signatures: PrimaryMap::new(),
             imported_funcs: Vec::new(),
             imported_globals: Vec::new(),
+            imported_tables: Vec::new(),
             functions: PrimaryMap::new(),
             function_bodies: PrimaryMap::new(),
             tables: PrimaryMap::new(),
@@ -398,6 +402,19 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     fn declare_table(&mut self, table: Table) {
         self.info.tables.push(Exportable::new(table));
     }
+
+    fn declare_table_import(
+        &mut self,
+        table: Table,
+        module: &'data str,
+        field: &'data str,
+    ) {
+        self.info.tables.push(Exportable::new(table));
+        self.info
+            .imported_tables
+            .push((String::from(module), String::from(field)));
+    }
+
     fn declare_table_elements(
         &mut self,
         _table_index: TableIndex,

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -387,12 +387,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         self.info.globals.push(Exportable::new(global));
     }
 
-    fn declare_global_import(
-        &mut self,
-        global: Global,
-        module: &'data str,
-        field: &'data str,
-    ) {
+    fn declare_global_import(&mut self, global: Global, module: &'data str, field: &'data str) {
         self.info.globals.push(Exportable::new(global));
         self.info
             .imported_globals
@@ -407,12 +402,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         self.info.tables.push(Exportable::new(table));
     }
 
-    fn declare_table_import(
-        &mut self,
-        table: Table,
-        module: &'data str,
-        field: &'data str,
-    ) {
+    fn declare_table_import(&mut self, table: Table, module: &'data str, field: &'data str) {
         self.info.tables.push(Exportable::new(table));
         self.info
             .imported_tables
@@ -433,12 +423,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         self.info.memories.push(Exportable::new(memory));
     }
 
-    fn declare_memory_import(
-        &mut self,
-        memory: Memory,
-        module: &'data str,
-        field: &'data str,
-    ) {
+    fn declare_memory_import(&mut self, memory: Memory, module: &'data str, field: &'data str) {
         self.info.memories.push(Exportable::new(memory));
         self.info
             .imported_memories

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -52,6 +52,9 @@ pub struct DummyModuleInfo {
     /// Module and field names of imported functions as provided by `declare_func_import`.
     pub imported_funcs: Vec<(String, String)>,
 
+    /// Module and field names of imported globals as provided by `declare_global_import`.
+    pub imported_globals: Vec<(String, String)>,
+
     /// Functions, imported and local.
     pub functions: PrimaryMap<FuncIndex, Exportable<SignatureIndex>>,
 
@@ -78,6 +81,7 @@ impl DummyModuleInfo {
             config,
             signatures: PrimaryMap::new(),
             imported_funcs: Vec::new(),
+            imported_globals: Vec::new(),
             functions: PrimaryMap::new(),
             function_bodies: PrimaryMap::new(),
             tables: PrimaryMap::new(),
@@ -373,6 +377,18 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
 
     fn declare_global(&mut self, global: Global) {
         self.info.globals.push(Exportable::new(global));
+    }
+
+    fn declare_global_import(
+        &mut self,
+        global: Global,
+        module: &'data str,
+        field: &'data str,
+    ) {
+        self.info.globals.push(Exportable::new(global));
+        self.info
+            .imported_globals
+            .push((String::from(module), String::from(field)));
     }
 
     fn get_global(&self, global_index: GlobalIndex) -> &Global {

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -58,6 +58,9 @@ pub struct DummyModuleInfo {
     /// Module and field names of imported tables as provided by `declare_table_import`.
     pub imported_tables: Vec<(String, String)>,
 
+    /// Module and field names of imported memories as provided by `declare_memory_import`.
+    pub imported_memories: Vec<(String, String)>,
+
     /// Functions, imported and local.
     pub functions: PrimaryMap<FuncIndex, Exportable<SignatureIndex>>,
 
@@ -86,6 +89,7 @@ impl DummyModuleInfo {
             imported_funcs: Vec::new(),
             imported_globals: Vec::new(),
             imported_tables: Vec::new(),
+            imported_memories: Vec::new(),
             functions: PrimaryMap::new(),
             function_bodies: PrimaryMap::new(),
             tables: PrimaryMap::new(),
@@ -424,9 +428,23 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     ) {
         // We do nothing
     }
+
     fn declare_memory(&mut self, memory: Memory) {
         self.info.memories.push(Exportable::new(memory));
     }
+
+    fn declare_memory_import(
+        &mut self,
+        memory: Memory,
+        module: &'data str,
+        field: &'data str,
+    ) {
+        self.info.memories.push(Exportable::new(memory));
+        self.info
+            .imported_memories
+            .push((String::from(module), String::from(field)));
+    }
+
     fn declare_data_initialization(
         &mut self,
         _memory_index: MemoryIndex,

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -281,6 +281,15 @@ pub trait ModuleEnvironment<'data> {
 
     /// Declares a table to the environment.
     fn declare_table(&mut self, table: Table);
+
+    /// Declares a table import to the environment.
+    fn declare_table_import(
+        &mut self,
+        table: Table,
+        module: &'data str,
+        field: &'data str,
+    );
+
     /// Fills a declared table with references to functions in the module.
     fn declare_table_elements(
         &mut self,

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -300,6 +300,15 @@ pub trait ModuleEnvironment<'data> {
     );
     /// Declares a memory to the environment
     fn declare_memory(&mut self, memory: Memory);
+
+    /// Declares a memory import to the environment.
+    fn declare_memory_import(
+        &mut self,
+        memory: Memory,
+        module: &'data str,
+        field: &'data str,
+    );
+
     /// Fills a declared memory with bytes at module instantiation.
     fn declare_data_initialization(
         &mut self,

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -268,6 +268,14 @@ pub trait ModuleEnvironment<'data> {
     /// Declares a global to the environment.
     fn declare_global(&mut self, global: Global);
 
+    /// Declares a global import to the environment.
+    fn declare_global_import(
+        &mut self,
+        global: Global,
+        module: &'data str,
+        field: &'data str,
+    );
+
     /// Return the global for the given global index.
     fn get_global(&self, global_index: GlobalIndex) -> &Global;
 

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -269,12 +269,7 @@ pub trait ModuleEnvironment<'data> {
     fn declare_global(&mut self, global: Global);
 
     /// Declares a global import to the environment.
-    fn declare_global_import(
-        &mut self,
-        global: Global,
-        module: &'data str,
-        field: &'data str,
-    );
+    fn declare_global_import(&mut self, global: Global, module: &'data str, field: &'data str);
 
     /// Return the global for the given global index.
     fn get_global(&self, global_index: GlobalIndex) -> &Global;
@@ -283,12 +278,7 @@ pub trait ModuleEnvironment<'data> {
     fn declare_table(&mut self, table: Table);
 
     /// Declares a table import to the environment.
-    fn declare_table_import(
-        &mut self,
-        table: Table,
-        module: &'data str,
-        field: &'data str,
-    );
+    fn declare_table_import(&mut self, table: Table, module: &'data str, field: &'data str);
 
     /// Fills a declared table with references to functions in the module.
     fn declare_table_elements(
@@ -302,12 +292,7 @@ pub trait ModuleEnvironment<'data> {
     fn declare_memory(&mut self, memory: Memory);
 
     /// Declares a memory import to the environment.
-    fn declare_memory_import(
-        &mut self,
-        memory: Memory,
-        module: &'data str,
-        field: &'data str,
-    );
+    fn declare_memory_import(&mut self, memory: Memory, module: &'data str, field: &'data str);
 
     /// Fills a declared memory with bytes at module instantiation.
     fn declare_data_initialization(

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -66,8 +66,8 @@ pub use environ::{
 pub use func_translator::FuncTranslator;
 pub use module_translator::translate_module;
 pub use translation_utils::{
-    DefinedFuncIndex, FuncIndex, Global, GlobalIndex, GlobalInit, Memory, MemoryIndex,
-    SignatureIndex, Table, TableIndex,
+    DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, Global,
+    GlobalIndex, GlobalInit, Memory, MemoryIndex, SignatureIndex, Table, TableIndex,
 };
 
 #[cfg(not(feature = "std"))]

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -93,13 +93,23 @@ pub fn parse_import_section<'data>(
             }
             Import {
                 ty: ImportSectionEntryType::Global(ref ty),
-                ..
+                module,
+                field,
             } => {
-                environ.declare_global(Global {
-                    ty: type_to_type(ty.content_type).unwrap(),
-                    mutability: ty.mutable,
-                    initializer: GlobalInit::Import(),
-                });
+                // The input has already been validated, so we should be able to
+                // assume valid UTF-8 and use `from_utf8_unchecked` if performance
+                // becomes a concern here.
+                let module_name = from_utf8(module).unwrap();
+                let field_name = from_utf8(field).unwrap();
+                environ.declare_global_import(
+                    Global {
+                        ty: type_to_type(ty.content_type).unwrap(),
+                        mutability: ty.mutable,
+                        initializer: GlobalInit::Import(),
+                    },
+                    module_name,
+                    field_name
+                );
             }
             Import {
                 ty: ImportSectionEntryType::Table(ref tab),

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -80,11 +80,15 @@ pub fn parse_import_section<'data>(
                 limits: ref memlimits,
                 shared,
             }) => {
-                environ.declare_memory(Memory {
-                    pages_count: memlimits.initial as usize,
-                    maximum: memlimits.maximum.map(|x| x as usize),
-                    shared,
-                });
+                environ.declare_memory_import(
+                    Memory {
+                        pages_count: memlimits.initial as usize,
+                        maximum: memlimits.maximum.map(|x| x as usize),
+                        shared,
+                    },
+                    module_name,
+                    field_name
+                );
             }
             ImportSectionEntryType::Global(ref ty) => {
                 environ.declare_global_import(

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -98,14 +98,18 @@ pub fn parse_import_section<'data>(
                 );
             }
             ImportSectionEntryType::Table(ref tab) => {
-                environ.declare_table(Table {
-                    ty: match type_to_type(tab.element_type) {
-                        Ok(t) => TableElementType::Val(t),
-                        Err(()) => TableElementType::Func(),
+                environ.declare_table_import(
+                    Table {
+                        ty: match type_to_type(tab.element_type) {
+                            Ok(t) => TableElementType::Val(t),
+                            Err(()) => TableElementType::Func(),
+                        },
+                        size: tab.limits.initial as usize,
+                        maximum: tab.limits.maximum.map(|x| x as usize),
                     },
-                    size: tab.limits.initial as usize,
-                    maximum: tab.limits.maximum.map(|x| x as usize),
-                });
+                    module_name,
+                    field_name,
+                );
             }
         }
     }

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -67,7 +67,7 @@ pub fn parse_import_section<'data>(
         // becomes a concern here.
         let module_name = from_utf8(import.module).unwrap();
         let field_name = from_utf8(import.field).unwrap();
-    
+
         match import.ty {
             ImportSectionEntryType::Function(sig) => {
                 environ.declare_func_import(
@@ -87,7 +87,7 @@ pub fn parse_import_section<'data>(
                         shared,
                     },
                     module_name,
-                    field_name
+                    field_name,
                 );
             }
             ImportSectionEntryType::Global(ref ty) => {
@@ -98,7 +98,7 @@ pub fn parse_import_section<'data>(
                         initializer: GlobalInit::Import(),
                     },
                     module_name,
-                    field_name
+                    field_name,
                 );
             }
             ImportSectionEntryType::Table(ref tab) => {

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -60,47 +60,33 @@ pub fn parse_import_section<'data>(
     environ: &mut ModuleEnvironment<'data>,
 ) -> WasmResult<()> {
     for entry in imports {
-        match entry? {
-            Import {
-                module,
-                field,
-                ty: ImportSectionEntryType::Function(sig),
-            } => {
-                // The input has already been validated, so we should be able to
-                // assume valid UTF-8 and use `from_utf8_unchecked` if performance
-                // becomes a concern here.
-                let module_name = from_utf8(module).unwrap();
-                let field_name = from_utf8(field).unwrap();
+        let import = entry?;
+
+        // The input has already been validated, so we should be able to
+        // assume valid UTF-8 and use `from_utf8_unchecked` if performance
+        // becomes a concern here.
+        let module_name = from_utf8(import.module).unwrap();
+        let field_name = from_utf8(import.field).unwrap();
+    
+        match import.ty {
+            ImportSectionEntryType::Function(sig) => {
                 environ.declare_func_import(
                     SignatureIndex::new(sig as usize),
                     module_name,
                     field_name,
                 );
             }
-            Import {
-                ty:
-                    ImportSectionEntryType::Memory(MemoryType {
-                        limits: ref memlimits,
-                        shared,
-                    }),
-                ..
-            } => {
+            ImportSectionEntryType::Memory(MemoryType {
+                limits: ref memlimits,
+                shared,
+            }) => {
                 environ.declare_memory(Memory {
                     pages_count: memlimits.initial as usize,
                     maximum: memlimits.maximum.map(|x| x as usize),
                     shared,
                 });
             }
-            Import {
-                ty: ImportSectionEntryType::Global(ref ty),
-                module,
-                field,
-            } => {
-                // The input has already been validated, so we should be able to
-                // assume valid UTF-8 and use `from_utf8_unchecked` if performance
-                // becomes a concern here.
-                let module_name = from_utf8(module).unwrap();
-                let field_name = from_utf8(field).unwrap();
+            ImportSectionEntryType::Global(ref ty) => {
                 environ.declare_global_import(
                     Global {
                         ty: type_to_type(ty.content_type).unwrap(),
@@ -111,17 +97,16 @@ pub fn parse_import_section<'data>(
                     field_name
                 );
             }
-            Import {
-                ty: ImportSectionEntryType::Table(ref tab),
-                ..
-            } => environ.declare_table(Table {
-                ty: match type_to_type(tab.element_type) {
-                    Ok(t) => TableElementType::Val(t),
-                    Err(()) => TableElementType::Func(),
-                },
-                size: tab.limits.initial as usize,
-                maximum: tab.limits.maximum.map(|x| x as usize),
-            }),
+            ImportSectionEntryType::Table(ref tab) => {
+                environ.declare_table(Table {
+                    ty: match type_to_type(tab.element_type) {
+                        Ok(t) => TableElementType::Val(t),
+                        Err(()) => TableElementType::Func(),
+                    },
+                    size: tab.limits.initial as usize,
+                    maximum: tab.limits.maximum.map(|x| x as usize),
+                });
+            }
         }
     }
     Ok(())

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -13,6 +13,21 @@ entity_impl!(FuncIndex);
 pub struct DefinedFuncIndex(u32);
 entity_impl!(DefinedFuncIndex);
 
+/// Index type of a defined table inside the WebAssembly module.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct DefinedTableIndex(u32);
+entity_impl!(DefinedTableIndex);
+
+/// Index type of a defined memory inside the WebAssembly module.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct DefinedMemoryIndex(u32);
+entity_impl!(DefinedMemoryIndex);
+
+/// Index type of a defined global inside the WebAssembly module.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct DefinedGlobalIndex(u32);
+entity_impl!(DefinedGlobalIndex);
+
 /// Index type of a table (imported or defined) inside the WebAssembly module.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 pub struct TableIndex(u32);


### PR DESCRIPTION

In order to support elem imported globals  in [wasmer](https://github.com/wafoundation/wasmer), we need to know where the global is being stored in the import object (that means, knowing it's `module` and `field`).

Example taken from [wasm spectests](https://github.com/WebAssembly/spec/blob/5aaea96eceb1e1a3956d7cbb499920e5b8c1109f/test/core/elem.wast#L60-L65):

```wasm
(module
  (global $g (import "spectest" "global_i32") i32)
  (table 1000 anyfunc)
  (func $f)
  (elem (get_global $g) $f)
)
```

For that to happen, `ModuleEnvironment` needs to know if a provided global is actually an import, so we are able to reference it properly when instantiating the module.

## Explanation
Currently, of all the WebAssembly imports (`func`, `memory`, `table`, `global`) only func is actually using the `module` and `field` through `define_func_import`.

For `memory`, `table` and `global` this values are skipped using the generic `declare_memory`, `declare_table` and `declare_global` functions in `ModuleEnvironment`.

This PR aims to fix this by providing new functions `declare_memory_import`, `declare_table_import` and `declare_global_import`