### PR TITLE
Preserve global wasm module offset in SourceLoc.

### DIFF
--- a/cranelift-wasm/src/environ/dummy.rs
+++ b/cranelift-wasm/src/environ/dummy.rs
@@ -458,7 +458,11 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         self.info.start_func = Some(func_index);
     }
 
-    fn define_function_body(&mut self, body_bytes: &'data [u8]) -> WasmResult<()> {
+    fn define_function_body(
+        &mut self,
+        body_bytes: &'data [u8],
+        body_offset: usize,
+    ) -> WasmResult<()> {
         let func = {
             let mut func_environ = DummyFuncEnvironment::new(&self.info, self.return_mode);
             let func_index =
@@ -467,7 +471,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
             let sig = func_environ.vmctx_sig(self.get_func_type(func_index));
             let mut func = ir::Function::with_name_signature(name, sig);
             self.trans
-                .translate(body_bytes, &mut func, &mut func_environ)?;
+                .translate(body_bytes, body_offset, &mut func, &mut func_environ)?;
             func
         };
         self.func_bytecode_sizes.push(body_bytes.len());

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -343,7 +343,11 @@ pub trait ModuleEnvironment<'data> {
     ///
     /// Note there's no `reserve_function_bodies` function because the number of
     /// functions is already provided by `reserve_func_types`.
-    fn define_function_body(&mut self, body_bytes: &'data [u8]) -> WasmResult<()>;
+    fn define_function_body(
+        &mut self,
+        body_bytes: &'data [u8],
+        body_offset: usize,
+    ) -> WasmResult<()>;
 
     /// Provides the number of data initializers up front. By default this does nothing, but
     /// implementations can use this to preallocate memory if desired.

--- a/cranelift-wasm/src/sections_translator.rs
+++ b/cranelift-wasm/src/sections_translator.rs
@@ -295,7 +295,8 @@ pub fn parse_code_section<'data>(
     for body in code {
         let mut reader = body?.get_binary_reader();
         let size = reader.bytes_remaining();
-        environ.define_function_body(reader.read_bytes(size)?)?;
+        let offset = reader.original_position();
+        environ.define_function_body(reader.read_bytes(size)?, offset)?;
     }
     Ok(())
 }


### PR DESCRIPTION
Making SourceLoc(u32) unique across the module.