### PR TITLE
Add an explicit trap code for wasm `unreachable`.

### DIFF
--- a/lib/codegen/src/ir/trapcode.rs
+++ b/lib/codegen/src/ir/trapcode.rs
@@ -42,6 +42,9 @@ pub enum TrapCode {
     /// Failed float-to-int conversion.
     BadConversionToInteger,
 
+    /// Code that was supposed to have been unreachable was reached.
+    UnreachableCodeReached,
+
     /// Execution has potentially run too long and may be interrupted.
     /// This trap is resumable.
     Interrupt,
@@ -63,6 +66,7 @@ impl Display for TrapCode {
             IntegerOverflow => "int_ovf",
             IntegerDivisionByZero => "int_divz",
             BadConversionToInteger => "bad_toint",
+            UnreachableCodeReached => "unreachable",
             Interrupt => "interrupt",
             User(x) => return write!(f, "user{}", x),
         };
@@ -85,6 +89,7 @@ impl FromStr for TrapCode {
             "int_ovf" => Ok(IntegerOverflow),
             "int_divz" => Ok(IntegerDivisionByZero),
             "bad_toint" => Ok(BadConversionToInteger),
+            "unreachable" => Ok(UnreachableCodeReached),
             "interrupt" => Ok(Interrupt),
             _ if s.starts_with("user") => s[4..].parse().map(User).map_err(|_| ()),
             _ => Err(()),
@@ -98,7 +103,7 @@ mod tests {
     use std::string::ToString;
 
     // Everything but user-defined codes.
-    const CODES: [TrapCode; 9] = [
+    const CODES: [TrapCode; 11] = [
         TrapCode::StackOverflow,
         TrapCode::HeapOutOfBounds,
         TrapCode::TableOutOfBounds,
@@ -108,6 +113,8 @@ mod tests {
         TrapCode::IntegerOverflow,
         TrapCode::IntegerDivisionByZero,
         TrapCode::BadConversionToInteger,
+        TrapCode::UnreachableCodeReached,
+        TrapCode::Interrupt,
     ];
 
     #[test]

--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -108,9 +108,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             // We do nothing
         }
         Operator::Unreachable => {
-            // We use `trap user0` to indicate a user-generated trap.
-            // We could make the trap code configurable if need be.
-            builder.ins().trap(ir::TrapCode::User(0));
+            builder.ins().trap(ir::TrapCode::UnreachableCodeReached);
             state.reachable = false;
         }
         /***************************** Control flow blocks **********************************


### PR DESCRIPTION
This eliminates the need for the last instance of `TrapCode::User` in cranelift-wasm, so all wasm traps have a clearly described cause.