### PR TITLE
Simplify, reorganize, and optimize `ModuleEnvironment`

### DIFF
--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -402,7 +402,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         _table_index: TableIndex,
         _base: Option<GlobalIndex>,
         _offset: usize,
-        _elements: Vec<FuncIndex>,
+        _elements: Box<[FuncIndex]>,
     ) {
         // We do nothing
     }

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -138,6 +138,15 @@ impl DummyEnvironment {
     pub fn func_env(&self) -> DummyFuncEnvironment {
         DummyFuncEnvironment::new(&self.info, self.return_mode)
     }
+
+    fn get_func_type(&self, func_index: FuncIndex) -> SignatureIndex {
+        self.info.functions[func_index].entity
+    }
+
+    /// Return the number of imported functions within this `DummyEnvironment`.
+    pub fn get_num_func_imports(&self) -> usize {
+        self.info.imported_funcs.len()
+    }
 }
 
 /// The `FuncEnvironment` implementation for use by the `DummyEnvironment`.
@@ -345,10 +354,6 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         self.info.signatures.push(sig.clone());
     }
 
-    fn get_signature(&self, sig_index: SignatureIndex) -> &ir::Signature {
-        &self.info.signatures[sig_index]
-    }
-
     fn declare_func_import(
         &mut self,
         sig_index: SignatureIndex,
@@ -366,16 +371,8 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
             .push((String::from(module), String::from(field)));
     }
 
-    fn get_num_func_imports(&self) -> usize {
-        self.info.imported_funcs.len()
-    }
-
     fn declare_func_type(&mut self, sig_index: SignatureIndex) {
         self.info.functions.push(Exportable::new(sig_index));
-    }
-
-    fn get_func_type(&self, func_index: FuncIndex) -> SignatureIndex {
-        self.info.functions[func_index].entity
     }
 
     fn declare_global(&mut self, global: Global) {
@@ -387,10 +384,6 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         self.info
             .imported_globals
             .push((String::from(module), String::from(field)));
-    }
-
-    fn get_global(&self, global_index: GlobalIndex) -> &Global {
-        &self.info.globals[global_index].entity
     }
 
     fn declare_table(&mut self, table: Table) {

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -350,8 +350,8 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         self.info.config
     }
 
-    fn declare_signature(&mut self, sig: &ir::Signature) {
-        self.info.signatures.push(sig.clone());
+    fn declare_signature(&mut self, sig: ir::Signature) {
+        self.info.signatures.push(sig);
     }
 
     fn declare_func_import(

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -245,8 +245,16 @@ pub trait ModuleEnvironment<'data> {
     /// Get the information needed to produce Cranelift IR for the current target.
     fn target_config(&self) -> TargetFrontendConfig;
 
+    /// Provides the number of signatures up front. By default this does nothing, but
+    /// implementations can use this to preallocate memory if desired.
+    fn reserve_signatures(&mut self, _num: u32) {}
+
     /// Declares a function signature to the environment.
     fn declare_signature(&mut self, sig: &ir::Signature);
+
+    /// Provides the number of imports up front. By default this does nothing, but
+    /// implementations can use this to preallocate memory if desired.
+    fn reserve_imports(&mut self, _num: u32) {}
 
     /// Declares a function import to the environment.
     fn declare_func_import(
@@ -256,20 +264,71 @@ pub trait ModuleEnvironment<'data> {
         field: &'data str,
     );
 
-    /// Declares the type (signature) of a local function in the module.
-    fn declare_func_type(&mut self, sig_index: SignatureIndex);
+    /// Declares a table import to the environment.
+    fn declare_table_import(&mut self, table: Table, module: &'data str, field: &'data str);
 
-    /// Declares a global to the environment.
-    fn declare_global(&mut self, global: Global);
+    /// Declares a memory import to the environment.
+    fn declare_memory_import(&mut self, memory: Memory, module: &'data str, field: &'data str);
 
     /// Declares a global import to the environment.
     fn declare_global_import(&mut self, global: Global, module: &'data str, field: &'data str);
 
+    /// Notifies the implementation that all imports have been declared.
+    fn finish_imports(&mut self) {}
+
+    /// Provides the number of defined functions up front. By default this does nothing, but
+    /// implementations can use this to preallocate memory if desired.
+    fn reserve_func_types(&mut self, _num: u32) {}
+
+    /// Declares the type (signature) of a local function in the module.
+    fn declare_func_type(&mut self, sig_index: SignatureIndex);
+
+    /// Provides the number of defined tables up front. By default this does nothing, but
+    /// implementations can use this to preallocate memory if desired.
+    fn reserve_tables(&mut self, _num: u32) {}
+
     /// Declares a table to the environment.
     fn declare_table(&mut self, table: Table);
 
-    /// Declares a table import to the environment.
-    fn declare_table_import(&mut self, table: Table, module: &'data str, field: &'data str);
+    /// Provides the number of defined memories up front. By default this does nothing, but
+    /// implementations can use this to preallocate memory if desired.
+    fn reserve_memories(&mut self, _num: u32) {}
+
+    /// Declares a memory to the environment
+    fn declare_memory(&mut self, memory: Memory);
+
+    /// Provides the number of defined globals up front. By default this does nothing, but
+    /// implementations can use this to preallocate memory if desired.
+    fn reserve_globals(&mut self, _num: u32) {}
+
+    /// Declares a global to the environment.
+    fn declare_global(&mut self, global: Global);
+
+    /// Provides the number of exports up front. By default this does nothing, but
+    /// implementations can use this to preallocate memory if desired.
+    fn reserve_exports(&mut self, _num: u32) {}
+
+    /// Declares a function export to the environment.
+    fn declare_func_export(&mut self, func_index: FuncIndex, name: &'data str);
+
+    /// Declares a table export to the environment.
+    fn declare_table_export(&mut self, table_index: TableIndex, name: &'data str);
+
+    /// Declares a memory export to the environment.
+    fn declare_memory_export(&mut self, memory_index: MemoryIndex, name: &'data str);
+
+    /// Declares a global export to the environment.
+    fn declare_global_export(&mut self, global_index: GlobalIndex, name: &'data str);
+
+    /// Notifies the implementation that all exports have been declared.
+    fn finish_exports(&mut self) {}
+
+    /// Declares the optional start function.
+    fn declare_start_func(&mut self, index: FuncIndex);
+
+    /// Provides the number of element initializers up front. By default this does nothing, but
+    /// implementations can use this to preallocate memory if desired.
+    fn reserve_table_elements(&mut self, _num: u32) {}
 
     /// Fills a declared table with references to functions in the module.
     fn declare_table_elements(
@@ -280,11 +339,12 @@ pub trait ModuleEnvironment<'data> {
         elements: Vec<FuncIndex>,
     );
 
-    /// Declares a memory to the environment
-    fn declare_memory(&mut self, memory: Memory);
+    /// Provides the contents of a function body.
+    fn define_function_body(&mut self, body_bytes: &'data [u8]) -> WasmResult<()>;
 
-    /// Declares a memory import to the environment.
-    fn declare_memory_import(&mut self, memory: Memory, module: &'data str, field: &'data str);
+    /// Provides the number of data initializers up front. By default this does nothing, but
+    /// implementations can use this to preallocate memory if desired.
+    fn reserve_data_initializers(&mut self, _num: u32) {}
 
     /// Fills a declared memory with bytes at module instantiation.
     fn declare_data_initialization(
@@ -294,19 +354,4 @@ pub trait ModuleEnvironment<'data> {
         offset: usize,
         data: &'data [u8],
     );
-
-    /// Declares a function export to the environment.
-    fn declare_func_export(&mut self, func_index: FuncIndex, name: &'data str);
-    /// Declares a table export to the environment.
-    fn declare_table_export(&mut self, table_index: TableIndex, name: &'data str);
-    /// Declares a memory export to the environment.
-    fn declare_memory_export(&mut self, memory_index: MemoryIndex, name: &'data str);
-    /// Declares a global export to the environment.
-    fn declare_global_export(&mut self, global_index: GlobalIndex, name: &'data str);
-
-    /// Declares a start function.
-    fn declare_start_func(&mut self, index: FuncIndex);
-
-    /// Provides the contents of a function body.
-    fn define_function_body(&mut self, body_bytes: &'data [u8]) -> WasmResult<()>;
 }

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -248,9 +248,6 @@ pub trait ModuleEnvironment<'data> {
     /// Declares a function signature to the environment.
     fn declare_signature(&mut self, sig: &ir::Signature);
 
-    /// Return the signature with the given index.
-    fn get_signature(&self, sig_index: SignatureIndex) -> &ir::Signature;
-
     /// Declares a function import to the environment.
     fn declare_func_import(
         &mut self,
@@ -259,23 +256,14 @@ pub trait ModuleEnvironment<'data> {
         field: &'data str,
     );
 
-    /// Return the number of imported funcs.
-    fn get_num_func_imports(&self) -> usize;
-
     /// Declares the type (signature) of a local function in the module.
     fn declare_func_type(&mut self, sig_index: SignatureIndex);
-
-    /// Return the signature index for the given function index.
-    fn get_func_type(&self, func_index: FuncIndex) -> SignatureIndex;
 
     /// Declares a global to the environment.
     fn declare_global(&mut self, global: Global);
 
     /// Declares a global import to the environment.
     fn declare_global_import(&mut self, global: Global, module: &'data str, field: &'data str);
-
-    /// Return the global for the given global index.
-    fn get_global(&self, global_index: GlobalIndex) -> &Global;
 
     /// Declares a table to the environment.
     fn declare_table(&mut self, table: Table);
@@ -291,6 +279,7 @@ pub trait ModuleEnvironment<'data> {
         offset: usize,
         elements: Vec<FuncIndex>,
     );
+
     /// Declares a memory to the environment
     fn declare_memory(&mut self, memory: Memory);
 

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -14,8 +14,8 @@ use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::{self, InstBuilder};
 use cranelift_codegen::isa::TargetFrontendConfig;
 use failure_derive::Fail;
+use std::boxed::Box;
 use std::convert::From;
-use std::vec::Vec;
 use wasmparser::BinaryReaderError;
 
 /// The value of a WebAssembly global variable.
@@ -336,7 +336,7 @@ pub trait ModuleEnvironment<'data> {
         table_index: TableIndex,
         base: Option<GlobalIndex>,
         offset: usize,
-        elements: Vec<FuncIndex>,
+        elements: Box<[FuncIndex]>,
     );
 
     /// Provides the contents of a function body.

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -340,6 +340,9 @@ pub trait ModuleEnvironment<'data> {
     );
 
     /// Provides the contents of a function body.
+    ///
+    /// Note there's no `reserve_function_bodies` function because the number of
+    /// functions is already provided by `reserve_func_types`.
     fn define_function_body(&mut self, body_bytes: &'data [u8]) -> WasmResult<()>;
 
     /// Provides the number of data initializers up front. By default this does nothing, but

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -250,7 +250,7 @@ pub trait ModuleEnvironment<'data> {
     fn reserve_signatures(&mut self, _num: u32) {}
 
     /// Declares a function signature to the environment.
-    fn declare_signature(&mut self, sig: &ir::Signature);
+    fn declare_signature(&mut self, sig: ir::Signature);
 
     /// Provides the number of imports up front. By default this does nothing, but
     /// implementations can use this to preallocate memory if desired.

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -244,14 +244,7 @@ pub fn parse_element_section<'data>(
         let mut init_expr_reader = init_expr.get_binary_reader();
         let (base, offset) = match init_expr_reader.read_operator()? {
             Operator::I32Const { value } => (None, value as u32 as usize),
-            Operator::GetGlobal { global_index } => match environ
-                .get_global(GlobalIndex::from_u32(global_index))
-                .initializer
-            {
-                GlobalInit::I32Const(value) => (None, value as u32 as usize),
-                GlobalInit::Import => (Some(GlobalIndex::from_u32(global_index)), 0),
-                _ => panic!("should not happen"),
-            },
+            Operator::GetGlobal { global_index } => (Some(GlobalIndex::from_u32(global_index)), 0),
             ref s => panic!("unsupported init expr in element section: {:?}", s),
         };
         let items_reader = items.get_items_reader()?;
@@ -292,14 +285,7 @@ pub fn parse_data_section<'data>(
         let mut init_expr_reader = init_expr.get_binary_reader();
         let (base, offset) = match init_expr_reader.read_operator()? {
             Operator::I32Const { value } => (None, value as u32 as usize),
-            Operator::GetGlobal { global_index } => match environ
-                .get_global(GlobalIndex::from_u32(global_index))
-                .initializer
-            {
-                GlobalInit::I32Const(value) => (None, value as u32 as usize),
-                GlobalInit::Import => (Some(GlobalIndex::from_u32(global_index)), 0),
-                _ => panic!("should not happen"),
-            },
+            Operator::GetGlobal { global_index } => (Some(GlobalIndex::from_u32(global_index)), 0),
             ref s => panic!("unsupported init expr in data section: {:?}", s),
         };
         environ.declare_data_initialization(

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -253,7 +253,12 @@ pub fn parse_element_section<'data>(
             let x = item?;
             elems.push(FuncIndex::from_u32(x));
         }
-        environ.declare_table_elements(TableIndex::from_u32(table_index), base, offset, elems)
+        environ.declare_table_elements(
+            TableIndex::from_u32(table_index),
+            base,
+            offset,
+            elems.into_boxed_slice(),
+        )
     }
     Ok(())
 }

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -28,6 +28,8 @@ pub fn parse_type_section(
     types: TypeSectionReader,
     environ: &mut ModuleEnvironment,
 ) -> WasmResult<()> {
+    environ.reserve_signatures(types.get_count());
+
     for entry in types {
         match entry? {
             FuncType {
@@ -59,6 +61,8 @@ pub fn parse_import_section<'data>(
     imports: ImportSectionReader<'data>,
     environ: &mut ModuleEnvironment<'data>,
 ) -> WasmResult<()> {
+    environ.reserve_imports(imports.get_count());
+
     for entry in imports {
         let import = entry?;
 
@@ -113,6 +117,8 @@ pub fn parse_import_section<'data>(
             }
         }
     }
+
+    environ.finish_imports();
     Ok(())
 }
 
@@ -121,10 +127,13 @@ pub fn parse_function_section(
     functions: FunctionSectionReader,
     environ: &mut ModuleEnvironment,
 ) -> WasmResult<()> {
+    environ.reserve_func_types(functions.get_count());
+
     for entry in functions {
         let sigindex = entry?;
         environ.declare_func_type(SignatureIndex::from_u32(sigindex));
     }
+
     Ok(())
 }
 
@@ -133,6 +142,8 @@ pub fn parse_table_section(
     tables: TableSectionReader,
     environ: &mut ModuleEnvironment,
 ) -> WasmResult<()> {
+    environ.reserve_tables(tables.get_count());
+
     for entry in tables {
         let table = entry?;
         environ.declare_table(Table {
@@ -144,6 +155,7 @@ pub fn parse_table_section(
             maximum: table.limits.maximum,
         });
     }
+
     Ok(())
 }
 
@@ -152,6 +164,8 @@ pub fn parse_memory_section(
     memories: MemorySectionReader,
     environ: &mut ModuleEnvironment,
 ) -> WasmResult<()> {
+    environ.reserve_memories(memories.get_count());
+
     for entry in memories {
         let memory = entry?;
         environ.declare_memory(Memory {
@@ -160,6 +174,7 @@ pub fn parse_memory_section(
             shared: memory.shared,
         });
     }
+
     Ok(())
 }
 
@@ -168,6 +183,8 @@ pub fn parse_global_section(
     globals: GlobalSectionReader,
     environ: &mut ModuleEnvironment,
 ) -> WasmResult<()> {
+    environ.reserve_globals(globals.get_count());
+
     for entry in globals {
         let wasmparser::Global {
             ty: GlobalType {
@@ -194,6 +211,7 @@ pub fn parse_global_section(
         };
         environ.declare_global(global);
     }
+
     Ok(())
 }
 
@@ -202,6 +220,8 @@ pub fn parse_export_section<'data>(
     exports: ExportSectionReader<'data>,
     environ: &mut ModuleEnvironment<'data>,
 ) -> WasmResult<()> {
+    environ.reserve_exports(exports.get_count());
+
     for entry in exports {
         let Export {
             field,
@@ -221,6 +241,8 @@ pub fn parse_export_section<'data>(
             ExternalKind::Global => environ.declare_global_export(GlobalIndex::new(index), name),
         }
     }
+
+    environ.finish_exports();
     Ok(())
 }
 
@@ -235,6 +257,8 @@ pub fn parse_element_section<'data>(
     elements: ElementSectionReader<'data>,
     environ: &mut ModuleEnvironment,
 ) -> WasmResult<()> {
+    environ.reserve_table_elements(elements.get_count());
+
     for entry in elements {
         let Element {
             table_index,
@@ -281,6 +305,8 @@ pub fn parse_data_section<'data>(
     data: DataSectionReader<'data>,
     environ: &mut ModuleEnvironment<'data>,
 ) -> WasmResult<()> {
+    environ.reserve_data_initializers(data.get_count());
+
     for entry in data {
         let Data {
             memory_index,
@@ -300,5 +326,6 @@ pub fn parse_data_section<'data>(
             data,
         );
     }
+
     Ok(())
 }

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -48,7 +48,7 @@ pub fn parse_type_section(
                         .expect("only numeric types are supported in function signatures");
                     AbiParam::new(cret_arg)
                 }));
-                environ.declare_signature(&sig);
+                environ.declare_signature(sig);
             }
             ref s => panic!("unsupported type: {:?}", s),
         }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -7,18 +7,16 @@
     allow(too_many_arguments, cyclomatic_complexity)
 )]
 
+use crate::utils::{parse_sets_and_triple, read_to_end};
 use cranelift_codegen::print_errors::{pretty_error, pretty_verifier_error};
 use cranelift_codegen::settings::FlagsOrIsa;
 use cranelift_codegen::timing;
 use cranelift_codegen::Context;
 use cranelift_entity::EntityRef;
-use cranelift_wasm::{
-    translate_module, DummyEnvironment, FuncIndex, ModuleEnvironment, ReturnMode,
-};
+use cranelift_wasm::{translate_module, DummyEnvironment, FuncIndex, ReturnMode};
 use std::path::Path;
 use std::path::PathBuf;
 use term;
-use crate::utils::{parse_sets_and_triple, read_to_end};
 use wabt::wat2wasm;
 
 macro_rules! vprintln {


### PR DESCRIPTION
This series of patches removes some unneeded functions from cranelift-wasm's `ModuleEnvironment`, reorders it to more closely reflect the sequence of calls that cranelift-wasm makes, and adds functions to allow implementations to use memory more efficiently.

This is an API change, requiring changes to cranelift-wasm users using `ModuleEnvironment`.