### PR TITLE
Fix global value colocated printing

### DIFF
--- a/cranelift-codegen/src/ir/globalvalue.rs
+++ b/cranelift-codegen/src/ir/globalvalue.rs
@@ -114,10 +114,12 @@ impl fmt::Display for GlobalValueData {
                 offset,
                 colocated,
             } => {
-                if colocated {
-                    write!(f, "colocated ")?;
-                }
-                write!(f, "symbol {}", name)?;
+                write!(
+                    f,
+                    "symbol {}{}",
+                    if colocated { "colocated " } else { "" },
+                    name
+                )?;
                 let offset_val: i64 = offset.into();
                 if offset_val > 0 {
                     write!(f, "+")?;


### PR DESCRIPTION
It used to print `gv0 = colocated symbol u1:1` while cranelift-reader expects `gv0 = symbol colocated u1:1`.

Fixes #640