### PR TITLE
Support heaps with no offset-guard pages.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ term = "0.5.1"
 capstone = { version = "0.5.0", optional = true }
 wabt = { version = "0.7.0", optional = true }
 target-lexicon = "0.2.0"
-pretty_env_logger = "0.2.4"
+pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.1"
 
 [features]

--- a/docs/heapex-dyn.clif
+++ b/docs/heapex-dyn.clif
@@ -4,7 +4,7 @@ function %add_members(i32, i64 vmctx) -> f32 baldrdash {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+64
     gv2 = load.i32 notrap aligned gv0+72
-    heap0 = dynamic gv1, min 0x1000, bound gv2, guard 0
+    heap0 = dynamic gv1, min 0x1000, bound gv2, offset_guard 0
 
 ebb0(v0: i32, v6: i64):
     v1 = heap_addr.i64 heap0, v0, 20

--- a/docs/heapex-sm32.clif
+++ b/docs/heapex-sm32.clif
@@ -3,7 +3,7 @@ test verifier
 function %add_members(i32, i32 vmctx) -> f32 baldrdash {
     gv0 = vmctx
     gv1 = load.i32 notrap aligned gv0+64
-    heap0 = static gv1, min 0x1000, bound 0x10_0000, guard 0x1000
+    heap0 = static gv1, min 0x1000, bound 0x10_0000, offset_guard 0x1000
 
 ebb0(v0: i32, v5: i32):
     v1 = heap_addr.i32 heap0, v0, 1

--- a/docs/heapex-sm64.clif
+++ b/docs/heapex-sm64.clif
@@ -3,7 +3,7 @@ test verifier
 function %add_members(i32, i64 vmctx) -> f32 baldrdash {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+64
-    heap0 = static gv1, min 0x1000, bound 0x1_0000_0000, guard 0x8000_0000
+    heap0 = static gv1, min 0x1000, bound 0x1_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v5: i64):
     v1 = heap_addr.i64 heap0, v0, 1

--- a/filetests/isa/x86/legalize-heaps.clif
+++ b/filetests/isa/x86/legalize-heaps.clif
@@ -10,23 +10,23 @@ function %heap_addrs(i32, i64, i64 vmctx) {
     gv2 = iadd_imm.i64 gv4, 80
     gv3 = load.i32 notrap aligned gv4+88
 
-    heap0 = static gv0, min 0x1_0000, bound 0x1_0000_0000, guard 0x8000_0000, index_type i32
-    heap1 = static gv0, guard 0x1000, bound 0x1_0000, index_type i32
-    heap2 = static gv0, min 0x1_0000, bound 0x1_0000_0000, guard 0x8000_0000, index_type i64
-    heap3 = static gv0, guard 0x1000, bound 0x1_0000, index_type i64
-    heap4 = dynamic gv1, min 0x1_0000, bound gv3, guard 0x8000_0000, index_type i32
-    heap5 = dynamic gv1, bound gv3, guard 0x1000, index_type i32
-    heap6 = dynamic gv1, min 0x1_0000, bound gv2, guard 0x8000_0000, index_type i64
-    heap7 = dynamic gv1, bound gv2, guard 0x1000, index_type i64
+    heap0 = static gv0, min 0x1_0000, bound 0x1_0000_0000, offset_guard 0x8000_0000, index_type i32
+    heap1 = static gv0, offset_guard 0x1000, bound 0x1_0000, index_type i32
+    heap2 = static gv0, min 0x1_0000, bound 0x1_0000_0000, offset_guard 0x8000_0000, index_type i64
+    heap3 = static gv0, offset_guard 0x1000, bound 0x1_0000, index_type i64
+    heap4 = dynamic gv1, min 0x1_0000, bound gv3, offset_guard 0x8000_0000, index_type i32
+    heap5 = dynamic gv1, bound gv3, offset_guard 0x1000, index_type i32
+    heap6 = dynamic gv1, min 0x1_0000, bound gv2, offset_guard 0x8000_0000, index_type i64
+    heap7 = dynamic gv1, bound gv2, offset_guard 0x1000, index_type i64
 
-    ; check: heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000, index_type i32
-    ; check: heap1 = static gv0, min 0, bound 0x0001_0000, guard 4096, index_type i32
-    ; check: heap2 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000, index_type i64
-    ; check: heap3 = static gv0, min 0, bound 0x0001_0000, guard 4096, index_type i64
-    ; check: heap4 = dynamic gv1, min 0x0001_0000, bound gv3, guard 0x8000_0000, index_type i32
-    ; check: heap5 = dynamic gv1, min 0, bound gv3, guard 4096, index_type i32
-    ; check: heap6 = dynamic gv1, min 0x0001_0000, bound gv2, guard 0x8000_0000, index_type i64
-    ; check: heap7 = dynamic gv1, min 0, bound gv2, guard 4096, index_type i64
+    ; check: heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000, index_type i32
+    ; check: heap1 = static gv0, min 0, bound 0x0001_0000, offset_guard 4096, index_type i32
+    ; check: heap2 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000, index_type i64
+    ; check: heap3 = static gv0, min 0, bound 0x0001_0000, offset_guard 4096, index_type i64
+    ; check: heap4 = dynamic gv1, min 0x0001_0000, bound gv3, offset_guard 0x8000_0000, index_type i32
+    ; check: heap5 = dynamic gv1, min 0, bound gv3, offset_guard 4096, index_type i32
+    ; check: heap6 = dynamic gv1, min 0x0001_0000, bound gv2, offset_guard 0x8000_0000, index_type i64
+    ; check: heap7 = dynamic gv1, min 0, bound gv2, offset_guard 4096, index_type i64
 
 ebb0(v0: i32, v1: i64, v3: i64):
     ; The fast-path; 32-bit index, static heap with a sufficient bound, no bounds check needed!

--- a/filetests/isa/x86/legalize-memory.clif
+++ b/filetests/isa/x86/legalize-memory.clif
@@ -47,7 +47,7 @@ ebb1:
 function %staticheap_sm64(i32, i64 vmctx) -> f32 baldrdash {
     gv0 = vmctx
     gv1 = iadd_imm.i64 gv0, 64
-    heap0 = static gv1, min 0x1000, bound 0x1_0000_0000, guard 0x8000_0000
+    heap0 = static gv1, min 0x1000, bound 0x1_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v999: i64):
     ; check: ebb0(
@@ -68,7 +68,7 @@ ebb0(v0: i32, v999: i64):
 function %staticheap_static_oob_sm64(i32, i64 vmctx) -> f32 baldrdash {
     gv0 = vmctx
     gv1 = iadd_imm.i64 gv0, 64
-    heap0 = static gv1, min 0x1000, bound 0x1000_0000, guard 0x8000_0000
+    heap0 = static gv1, min 0x1000, bound 0x1000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v999: i64):
     ; Everything after the obviously OOB access should be eliminated, leaving
@@ -92,7 +92,7 @@ ebb0(v0: i32, v999: i64):
 function %staticheap_sm64(i32, i64 vmctx) -> f32 baldrdash {
     gv0 = vmctx
     gv1 = iadd_imm.i64 gv0, 64
-    heap0 = static gv1, min 0x1000, bound 0x1_0000_0000, guard 0x8000_0000
+    heap0 = static gv1, min 0x1000, bound 0x1_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v999: i64):
     ; check: ebb0(

--- a/filetests/parser/memory.clif
+++ b/filetests/parser/memory.clif
@@ -52,13 +52,13 @@ ebb0:
 
 ; Declare static heaps.
 function %sheap(i32, i64 vmctx) -> i64 {
-    heap1 = static gv5, min 0x1_0000, bound 0x1_0000_0000, guard 0x8000_0000
-    heap2 = static gv5, guard 0x1000, bound 0x1_0000
+    heap1 = static gv5, min 0x1_0000, bound 0x1_0000_0000, offset_guard 0x8000_0000
+    heap2 = static gv5, offset_guard 0x1000, bound 0x1_0000
     gv4 = vmctx
     gv5 = iadd_imm.i64 gv4, 64
 
-    ; check: heap1 = static gv5, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
-    ; check: heap2 = static gv5, min 0, bound 0x0001_0000, guard 4096
+    ; check: heap1 = static gv5, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
+    ; check: heap2 = static gv5, min 0, bound 0x0001_0000, offset_guard 4096
 ebb0(v1: i32, v2: i64):
     v3 = heap_addr.i64 heap1, v1, 0
     ; check: v3 = heap_addr.i64 heap1, v1, 0
@@ -67,14 +67,14 @@ ebb0(v1: i32, v2: i64):
 
 ; Declare dynamic heaps.
 function %dheap(i32, i64 vmctx) -> i64 {
-    heap1 = dynamic gv5, min 0x1_0000, bound gv6, guard 0x8000_0000
-    heap2 = dynamic gv5, bound gv6, guard 0x1000
+    heap1 = dynamic gv5, min 0x1_0000, bound gv6, offset_guard 0x8000_0000
+    heap2 = dynamic gv5, bound gv6, offset_guard 0x1000
     gv4 = vmctx
     gv5 = iadd_imm.i64 gv4, 64
     gv6 = iadd_imm.i64 gv4, 72
 
-    ; check: heap1 = dynamic gv5, min 0x0001_0000, bound gv6, guard 0x8000_0000
-    ; check: heap2 = dynamic gv5, min 0, bound gv6, guard 4096
+    ; check: heap1 = dynamic gv5, min 0x0001_0000, bound gv6, offset_guard 0x8000_0000
+    ; check: heap2 = dynamic gv5, min 0, bound gv6, offset_guard 4096
 ebb0(v1: i32, v2: i64):
     v3 = heap_addr.i64 heap2, v1, 0
     ; check: v3 = heap_addr.i64 heap2, v1, 0

--- a/filetests/regalloc/aliases.clif
+++ b/filetests/regalloc/aliases.clif
@@ -3,7 +3,7 @@ target x86_64 haswell
 
 function %value_aliases(i32, f32, i64 vmctx) baldrdash {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: f32, v2: i64):
     v3 = iconst.i32 0

--- a/filetests/regalloc/coalescing-207.clif
+++ b/filetests/regalloc/coalescing-207.clif
@@ -7,7 +7,7 @@ target x86_64 haswell
 function %pr207(i64 vmctx, i32, i32) -> i32 system_v {
     gv1 = vmctx
     gv0 = iadd_imm.i64 gv1, -8
-    heap0 = static gv0, min 0, bound 0x5000, guard 0x0040_0000
+    heap0 = static gv0, min 0, bound 0x5000, offset_guard 0x0040_0000
     sig0 = (i64 vmctx, i32, i32) -> i32 system_v
     sig1 = (i64 vmctx, i32, i32, i32) -> i32 system_v
     sig2 = (i64 vmctx, i32, i32, i32) -> i32 system_v
@@ -1036,7 +1036,7 @@ ebb92(v767: i32):
 ; Same problem from musl.wasm.
 function %musl(f64 [%xmm0], i64 vmctx [%rdi]) -> f64 [%xmm0] system_v {
     gv0 = vmctx
-    heap0 = static gv0, min 0, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0, bound 0x0001_0000_0000, offset_guard 0x8000_0000
     sig0 = (f64 [%xmm0], i32 [%rdi], i64 vmctx [%rsi]) -> f64 [%xmm0] system_v
     fn0 = u0:517 sig0
 

--- a/filetests/regalloc/coloring-227.clif
+++ b/filetests/regalloc/coloring-227.clif
@@ -3,7 +3,7 @@ target x86_64 haswell
 
 function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8]) system_v {
     gv0 = vmctx
-    heap0 = static gv0, min 0, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
                           ebb0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i64):
 [RexOp1pu_id#b8]              v5 = iconst.i32 0

--- a/filetests/regalloc/reload-208.clif
+++ b/filetests/regalloc/reload-208.clif
@@ -13,7 +13,7 @@ target x86_64 haswell
 function %pr208(i64 vmctx [%rdi]) system_v {
     gv1 = vmctx
     gv0 = iadd_imm.i64 gv1, -8
-    heap0 = static gv0, min 0, bound 0x5000, guard 0x0040_0000
+    heap0 = static gv0, min 0, bound 0x5000, offset_guard 0x0040_0000
     sig0 = (i64 vmctx [%rdi]) -> i32 [%rax] system_v
     sig1 = (i64 vmctx [%rdi], i32 [%rsi]) system_v
     fn0 = u0:1 sig0

--- a/filetests/simple_gvn/readonly.clif
+++ b/filetests/simple_gvn/readonly.clif
@@ -5,7 +5,7 @@ target x86_64
 function %eliminate_redundant_global_loads(i32, i64 vmctx) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned readonly gv0
-    heap0 = static gv1, min 0x1_0000, bound 0x1_0000_0000, guard 0x8000_0000, index_type i32
+    heap0 = static gv1, min 0x1_0000, bound 0x1_0000_0000, offset_guard 0x8000_0000, index_type i32
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1

--- a/filetests/verifier/heap.clif
+++ b/filetests/verifier/heap.clif
@@ -4,7 +4,7 @@ target x86_64
 function %heap_base_type(i64 vmctx) {
     gv0 = vmctx
     gv1 = load.i32 notrap aligned gv0
-    heap0 = static gv1, guard 0x1000, bound 0x1_0000, index_type i32 ; error: heap base has type i32, which is not the pointer type i64
+    heap0 = static gv1, offset_guard 0x1000, bound 0x1_0000, index_type i32 ; error: heap base has type i32, which is not the pointer type i64
 
 ebb0(v0: i64):
     return
@@ -12,7 +12,7 @@ ebb0(v0: i64):
 
 function %invalid_base(i64 vmctx) {
     gv0 = vmctx
-    heap0 = dynamic gv1, bound gv0, guard 0x1000, index_type i64 ; error: invalid base global value gv1
+    heap0 = dynamic gv1, bound gv0, offset_guard 0x1000, index_type i64 ; error: invalid base global value gv1
 
 ebb0(v0: i64):
     return
@@ -20,7 +20,7 @@ ebb0(v0: i64):
 
 function %invalid_bound(i64 vmctx) {
     gv0 = vmctx
-    heap0 = dynamic gv0, bound gv1, guard 0x1000, index_type i64 ; error: invalid bound global value gv1
+    heap0 = dynamic gv0, bound gv1, offset_guard 0x1000, index_type i64 ; error: invalid bound global value gv1
 
 ebb0(v0: i64):
     return
@@ -29,7 +29,7 @@ ebb0(v0: i64):
 function %heap_bound_type(i64 vmctx) {
     gv0 = vmctx
     gv1 = load.i16 notrap aligned gv0
-    heap0 = dynamic gv0, bound gv1, guard 0x1000, index_type i32 ; error: heap index type i32 differs from the type of its bound, i16
+    heap0 = dynamic gv0, bound gv1, offset_guard 0x1000, index_type i32 ; error: heap index type i32 differs from the type of its bound, i16
 
 ebb0(v0: i64):
     return
@@ -37,7 +37,7 @@ ebb0(v0: i64):
 
 function %heap_addr_index_type(i64 vmctx, i64) {
     gv0 = vmctx
-    heap0 = static gv0, guard 0x1000, bound 0x1_0000, index_type i32
+    heap0 = static gv0, offset_guard 0x1000, bound 0x1_0000, index_type i32
 
 ebb0(v0: i64, v1: i64):
     v2 = heap_addr.i64 heap0, v1, 0; error: index type i64 differs from heap index type i32

--- a/filetests/wasm/f32-memory64.clif
+++ b/filetests/wasm/f32-memory64.clif
@@ -7,7 +7,7 @@ target x86_64 haswell
 
 function %f32_load(i32, i64 vmctx) -> f32 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -17,7 +17,7 @@ ebb0(v0: i32, v1: i64):
 
 function %f32_store(f32, i32, i64 vmctx) {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: f32, v1: i32, v2: i64):
     v3 = heap_addr.i64 heap0, v1, 1

--- a/filetests/wasm/f64-memory64.clif
+++ b/filetests/wasm/f64-memory64.clif
@@ -7,7 +7,7 @@ target x86_64 haswell
 
 function %f64_load(i32, i64 vmctx) -> f64 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -17,7 +17,7 @@ ebb0(v0: i32, v1: i64):
 
 function %f64_store(f64, i32, i64 vmctx) {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: f64, v1: i32, v2: i64):
     v3 = heap_addr.i64 heap0, v1, 1

--- a/filetests/wasm/i32-memory64.clif
+++ b/filetests/wasm/i32-memory64.clif
@@ -7,7 +7,7 @@ target x86_64 haswell
 
 function %i32_load(i32, i64 vmctx) -> i32 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -17,7 +17,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i32_store(i32, i32, i64 vmctx) {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i32, v2: i64):
     v3 = heap_addr.i64 heap0, v1, 1
@@ -27,7 +27,7 @@ ebb0(v0: i32, v1: i32, v2: i64):
 
 function %i32_load8_s(i32, i64 vmctx) -> i32 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -37,7 +37,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i32_load8_u(i32, i64 vmctx) -> i32 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -47,7 +47,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i32_store8(i32, i32, i64 vmctx) {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i32, v2: i64):
     v3 = heap_addr.i64 heap0, v1, 1
@@ -57,7 +57,7 @@ ebb0(v0: i32, v1: i32, v2: i64):
 
 function %i32_load16_s(i32, i64 vmctx) -> i32 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -67,7 +67,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i32_load16_u(i32, i64 vmctx) -> i32 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -77,7 +77,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i32_store16(i32, i32, i64 vmctx) {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i32, v2: i64):
     v3 = heap_addr.i64 heap0, v1, 1

--- a/filetests/wasm/i64-memory64.clif
+++ b/filetests/wasm/i64-memory64.clif
@@ -7,7 +7,7 @@ target x86_64 haswell
 
 function %i64_load(i32, i64 vmctx) -> i64 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -17,7 +17,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i64_store(i64, i32, i64 vmctx) {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i64, v1: i32, v2: i64):
     v3 = heap_addr.i64 heap0, v1, 1
@@ -27,7 +27,7 @@ ebb0(v0: i64, v1: i32, v2: i64):
 
 function %i64_load8_s(i32, i64 vmctx) -> i64 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -37,7 +37,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i64_load8_u(i32, i64 vmctx) -> i64 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -47,7 +47,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i64_store8(i64, i32, i64 vmctx) {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i64, v1: i32, v2: i64):
     v3 = heap_addr.i64 heap0, v1, 1
@@ -57,7 +57,7 @@ ebb0(v0: i64, v1: i32, v2: i64):
 
 function %i64_load16_s(i32, i64 vmctx) -> i64 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -67,7 +67,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i64_load16_u(i32, i64 vmctx) -> i64 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -77,7 +77,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i64_store16(i64, i32, i64 vmctx) {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i64, v1: i32, v2: i64):
     v3 = heap_addr.i64 heap0, v1, 1
@@ -87,7 +87,7 @@ ebb0(v0: i64, v1: i32, v2: i64):
 
 function %i64_load32_s(i32, i64 vmctx) -> i64 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -97,7 +97,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i64_load32_u(i32, i64 vmctx) -> i64 {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i32, v1: i64):
     v2 = heap_addr.i64 heap0, v0, 1
@@ -107,7 +107,7 @@ ebb0(v0: i32, v1: i64):
 
 function %i64_store32(i64, i32, i64 vmctx) {
     gv0 = vmctx
-    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, guard 0x8000_0000
+    heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 ebb0(v0: i64, v1: i32, v2: i64):
     v3 = heap_addr.i64 heap0, v1, 1

--- a/lib/codegen/src/ir/heap.rs
+++ b/lib/codegen/src/ir/heap.rs
@@ -1,6 +1,6 @@
 //! Heaps.
 
-use ir::immediates::Imm64;
+use ir::immediates::Uimm64;
 use ir::{GlobalValue, Type};
 use std::fmt;
 
@@ -12,10 +12,10 @@ pub struct HeapData {
 
     /// Guaranteed minimum heap size in bytes. Heap accesses before `min_size` don't need bounds
     /// checking.
-    pub min_size: Imm64,
+    pub min_size: Uimm64,
 
-    /// Size in bytes of the guard pages following the heap.
-    pub guard_size: Imm64,
+    /// Size in bytes of the offset-guard pages following the heap.
+    pub offset_guard_size: Uimm64,
 
     /// Heap style, with additional style-specific info.
     pub style: HeapStyle,
@@ -34,10 +34,10 @@ pub enum HeapStyle {
     },
 
     /// A static heap has a fixed base address and a number of not-yet-allocated pages before the
-    /// guard pages.
+    /// offset-guard pages.
     Static {
-        /// Heap bound in bytes. The guard pages are allocated after the bound.
-        bound: Imm64,
+        /// Heap bound in bytes. The offset-guard pages are allocated after the bound.
+        bound: Uimm64,
     },
 }
 
@@ -55,8 +55,8 @@ impl fmt::Display for HeapData {
         }
         write!(
             f,
-            ", guard {}, index_type {}",
-            self.guard_size, self.index_type
+            ", offset_guard {}, index_type {}",
+            self.offset_guard_size, self.index_type
         )
     }
 }

--- a/lib/codegen/src/ir/memflags.rs
+++ b/lib/codegen/src/ir/memflags.rs
@@ -26,6 +26,15 @@ impl MemFlags {
         Self { bits: 0 }
     }
 
+    /// Create a set of flags representing an access from a "trusted" address, meaning it's
+    /// known to be aligned and non-trapping.
+    pub fn trusted() -> Self {
+        let mut result = Self::new();
+        result.set_notrap();
+        result.set_aligned();
+        result
+    }
+
     /// Read a flag bit.
     fn read(self, bit: FlagBit) -> bool {
         self.bits & (1 << bit as usize) != 0

--- a/lib/codegen/src/ir/progpoint.rs
+++ b/lib/codegen/src/ir/progpoint.rs
@@ -85,9 +85,9 @@ impl From<ValueDef> for ExpandedProgramPoint {
 impl From<ProgramPoint> for ExpandedProgramPoint {
     fn from(pp: ProgramPoint) -> Self {
         if pp.0 & 1 == 0 {
-            ExpandedProgramPoint::Inst(Inst::new((pp.0 / 2) as usize))
+            ExpandedProgramPoint::Inst(Inst::from_u32(pp.0 / 2))
         } else {
-            ExpandedProgramPoint::Ebb(Ebb::new((pp.0 / 2) as usize))
+            ExpandedProgramPoint::Ebb(Ebb::from_u32(pp.0 / 2))
         }
     }
 }

--- a/lib/codegen/src/ir/table.rs
+++ b/lib/codegen/src/ir/table.rs
@@ -1,6 +1,6 @@
 //! Tables.
 
-use ir::immediates::Imm64;
+use ir::immediates::Uimm64;
 use ir::{GlobalValue, Type};
 use std::fmt;
 
@@ -12,13 +12,13 @@ pub struct TableData {
 
     /// Guaranteed minimum table size in elements. Table accesses before `min_size` don't need
     /// bounds checking.
-    pub min_size: Imm64,
+    pub min_size: Uimm64,
 
     /// Global value giving the current bound of the table, in elements.
     pub bound_gv: GlobalValue,
 
     /// The size of a table element, in bytes.
-    pub element_size: Imm64,
+    pub element_size: Uimm64,
 
     /// The index type for the table.
     pub index_type: Type,

--- a/lib/codegen/src/ir/trapcode.rs
+++ b/lib/codegen/src/ir/trapcode.rs
@@ -17,7 +17,8 @@ pub enum TrapCode {
     /// A `heap_addr` instruction detected an out-of-bounds error.
     ///
     /// Note that not all out-of-bounds heap accesses are reported this way;
-    /// some are detected by a segmentation fault on the heap guard pages.
+    /// some are detected by a segmentation fault on the heap unmapped or
+    /// offset-guard pages.
     HeapOutOfBounds,
 
     /// A `table_addr` instruction detected an out-of-bounds error.

--- a/lib/codegen/src/ir/types.rs
+++ b/lib/codegen/src/ir/types.rs
@@ -2,6 +2,7 @@
 
 use std::default::Default;
 use std::fmt::{self, Debug, Display, Formatter};
+use target_lexicon::{PointerWidth, Triple};
 
 /// The type of an SSA value.
 ///
@@ -270,6 +271,16 @@ impl Type {
     /// 2. `self.lane_bits() >= other.lane_bits()`
     pub fn wider_or_equal(self, other: Self) -> bool {
         self.lane_count() == other.lane_count() && self.lane_bits() >= other.lane_bits()
+    }
+
+    /// Return the pointer type for the given target triple.
+    pub fn triple_pointer_type(triple: &Triple) -> Self {
+        match triple.pointer_width() {
+            Ok(PointerWidth::U16) => I16,
+            Ok(PointerWidth::U32) => I32,
+            Ok(PointerWidth::U64) => I64,
+            Err(()) => panic!("unable to determine architecture pointer width"),
+        }
     }
 }
 

--- a/lib/codegen/src/isa/call_conv.rs
+++ b/lib/codegen/src/isa/call_conv.rs
@@ -21,7 +21,7 @@ pub enum CallConv {
 
 impl CallConv {
     /// Return the default calling convention for the given target triple.
-    pub fn default_for_triple(triple: &Triple) -> Self {
+    pub fn triple_default(triple: &Triple) -> Self {
         match triple.default_calling_convention() {
             // Default to System V for unknown targets because most everything
             // uses System V.

--- a/lib/codegen/src/isa/mod.rs
+++ b/lib/codegen/src/isa/mod.rs
@@ -208,7 +208,7 @@ pub trait TargetIsa: fmt::Display + Sync {
 
     /// Get the default calling convention of this target.
     fn default_call_conv(&self) -> CallConv {
-        CallConv::default_for_triple(self.triple())
+        CallConv::triple_default(self.triple())
     }
 
     /// Get the pointer type of this ISA.

--- a/lib/codegen/src/legalizer/globalvalue.rs
+++ b/lib/codegen/src/legalizer/globalvalue.rs
@@ -110,9 +110,7 @@ fn load_addr(
     };
 
     // Global-value loads are always notrap and aligned. They may be readonly.
-    let mut mflags = ir::MemFlags::new();
-    mflags.set_notrap();
-    mflags.set_aligned();
+    let mut mflags = ir::MemFlags::trusted();
     if readonly {
         mflags.set_readonly();
     }

--- a/lib/codegen/src/legalizer/heap.rs
+++ b/lib/codegen/src/legalizer/heap.rs
@@ -49,7 +49,7 @@ fn dynamic_addr(
     bound_gv: ir::GlobalValue,
     func: &mut ir::Function,
 ) {
-    let access_size = i64::from(access_size);
+    let access_size = u64::from(access_size);
     let offset_ty = func.dfg.value_type(offset);
     let addr_ty = func.dfg.value_type(func.dfg.first_result(inst));
     let min_size = func.heaps[heap].min_size.into();
@@ -67,13 +67,13 @@ fn dynamic_addr(
     } else if access_size <= min_size {
         // We know that bound >= min_size, so here we can compare `offset > bound - access_size`
         // without wrapping.
-        let adj_bound = pos.ins().iadd_imm(bound, -access_size);
+        let adj_bound = pos.ins().iadd_imm(bound, -(access_size as i64));
         oob = pos
             .ins()
             .icmp(IntCC::UnsignedGreaterThan, offset, adj_bound);
     } else {
         // We need an overflow check for the adjusted offset.
-        let access_size_val = pos.ins().iconst(offset_ty, access_size);
+        let access_size_val = pos.ins().iconst(offset_ty, access_size as i64);
         let (adj_offset, overflow) = pos.ins().iadd_cout(offset, access_size_val);
         pos.ins().trapnz(overflow, ir::TrapCode::HeapOutOfBounds);
         oob = pos
@@ -91,11 +91,11 @@ fn static_addr(
     heap: ir::Heap,
     offset: ir::Value,
     access_size: u32,
-    bound: i64,
+    bound: u64,
     func: &mut ir::Function,
     cfg: &mut ControlFlowGraph,
 ) {
-    let access_size = i64::from(access_size);
+    let access_size = u64::from(access_size);
     let offset_ty = func.dfg.value_type(offset);
     let addr_ty = func.dfg.value_type(func.dfg.first_result(inst));
     let mut pos = FuncCursor::new(func).at_inst(inst);
@@ -117,7 +117,7 @@ fn static_addr(
     }
 
     // Check `offset > limit` which is now known non-negative.
-    let limit = bound - access_size;
+    let limit = bound - u64::from(access_size);
 
     // We may be able to omit the check entirely for 32-bit offsets if the heap bound is 4 GB or
     // more.
@@ -126,10 +126,10 @@ fn static_addr(
             // Prefer testing `offset >= limit - 1` when limit is odd because an even number is
             // likely to be a convenient constant on ARM and other RISC architectures.
             pos.ins()
-                .icmp_imm(IntCC::UnsignedGreaterThanOrEqual, offset, limit - 1)
+                .icmp_imm(IntCC::UnsignedGreaterThanOrEqual, offset, limit as i64 - 1)
         } else {
             pos.ins()
-                .icmp_imm(IntCC::UnsignedGreaterThan, offset, limit)
+                .icmp_imm(IntCC::UnsignedGreaterThan, offset, limit as i64)
         };
         pos.ins().trapnz(oob, ir::TrapCode::HeapOutOfBounds);
     }

--- a/lib/codegen/src/legalizer/mod.rs
+++ b/lib/codegen/src/legalizer/mod.rs
@@ -400,10 +400,8 @@ fn expand_stack_load(
 
     let addr = pos.ins().stack_addr(addr_ty, stack_slot, offset);
 
-    let mut mflags = MemFlags::new();
     // Stack slots are required to be accessible and aligned.
-    mflags.set_notrap();
-    mflags.set_aligned();
+    let mflags = MemFlags::trusted();
     pos.func.dfg.replace(inst).load(ty, mflags, addr, 0);
 }
 

--- a/lib/codegen/src/legalizer/table.rs
+++ b/lib/codegen/src/legalizer/table.rs
@@ -92,17 +92,15 @@ fn compute_addr(
 
     let element_size = pos.func.tables[table].element_size;
     let mut offset;
-    let element_size_i64: i64 = element_size.into();
-    debug_assert!(element_size_i64 >= 0);
-    let element_size_u64 = element_size_i64 as u64;
-    if element_size_u64 == 1 {
+    let element_size: u64 = element_size.into();
+    if element_size == 1 {
         offset = index;
-    } else if element_size_u64.is_power_of_two() {
+    } else if element_size.is_power_of_two() {
         offset = pos
             .ins()
-            .ishl_imm(index, i64::from(element_size_u64.trailing_zeros()));
+            .ishl_imm(index, i64::from(element_size.trailing_zeros()));
     } else {
-        offset = pos.ins().imul_imm(index, element_size);
+        offset = pos.ins().imul_imm(index, element_size as i64);
     }
 
     if element_offset == Offset32::new(0) {

--- a/lib/codegen/src/regalloc/virtregs.rs
+++ b/lib/codegen/src/regalloc/virtregs.rs
@@ -266,7 +266,7 @@ impl UFEntry {
 
     /// Encode a link entry.
     fn encode_link(v: Value) -> i32 {
-        !(v.index() as i32)
+        !(v.as_u32() as i32)
     }
 }
 

--- a/lib/codegen/src/regalloc/virtregs.rs
+++ b/lib/codegen/src/regalloc/virtregs.rs
@@ -13,7 +13,6 @@
 
 use dbg::DisplayList;
 use dominator_tree::DominatorTreePreorder;
-use entity::EntityRef;
 use entity::{EntityList, ListPool};
 use entity::{Keys, PrimaryMap, SecondaryMap};
 use ir::{Function, Value};
@@ -258,7 +257,7 @@ impl UFEntry {
     /// Decode a table entry.
     fn decode(x: i32) -> Self {
         if x < 0 {
-            UFEntry::Link(Value::new((!x) as usize))
+            UFEntry::Link(Value::from_u32((!x) as u32))
         } else {
             UFEntry::Rank(x as u32)
         }

--- a/lib/entity/src/boxed_slice.rs
+++ b/lib/entity/src/boxed_slice.rs
@@ -1,54 +1,34 @@
-//! Densely numbered entity references as mapping keys.
-use boxed_slice::BoxedSlice;
+//! Boxed slices for `PrimaryMap`.
+
 use iter::{Iter, IterMut};
 use keys::Keys;
-use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 use std::slice;
-use std::vec::Vec;
 use EntityRef;
 
-/// A primary mapping `K -> V` allocating dense entity references.
+/// A slice mapping `K -> V` allocating dense entity references.
 ///
-/// The `PrimaryMap` data structure uses the dense index space to implement a map with a vector.
-///
-/// A primary map contains the main definition of an entity, and it can be used to allocate new
-/// entity references with the `push` method.
-///
-/// There should only be a single `PrimaryMap` instance for a given `EntityRef` type, otherwise
-/// conflicting references will be created. Using unknown keys for indexing will cause a panic.
-///
-/// Note that `PrimaryMap` doesn't implement `Deref` or `DerefMut`, which would allow
-/// `&PrimaryMap<K, V>` to convert to `&[V]`. One of the main advantages of `PrimaryMap` is
-/// that it only allows indexing with the distinct `EntityRef` key type, so converting to a
-/// plain slice would make it easier to use incorrectly. To make a slice of a `PrimaryMap`, use
-/// `into_boxed_slice`.
+/// The `BoxedSlice` data structure uses the dense index space to implement a map with a boxed
+/// slice.
 #[derive(Debug, Clone)]
-pub struct PrimaryMap<K, V>
+pub struct BoxedSlice<K, V>
 where
     K: EntityRef,
 {
-    elems: Vec<V>,
+    elems: Box<[V]>,
     unused: PhantomData<K>,
 }
 
-impl<K, V> PrimaryMap<K, V>
+impl<K, V> BoxedSlice<K, V>
 where
     K: EntityRef,
 {
-    /// Create a new empty map.
-    pub fn new() -> Self {
+    /// Create a new slice from a raw pointer. A safer way to create slices is
+    /// to use `PrimaryMap::into_boxed_slice()`.
+    pub unsafe fn from_raw(raw: *mut [V]) -> Self {
         Self {
-            elems: Vec::new(),
-            unused: PhantomData,
-        }
-    }
-
-    /// Create a new empty map with the given capacity.
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            elems: Vec::with_capacity(capacity),
+            elems: Box::from_raw(raw),
             unused: PhantomData,
         }
     }
@@ -103,47 +83,20 @@ where
         IterMut::new(self.elems.iter_mut())
     }
 
-    /// Remove all entries from this map.
-    pub fn clear(&mut self) {
-        self.elems.clear()
-    }
-
     /// Get the key that will be assigned to the next pushed value.
     pub fn next_key(&self) -> K {
         K::new(self.elems.len())
-    }
-
-    /// Append `v` to the mapping, assigning a new key which is returned.
-    pub fn push(&mut self, v: V) -> K {
-        let k = self.next_key();
-        self.elems.push(v);
-        k
     }
 
     /// Returns the last element that was inserted in the map.
     pub fn last(&self) -> Option<&V> {
         self.elems.last()
     }
-
-    /// Reserves capacity for at least `additional` more elements to be inserted.
-    pub fn reserve(&mut self, additional: usize) {
-        self.elems.reserve(additional)
-    }
-
-    /// Reserves the minimum capacity for exactly `additional` more elements to be inserted.
-    pub fn reserve_exact(&mut self, additional: usize) {
-        self.elems.reserve_exact(additional)
-    }
-
-    /// Consumes this `PrimaryMap` and produces a `BoxedSlice`.
-    pub fn into_boxed_slice(self) -> BoxedSlice<K, V> {
-        unsafe { BoxedSlice::<K, V>::from_raw(Box::<[V]>::into_raw(self.elems.into_boxed_slice())) }
-    }
 }
 
-/// Immutable indexing into an `PrimaryMap`.
+/// Immutable indexing into a `BoxedSlice`.
 /// The indexed value must be in the map.
-impl<K, V> Index<K> for PrimaryMap<K, V>
+impl<K, V> Index<K> for BoxedSlice<K, V>
 where
     K: EntityRef,
 {
@@ -154,8 +107,8 @@ where
     }
 }
 
-/// Mutable indexing into an `PrimaryMap`.
-impl<K, V> IndexMut<K> for PrimaryMap<K, V>
+/// Mutable indexing into a `BoxedSlice`.
+impl<K, V> IndexMut<K> for BoxedSlice<K, V>
 where
     K: EntityRef,
 {
@@ -164,7 +117,7 @@ where
     }
 }
 
-impl<'a, K, V> IntoIterator for &'a PrimaryMap<K, V>
+impl<'a, K, V> IntoIterator for &'a BoxedSlice<K, V>
 where
     K: EntityRef,
 {
@@ -176,7 +129,7 @@ where
     }
 }
 
-impl<'a, K, V> IntoIterator for &'a mut PrimaryMap<K, V>
+impl<'a, K, V> IntoIterator for &'a mut BoxedSlice<K, V>
 where
     K: EntityRef,
 {
@@ -188,24 +141,10 @@ where
     }
 }
 
-impl<K, V> FromIterator<V> for PrimaryMap<K, V>
-where
-    K: EntityRef,
-{
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = V>,
-    {
-        Self {
-            elems: Vec::from_iter(iter),
-            unused: PhantomData,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use primary::PrimaryMap;
 
     // `EntityRef` impl for testing.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -224,7 +163,8 @@ mod tests {
     fn basic() {
         let r0 = E(0);
         let r1 = E(1);
-        let m = PrimaryMap::<E, isize>::new();
+        let p = PrimaryMap::<E, isize>::new();
+        let m = p.into_boxed_slice();
 
         let v: Vec<E> = m.keys().collect();
         assert_eq!(v, []);
@@ -234,23 +174,11 @@ mod tests {
     }
 
     #[test]
-    fn push() {
-        let mut m = PrimaryMap::new();
-        let k0: E = m.push(12);
-        let k1 = m.push(33);
-
-        assert_eq!(m[k0], 12);
-        assert_eq!(m[k1], 33);
-
-        let v: Vec<E> = m.keys().collect();
-        assert_eq!(v, [k0, k1]);
-    }
-
-    #[test]
     fn iter() {
-        let mut m: PrimaryMap<E, usize> = PrimaryMap::new();
-        m.push(12);
-        m.push(33);
+        let mut p: PrimaryMap<E, usize> = PrimaryMap::new();
+        p.push(12);
+        p.push(33);
+        let mut m = p.into_boxed_slice();
 
         let mut i = 0;
         for (key, value) in &m {
@@ -276,9 +204,10 @@ mod tests {
 
     #[test]
     fn iter_rev() {
-        let mut m: PrimaryMap<E, usize> = PrimaryMap::new();
-        m.push(12);
-        m.push(33);
+        let mut p: PrimaryMap<E, usize> = PrimaryMap::new();
+        p.push(12);
+        p.push(33);
+        let mut m = p.into_boxed_slice();
 
         let mut i = 2;
         for (key, value) in m.iter().rev() {
@@ -304,9 +233,10 @@ mod tests {
     }
     #[test]
     fn keys() {
-        let mut m: PrimaryMap<E, usize> = PrimaryMap::new();
-        m.push(12);
-        m.push(33);
+        let mut p: PrimaryMap<E, usize> = PrimaryMap::new();
+        p.push(12);
+        p.push(33);
+        let m = p.into_boxed_slice();
 
         let mut i = 0;
         for key in m.keys() {
@@ -317,9 +247,10 @@ mod tests {
 
     #[test]
     fn keys_rev() {
-        let mut m: PrimaryMap<E, usize> = PrimaryMap::new();
-        m.push(12);
-        m.push(33);
+        let mut p: PrimaryMap<E, usize> = PrimaryMap::new();
+        p.push(12);
+        p.push(33);
+        let m = p.into_boxed_slice();
 
         let mut i = 2;
         for key in m.keys().rev() {
@@ -330,9 +261,10 @@ mod tests {
 
     #[test]
     fn values() {
-        let mut m: PrimaryMap<E, usize> = PrimaryMap::new();
-        m.push(12);
-        m.push(33);
+        let mut p: PrimaryMap<E, usize> = PrimaryMap::new();
+        p.push(12);
+        p.push(33);
+        let mut m = p.into_boxed_slice();
 
         let mut i = 0;
         for value in m.values() {
@@ -356,9 +288,10 @@ mod tests {
 
     #[test]
     fn values_rev() {
-        let mut m: PrimaryMap<E, usize> = PrimaryMap::new();
-        m.push(12);
-        m.push(33);
+        let mut p: PrimaryMap<E, usize> = PrimaryMap::new();
+        p.push(12);
+        p.push(33);
+        let mut m = p.into_boxed_slice();
 
         let mut i = 2;
         for value in m.values().rev() {
@@ -377,19 +310,6 @@ mod tests {
                 1 => assert_eq!(*value_mut, 33),
                 _ => panic!(),
             }
-        }
-    }
-
-    #[test]
-    fn from_iter() {
-        let mut m: PrimaryMap<E, usize> = PrimaryMap::new();
-        m.push(12);
-        m.push(33);
-
-        let n = m.values().collect::<PrimaryMap<E, _>>();
-        assert!(m.len() == n.len());
-        for (me, ne) in m.values().zip(n.values()) {
-            assert!(*me == **ne);
         }
     }
 }

--- a/lib/entity/src/lib.rs
+++ b/lib/entity/src/lib.rs
@@ -102,6 +102,13 @@ macro_rules! entity_impl {
         impl $entity {
             /// Return the underlying index value as a `u32`.
             #[allow(dead_code)]
+            pub fn from_u32(x: u32) -> Self {
+                debug_assert!(x < $crate::__core::u32::MAX);
+                $entity(x)
+            }
+
+            /// Return the underlying index value as a `u32`.
+            #[allow(dead_code)]
             pub fn as_u32(self) -> u32 {
                 self.0
             }

--- a/lib/entity/src/lib.rs
+++ b/lib/entity/src/lib.rs
@@ -101,6 +101,7 @@ macro_rules! entity_impl {
 
         impl $entity {
             /// Return the underlying index value as a `u32`.
+            #[allow(dead_code)]
             pub fn as_u32(self) -> u32 {
                 self.0
             }

--- a/lib/entity/src/lib.rs
+++ b/lib/entity/src/lib.rs
@@ -129,6 +129,7 @@ macro_rules! entity_impl {
 
 pub mod packed_option;
 
+mod boxed_slice;
 mod iter;
 mod keys;
 mod list;
@@ -137,6 +138,7 @@ mod primary;
 mod set;
 mod sparse;
 
+pub use self::boxed_slice::BoxedSlice;
 pub use self::iter::{Iter, IterMut};
 pub use self::keys::Keys;
 pub use self::list::{EntityList, ListPool};

--- a/lib/entity/src/lib.rs
+++ b/lib/entity/src/lib.rs
@@ -98,6 +98,13 @@ macro_rules! entity_impl {
                 $entity($crate::__core::u32::MAX)
             }
         }
+
+        impl $entity {
+            /// Return the underlying index value as a `u32`.
+            pub fn as_u32(self) -> u32 {
+                self.0
+            }
+        }
     };
 
     // Include basic `Display` impl using the given display prefix.

--- a/lib/entity/src/map.rs
+++ b/lib/entity/src/map.rs
@@ -1,10 +1,12 @@
 //! Densely numbered entity references as mapping keys.
 
+use iter::{Iter, IterMut};
+use keys::Keys;
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 use std::slice;
 use std::vec::Vec;
-use {EntityRef, Iter, IterMut, Keys};
+use EntityRef;
 
 /// A mapping `K -> V` for densely indexed entity references.
 ///

--- a/lib/entity/src/primary.rs
+++ b/lib/entity/src/primary.rs
@@ -371,6 +371,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn from_iter() {
         let mut m: PrimaryMap<E, usize> = PrimaryMap::new();
         m.push(12);

--- a/lib/entity/src/primary.rs
+++ b/lib/entity/src/primary.rs
@@ -41,6 +41,14 @@ where
         }
     }
 
+    /// Create a new empty map with the given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            elems: Vec::with_capacity(capacity),
+            unused: PhantomData,
+        }
+    }
+
     /// Check if `k` is a valid key in the map.
     pub fn is_valid(&self, k: K) -> bool {
         k.index() < self.elems.len()

--- a/lib/entity/src/primary.rs
+++ b/lib/entity/src/primary.rs
@@ -1,10 +1,12 @@
 //! Densely numbered entity references as mapping keys.
+use iter::{Iter, IterMut};
+use keys::Keys;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 use std::slice;
 use std::vec::Vec;
-use {EntityRef, Iter, IterMut, Keys};
+use EntityRef;
 
 /// A primary mapping `K -> V` allocating dense entity references.
 ///

--- a/lib/entity/src/primary.rs
+++ b/lib/entity/src/primary.rs
@@ -1,4 +1,5 @@
 //! Densely numbered entity references as mapping keys.
+use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 use std::slice;
@@ -167,6 +168,21 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         IterMut::new(self.elems.iter_mut())
+    }
+}
+
+impl<K, V> FromIterator<V> for PrimaryMap<K, V>
+where
+    K: EntityRef,
+{
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = V>,
+    {
+        Self {
+            elems: Vec::from_iter(iter),
+            unused: PhantomData,
+        }
     }
 }
 
@@ -344,6 +360,17 @@ mod tests {
                 1 => assert_eq!(*value_mut, 33),
                 _ => panic!(),
             }
+        }
+    }
+
+    fn from_iter() {
+        let mut m: PrimaryMap<E, usize> = PrimaryMap::new();
+        m.push(12);
+        m.push(33);
+        let n = m.values().collect::<PrimaryMap<E, _>>();
+        assert!(m.len() == n.len());
+        for (me, ne) in m.values().zip(n.values()) {
+            assert!(*me == **ne);
         }
     }
 }

--- a/lib/entity/src/set.rs
+++ b/lib/entity/src/set.rs
@@ -1,8 +1,9 @@
 //! Densely numbered entity references as set keys.
 
+use keys::Keys;
 use std::marker::PhantomData;
 use std::vec::Vec;
-use {EntityRef, Keys};
+use EntityRef;
 
 /// A set of `K` for densely indexed entity references.
 ///

--- a/lib/entity/src/sparse.rs
+++ b/lib/entity/src/sparse.rs
@@ -7,11 +7,12 @@
 //! > Briggs, Torczon, *An efficient representation for sparse sets*,
 //!   ACM Letters on Programming Languages and Systems, Volume 2, Issue 1-4, March-Dec. 1993.
 
+use map::SecondaryMap;
 use std::mem;
 use std::slice;
 use std::u32;
 use std::vec::Vec;
-use {EntityRef, SecondaryMap};
+use EntityRef;
 
 /// Trait for extracting keys from values stored in a `SparseMap`.
 ///

--- a/lib/filetests/src/concurrent.rs
+++ b/lib/filetests/src/concurrent.rs
@@ -7,13 +7,14 @@ use cranelift_codegen::dbg::LOG_FILENAME_PREFIX;
 use cranelift_codegen::timing;
 use file_per_thread_logger;
 use num_cpus;
+use runone;
 use std::panic::catch_unwind;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
-use {runone, TestResult};
+use TestResult;
 
 /// Request sent to worker threads contains jobid and path.
 struct Request(usize, PathBuf);

--- a/lib/filetests/src/runner.rs
+++ b/lib/filetests/src/runner.rs
@@ -5,12 +5,13 @@
 
 use concurrent::{ConcurrentRunner, Reply};
 use cranelift_codegen::timing;
+use runone;
 use std::error::Error;
 use std::ffi::OsStr;
 use std::fmt::{self, Display};
 use std::path::{Path, PathBuf};
 use std::time;
-use {runone, TestResult};
+use TestResult;
 
 /// Timeout in seconds when we're not making progress.
 const TIMEOUT_PANIC: usize = 10;

--- a/lib/frontend/src/ssa.rs
+++ b/lib/frontend/src/ssa.rs
@@ -192,9 +192,9 @@ impl SSABuilder {
 /// Small enum used for clarity in some functions.
 #[derive(Debug)]
 enum ZeroOneOrMore<T> {
-    Zero(),
+    Zero,
     One(T),
-    More(),
+    More,
 }
 
 #[derive(Debug)]
@@ -526,7 +526,7 @@ impl SSABuilder {
         temp_arg_var: Variable,
         dest_ebb: Ebb,
     ) {
-        let mut pred_values: ZeroOneOrMore<Value> = ZeroOneOrMore::Zero();
+        let mut pred_values: ZeroOneOrMore<Value> = ZeroOneOrMore::Zero;
 
         // Iterate over the predecessors.
         for _ in 0..self.predecessors(dest_ebb).len() {
@@ -534,21 +534,21 @@ impl SSABuilder {
             // to var and we put it as an argument of the branch instruction.
             let pred_val = self.results.pop().unwrap();
             match pred_values {
-                ZeroOneOrMore::Zero() => {
+                ZeroOneOrMore::Zero => {
                     if pred_val != temp_arg_val {
                         pred_values = ZeroOneOrMore::One(pred_val);
                     }
                 }
                 ZeroOneOrMore::One(old_val) => {
                     if pred_val != temp_arg_val && pred_val != old_val {
-                        pred_values = ZeroOneOrMore::More();
+                        pred_values = ZeroOneOrMore::More;
                     }
                 }
-                ZeroOneOrMore::More() => {}
+                ZeroOneOrMore::More => {}
             }
         }
         let result_val = match pred_values {
-            ZeroOneOrMore::Zero() => {
+            ZeroOneOrMore::Zero => {
                 // The variable is used but never defined before. This is an irregularity in the
                 // code, but rather than throwing an error we silently initialize the variable to
                 // 0. This will have no effect since this situation happens in unreachable code.
@@ -583,7 +583,7 @@ impl SSABuilder {
                 func.dfg.change_to_alias(temp_arg_val, resolved);
                 resolved
             }
-            ZeroOneOrMore::More() => {
+            ZeroOneOrMore::More => {
                 // There is disagreement in the predecessors on which value to use so we have
                 // to keep the ebb argument. To avoid borrowing `self` for the whole loop,
                 // temporarily detach the predecessors list and replace it with an empty list.

--- a/lib/module/src/data_context.rs
+++ b/lib/module/src/data_context.rs
@@ -132,8 +132,8 @@ impl DataContext {
 
 #[cfg(test)]
 mod tests {
+    use super::{DataContext, Init};
     use cranelift_codegen::ir;
-    use {DataContext, Init};
 
     #[test]
     fn basic_data_context() {

--- a/lib/module/src/module.rs
+++ b/lib/module/src/module.rs
@@ -473,7 +473,7 @@ where
         let signature = in_func.import_signature(decl.signature.clone());
         let colocated = decl.linkage.is_final();
         in_func.import_function(ir::ExtFuncData {
-            name: ir::ExternalName::user(0, func.index() as u32),
+            name: ir::ExternalName::user(0, func.as_u32()),
             signature,
             colocated,
         })
@@ -486,7 +486,7 @@ where
         let decl = &self.contents.data_objects[data].decl;
         let colocated = decl.linkage.is_final();
         func.create_global_value(ir::GlobalValueData::Symbol {
-            name: ir::ExternalName::user(1, data.index() as u32),
+            name: ir::ExternalName::user(1, data.as_u32()),
             offset: ir::immediates::Imm64::new(0),
             colocated,
         })
@@ -494,12 +494,12 @@ where
 
     /// TODO: Same as above.
     pub fn declare_func_in_data(&self, func: FuncId, ctx: &mut DataContext) -> ir::FuncRef {
-        ctx.import_function(ir::ExternalName::user(0, func.index() as u32))
+        ctx.import_function(ir::ExternalName::user(0, func.as_u32()))
     }
 
     /// TODO: Same as above.
     pub fn declare_data_in_data(&self, data: DataId, ctx: &mut DataContext) -> ir::GlobalValue {
-        ctx.import_global_value(ir::ExternalName::user(1, data.index() as u32))
+        ctx.import_global_value(ir::ExternalName::user(1, data.as_u32()))
     }
 
     /// Define a function, producing the function body from the given `Context`.

--- a/lib/module/src/module.rs
+++ b/lib/module/src/module.rs
@@ -5,7 +5,7 @@
 // TODO: Factor out `ir::Function`'s `ext_funcs` and `global_values` into a struct
 // shared with `DataContext`?
 
-use cranelift_codegen::entity::{EntityRef, PrimaryMap};
+use cranelift_codegen::entity::PrimaryMap;
 use cranelift_codegen::{binemit, ir, isa, CodegenError, Context};
 use data_context::DataContext;
 use std::borrow::ToOwned;
@@ -222,7 +222,7 @@ where
     fn get_function_info(&self, name: &ir::ExternalName) -> &ModuleFunction<B> {
         if let ir::ExternalName::User { namespace, index } = *name {
             debug_assert_eq!(namespace, 0);
-            let func = FuncId::new(index as usize);
+            let func = FuncId::from_u32(index);
             &self.functions[func]
         } else {
             panic!("unexpected ExternalName kind {}", name)
@@ -233,7 +233,7 @@ where
     fn get_data_info(&self, name: &ir::ExternalName) -> &ModuleData<B> {
         if let ir::ExternalName::User { namespace, index } = *name {
             debug_assert_eq!(namespace, 1);
-            let data = DataId::new(index as usize);
+            let data = DataId::from_u32(index);
             &self.data_objects[data]
         } else {
             panic!("unexpected ExternalName kind {}", name)

--- a/lib/simplejit/examples/simplejit-minimal.rs
+++ b/lib/simplejit/examples/simplejit-minimal.rs
@@ -27,7 +27,7 @@ fn main() {
         .unwrap();
 
     ctx.func.signature = sig_a;
-    ctx.func.name = ExternalName::user(0, func_a.index() as u32);
+    ctx.func.name = ExternalName::user(0, func_a.as_u32());
     {
         let mut bcx: FunctionBuilder = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);
         let ebb = bcx.create_ebb();
@@ -45,7 +45,7 @@ fn main() {
     module.clear_context(&mut ctx);
 
     ctx.func.signature = sig_b;
-    ctx.func.name = ExternalName::user(0, func_b.index() as u32);
+    ctx.func.name = ExternalName::user(0, func_b.as_u32());
     {
         let mut bcx: FunctionBuilder = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);
         let ebb = bcx.create_ebb();

--- a/lib/simplejit/tests/basic.rs
+++ b/lib/simplejit/tests/basic.rs
@@ -42,7 +42,7 @@ fn define_simple_function(module: &mut Module<SimpleJITBackend>) -> FuncId {
         .unwrap();
 
     let mut ctx = Context::new();
-    ctx.func = Function::with_name_signature(ExternalName::user(0, func_id.index() as u32), sig);
+    ctx.func = Function::with_name_signature(ExternalName::user(0, func_id.as_u32()), sig);
     let mut func_ctx = FunctionBuilderContext::new();
     {
         let mut bcx: FunctionBuilder = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);

--- a/lib/umbrella/src/lib.rs
+++ b/lib/umbrella/src/lib.rs
@@ -36,7 +36,7 @@ pub mod prelude {
     pub use codegen;
     pub use codegen::entity::EntityRef;
     pub use codegen::ir::condcodes::{FloatCC, IntCC};
-    pub use codegen::ir::immediates::{Ieee32, Ieee64, Imm64};
+    pub use codegen::ir::immediates::{Ieee32, Ieee64, Imm64, Uimm64};
     pub use codegen::ir::types;
     pub use codegen::ir::{
         AbiParam, Ebb, ExtFuncData, ExternalName, GlobalValueData, InstBuilder, JumpTableData,

--- a/lib/wasm/Cargo.toml
+++ b/lib/wasm/Cargo.toml
@@ -18,6 +18,7 @@ hashmap_core = { version = "0.1.9", optional = true }
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }
 log = { version = "0.4.4", default-features = false }
+cast = { version = "0.2.2" }
 
 [dev-dependencies]
 wabt = "0.7.0"

--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -26,7 +26,6 @@ use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{self, InstBuilder, JumpTableData, MemFlags};
 use cranelift_codegen::packed_option::ReservedValue;
-use cranelift_entity::EntityRef;
 use cranelift_frontend::{FunctionBuilder, Variable};
 use environ::{FuncEnvironment, GlobalVariable, ReturnMode, WasmError, WasmResult};
 use state::{ControlStackFrame, TranslationState};
@@ -355,7 +354,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (fref, num_args) = state.get_direct_func(builder.func, function_index, environ);
             let call = environ.translate_call(
                 builder.cursor(),
-                FuncIndex::new(function_index as usize),
+                FuncIndex::from_u32(function_index),
                 fref,
                 state.peekn(num_args),
             )?;
@@ -378,9 +377,9 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let callee = state.pop1();
             let call = environ.translate_call_indirect(
                 builder.cursor(),
-                TableIndex::new(table_index as usize),
+                TableIndex::from_u32(table_index),
                 table,
-                SignatureIndex::new(index as usize),
+                SignatureIndex::from_u32(index),
                 sigref,
                 callee,
                 state.peekn(num_args),
@@ -401,13 +400,13 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::MemoryGrow { reserved } => {
             // The WebAssembly MVP only supports one linear memory, but we expect the reserved
             // argument to be a memory index.
-            let heap_index = MemoryIndex::new(reserved as usize);
+            let heap_index = MemoryIndex::from_u32(reserved);
             let heap = state.get_heap(builder.func, reserved, environ);
             let val = state.pop1();
             state.push1(environ.translate_memory_grow(builder.cursor(), heap_index, heap, val)?)
         }
         Operator::MemorySize { reserved } => {
-            let heap_index = MemoryIndex::new(reserved as usize);
+            let heap_index = MemoryIndex::from_u32(reserved);
             let heap = state.get_heap(builder.func, reserved, environ);
             state.push1(environ.translate_memory_size(builder.cursor(), heap_index, heap)?);
         }

--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -77,9 +77,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 GlobalVariable::Const(val) => val,
                 GlobalVariable::Memory { gv, offset, ty } => {
                     let addr = builder.ins().global_value(environ.pointer_type(), gv);
-                    let mut flags = ir::MemFlags::new();
-                    flags.set_notrap();
-                    flags.set_aligned();
+                    let flags = ir::MemFlags::trusted();
                     builder.ins().load(ty, flags, addr, offset)
                 }
             };
@@ -90,9 +88,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 GlobalVariable::Const(_) => panic!("global #{} is a constant", global_index),
                 GlobalVariable::Memory { gv, offset, ty } => {
                     let addr = builder.ins().global_value(environ.pointer_type(), gv);
-                    let mut flags = ir::MemFlags::new();
-                    flags.set_notrap();
-                    flags.set_aligned();
+                    let flags = ir::MemFlags::trusted();
                     let val = state.pop1();
                     debug_assert_eq!(ty, builder.func.dfg.value_type(val));
                     builder.ins().store(flags, val, addr, offset);

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -342,10 +342,6 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         self.info.config
     }
 
-    fn get_func_name(&self, func_index: FuncIndex) -> ir::ExternalName {
-        get_func_name(func_index)
-    }
-
     fn declare_signature(&mut self, sig: &ir::Signature) {
         self.info.signatures.push(sig.clone());
     }

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -270,9 +270,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
             let ext = pos.ins().uextend(I64, callee);
             pos.ins().imul_imm(ext, 4)
         };
-        let mut mflags = ir::MemFlags::new();
-        mflags.set_notrap();
-        mflags.set_aligned();
+        let mflags = ir::MemFlags::trusted();
         let func_ptr = pos.ins().load(ptr, mflags, callee_offset, 0);
 
         // Build a value list for the indirect call instruction containing the callee, call_args,

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -18,7 +18,7 @@ use translation_utils::{
 
 /// Compute a `ir::ExternalName` for a given wasm function index.
 fn get_func_name(func_index: FuncIndex) -> ir::ExternalName {
-    ir::ExternalName::user(0, func_index.index() as u32)
+    ir::ExternalName::user(0, func_index.as_u32())
 }
 
 /// A collection of names under which a given entity is exported.

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -2,7 +2,7 @@
 //! wasm translation.
 
 use cranelift_codegen::cursor::FuncCursor;
-use cranelift_codegen::ir::immediates::{Imm64, Offset32};
+use cranelift_codegen::ir::immediates::{Offset32, Uimm64};
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{self, InstBuilder};
 use cranelift_codegen::isa::TargetFrontendConfig;
@@ -195,7 +195,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         func.create_heap(ir::HeapData {
             base: gv,
             min_size: 0.into(),
-            guard_size: 0x8000_0000.into(),
+            offset_guard_size: 0x8000_0000.into(),
             style: ir::HeapStyle::Static {
                 bound: 0x1_0000_0000.into(),
             },
@@ -221,9 +221,9 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
 
         func.create_table(ir::TableData {
             base_gv,
-            min_size: Imm64::new(0),
+            min_size: Uimm64::new(0),
             bound_gv,
-            element_size: Imm64::new(i64::from(self.pointer_bytes()) * 2),
+            element_size: Uimm64::from(u64::from(self.pointer_bytes()) * 2),
             index_type: I32,
         })
     }

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -1,6 +1,7 @@
 //! "Dummy" implementations of `ModuleEnvironment` and `FuncEnvironment` for testing
 //! wasm translation.
 
+use cast;
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::immediates::{Offset32, Uimm64};
 use cranelift_codegen::ir::types::*;
@@ -169,15 +170,11 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
 
     fn make_global(&mut self, func: &mut ir::Function, index: GlobalIndex) -> GlobalVariable {
         // Just create a dummy `vmctx` global.
-        let offset = ((index.index() * 8) as i64 + 8).into();
+        let offset = cast::i32((index.index() * 8) + 8).unwrap().into();
         let vmctx = func.create_global_value(ir::GlobalValueData::VMContext {});
-        let iadd = func.create_global_value(ir::GlobalValueData::IAddImm {
-            base: vmctx,
-            offset,
-            global_type: self.pointer_type(),
-        });
         GlobalVariable::Memory {
-            gv: iadd,
+            gv: vmctx,
+            offset: offset,
             ty: self.mod_info.globals[index].entity.ty,
         }
     }

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -1,6 +1,7 @@
 //! All the runtime support necessary for the wasm to cranelift translation is formalized by the
 //! traits `FunctionEnvironment` and `ModuleEnvironment`.
 use cranelift_codegen::cursor::FuncCursor;
+use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::{self, InstBuilder};
 use cranelift_codegen::isa::TargetFrontendConfig;
 use std::convert::From;
@@ -20,6 +21,8 @@ pub enum GlobalVariable {
     Memory {
         /// The address of the global variable storage.
         gv: ir::GlobalValue,
+        /// An offset to add to the address.
+        offset: Offset32,
         /// The global variable's type.
         ty: ir::Type,
     },

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -235,9 +235,6 @@ pub trait ModuleEnvironment<'data> {
     /// Get the information needed to produce Cranelift IR for the current target.
     fn target_config(&self) -> TargetFrontendConfig;
 
-    /// Return the name for the given function index.
-    fn get_func_name(&self, func_index: FuncIndex) -> ir::ExternalName;
-
     /// Declares a function signature to the environment.
     fn declare_signature(&mut self, sig: &ir::Signature);
 

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -64,7 +64,8 @@ pub use func_translator::FuncTranslator;
 pub use module_translator::translate_module;
 pub use translation_utils::{
     DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, Global,
-    GlobalIndex, GlobalInit, Memory, MemoryIndex, SignatureIndex, Table, TableIndex,
+    GlobalIndex, GlobalInit, Memory, MemoryIndex, SignatureIndex, Table, TableElementType,
+    TableIndex,
 };
 
 #[cfg(not(feature = "std"))]

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -36,6 +36,7 @@
 extern crate cranelift_codegen;
 #[macro_use]
 extern crate cranelift_entity;
+extern crate cast;
 extern crate cranelift_frontend;
 #[cfg(test)]
 extern crate target_lexicon;

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -187,7 +187,7 @@ pub fn parse_global_section(
             Operator::F32Const { value } => GlobalInit::F32Const(value.bits()),
             Operator::F64Const { value } => GlobalInit::F64Const(value.bits()),
             Operator::GetGlobal { global_index } => {
-                GlobalInit::GlobalRef(GlobalIndex::new(global_index as usize))
+                GlobalInit::GetGlobal(GlobalIndex::new(global_index as usize))
             }
             ref s => panic!("unsupported init expr in global section: {:?}", s),
         };

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -106,7 +106,7 @@ pub fn parse_import_section<'data>(
                     Table {
                         ty: match type_to_type(tab.element_type) {
                             Ok(t) => TableElementType::Val(t),
-                            Err(()) => TableElementType::Func(),
+                            Err(()) => TableElementType::Func,
                         },
                         minimum: tab.limits.initial,
                         maximum: tab.limits.maximum,
@@ -142,7 +142,7 @@ pub fn parse_table_section(
         environ.declare_table(Table {
             ty: match type_to_type(table.element_type) {
                 Ok(t) => TableElementType::Val(t),
-                Err(()) => TableElementType::Func(),
+                Err(()) => TableElementType::Func,
             },
             minimum: table.limits.initial,
             maximum: table.limits.maximum,

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -95,7 +95,7 @@ pub fn parse_import_section<'data>(
                     Global {
                         ty: type_to_type(ty.content_type).unwrap(),
                         mutability: ty.mutable,
-                        initializer: GlobalInit::Import(),
+                        initializer: GlobalInit::Import,
                     },
                     module_name,
                     field_name,
@@ -253,7 +253,7 @@ pub fn parse_element_section<'data>(
                 .initializer
             {
                 GlobalInit::I32Const(value) => (None, value as u32 as usize),
-                GlobalInit::Import() => (Some(GlobalIndex::new(global_index as usize)), 0),
+                GlobalInit::Import => (Some(GlobalIndex::new(global_index as usize)), 0),
                 _ => panic!("should not happen"),
             },
             ref s => panic!("unsupported init expr in element section: {:?}", s),
@@ -301,7 +301,7 @@ pub fn parse_data_section<'data>(
                 .initializer
             {
                 GlobalInit::I32Const(value) => (None, value as u32 as usize),
-                GlobalInit::Import() => (Some(GlobalIndex::new(global_index as usize)), 0),
+                GlobalInit::Import => (Some(GlobalIndex::new(global_index as usize)), 0),
                 _ => panic!("should not happen"),
             },
             ref s => panic!("unsupported init expr in data section: {:?}", s),

--- a/lib/wasm/src/state.rs
+++ b/lib/wasm/src/state.rs
@@ -4,7 +4,6 @@
 //! value and control stacks during the translation of a single function.
 
 use cranelift_codegen::ir::{self, Ebb, Inst, Value};
-use cranelift_entity::EntityRef;
 use environ::{FuncEnvironment, GlobalVariable};
 use std::collections::HashMap;
 use std::vec::Vec;
@@ -287,7 +286,7 @@ impl TranslationState {
         index: u32,
         environ: &mut FE,
     ) -> GlobalVariable {
-        let index = GlobalIndex::new(index as usize);
+        let index = GlobalIndex::from_u32(index);
         *self
             .globals
             .entry(index)
@@ -302,7 +301,7 @@ impl TranslationState {
         index: u32,
         environ: &mut FE,
     ) -> ir::Heap {
-        let index = MemoryIndex::new(index as usize);
+        let index = MemoryIndex::from_u32(index);
         *self
             .heaps
             .entry(index)
@@ -317,7 +316,7 @@ impl TranslationState {
         index: u32,
         environ: &mut FE,
     ) -> ir::Table {
-        let index = TableIndex::new(index as usize);
+        let index = TableIndex::from_u32(index);
         *self
             .tables
             .entry(index)
@@ -334,7 +333,7 @@ impl TranslationState {
         index: u32,
         environ: &mut FE,
     ) -> (ir::SigRef, usize) {
-        let index = SignatureIndex::new(index as usize);
+        let index = SignatureIndex::from_u32(index);
         *self.signatures.entry(index).or_insert_with(|| {
             let sig = environ.make_indirect_sig(func, index);
             (sig, normal_args(&func.dfg.signatures[sig]))
@@ -351,7 +350,7 @@ impl TranslationState {
         index: u32,
         environ: &mut FE,
     ) -> (ir::FuncRef, usize) {
-        let index = FuncIndex::new(index as usize);
+        let index = FuncIndex::from_u32(index);
         *self.functions.entry(index).or_insert_with(|| {
             let fref = environ.make_direct_func(func, index);
             let sig = func.dfg.ext_funcs[fref].signature;

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -71,7 +71,7 @@ pub enum GlobalInit {
     /// An `f64.const`.
     F64Const(u64),
     /// A `get_global` of another global.
-    GlobalRef(GlobalIndex),
+    GetGlobal(GlobalIndex),
     ///< The global is imported from, and thus initialized by, a different module.
     Import,
 }

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -90,7 +90,9 @@ pub struct Table {
 /// WebAssembly table element. Can be a function or a scalar type.
 #[derive(Debug, Clone, Copy)]
 pub enum TableElementType {
+    /// A scalar type.
     Val(ir::Type),
+    /// A function.
     Func,
 }
 

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -91,7 +91,7 @@ pub struct Table {
 #[derive(Debug, Clone, Copy)]
 pub enum TableElementType {
     Val(ir::Type),
-    Func(),
+    Func,
 }
 
 /// WebAssembly linear memory.

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -73,7 +73,7 @@ pub enum GlobalInit {
     /// A `get_global` of another global.
     GlobalRef(GlobalIndex),
     ///< The global is imported from, and thus initialized by, a different module.
-    Import(),
+    Import,
 }
 
 /// WebAssembly table.


### PR DESCRIPTION
Also, say "guard-offset pages" rather than just "guard pages" to describe the
region of a heap which is never accessible and which exists to support
optimizations for heap accesses with offsets.

And, introduce a `Uimm64` immediate type, and make all heap fields use
`Uimm64` instead of `Imm64` since they really are unsigned.