### PR TITLE
[WIP] Emit source location map: wasm bytecode to native byte offsets.

### DIFF
--- a/lib/codegen/src/binemit/mod.rs
+++ b/lib/codegen/src/binemit/mod.rs
@@ -7,7 +7,9 @@ mod memorysink;
 mod relaxation;
 mod shrink;
 
-pub use self::memorysink::{MemoryCodeSink, NullTrapSink, RelocSink, TrapSink};
+pub use self::memorysink::{
+    MemoryCodeSink, NullSourceLocSink, NullTrapSink, RelocSink, SourceLocSink, TrapSink,
+};
 pub use self::relaxation::relax_branches;
 pub use self::shrink::shrink_instructions;
 pub use crate::regalloc::RegDiversions;
@@ -92,6 +94,9 @@ pub trait CodeSink {
     /// Add a relocation referencing a jump table.
     fn reloc_jt(&mut self, _: Reloc, _: JumpTable);
 
+    /// Add srcloc for following instructions.
+    fn set_srcloc(&mut self, _: SourceLoc);
+
     /// Add trap information for the current offset.
     fn trap(&mut self, _: TrapCode, _: SourceLoc);
 
@@ -123,6 +128,7 @@ where
         divert.clear();
         debug_assert_eq!(func.offsets[ebb], sink.offset());
         for inst in func.layout.ebb_insts(ebb) {
+            sink.set_srcloc(func.srclocs[inst]);
             emit_inst(func, inst, &mut divert, sink);
         }
     }

--- a/lib/faerie/src/backend.rs
+++ b/lib/faerie/src/backend.rs
@@ -2,7 +2,9 @@
 
 use crate::container;
 use crate::traps::{FaerieTrapManifest, FaerieTrapSink};
-use cranelift_codegen::binemit::{Addend, CodeOffset, NullTrapSink, Reloc, RelocSink};
+use cranelift_codegen::binemit::{
+    Addend, CodeOffset, NullSourceLocSink, NullTrapSink, Reloc, RelocSink,
+};
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::{self, binemit, ir};
 use cranelift_module::{
@@ -163,6 +165,7 @@ impl Backend for FaerieBackend {
                 libcall_names: &*self.libcall_names,
             };
 
+            let mut srcloc_sink = NullSourceLocSink {};
             if let Some(ref mut trap_manifest) = self.trap_manifest {
                 let mut trap_sink = FaerieTrapSink::new(name, code_size);
                 unsafe {
@@ -171,6 +174,7 @@ impl Backend for FaerieBackend {
                         code.as_mut_ptr(),
                         &mut reloc_sink,
                         &mut trap_sink,
+                        &mut srcloc_sink,
                     )
                 };
                 trap_manifest.add_sink(trap_sink);
@@ -182,6 +186,7 @@ impl Backend for FaerieBackend {
                         code.as_mut_ptr(),
                         &mut reloc_sink,
                         &mut trap_sink,
+                        &mut srcloc_sink,
                     )
                 };
             }

--- a/lib/filetests/src/test_binemit.rs
+++ b/lib/filetests/src/test_binemit.rs
@@ -92,6 +92,10 @@ impl binemit::CodeSink for TextSink {
         write!(self.text, "{}({}) ", reloc, jt).unwrap();
     }
 
+    fn set_srcloc(&mut self, _srcloc: ir::SourceLoc) {
+        // TODO
+    }
+
     fn trap(&mut self, code: ir::TrapCode, _srcloc: ir::SourceLoc) {
         write!(self.text, "{} ", code).unwrap();
     }

--- a/lib/filetests/src/test_compile.rs
+++ b/lib/filetests/src/test_compile.rs
@@ -105,5 +105,6 @@ impl binemit::CodeSink for SizeSink {
     }
     fn reloc_jt(&mut self, _reloc: binemit::Reloc, _jt: ir::JumpTable) {}
     fn trap(&mut self, _code: ir::TrapCode, _srcloc: ir::SourceLoc) {}
+    fn set_srcloc(&mut self, _srcloc: ir::SourceLoc) {}
     fn begin_rodata(&mut self) {}
 }

--- a/lib/simplejit/src/backend.rs
+++ b/lib/simplejit/src/backend.rs
@@ -1,7 +1,9 @@
 //! Defines `SimpleJITBackend`.
 
 use crate::memory::Memory;
-use cranelift_codegen::binemit::{Addend, CodeOffset, NullTrapSink, Reloc, RelocSink};
+use cranelift_codegen::binemit::{
+    Addend, CodeOffset, NullSourceLocSink, NullTrapSink, Reloc, RelocSink,
+};
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::{self, ir, settings};
 use cranelift_module::{
@@ -194,7 +196,16 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         // Ignore traps for now. For now, frontends should just avoid generating code
         // that traps.
         let mut trap_sink = NullTrapSink {};
-        unsafe { ctx.emit_to_memory(&*self.isa, ptr, &mut reloc_sink, &mut trap_sink) };
+        let mut srcloc_sink = NullSourceLocSink {};
+        unsafe {
+            ctx.emit_to_memory(
+                &*self.isa,
+                ptr,
+                &mut reloc_sink,
+                &mut trap_sink,
+                &mut srcloc_sink,
+            )
+        };
 
         Ok(Self::CompiledFunction {
             code: ptr,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -59,6 +59,18 @@ impl binemit::TrapSink for PrintTraps {
     }
 }
 
+struct PrintSourceLocs {
+    flag_print: bool,
+}
+
+impl binemit::SourceLocSink for PrintSourceLocs {
+    fn set_srcloc(&mut self, offset: binemit::CodeOffset, srcloc: ir::SourceLoc) {
+        if self.flag_print {
+            println!("srcloc: {} at {}", srcloc, offset);
+        }
+    }
+}
+
 pub fn run(
     files: Vec<String>,
     flag_print: bool,
@@ -114,9 +126,15 @@ fn handle_module(
         let mut mem = vec![0; total_size as usize];
         let mut relocs = PrintRelocs { flag_print };
         let mut traps = PrintTraps { flag_print };
+        let mut source_locs = PrintSourceLocs { flag_print };
         let mut code_sink: binemit::MemoryCodeSink;
         unsafe {
-            code_sink = binemit::MemoryCodeSink::new(mem.as_mut_ptr(), &mut relocs, &mut traps);
+            code_sink = binemit::MemoryCodeSink::new(
+                mem.as_mut_ptr(),
+                &mut relocs,
+                &mut traps,
+                &mut source_locs,
+            );
         }
         isa.emit_function_to_memory(&context.func, &mut code_sink);
 


### PR DESCRIPTION
Adds the `SourceLocSink` to the `compile` process to record the map of all bitemit produced offsets to the wasm read `SourceLoc`'s.