### PR TITLE
windows/x64 call convention: only use XMM0 for float return values

### DIFF
--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -161,13 +161,14 @@ pub fn legalize_signature(sig: &mut ir::Signature, triple: &Triple, _current: bo
 
     legalize_args(&mut sig.params, &mut args);
 
-    let regs = if sig.call_conv == CallConv::WindowsFastcall {
-        &RET_GPRS_WIN_FASTCALL_X64[..]
+    let (regs, fpr_limit) = if sig.call_conv == CallConv::WindowsFastcall {
+        // windows-x64 calling convention only uses XMM0 or RAX for return values
+        (&RET_GPRS_WIN_FASTCALL_X64[..], 1)
     } else {
-        &RET_GPRS[..]
+        (&RET_GPRS[..], 2)
     };
 
-    let mut rets = Args::new(bits, regs, 2, sig.call_conv);
+    let mut rets = Args::new(bits, regs, fpr_limit, sig.call_conv);
     legalize_args(&mut sig.returns, &mut rets);
 }
 

--- a/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/filetests/isa/x86/windows_fastcall_x64.clif
@@ -37,3 +37,9 @@ ebb0(v0: i64, v1: f64, v2: i64, v3: f32):
     return
 }
 ; check: function %mixed_int_float(i64 [%rcx], f64 [%xmm1], i64 [%r8], f32 [%xmm3], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
+
+function %ret_val_float(f32, f64, i64, i64) -> f64 windows_fastcall {
+ebb0(v0: f32, v1: f64, v2: i64, v3: i64):
+    return v1
+}
+; check: function %ret_val_float(f32 [%xmm0], f64 [%xmm1], i64 [%r8], i64 [%r9], i64 fp [%rbp]) -> f64 [%xmm0], i64 fp [%rbp] windows_fastcall {


### PR DESCRIPTION
Previously we triggered the debug_assert for functions  returning floats.
This adds a testcase and fixes the behavior.

#691