### PR TITLE
Make TargetIsa thread-safe

### DIFF
--- a/lib/codegen/src/isa/mod.rs
+++ b/lib/codegen/src/isa/mod.rs
@@ -196,7 +196,7 @@ impl TargetFrontendConfig {
 
 /// Methods that are specialized to a target ISA. Implies a Display trait that shows the
 /// shared flags, as well as any isa-specific flags.
-pub trait TargetIsa: fmt::Display {
+pub trait TargetIsa: fmt::Display + Sync {
     /// Get the name of this ISA.
     fn name(&self) -> &'static str;
 


### PR DESCRIPTION
In order to parallelize function compilation (`compile_and_emit` from `Context`), the trait `TargetIsa` needs to be `Sync`.