### PR TITLE
Fixes #614: Implement a debug trap

### DIFF
--- a/filetests/isa/x86/binary64.clif
+++ b/filetests/isa/x86/binary64.clif
@@ -784,6 +784,9 @@ ebb1:
     ; asm: jnbe .+4; ud2
     trapif ule v11, user0                          ; bin: 77 02 user0 0f 0b
 
+    ; Debug trap.
+    debugtrap ; bin: cc
+
     ; Stack check.
     ; asm: cmpq %rsp, %rcx
     [-,%rflags]         v40 = ifcmp_sp v1       ; bin: 48 39 e1

--- a/lib/codegen/meta-python/base/instructions.py
+++ b/lib/codegen/meta-python/base/instructions.py
@@ -181,6 +181,10 @@ indirect_jump_table_br = Instruction(
     ins=(addr, JT),
     is_branch=True, is_indirect_branch=True, is_terminator=True)
 
+debugtrap = Instruction('debugtrap', r"""
+    Encodes an assembly debug trap.
+    """, can_load=True, can_store=True, other_side_effects=True)
+
 code = Operand('code', trapcode)
 trap = Instruction(
         'trap', r"""

--- a/lib/codegen/meta-python/isa/x86/encodings.py
+++ b/lib/codegen/meta-python/isa/x86/encodings.py
@@ -521,11 +521,16 @@ X86_32.enc(base.jump_table_base.i32, *r.jt_base(0x8d))
 
 enc_x86_64(base.indirect_jump_table_br.i64, r.indirect_jmp, 0xff, rrr=4)
 X86_32.enc(base.indirect_jump_table_br.i32, *r.indirect_jmp(0xff, rrr=4))
+
 #
 # Trap as ud2
 #
 X86_32.enc(base.trap, *r.trap(0x0f, 0x0b))
 X86_64.enc(base.trap, *r.trap(0x0f, 0x0b))
+
+# Debug trap as int3
+X86_32.enc(base.debugtrap, r.debugtrap, 0)
+X86_64.enc(base.debugtrap, r.debugtrap, 0)
 
 # Using a standard EncRecipe, not the TailRecipe.
 X86_32.enc(base.trapif, r.trapif, 0)

--- a/lib/codegen/meta-python/isa/x86/recipes.py
+++ b/lib/codegen/meta-python/isa/x86/recipes.py
@@ -295,6 +295,11 @@ def valid_scale(iform):
 # copies and no-op conversions.
 null = EncRecipe('null', Unary, base_size=0, ins=GPR, outs=0, emit='')
 
+debugtrap = EncRecipe('debugtrap', NullAry, base_size=1, ins=(), outs=(),
+                      emit='''
+                      sink.put1(0xcc);
+                      ''')
+
 # XX opcode, no ModR/M.
 trap = TailRecipe(
         'trap', Trap, base_size=0, ins=(), outs=(),


### PR DESCRIPTION
It's quite simple, and I've checked that it works in Spidermonkey (which had me add the `other_side_effects` flag so it wouldn't get removed by DCE). There weren't any other nullary recipe I could use for this, so I implemented it the simplest way; if we want more nullary instructions in the future, we can probably factor the recipe better.