### PR TITLE
WIP: Add support for an HeapBase argument

### DIFF
--- a/lib/codegen/src/ir/extfunc.rs
+++ b/lib/codegen/src/ir/extfunc.rs
@@ -265,6 +265,12 @@ pub enum ArgumentPurpose {
     /// caller in an indirect call. The callee can verify that the expected signature ID matches.
     SignatureId,
 
+    /// A pointer to the base of a single heap.
+    ///
+    /// This is a special-purpose argument used to contain the base of a heap, that can then be
+    /// reused in heap_load/heap_store instructions.
+    HeapBase,
+
     /// A stack limit pointer.
     ///
     /// This is a pointer to a stack limit. It is used to check the current stack pointer
@@ -273,7 +279,7 @@ pub enum ArgumentPurpose {
 }
 
 /// Text format names of the `ArgumentPurpose` variants.
-static PURPOSE_NAMES: [&str; 8] = [
+static PURPOSE_NAMES: [&str; 9] = [
     "normal",
     "sret",
     "link",
@@ -281,6 +287,7 @@ static PURPOSE_NAMES: [&str; 8] = [
     "csr",
     "vmctx",
     "sigid",
+    "heap_base",
     "stack_limit",
 ];
 
@@ -301,6 +308,7 @@ impl FromStr for ArgumentPurpose {
             "csr" => Ok(ArgumentPurpose::CalleeSaved),
             "vmctx" => Ok(ArgumentPurpose::VMContext),
             "sigid" => Ok(ArgumentPurpose::SignatureId),
+            "heap_base" => Ok(ArgumentPurpose::HeapBase),
             "stack_limit" => Ok(ArgumentPurpose::StackLimit),
             _ => Err(()),
         }
@@ -358,6 +366,7 @@ mod tests {
             ArgumentPurpose::CalleeSaved,
             ArgumentPurpose::VMContext,
             ArgumentPurpose::SignatureId,
+            ArgumentPurpose::HeapBase,
             ArgumentPurpose::StackLimit,
         ];
         for (&e, &n) in all_purpose.iter().zip(PURPOSE_NAMES.iter()) {

--- a/lib/codegen/src/isa/x86/abi.rs
+++ b/lib/codegen/src/isa/x86/abi.rs
@@ -103,6 +103,13 @@ impl ArgAssigner for Args {
                 }
                 // This is SpiderMonkey's `WasmTableCallSigReg`.
                 ArgumentPurpose::SignatureId => return ArgumentLoc::Reg(RU::r10 as RegUnit).into(),
+                ArgumentPurpose::HeapBase => {
+                    assert!(
+                        self.pointer_bits == 64,
+                        "x86 32-bits doesn't use a heap register"
+                    );
+                    return ArgumentLoc::Reg(RU::r15 as RegUnit).into();
+                }
                 _ => {}
             }
         }

--- a/lib/codegen/src/legalizer/boundary.rs
+++ b/lib/codegen/src/legalizer/boundary.rs
@@ -74,6 +74,7 @@ fn legalize_entry_params(func: &mut Function, entry: Ebb) {
     let mut has_vmctx = false;
     let mut has_sigid = false;
     let mut has_stack_limit = false;
+    let mut has_heap_base = false;
 
     // Insert position for argument conversion code.
     // We want to insert instructions before the first instruction in the entry block.
@@ -111,6 +112,10 @@ fn legalize_entry_params(func: &mut Function, entry: Ebb) {
                 ArgumentPurpose::SignatureId => {
                     debug_assert!(!has_sigid, "Multiple sigid arguments found");
                     has_sigid = true;
+                }
+                ArgumentPurpose::HeapBase => {
+                    debug_assert!(!has_heap_base, "Multiple heap base arguments found");
+                    has_heap_base = true;
                 }
                 ArgumentPurpose::StackLimit => {
                     debug_assert!(!has_stack_limit, "Multiple stack_limit arguments found");
@@ -175,6 +180,10 @@ fn legalize_entry_params(func: &mut Function, entry: Ebb) {
             ArgumentPurpose::StackLimit => {
                 debug_assert!(!has_stack_limit, "Multiple stack_limit parameters found");
                 has_stack_limit = true;
+            }
+            ArgumentPurpose::HeapBase => {
+                debug_assert!(!has_heap_base, "Multiple heap base parameters found");
+                has_heap_base = true;
             }
         }
 

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -52,6 +52,7 @@ pub use crate::translation_utils::{
     GlobalIndex, GlobalInit, Memory, MemoryIndex, SignatureIndex, Table, TableElementType,
     TableIndex,
 };
+pub use cranelift_frontend::{FunctionBuilder, Variable};
 
 #[cfg(not(feature = "std"))]
 mod std {


### PR DESCRIPTION
That's mostly for Spidermonkey, which uses a pinned register to contain the HeapBase on x64. It is supposed to be callee preserved, so we need a way to keep it alive (by passing it as an argument and returning it).

I'm not too happy with the changes that leak in here. Avoiding to push special purpose return values onto the wasm value stack seems fine, but the change in the frontend change feels wrong. I've had to do this, because otherwise the exit block will have the HeapBase as an EBB input; in which case every single jump to the exit block (natural jumps or jumps threaded to the return in FallthroughReturn mode) will need to have the HeapBase argument, and thus rematerialize it sometimes. I don't know much what to do here, so we'll need to think it through.