### PR TITLE
Branch comparison folding and order optimizations

### DIFF
--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -225,7 +225,7 @@ impl Context {
 
     /// Perform pre-legalization rewrites on the function.
     pub fn preopt(&mut self, isa: &TargetIsa) -> CodegenResult<()> {
-        do_preopt(&mut self.func);
+        do_preopt(&mut self.func, &mut self.cfg);
         self.verify_if(isa)?;
         Ok(())
     }

--- a/cranelift-codegen/src/simple_preopt.rs
+++ b/cranelift-codegen/src/simple_preopt.rs
@@ -1,4 +1,8 @@
 //! A pre-legalization rewriting pass.
+//!
+//! This module provides early-stage optimizations. The optimizations found
+//! should be useful for already well-optimized code. More general purpose
+//! early-stage optimizations can be found in the preopt crate.
 
 #![allow(non_snake_case)]
 

--- a/cranelift-codegen/src/simple_preopt.rs
+++ b/cranelift-codegen/src/simple_preopt.rs
@@ -555,6 +555,11 @@ enum BranchOptKind {
     NotEqualZero,
 }
 
+/// Fold comparisons into branch operations when possible.
+///
+/// This matches against operations which compare against zero, then use the
+/// result in a `brz` or `brnz` branch. It folds those two operations into a
+/// single `brz` or `brnz`.
 fn branch_opt(pos: &mut FuncCursor, inst: Inst) {
     let info = match pos.func.dfg[inst] {
         InstructionData::Branch {
@@ -648,6 +653,11 @@ enum BranchOrderKind {
     InvertIcmpCond(IntCC, Value, Value),
 }
 
+/// Reorder branches to encourage fallthroughs.
+///
+/// When an ebb ends with a conditional branch followed by an unconditional
+/// branch, this will reorder them if one of them is branching to the next Ebb
+/// layout-wise. The unconditional jump can then become a fallthrough.
 fn branch_order(pos: &mut FuncCursor, cfg: &mut ControlFlowGraph, ebb: Ebb, inst: Inst) {
     let info = match pos.func.dfg[inst] {
         InstructionData::Jump {

--- a/cranelift-codegen/src/simple_preopt.rs
+++ b/cranelift-codegen/src/simple_preopt.rs
@@ -616,25 +616,6 @@ fn branch_opt(pos: &mut FuncCursor, inst: Inst) {
     } else {
         panic!();
     }
-
-    /*
-        match info.kind {
-            BranchOptKind::EqualZero => {
-                let args = info.args.as_slice(&pos.func.dfg.value_lists)[1..].to_vec();
-                pos.func
-                    .dfg
-                    .replace(info.br_inst)
-                    .brz(info.cmp_arg, info.destination, &args);
-            }
-            BranchOptKind::NotEqualZero => {
-                let args = info.args.as_slice(&pos.func.dfg.value_lists)[1..].to_vec();
-                pos.func
-                    .dfg
-                    .replace(info.br_inst)
-                    .brnz(info.cmp_arg, info.destination, &args);
-            }
-        }
-    */
 }
 
 struct BranchOrderInfo {

--- a/cranelift-filetests/src/test_simple_preopt.rs
+++ b/cranelift-filetests/src/test_simple_preopt.rs
@@ -33,11 +33,10 @@ impl SubTest for TestSimplePreopt {
         let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
         let isa = context.isa.expect("preopt needs an ISA");
 
-        comp_ctx.flowgraph();
+        comp_ctx.compute_cfg();
         comp_ctx
             .preopt(isa)
             .map_err(|e| pretty_error(&comp_ctx.func, context.isa, Into::into(e)))?;
-
         let text = &comp_ctx.func.display(isa).to_string();
         run_filecheck(&text, context)
     }

--- a/filetests/simple_preopt/branch.clif
+++ b/filetests/simple_preopt/branch.clif
@@ -1,31 +1,58 @@
 test simple_preopt
 target x86_64
 
-function %brif_to_brz_fold(i32) -> i32 {
+function %icmp_to_brz_fold(i32) -> i32 {
 ebb0(v0: i32):
-    v1 = ifcmp_imm v0, 0
-    brif eq v1, ebb1
+    v1 = icmp_imm eq v0, 0
+    brnz v1, ebb1
     jump ebb2
 ebb1:
-    v2 = iconst.i32 1
-    return v2
-ebb2:
-    v3 = iconst.i32 2
+    v3 = iconst.i32 1
     return v3
+ebb2:
+    v4 = iconst.i32 2
+    return v4
 }
-; sameln: function %brif_to_brz_fold
+; sameln: function %icmp_to_brz_fold
 ; nextln: ebb0(v0: i32):
-; nextln:     v1 = ifcmp_imm v0, 0
+; nextln:     v1 = icmp_imm eq v0, 0
 ; nextln:     brnz v0, ebb2
 ; nextln:     fallthrough ebb1
 ; nextln: 
 ; nextln: ebb1:
-; nextln:     v2 = iconst.i32 1
-; nextln:     return v2
+; nextln:     v3 = iconst.i32 1
+; nextln:     return v3
 ; nextln: 
 ; nextln: ebb2:
-; nextln:     v3 = iconst.i32 2
+; nextln:     v4 = iconst.i32 2
+; nextln:     return v4
+; nextln: }
+
+function %icmp_to_brz_inverted_fold(i32) -> i32 {
+ebb0(v0: i32):
+    v1 = icmp_imm ne v0, 0
+    brz v1, ebb1
+    jump ebb2
+ebb1:
+    v3 = iconst.i32 1
+    return v3
+ebb2:
+    v4 = iconst.i32 2
+    return v4
+}
+; sameln: function %icmp_to_brz_inve
+; nextln: ebb0(v0: i32):
+; nextln:     v1 = icmp_imm ne v0, 0
+; nextln:     brnz v0, ebb2
+; nextln:     fallthrough ebb1
+; nextln: 
+; nextln: ebb1:
+; nextln:     v3 = iconst.i32 1
 ; nextln:     return v3
+; nextln: 
+; nextln: ebb2:
+; nextln:     v4 = iconst.i32 2
+; nextln:     return v4
 ; nextln: }
 
 function %brif_inversion(i32) -> i32 {

--- a/filetests/simple_preopt/branch.clif
+++ b/filetests/simple_preopt/branch.clif
@@ -16,8 +16,8 @@ ebb2:
 ; sameln: function %brif_to_brz_fold
 ; nextln: ebb0(v0: i32):
 ; nextln:     v1 = ifcmp_imm v0, 0
-; nextln:     brz v0, ebb1
-; nextln:     jump ebb2
+; nextln:     brnz v0, ebb2
+; nextln:     fallthrough ebb1
 ; nextln: 
 ; nextln: ebb1:
 ; nextln:     v2 = iconst.i32 1
@@ -26,4 +26,58 @@ ebb2:
 ; nextln: ebb2:
 ; nextln:     v3 = iconst.i32 2
 ; nextln:     return v3
+; nextln: }
+
+function %brif_inversion(i32) -> i32 {
+ebb0(v0: i32):
+    v1 = ifcmp_imm v0, 42
+    brif ugt v1, ebb1
+    jump ebb2
+ebb1:
+    v2 = iconst.i32 1
+    return v2
+ebb2:
+    v3 = iconst.i32 2
+    return v3
+}
+; sameln: function %brif_inversion
+; nextln: ebb0(v0: i32):
+; nextln:     v1 = ifcmp_imm v0, 42
+; nextln:     brif ule v1, ebb2
+; nextln:     fallthrough ebb1
+; nextln: 
+; nextln: ebb1:
+; nextln:     v2 = iconst.i32 1
+; nextln:     return v2
+; nextln: 
+; nextln: ebb2:
+; nextln:     v3 = iconst.i32 2
+; nextln:     return v3
+; nextln: }
+
+function %brff_inversion(f32, f32) -> i32 {
+ebb0(v0: f32, v1: f32):
+    v2 = ffcmp v0, v1
+    brff gt v2, ebb1
+    jump ebb2
+ebb1:
+    v3 = iconst.i32 1
+    return v3
+ebb2:
+    v4 = iconst.i32 2
+    return v4
+}
+; sameln: function %brff_inversion
+; nextln: ebb0(v0: f32, v1: f32):
+; nextln:     v2 = ffcmp v0, v1
+; nextln:     brff ule v2, ebb2
+; nextln:     fallthrough ebb1
+; nextln: 
+; nextln: ebb1:
+; nextln:     v3 = iconst.i32 1
+; nextln:     return v3
+; nextln: 
+; nextln: ebb2:
+; nextln:     v4 = iconst.i32 2
+; nextln:     return v4
 ; nextln: }

--- a/filetests/simple_preopt/branch.clif
+++ b/filetests/simple_preopt/branch.clif
@@ -55,10 +55,9 @@ ebb2:
 ; nextln:     return v4
 ; nextln: }
 
-function %brif_inversion(i32) -> i32 {
-ebb0(v0: i32):
-    v1 = ifcmp_imm v0, 42
-    brif ugt v1, ebb1
+function %br_icmp_inversion(i32, i32) -> i32 {
+ebb0(v0: i32, v1: i32):
+    br_icmp ugt v0, v1, ebb1
     jump ebb2
 ebb1:
     v2 = iconst.i32 1
@@ -67,10 +66,9 @@ ebb2:
     v3 = iconst.i32 2
     return v3
 }
-; sameln: function %brif_inversion
-; nextln: ebb0(v0: i32):
-; nextln:     v1 = ifcmp_imm v0, 42
-; nextln:     brif ule v1, ebb2
+; sameln: function %br_icmp_inversio
+; nextln: ebb0(v0: i32, v1: i32):
+; nextln:     br_icmp ule v0, v1, ebb2
 ; nextln:     fallthrough ebb1
 ; nextln: 
 ; nextln: ebb1:
@@ -80,31 +78,4 @@ ebb2:
 ; nextln: ebb2:
 ; nextln:     v3 = iconst.i32 2
 ; nextln:     return v3
-; nextln: }
-
-function %brff_inversion(f32, f32) -> i32 {
-ebb0(v0: f32, v1: f32):
-    v2 = ffcmp v0, v1
-    brff gt v2, ebb1
-    jump ebb2
-ebb1:
-    v3 = iconst.i32 1
-    return v3
-ebb2:
-    v4 = iconst.i32 2
-    return v4
-}
-; sameln: function %brff_inversion
-; nextln: ebb0(v0: f32, v1: f32):
-; nextln:     v2 = ffcmp v0, v1
-; nextln:     brff ule v2, ebb2
-; nextln:     fallthrough ebb1
-; nextln: 
-; nextln: ebb1:
-; nextln:     v3 = iconst.i32 1
-; nextln:     return v3
-; nextln: 
-; nextln: ebb2:
-; nextln:     v4 = iconst.i32 2
-; nextln:     return v4
 ; nextln: }

--- a/filetests/simple_preopt/branch.clif
+++ b/filetests/simple_preopt/branch.clif
@@ -17,7 +17,7 @@ ebb2:
 ; nextln: ebb0(v0: i32):
 ; nextln:     v1 = icmp_imm eq v0, 0
 ; nextln:     brnz v0, ebb2
-; nextln:     fallthrough ebb1
+; nextln:     jump ebb1
 ; nextln: 
 ; nextln: ebb1:
 ; nextln:     v3 = iconst.i32 1
@@ -44,7 +44,7 @@ ebb2:
 ; nextln: ebb0(v0: i32):
 ; nextln:     v1 = icmp_imm ne v0, 0
 ; nextln:     brnz v0, ebb2
-; nextln:     fallthrough ebb1
+; nextln:     jump ebb1
 ; nextln: 
 ; nextln: ebb1:
 ; nextln:     v3 = iconst.i32 1
@@ -69,7 +69,7 @@ ebb2:
 ; sameln: function %br_icmp_inversio
 ; nextln: ebb0(v0: i32, v1: i32):
 ; nextln:     br_icmp ule v0, v1, ebb2
-; nextln:     fallthrough ebb1
+; nextln:     jump ebb1
 ; nextln: 
 ; nextln: ebb1:
 ; nextln:     v2 = iconst.i32 1

--- a/filetests/simple_preopt/branch.clif
+++ b/filetests/simple_preopt/branch.clif
@@ -1,0 +1,29 @@
+test simple_preopt
+target x86_64
+
+function %brif_to_brz_fold(i32) -> i32 {
+ebb0(v0: i32):
+    v1 = ifcmp_imm v0, 0
+    brif eq v1, ebb1
+    jump ebb2
+ebb1:
+    v2 = iconst.i32 1
+    return v2
+ebb2:
+    v3 = iconst.i32 2
+    return v3
+}
+; sameln: function %brif_to_brz_fold
+; nextln: ebb0(v0: i32):
+; nextln:     v1 = ifcmp_imm v0, 0
+; nextln:     brz v0, ebb1
+; nextln:     jump ebb2
+; nextln: 
+; nextln: ebb1:
+; nextln:     v2 = iconst.i32 1
+; nextln:     return v2
+; nextln: 
+; nextln: ebb2:
+; nextln:     v3 = iconst.i32 2
+; nextln:     return v3
+; nextln: }

--- a/filetests/simple_preopt/simplify.clif
+++ b/filetests/simple_preopt/simplify.clif
@@ -64,7 +64,7 @@ ebb2:
 ; nextln:    v2 = select v3, v1, v1
 ; nextln:    trapz v3, user0
 ; nextln:    brnz v3, ebb2
-; nextln:    fallthrough ebb1
+; nextln:    jump ebb1
 
 function %irsub_imm(i32) -> i32 {
 ebb0(v0: i32):

--- a/filetests/simple_preopt/simplify.clif
+++ b/filetests/simple_preopt/simplify.clif
@@ -63,8 +63,8 @@ ebb2:
 ; nextln:    v1 = bint.i32 v3
 ; nextln:    v2 = select v3, v1, v1
 ; nextln:    trapz v3, user0
-; nextln:    brz v3, ebb1
-; nextln:    jump ebb2
+; nextln:    brnz v3, ebb2
+; nextln:    fallthrough ebb1
 
 function %irsub_imm(i32) -> i32 {
 ebb0(v0: i32):


### PR DESCRIPTION
Fixes #606.

This PR add two optimizations to `simple_preopt.rs`. The first is to fold code where we compare against zero, then use an explicit conditional branch. For instance:
```
v1 = icmp_imm v0, 0
brz v1, ebb1
```
becomes
```
brnz v0, ebb1
```
For x86-64 this doesn't actually make much difference, as it compiles to a `test` rather than a `cmp`, which should be very near equivalent. But it does save a byte on a very common operation, so hey.

The second is reordering branches at the end of ebbs to encourage fallthroughs. As pointed out in #606, it's common for wasm code to be compiled like this:
```
    brz v0, ebb1
    jump ebb2
ebb1:
    ...
ebb2:
    ...
```
Which ends up being compiled as a conditional jump followed by a jump. However, we can switch those instructions by flipping the destinations and inverting the conditional jump's condition, like so:
```
    brnz v0, ebb2
    fallthrough ebb1
ebb1:
    ...
ebb2:
    ...
```
And when we do that we eliminate the latter jump entirely.

