### PR TITLE
Fix #686: Allow code shrink in relaxation if the shrinking pass hasn't run

### DIFF
--- a/filetests/regress/allow-relaxation-shrink.clif
+++ b/filetests/regress/allow-relaxation-shrink.clif
@@ -1,0 +1,53 @@
+test compile
+target x86_64
+
+; This checks that code shrink is allowed while relaxing code, when code shrink
+; has not run.
+
+function u0:0(i64, i64) -> i64 system_v {
+    ss1 = explicit_slot 8
+    sig0 = (i64) -> i64 system_v
+    fn0 = u0:8 sig0
+
+ebb0(v0: i64, v1: i64):
+    v3 = stack_addr.i64 ss1
+    v5 = call fn0(v1)
+    v6 = iconst.i64 0
+    v8 = iconst.i64 0
+    jump ebb3(v6, v1, v8)
+
+ebb3(v39: i64, v40: i64, v42: i64):
+    v9 = load.i64 v3
+    v11 = icmp_imm ugt v9, 1
+    v12 = bint.i8 v11
+    v13 = uextend.i32 v12
+    v14 = icmp_imm eq v13, 0
+    brnz v14, ebb4
+    jump ebb5
+
+ebb4:
+    v18 = icmp_imm.i64 eq v40, 0
+    v19 = bint.i8 v18
+    v20 = uextend.i32 v19
+    brz v20, ebb6
+    trap user0
+
+ebb5:
+    v22 = iconst.i32 1
+    v23 = ishl.i64 v39, v22
+    v25 = iconst.i64 1
+    v26 = band.i64 v42, v25
+    v27 = bor v23, v26
+    v28 = iconst.i32 1
+    v29 = ushr.i64 v42, v28
+    v30 = load.i64 v3
+    v31 = iconst.i32 1
+    v32 = ushr v30, v31
+    store v32, v3
+    jump ebb3(v27, v40, v29)
+
+ebb6:
+    v38 = iconst.i64 0
+    return v38
+}
+


### PR DESCRIPTION
Also:
- make sure to apply diversions when determining offsets for code
relaxation.
- select the smallest encoding when selecting a relaxed branch
instruction.

I didn't know where to put the test case, so I added a "regress" directory for regression tests (found by fuzzers), but I could move it to another directory. (`isa/` didn't seem quite appropriate, but other relaxation tests are there, so maybe it is)

@sunfishcode Can you have a look, please? Thanks!