### PR TITLE
Use single index for param register allocation for windows callconv (…

### DIFF
--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -116,10 +116,10 @@ impl ArgAssigner for Args {
 
         // Try to use an FPR.
         let fpr_offset = if self.call_conv == CallConv::WindowsFastcall {
-            // For registers and Win64, the registers always depend on the parameter index.
-            // The first argument either uses RCX (int)/XMM0 (float) and the second RDX/XMM1.
-            // XMM0 is never used for the second parameter, even if the first parameter uses RCX
-            // and XMM0 theoretically would still be "available".
+            // Float and general registers on windows share the same parameter index.
+            // The used register depends entirely on the parameter index: Even if XMM0
+            // is not used for the first parameter, it cannot be used for the second parameter.
+            debug_assert_eq!(self.fpr_limit, self.gpr.len());
             &mut self.gpr_used
         } else {
             &mut self.fpr_used

--- a/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/filetests/isa/x86/windows_fastcall_x64.clif
@@ -31,3 +31,9 @@ ebb0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
     return
 }
 ; check: function %five_args(i64 [%rcx], i64 [%rdx], i64 [%r8], i64 [%r9], i64 [32], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
+
+function %mixed_int_float(i64, f64, i64, f32) windows_fastcall {
+ebb0(v0: i64, v1: f64, v2: i64, v3: f32):
+    return
+}
+; check: function %mixed_int_float(i64 [%rcx], f64 [%xmm1], i64 [%r8], f32 [%xmm3], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {


### PR DESCRIPTION
…#691)

The used registers depend entirely on the parameter index (1st, 2nd, 3rd, 4th, ... param)
and we cannot shift unused registers to other indexes, if they are not designated for
the use for that parameter index.