### PR TITLE
cranelift-faerie: convert to use new extensible decl format

### DIFF
--- a/cranelift-faerie/Cargo.toml
+++ b/cranelift-faerie/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.28.0" }
 cranelift-module = { path = "../cranelift-module", version = "0.28.0" }
-faerie = "0.7.0"
-goblin = "0.0.19"
+faerie = "0.8.0"
+goblin = "0.0.21"
 failure = "0.1.2"
 target-lexicon = "0.2.0"
 

--- a/cranelift-faerie/src/backend.rs
+++ b/cranelift-faerie/src/backend.rs
@@ -334,26 +334,19 @@ impl FaerieProduct {
 
 fn translate_function_linkage(linkage: Linkage) -> faerie::Decl {
     match linkage {
-        Linkage::Import => faerie::Decl::FunctionImport,
-        Linkage::Local => faerie::Decl::Function { global: false },
-        Linkage::Preemptible | Linkage::Export => faerie::Decl::Function { global: true },
+        Linkage::Import => faerie::Decl::function_import().into(),
+        Linkage::Local => faerie::Decl::function().into(),
+        Linkage::Export => faerie::Decl::function().global().into(),
+        Linkage::Preemptible => faerie::Decl::function().weak().into(),
     }
 }
 
 fn translate_data_linkage(linkage: Linkage, writable: bool) -> faerie::Decl {
     match linkage {
-        Linkage::Import => faerie::Decl::DataImport,
-        Linkage::Local => faerie::Decl::Data {
-            global: false,
-            writable,
-        },
-        Linkage::Export => faerie::Decl::Data {
-            global: true,
-            writable,
-        },
-        Linkage::Preemptible => {
-            unimplemented!("faerie doesn't support preemptible globals yet");
-        }
+        Linkage::Import => faerie::Decl::data_import().into(),
+        Linkage::Local => faerie::Decl::data().with_writable(writable).into(),
+        Linkage::Export => faerie::Decl::data().global().with_writable(writable).into(),
+        Linkage::Preemptible => faerie::Decl::data().weak().with_writable(writable).into(),
     }
 }
 
@@ -388,7 +381,7 @@ impl<'a> RelocSink for FaerieRelocSink<'a> {
             ir::ExternalName::LibCall(ref libcall) => {
                 let sym = (self.libcall_names)(*libcall);
                 self.artifact
-                    .declare(sym.clone(), faerie::Decl::FunctionImport)
+                    .declare(sym.clone(), faerie::Decl::function_import())
                     .expect("faerie declaration of libcall");
                 sym
             }


### PR DESCRIPTION
Bump faerie to 0.8.0 and goblin to 0.0.21.

* Preemptible linkages are now weak symbols
* Faerie will put read-only data in .rodata for elf
