### PR TITLE
Add missing use_srcloc in postopt and regalloc passes

### DIFF
--- a/cranelift-codegen/src/postopt.rs
+++ b/cranelift-codegen/src/postopt.rs
@@ -128,6 +128,7 @@ fn optimize_cpu_flags(
     // We found a compare+branch pattern. Transform it to use flags.
     let args = info.args.as_slice(&pos.func.dfg.value_lists)[1..].to_vec();
     pos.goto_inst(info.cmp_inst);
+    pos.use_srcloc(info.cmp_inst);
     match info.kind {
         CmpBrKind::Icmp { mut cond, arg } => {
             let flags = pos.ins().ifcmp(info.cmp_arg, arg);

--- a/cranelift-codegen/src/regalloc/coalescing.rs
+++ b/cranelift-codegen/src/regalloc/coalescing.rs
@@ -292,6 +292,9 @@ impl<'a> Context<'a> {
 
         // Insert a copy instruction at the top of `ebb`.
         let mut pos = EncCursor::new(self.func, self.isa).at_first_inst(ebb);
+        if let Some(inst) = pos.current_inst() {
+            pos.use_srcloc(inst);
+        }
         pos.ins().with_result(param).copy(new_val);
         let inst = pos.built_inst();
         self.liveness.move_def_locally(param, inst);
@@ -347,6 +350,7 @@ impl<'a> Context<'a> {
         pred_val: Value,
     ) -> Value {
         let mut pos = EncCursor::new(self.func, self.isa).at_inst(pred_inst);
+        pos.use_srcloc(pred_inst);
         let copy = pos.ins().copy(pred_val);
         let inst = pos.built_inst();
 

--- a/cranelift-codegen/src/regalloc/spilling.rs
+++ b/cranelift-codegen/src/regalloc/spilling.rs
@@ -420,6 +420,7 @@ impl<'a> Context<'a> {
         // secondary `opidx` key makes it possible to use an unstable (non-allocating) sort.
         self.reg_uses.sort_unstable_by_key(|u| (u.value, u.opidx));
 
+        self.cur.use_srcloc(inst);
         for i in 0..self.reg_uses.len() {
             let ru = self.reg_uses[i];
 


### PR DESCRIPTION
Trying to fill the gaps into `SourceLoc` information (after some cranelift passes). Currently I just used [fib2_o2.wasm](https://github.com/yurydelendik/old-man-sandbox/blob/master/fibdbg/fib2_o2.wasm) to find such spots.