### PR TITLE
Use an `FxHashMap` in `RegDiversions`.

### DIFF
--- a/lib/codegen/src/regalloc/coloring.rs
+++ b/lib/codegen/src/regalloc/coloring.rs
@@ -654,10 +654,10 @@ impl<'a> Context<'a> {
     where
         Pred: FnMut(&LiveRange, LiveRangeContext<Layout>) -> bool,
     {
-        for rdiv in self.divert.all() {
+        for (&value, rdiv) in self.divert.iter() {
             let lr = self
                 .liveness
-                .get(rdiv.value)
+                .get(value)
                 .expect("Missing live range for diverted register");
             if pred(lr, self.liveness.context(&self.cur.func.layout)) {
                 if let Affinity::Reg(rci) = lr.affinity {
@@ -665,7 +665,7 @@ impl<'a> Context<'a> {
                     // Stack diversions should not be possible here. The only live transiently
                     // during `shuffle_inputs()`.
                     self.solver.reassign_in(
-                        rdiv.value,
+                        value,
                         rc,
                         rdiv.to.unwrap_reg(),
                         rdiv.from.unwrap_reg(),
@@ -673,7 +673,7 @@ impl<'a> Context<'a> {
                 } else {
                     panic!(
                         "Diverted register {} with {} affinity",
-                        rdiv.value,
+                        value,
                         lr.affinity.display(&self.reginfo)
                     );
                 }

--- a/lib/codegen/src/verifier/locations.rs
+++ b/lib/codegen/src/verifier/locations.rs
@@ -318,14 +318,14 @@ impl<'a> LocationVerifier<'a> {
                 dfg.display_inst(inst, self.isa)
             ),
             SingleDest(ebb, _) => {
-                for d in divert.all() {
-                    let lr = &liveness[d.value];
+                for (&value, d) in divert.iter() {
+                    let lr = &liveness[value];
                     if lr.is_livein(ebb, liveness.context(&self.func.layout)) {
                         return fatal!(
                             errors,
                             inst,
                             "{} is diverted to {} and live in to {}",
-                            d.value,
+                            value,
                             d.to.display(&self.reginfo),
                             ebb
                         );
@@ -333,15 +333,15 @@ impl<'a> LocationVerifier<'a> {
                 }
             }
             Table(jt, ebb) => {
-                for d in divert.all() {
-                    let lr = &liveness[d.value];
+                for (&value, d) in divert.iter() {
+                    let lr = &liveness[value];
                     if let Some(ebb) = ebb {
                         if lr.is_livein(ebb, liveness.context(&self.func.layout)) {
                             return fatal!(
                                 errors,
                                 inst,
                                 "{} is diverted to {} and live in to {}",
-                                d.value,
+                                value,
                                 d.to.display(&self.reginfo),
                                 ebb
                             );
@@ -353,7 +353,7 @@ impl<'a> LocationVerifier<'a> {
                                 errors,
                                 inst,
                                 "{} is diverted to {} and live in to {}",
-                                d.value,
+                                value,
                                 d.to.display(&self.reginfo),
                                 ebb
                             );

--- a/lib/entity/src/map.rs
+++ b/lib/entity/src/map.rs
@@ -97,6 +97,7 @@ where
     }
 
     /// Resize the map to have `n` entries by adding default entries as needed.
+    #[inline]
     pub fn resize(&mut self, n: usize) {
         self.elems.resize(n, self.default.clone());
     }
@@ -125,6 +126,7 @@ where
     K: EntityRef,
     V: Clone,
 {
+    #[inline]
     fn index_mut(&mut self, k: K) -> &mut V {
         let i = k.index();
         if i >= self.elems.len() {


### PR DESCRIPTION
Because it's hot and the number of entries can reach the 1000s, so
linear insertion and search is bad.

This reduces runtime for `sqlite` and `UE4Game-HTML5-Shipping` by 3-4%,
and a couple of other benchmarks (`sqlite`, `godot`, `clang`) by smaller
amounts.

It also increases runtime for `mono` and `tanks` by about 1%; this seems
to be due to incidental changes in which functions are inlined more than
algorithmic changes.