### PR TITLE
avoid directories for cargo build dependencies

### DIFF
--- a/lib/codegen/meta-python/gen_build_deps.py
+++ b/lib/codegen/meta-python/gen_build_deps.py
@@ -22,22 +22,11 @@ except ImportError:
     pass
 
 
-def source_files(top):
-    # type: (str) -> Iterable[str]
-    """
-    Recursively find all interesting source files and directories in the
-    directory tree starting at top. Yield a path to each file.
-    """
-    for (dirpath, dirnames, filenames) in os.walk(top):
-        yield dirpath
-        for f in filenames:
-            if f.endswith('.py'):
-                yield join(dirpath, f)
-
-
 def generate():
     # type: () -> None
     print("Dependencies from meta language directory:")
     meta = dirname(abspath(__file__))
-    for path in source_files(meta):
-        print("cargo:rerun-if-changed=" + path)
+    for (dirpath, _, filenames) in os.walk(meta):
+        for f in filenames:
+            if f.endswith('.py'):
+                print("cargo:rerun-if-changed=" + join(dirpath, f))


### PR DESCRIPTION
We are facing peculiar Windows-only regressions in build times in
https://bugzilla.mozilla.org/show_bug.cgi?id=1506511 and while the build
times might just be Windows being slow, putting directories in
`rerun-if-changed` might also be causing problems.  The build only
depends on the files, anyway, so let's just say that.