### PR TITLE
[meta] Port recipes

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/formats.rs
+++ b/cranelift-codegen/meta/src/cdsl/formats.rs
@@ -200,6 +200,12 @@ impl FormatRegistry {
             .expect("unknown InstructionFormat; please define it in shared/formats.rs first")
     }
 
+    pub fn lookup_by_name(&self, name: &str) -> InstructionFormatIndex {
+        self.map.iter().find(|(_key, value)| {
+            value.name == name
+        }).unwrap().0
+    }
+
     pub fn get(&self, index: InstructionFormatIndex) -> &InstructionFormat {
         self.map.get(index).unwrap()
     }

--- a/cranelift-codegen/meta/src/cdsl/isa.rs
+++ b/cranelift-codegen/meta/src/cdsl/isa.rs
@@ -1,7 +1,8 @@
 use crate::cdsl::cpu_modes::CpuMode;
+use crate::cdsl::formats::{FormatRegistry, InstructionFormatIndex};
 use crate::cdsl::inst::InstructionGroup;
-use crate::cdsl::regs::IsaRegs;
-use crate::cdsl::settings::SettingGroup;
+use crate::cdsl::regs::{IsaRegs, RegClassIndex, Register, Stack};
+use crate::cdsl::settings::{SettingGroup, PredicateNode};
 use crate::cdsl::xform::{TransformGroupIndex, TransformGroups};
 
 use std::collections::HashSet;
@@ -58,4 +59,163 @@ impl TargetIsa {
         vec.sort();
         vec
     }
+}
+
+pub struct BranchRange(Vec<u64>);
+
+#[allow(dead_code)] //FIXME use it
+#[derive(Copy, Clone)]
+pub enum OperandConstraint {
+    RegClass(RegClassIndex),
+    Register(Register),
+    InputReference(usize), // FIXME what does it mean?
+    Stack(Stack),
+}
+
+/// A recipe for encoding instructions with a given format.
+///
+/// Many different instructions can be encoded by the same recipe, but they
+/// must all have the same instruction format.
+pub struct EncRecipe {
+    pub name: String,
+    pub format: InstructionFormatIndex,
+    pub base_size: u64,
+    pub ins: Vec<OperandConstraint>,
+    pub outs: Vec<OperandConstraint>,
+
+    // These have defaults
+    pub compute_size: String,
+    pub branch_range: Option<BranchRange>,
+    pub clobbers_flags: bool,
+    pub instp: Option<PredicateNode>,
+    pub isap: Option<PredicateNode>,
+    pub emit: Option<String>,
+    pub number: Option<u64>,
+}
+
+impl EncRecipe {
+    /// The `ins` and `outs` arguments are tuples specifying the register
+    /// allocation constraints for the value operands and results respectively. The
+    /// possible constraints for an operand are:
+    ///
+    /// - A `RegClass` specifying the set of allowed registers.
+    /// - A `Register` specifying a fixed-register operand.
+    /// - An integer indicating that this result is tied to a value operand, so
+    ///   they must use the same register.
+    /// - A `Stack` specifying a value in a stack slot.
+    ///
+    /// The `branch_range` argument must be provided for recipes that can encode
+    /// branch instructions. It is an `(origin, bits)` tuple describing the exact
+    /// range that can be encoded in a branch instruction.
+    ///
+    /// For ISAs that use CPU flags in `iflags` and `fflags` value types, the
+    /// `clobbers_flags` is used to indicate instruction encodings that clobbers
+    /// the CPU flags, so they can't be used where a flag value is live.
+    ///
+    /// :param name: Short mnemonic name for this recipe.
+    /// :param format: All encoded instructions must have this
+    ///         :py:class:`InstructionFormat`.
+    /// :param base_size: Base number of bytes in the binary encoded instruction.
+    /// :param compute_size: Function name to use when computing actual size.
+    /// :param ins: Tuple of register constraints for value operands.
+    /// :param outs: Tuple of register constraints for results.
+    /// :param branch_range: `(origin, bits)` range for branches.
+    /// :param clobbers_flags: This instruction clobbers `iflags` and `fflags`.
+    /// :param instp: Instruction predicate.
+    /// :param isap: ISA predicate.
+    /// :param emit: Rust code for binary emission.
+    #[allow(dead_code)] //FIXME use it
+    pub fn new(
+        name: &str,
+        formats: &FormatRegistry,
+        format_name: &str,
+        base_size: u64,
+        ins: Vec<OperandConstraint>,
+        outs: Vec<OperandConstraint>,
+    ) -> Self {
+        let format = formats.lookup_by_name(format_name);
+        if !formats.get(format).has_value_list {
+            assert!(ins.len() == formats.get(format).num_value_operands);
+        }
+
+        Self::verify_constraints(&ins, &ins);
+        Self::verify_constraints(&ins, &outs);
+
+        Self {
+            name: name.to_string(),
+            format,
+            base_size,
+            ins,
+            outs,
+
+            compute_size: "base_size".to_string(),
+            branch_range: None,
+            clobbers_flags: false,
+            instp: None,
+            isap: None,
+            emit: None,
+            number: None,
+        }
+    }
+
+    #[allow(dead_code)] //FIXME use it
+    fn verify_constraints(in_constrains: &[OperandConstraint], constraints: &[OperandConstraint]) {
+        for c in constraints {
+            match *c {
+                OperandConstraint::InputReference(n) => assert!(n < in_constrains.len()),
+                _ => {}
+            }
+        }
+    }
+
+    pub fn compute_size(self, compute_size: &str) -> Self {
+        Self {
+            compute_size: compute_size.to_string(),
+            ..self
+        }
+    }
+
+    pub fn branch_range(self, branch_range: BranchRange) -> Self {
+        Self {
+            branch_range: Some(branch_range),
+            ..self
+        }
+    }
+
+    pub fn clobbers_flags(self) -> Self {
+        Self {
+            clobbers_flags: true,
+            ..self
+        }
+    }
+
+    pub fn instp(self, instp: PredicateNode) -> Self {
+        Self {
+            instp: Some(instp),
+            ..self
+        }
+    }
+
+    pub fn isap(self, isap: PredicateNode) -> Self {
+        Self {
+            isap: Some(isap),
+            ..self
+        }
+    }
+
+    pub fn emit(self, emit: &str) -> Self {
+        Self {
+            emit: Some(emit.to_string()),
+            ..self
+        }
+    }
+}
+
+pub struct Encoding {
+    pub cpu_mode: CpuMode,
+    //pub inst: InstSpec,
+    pub recipe: EncRecipe,
+    pub encbits: u64,
+    pub instp: Option<PredicateNode>,
+    pub isap: Option<PredicateNode>,
 }

--- a/cranelift-codegen/meta/src/cdsl/regs.rs
+++ b/cranelift-codegen/meta/src/cdsl/regs.rs
@@ -37,7 +37,7 @@ impl RegBank {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 pub struct RegClassIndex(u32);
 entity_impl!(RegClassIndex);
 
@@ -351,5 +351,37 @@ impl IsaRegs {
         classes: PrimaryMap<RegClassIndex, RegClass>,
     ) -> Self {
         Self { banks, classes }
+    }
+}
+
+/// A specific register in a register class.
+///
+/// A register is identified by the top-level register class it belongs to and
+/// its first register unit.
+///
+/// Specific registers are used to describe constraints on instructions where
+/// some operands must use a fixed register.
+///
+/// Register instances can be created with the constructor, or accessed as
+/// attributes on the register class: `GPR.rcx`.
+#[derive(Copy, Clone)]
+pub struct Register {
+    pub regclass: RegClassIndex,
+    pub unit: u64,
+}
+
+/// An operand that must be in a stack slot.
+///
+/// A `Stack` object can be used to indicate an operand constraint for a value
+/// operand that must live in a stack slot.
+#[derive(Copy, Clone)]
+pub struct Stack {
+    pub regclass: RegClassIndex,
+}
+
+impl Stack {
+    pub fn stack_base_mask(&self) -> &'static str {
+        // TODO: Make this configurable instead of just using the SP.
+        "StackBaseMask(1)"
     }
 }

--- a/cranelift-codegen/meta/src/gen_binemit.rs
+++ b/cranelift-codegen/meta/src/gen_binemit.rs
@@ -1,0 +1,187 @@
+//! Generate binary emission code for each ISA.
+
+use crate::cdsl::isa::{EncRecipe, OperandConstraint};
+use crate::cdsl::formats::FormatRegistry;
+use crate::error;
+use crate::srcgen::Formatter;
+
+/// Generate code to handle a single recipe.
+///
+/// - Unpack the instruction data, knowing the format.
+/// - Determine register locations for operands with register constraints.
+/// - Determine stack slot locations for operands with stack constraints.
+/// - Call hand-written code for the actual emission.
+fn gen_recipe(formats: &FormatRegistry, recipe: &EncRecipe, fmt: &mut Formatter) {
+    let iform = formats.get(recipe.format);
+    let nvops = iform.num_value_operands;
+    let want_args = recipe.ins.iter().any(|c| match c {
+        OperandConstraint::RegClass(_) | OperandConstraint::Stack(_) => true,
+        OperandConstraint::Register(_) | OperandConstraint::InputReference(_) => false,
+    });
+    let want_outs = recipe.outs.iter().any(|c| match c {
+        OperandConstraint::RegClass(_) | OperandConstraint::Stack(_) => true,
+        OperandConstraint::Register(_) | OperandConstraint::InputReference(_) => false,
+    });
+
+    let is_regmove = ["RegMove", "RegSpill", "RegFill"].contains(&iform.name);
+
+    fmtln!(fmt, "if let InstructionData::{} {{", iform.name);
+    fmt.indent(|fmt| {
+        fmt.line("opcode,");
+        for f in &iform.imm_fields {
+            fmtln!(fmt, "{},", f.member);
+        }
+        if want_args {
+            if iform.has_value_list || nvops > 1 {
+                fmt.line("ref args,");
+            } else {
+                fmt.line("arg,");
+            }
+            fmt.line("..");
+            fmt.indent_pop();
+            fmt.line("} = func.dfg[inst] {");
+            fmt.indent_push();
+
+            // Pass recipe arguments in this order: inputs, imm_fields, outputs.
+            let mut args = String::new();
+
+            // Pass recipe arguments in this order: inputs, imm_fields, outputs.
+            if want_args && !is_regmove {
+                if iform.has_value_list {
+                    fmt.line("let args = args.as_slice(&func.dfg.value_lists);");
+                } else if nvops == 1 {
+                    fmt.line("let args = [arg];");
+                }
+                args += &unwrap_values(&recipe.ins, "in", "args", fmt);
+            }
+
+            for f in &iform.imm_fields {
+                args += ", ";
+                args += f.member;
+            }
+
+            // Unwrap interesting output arguments.
+            if want_outs {
+                if recipe.outs.len() == 1 {
+                    fmt.line("let results = [func.dfg.first_result(inst)];")
+                } else {
+                    fmt.line("let results = func.dfg.inst_results(inst);");
+                }
+                args += &unwrap_values(&recipe.outs, "out", "results", fmt);
+            }
+
+            // Special handling for regmove instructions. Update the register
+            // diversion tracker
+            match &*iform.name {
+                "RegMove" => fmt.line("divert.regmove(arg, src, dst);"),
+                "RegSpill" => fmt.line("divert.regspill(arg, src, dst);"),
+                "RegFill" => fmt.line("divert.regfill(arg, src, dst);"),
+                _ => {}
+            }
+
+            if let Some(emit) = &recipe.emit {
+                fmt.multi_line(emit);
+                fmt.line("return;");
+            } else {
+                fmtln!(fmt, "return recipe_{}(func, inst, sink, bits{});", recipe.name.to_lowercase(), args)
+            }
+        }
+    });
+    fmt.line("}");
+}
+
+/// Emit code that unwraps values living in registers or stack slots.
+///
+/// :param args: Input or output constraints.
+/// :param prefix: Prefix to be used for the generated local variables.
+/// :param values: Name of slice containing the values to be unwrapped.
+/// :returns: Comma separated list of the generated variables
+fn unwrap_values(args: &[OperandConstraint], prefix: &str, values: &str, fmt: &mut Formatter) -> String {
+    let mut varlist = String::new();
+    for (i, cst) in args.iter().enumerate() {
+        match cst {
+            OperandConstraint::RegClass(_reg_class) => {
+                let v = format!("{}_reg{}", prefix, i);
+                varlist += ", ";
+                varlist += &v;
+                fmtln!(fmt, "let {} = divert.reg({}[{}], &func.locations);", v, values, i);
+
+            }
+            OperandConstraint::Stack(stack) => {
+                let v = format!("{}_stk{}", prefix, i);
+                varlist += ", ";
+                varlist += &v;
+                fmtln!(fmt, "let {} = StackRef::masked(", v);
+                fmt.indent(|fmt| {
+                    fmtln!(fmt, "divert.stack({}[{}], &func.locations),", values, i);
+                    fmt.line(stack.stack_base_mask());
+                    fmt.line("&func.stack_slots,");
+                });
+                fmt.line(").unwrap();");
+            }
+            _ => {}
+        }
+    }
+
+    varlist
+}
+
+fn gen_isa(formats: &FormatRegistry, isa_name: &str, all_recipes: &[EncRecipe], fmt: &mut Formatter) {
+    fmt.doc_comment(format!("Emit binary machine code for `inst` for the {} ISA", isa_name));
+    fmt.line("#[allow(unused_variables, unreachable_code)]");
+    fmt.line("pub fn emit_inst<CS: CodeSink + ?Sized>(");
+    fmt.indent(|fmt| {
+        fmt.line("func: &Function,");
+        fmt.line("inst: Inst,");
+        fmt.line("divert: &mut RegDiversions,");
+        fmt.line("sink: &mut CS,");
+    });
+    fmt.line(") {");
+    fmt.indent(|fmt| {
+        if all_recipes.is_empty() {
+            // No encoding recipes: Emit a stub.
+            fmt.line("bad_encoding(func, inst);");
+        } else {
+            fmt.line("let encoding = func.encodings[inst]");
+            fmt.line("let bits = encoding.bits();");
+            fmt.line("match func.encodings[inst].recipe() {");
+            fmt.indent(|fmt| {
+                for (i, recipe) in all_recipes.iter().enumerate() {
+                    fmt.comment(format!("Recipe {}", recipe.name));
+                    fmtln!(fmt, "{} => {{", i);
+                    fmt.indent(|fmt| {
+                        gen_recipe(formats, recipe, fmt);
+                    });
+                    fmt.line("}");
+                }
+                fmt.line("_ => {},");
+            });
+            fmt.line("}");
+
+            // Allow for un-encoded ghost instructions.
+            // Verifier checks the details.
+            fmt.line("if encoding.is_legal() {");
+            fmt.indent(|fmt| {
+                fmt.line("bad_encoding(func, inst);");
+            });
+            fmt.line("}");
+        }
+    });
+    fmt.line("}");
+}
+
+// FIXME use it
+#[allow(dead_code)]
+pub fn generate(
+    formats: &FormatRegistry,
+    isa_name: &str,
+    all_recipes: &[EncRecipe],
+    binemit_filename: &str,
+    out_dir: &str,
+) -> Result<(), error::Error> {
+    let mut fmt = Formatter::new();
+    gen_isa(formats, isa_name, all_recipes, &mut fmt);
+    fmt.update_file(binemit_filename, out_dir)?;
+
+    Ok(())
+}

--- a/cranelift-codegen/meta/src/lib.rs
+++ b/cranelift-codegen/meta/src/lib.rs
@@ -5,6 +5,7 @@ mod srcgen;
 pub mod error;
 pub mod isa;
 
+mod gen_binemit;
 mod gen_inst;
 mod gen_legalizer;
 mod gen_registers;
@@ -62,6 +63,7 @@ pub fn generate(isas: &Vec<isa::Isa>, out_dir: &str) -> Result<(), error::Error>
             &format!("settings-{}.rs", isa.name),
             &out_dir,
         )?;
+        //gen_binemit::generate(&shared_defs.format_registry, &isa.name, &isa.all_recipes, &format!("new_binemit-{}.rs", isa.name), &out_dir)?;
     }
 
     Ok(())


### PR DESCRIPTION
Based on #694

While `gen_binemit.py` has been ported, I still need to port `Encoding` and parts of `TargetIsa` to make it usable. Those are a bit harder as they seem to rely on the fact that python objects are not copied on assignment, but shared. Eg `EncRecipe` contains a `number` field which gets manipulated afterwards.