### PR TITLE
Name Table and Memory's initial field `minimum` and make it u32.

### DIFF
--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -82,8 +82,8 @@ pub fn parse_import_section<'data>(
             }) => {
                 environ.declare_memory_import(
                     Memory {
-                        pages_count: memlimits.initial as usize,
-                        maximum: memlimits.maximum.map(|x| x as usize),
+                        minimum: memlimits.initial,
+                        maximum: memlimits.maximum,
                         shared,
                     },
                     module_name,
@@ -108,8 +108,8 @@ pub fn parse_import_section<'data>(
                             Ok(t) => TableElementType::Val(t),
                             Err(()) => TableElementType::Func(),
                         },
-                        size: tab.limits.initial as usize,
-                        maximum: tab.limits.maximum.map(|x| x as usize),
+                        minimum: tab.limits.initial,
+                        maximum: tab.limits.maximum,
                     },
                     module_name,
                     field_name,
@@ -144,8 +144,8 @@ pub fn parse_table_section(
                 Ok(t) => TableElementType::Val(t),
                 Err(()) => TableElementType::Func(),
             },
-            size: table.limits.initial as usize,
-            maximum: table.limits.maximum.map(|x| x as usize),
+            minimum: table.limits.initial,
+            maximum: table.limits.maximum,
         });
     }
     Ok(())
@@ -159,8 +159,8 @@ pub fn parse_memory_section(
     for entry in memories {
         let memory = entry?;
         environ.declare_memory(Memory {
-            pages_count: memory.limits.initial as usize,
-            maximum: memory.limits.maximum.map(|x| x as usize),
+            minimum: memory.limits.initial,
+            maximum: memory.limits.maximum,
             shared: memory.shared,
         });
     }

--- a/lib/wasm/src/translation_utils.rs
+++ b/lib/wasm/src/translation_utils.rs
@@ -82,9 +82,9 @@ pub struct Table {
     /// The type of data stored in elements of the table.
     pub ty: TableElementType,
     /// The minimum number of elements in the table.
-    pub size: usize,
+    pub minimum: u32,
     /// The maximum number of elements in the table.
-    pub maximum: Option<usize>,
+    pub maximum: Option<u32>,
 }
 
 /// WebAssembly table element. Can be a function or a scalar type.
@@ -98,9 +98,9 @@ pub enum TableElementType {
 #[derive(Debug, Clone, Copy)]
 pub struct Memory {
     /// The minimum number of pages in the memory.
-    pub pages_count: usize,
+    pub minimum: u32,
     /// The maximum number of pages in the memory.
-    pub maximum: Option<usize>,
+    pub maximum: Option<u32>,
     /// Whether the memory may be shared between multiple threads.
     pub shared: bool,
 }


### PR DESCRIPTION
The spec has switched to calling the "initial" field the "minimum" field
because when linear memory is imported, it may initially be greater than
the "initial" value.

Making it u32 instead of usize will help avoid accidental host-specific
behavior.