### PR TITLE
Add a --disasm option to clif-util `wasm` and `compile`

### DIFF
--- a/src/clif-util.rs
+++ b/src/clif-util.rs
@@ -30,6 +30,7 @@ use std::process;
 
 mod cat;
 mod compile;
+mod disasm;
 mod print_cfg;
 mod utils;
 
@@ -67,6 +68,19 @@ fn add_time_flag<'a>() -> clap::Arg<'a, 'a> {
     Arg::with_name("time-passes")
         .short("T")
         .help("Print pass timing report for test")
+}
+
+fn add_size_flag<'a>() -> clap::Arg<'a, 'a> {
+    Arg::with_name("print-size")
+        .short("X")
+        .help("Print bytecode size")
+}
+
+fn add_disasm_flag<'a>() -> clap::Arg<'a, 'a> {
+    Arg::with_name("disasm")
+        .long("disasm")
+        .short("D")
+        .help("Disassemble machine code")
 }
 
 fn add_set_flag<'a>() -> clap::Arg<'a, 'a> {
@@ -120,6 +134,8 @@ fn add_wasm_or_compile<'a>(cmd: &str) -> clap::App<'a, 'a> {
         .arg(add_verbose_flag())
         .arg(add_print_flag())
         .arg(add_time_flag())
+        .arg(add_size_flag())
+        .arg(add_disasm_flag())
         .arg(add_set_flag())
         .arg(add_target_flag())
         .arg(add_input_file_arg())
@@ -226,6 +242,7 @@ fn main() {
             compile::run(
                 get_vec(rest_cmd.values_of("file")),
                 rest_cmd.is_present("print"),
+                rest_cmd.is_present("disasm"),
                 rest_cmd.is_present("time-passes"),
                 &get_vec(rest_cmd.values_of("set")),
                 target_val,
@@ -247,6 +264,7 @@ fn main() {
                     rest_cmd.is_present("just-decode"),
                     rest_cmd.is_present("check-translation"),
                     rest_cmd.is_present("print"),
+                    rest_cmd.is_present("disasm"),
                     &get_vec(rest_cmd.values_of("set")),
                     target_val,
                     rest_cmd.is_present("print-size"),

--- a/src/clif-util.rs
+++ b/src/clif-util.rs
@@ -80,7 +80,7 @@ fn add_disasm_flag<'a>() -> clap::Arg<'a, 'a> {
     Arg::with_name("disasm")
         .long("disasm")
         .short("D")
-        .help("Disassemble machine code")
+        .help("Print machine code disassembly")
 }
 
 fn add_set_flag<'a>() -> clap::Arg<'a, 'a> {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,12 +1,12 @@
 //! CLI tool to read Cranelift IR files and compile them into native code.
 
-use crate::disasm::{print_disassembly, print_readonly_data, print_bytes, PrintRelocs, PrintTraps};
+use crate::disasm::{print_bytes, print_disassembly, print_readonly_data, PrintRelocs, PrintTraps};
 use crate::utils::{parse_sets_and_triple, read_to_string};
+use cranelift_codegen::binemit;
 use cranelift_codegen::print_errors::pretty_error;
 use cranelift_codegen::settings::FlagsOrIsa;
 use cranelift_codegen::timing;
 use cranelift_codegen::Context;
-use cranelift_codegen::binemit;
 use cranelift_reader::parse_test;
 use std::path::Path;
 use std::path::PathBuf;

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,67 +1,20 @@
 //! CLI tool to read Cranelift IR files and compile them into native code.
 
+use crate::disasm::{print_disassembly, print_readonly_data, print_bytes, PrintRelocs, PrintTraps};
 use crate::utils::{parse_sets_and_triple, read_to_string};
-use cfg_if::cfg_if;
-use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::print_errors::pretty_error;
 use cranelift_codegen::settings::FlagsOrIsa;
 use cranelift_codegen::timing;
 use cranelift_codegen::Context;
-use cranelift_codegen::{binemit, ir};
+use cranelift_codegen::binemit;
 use cranelift_reader::parse_test;
 use std::path::Path;
 use std::path::PathBuf;
 
-struct PrintRelocs {
-    flag_print: bool,
-}
-
-impl binemit::RelocSink for PrintRelocs {
-    fn reloc_ebb(
-        &mut self,
-        where_: binemit::CodeOffset,
-        r: binemit::Reloc,
-        offset: binemit::CodeOffset,
-    ) {
-        if self.flag_print {
-            println!("reloc_ebb: {} {} at {}", r, offset, where_);
-        }
-    }
-
-    fn reloc_external(
-        &mut self,
-        where_: binemit::CodeOffset,
-        r: binemit::Reloc,
-        name: &ir::ExternalName,
-        addend: binemit::Addend,
-    ) {
-        if self.flag_print {
-            println!("reloc_external: {} {} {} at {}", r, name, addend, where_);
-        }
-    }
-
-    fn reloc_jt(&mut self, where_: binemit::CodeOffset, r: binemit::Reloc, jt: ir::JumpTable) {
-        if self.flag_print {
-            println!("reloc_jt: {} {} at {}", r, jt, where_);
-        }
-    }
-}
-
-struct PrintTraps {
-    flag_print: bool,
-}
-
-impl binemit::TrapSink for PrintTraps {
-    fn trap(&mut self, offset: binemit::CodeOffset, _srcloc: ir::SourceLoc, code: ir::TrapCode) {
-        if self.flag_print {
-            println!("trap: {} at {}", code, offset);
-        }
-    }
-}
-
 pub fn run(
     files: Vec<String>,
     flag_print: bool,
+    flag_disasm: bool,
     flag_report_times: bool,
     flag_set: &[String],
     flag_isa: &str,
@@ -73,6 +26,7 @@ pub fn run(
         let name = String::from(path.as_os_str().to_string_lossy());
         handle_module(
             flag_print,
+            flag_disasm,
             flag_report_times,
             &path.to_path_buf(),
             &name,
@@ -84,6 +38,7 @@ pub fn run(
 
 fn handle_module(
     flag_print: bool,
+    flag_disasm: bool,
     flag_report_times: bool,
     path: &PathBuf,
     name: &str,
@@ -124,19 +79,8 @@ fn handle_module(
             println!("{}", context.func.display(isa));
         }
 
-        if flag_print {
-            print!(".byte ");
-            let mut first = true;
-            for byte in &mem {
-                if first {
-                    first = false;
-                } else {
-                    print!(", ");
-                }
-                print!("{}", byte);
-            }
-
-            println!();
+        if flag_disasm {
+            print_bytes(&mem);
             print_disassembly(isa, &mem[0..code_sink.code_size as usize])?;
             print_readonly_data(&mem[code_sink.code_size as usize..total_size as usize]);
         }
@@ -147,100 +91,4 @@ fn handle_module(
     }
 
     Ok(())
-}
-
-fn print_readonly_data(mem: &[u8]) {
-    if mem.is_empty() {
-        return;
-    }
-
-    println!("\nFollowed by {} bytes of read-only data:", mem.len());
-
-    for (i, byte) in mem.iter().enumerate() {
-        if i % 16 == 0 {
-            if i != 0 {
-                println!();
-            }
-            print!("{:4}: ", i);
-        }
-        if i % 4 == 0 {
-            print!(" ");
-        }
-        print!("{:02x} ", byte);
-    }
-    println!();
-}
-
-cfg_if! {
-    if #[cfg(feature = "disas")] {
-        use capstone::prelude::*;
-        use target_lexicon::Architecture;
-        use std::fmt::Write;
-
-        fn get_disassembler(isa: &TargetIsa) -> Result<Capstone, String> {
-            let cs = match isa.triple().architecture {
-                Architecture::Riscv32 | Architecture::Riscv64 => {
-                    return Err(String::from("No disassembler for RiscV"))
-                }
-                Architecture::I386 | Architecture::I586 | Architecture::I686 => Capstone::new()
-                    .x86()
-                    .mode(arch::x86::ArchMode::Mode32)
-                    .build(),
-                Architecture::X86_64 => Capstone::new()
-                    .x86()
-                    .mode(arch::x86::ArchMode::Mode64)
-                    .build(),
-                Architecture::Arm
-                | Architecture::Armv4t
-                | Architecture::Armv5te
-                | Architecture::Armv7
-                | Architecture::Armv7s => Capstone::new().arm().mode(arch::arm::ArchMode::Arm).build(),
-                Architecture::Thumbv6m | Architecture::Thumbv7em | Architecture::Thumbv7m => Capstone::new(
-                ).arm()
-                    .mode(arch::arm::ArchMode::Thumb)
-                    .build(),
-                Architecture::Aarch64 => Capstone::new()
-                    .arm64()
-                    .mode(arch::arm64::ArchMode::Arm)
-                    .build(),
-                _ => return Err(String::from("Unknown ISA")),
-            };
-
-            cs.map_err(|err| err.to_string())
-        }
-
-        fn print_disassembly(isa: &TargetIsa, mem: &[u8]) -> Result<(), String> {
-            let mut cs = get_disassembler(isa)?;
-
-            println!("\nDisassembly of {} bytes:", mem.len());
-            let insns = cs.disasm_all(&mem, 0x0).unwrap();
-            for i in insns.iter() {
-                let mut line = String::new();
-
-                write!(&mut line, "{:4x}:\t", i.address()).unwrap();
-
-                let mut bytes_str = String::new();
-                for b in i.bytes() {
-                    write!(&mut bytes_str, "{:02x} ", b).unwrap();
-                }
-                write!(&mut line, "{:21}\t", bytes_str).unwrap();
-
-                if let Some(s) = i.mnemonic() {
-                    write!(&mut line, "{}\t", s).unwrap();
-                }
-
-                if let Some(s) = i.op_str() {
-                    write!(&mut line, "{}", s).unwrap();
-                }
-
-                println!("{}", line);
-            }
-            Ok(())
-        }
-    } else {
-        fn print_disassembly(_: &TargetIsa, _: &[u8]) -> Result<(), String> {
-            println!("\nNo disassembly available.");
-            Ok(())
-        }
-    }
 }

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -5,12 +5,15 @@ use std::fmt::Write;
 
 pub struct PrintRelocs {
     pub flag_print: bool,
-    pub text: String
+    pub text: String,
 }
 
 impl PrintRelocs {
-    pub fn new(flag_print:bool) -> PrintRelocs {
-        Self { flag_print, text: String::new() }
+    pub fn new(flag_print: bool) -> PrintRelocs {
+        Self {
+            flag_print,
+            text: String::new(),
+        }
     }
 }
 
@@ -22,7 +25,12 @@ impl binemit::RelocSink for PrintRelocs {
         offset: binemit::CodeOffset,
     ) {
         if self.flag_print {
-            write!(&mut self.text, "reloc_ebb: {} {} at {}\n", r, offset, where_).unwrap();
+            write!(
+                &mut self.text,
+                "reloc_ebb: {} {} at {}\n",
+                r, offset, where_
+            )
+            .unwrap();
         }
     }
 
@@ -34,7 +42,12 @@ impl binemit::RelocSink for PrintRelocs {
         addend: binemit::Addend,
     ) {
         if self.flag_print {
-            write!(&mut self.text, "reloc_external: {} {} {} at {}\n", r, name, addend, where_).unwrap();
+            write!(
+                &mut self.text,
+                "reloc_external: {} {} {} at {}\n",
+                r, name, addend, where_
+            )
+            .unwrap();
         }
     }
 
@@ -47,12 +60,15 @@ impl binemit::RelocSink for PrintRelocs {
 
 pub struct PrintTraps {
     pub flag_print: bool,
-    pub text: String
+    pub text: String,
 }
 
 impl PrintTraps {
-    pub fn new(flag_print:bool) -> PrintTraps {
-        Self { flag_print, text: String::new() }
+    pub fn new(flag_print: bool) -> PrintTraps {
+        Self {
+            flag_print,
+            text: String::new(),
+        }
     }
 }
 
@@ -147,11 +163,17 @@ cfg_if! {
     }
 }
 
-pub fn print_all(isa: &TargetIsa, mem: &[u8], code_size: u32, rodata_size: u32,
-                 relocs: &PrintRelocs, traps: &PrintTraps) -> Result<(), String> {
+pub fn print_all(
+    isa: &TargetIsa,
+    mem: &[u8],
+    code_size: u32,
+    rodata_size: u32,
+    relocs: &PrintRelocs,
+    traps: &PrintTraps,
+) -> Result<(), String> {
     print_bytes(&mem);
     print_disassembly(isa, &mem[0..code_size as usize])?;
-    print_readonly_data(&mem[code_size as usize..(code_size+rodata_size) as usize]);
+    print_readonly_data(&mem[code_size as usize..(code_size + rodata_size) as usize]);
     println!("\n{}\n{}", &relocs.text, &traps.text);
     Ok(())
 }

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -1,0 +1,170 @@
+use cfg_if::cfg_if;
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::{binemit, ir};
+
+pub struct PrintRelocs {
+    pub flag_print: bool,
+}
+
+impl binemit::RelocSink for PrintRelocs {
+    fn reloc_ebb(
+        &mut self,
+        where_: binemit::CodeOffset,
+        r: binemit::Reloc,
+        offset: binemit::CodeOffset,
+    ) {
+        if self.flag_print {
+            println!("reloc_ebb: {} {} at {}", r, offset, where_);
+        }
+    }
+
+    fn reloc_external(
+        &mut self,
+        where_: binemit::CodeOffset,
+        r: binemit::Reloc,
+        name: &ir::ExternalName,
+        addend: binemit::Addend,
+    ) {
+        if self.flag_print {
+            println!("reloc_external: {} {} {} at {}", r, name, addend, where_);
+        }
+    }
+
+    fn reloc_jt(&mut self, where_: binemit::CodeOffset, r: binemit::Reloc, jt: ir::JumpTable) {
+        if self.flag_print {
+            println!("reloc_jt: {} {} at {}", r, jt, where_);
+        }
+    }
+}
+
+pub struct PrintTraps {
+    pub flag_print: bool,
+}
+
+impl binemit::TrapSink for PrintTraps {
+    fn trap(&mut self, offset: binemit::CodeOffset, _srcloc: ir::SourceLoc, code: ir::TrapCode) {
+        if self.flag_print {
+            println!("trap: {} at {}", code, offset);
+        }
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "disas")] {
+        use capstone::prelude::*;
+        use target_lexicon::Architecture;
+        use std::fmt::Write;
+
+        fn get_disassembler(isa: &TargetIsa) -> Result<Capstone, String> {
+            let cs = match isa.triple().architecture {
+                Architecture::Riscv32 | Architecture::Riscv64 => {
+                    return Err(String::from("No disassembler for RiscV"))
+                }
+                Architecture::I386 | Architecture::I586 | Architecture::I686 => Capstone::new()
+                    .x86()
+                    .mode(arch::x86::ArchMode::Mode32)
+                    .build(),
+                Architecture::X86_64 => Capstone::new()
+                    .x86()
+                    .mode(arch::x86::ArchMode::Mode64)
+                    .build(),
+                Architecture::Arm
+                | Architecture::Armv4t
+                | Architecture::Armv5te
+                | Architecture::Armv7
+                | Architecture::Armv7s => Capstone::new().arm().mode(arch::arm::ArchMode::Arm).build(),
+                Architecture::Thumbv6m | Architecture::Thumbv7em | Architecture::Thumbv7m => Capstone::new(
+                ).arm()
+                    .mode(arch::arm::ArchMode::Thumb)
+                    .build(),
+                Architecture::Aarch64 => Capstone::new()
+                    .arm64()
+                    .mode(arch::arm64::ArchMode::Arm)
+                    .build(),
+                _ => return Err(String::from("Unknown ISA")),
+            };
+
+            cs.map_err(|err| err.to_string())
+        }
+
+        pub fn print_disassembly(isa: &TargetIsa, mem: &[u8]) -> Result<(), String> {
+            let mut cs = get_disassembler(isa)?;
+
+            println!("\nDisassembly of {} bytes:", mem.len());
+            let insns = cs.disasm_all(&mem, 0x0).unwrap();
+            for i in insns.iter() {
+                let mut line = String::new();
+
+                write!(&mut line, "{:4x}:\t", i.address()).unwrap();
+
+                let mut bytes_str = String::new();
+                let mut len = 0;
+                let mut first = true;
+                for b in i.bytes() {
+                    write!(&mut bytes_str, "{:02x}", b).unwrap();
+                    if !first {
+                        write!(&mut bytes_str, " ").unwrap();
+                    }
+                    len += 1;
+                    first = false;
+                }
+                write!(&mut line, "{:21}\t", bytes_str).unwrap();
+                if len > 8 {
+                    write!(&mut line, "\n\t\t\t\t").unwrap();
+                }
+
+                if let Some(s) = i.mnemonic() {
+                    write!(&mut line, "{}\t", s).unwrap();
+                }
+
+                if let Some(s) = i.op_str() {
+                    write!(&mut line, "{}", s).unwrap();
+                }
+
+                println!("{}", line);
+            }
+            Ok(())
+        }
+    } else {
+        pub fn print_disassembly(_: &TargetIsa, _: &[u8]) -> Result<(), String> {
+            println!("\nNo disassembly available.");
+            Ok(())
+        }
+    }
+}
+
+pub fn print_bytes(mem: &[u8]) {
+    print!(".byte ");
+    let mut first = true;
+    for byte in mem.iter() {
+        if first {
+            first = false;
+        } else {
+            print!(", ");
+        }
+        print!("{}", byte);
+    }
+    println!();
+}
+
+pub fn print_readonly_data(mem: &[u8]) {
+    if mem.is_empty() {
+        return;
+    }
+
+    println!("\nFollowed by {} bytes of read-only data:", mem.len());
+
+    for (i, byte) in mem.iter().enumerate() {
+        if i % 16 == 0 {
+            if i != 0 {
+                println!();
+            }
+            print!("{:4}: ", i);
+        }
+        if i % 4 == 0 {
+            print!(" ");
+        }
+        print!("{:02x} ", byte);
+    }
+    println!();
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -7,12 +7,12 @@
     allow(clippy::too_many_arguments, clippy::cyclomatic_complexity)
 )]
 
-use crate::disasm::{print_disassembly, print_readonly_data, print_bytes, PrintRelocs, PrintTraps};
+use crate::disasm::{print_bytes, print_disassembly, print_readonly_data, PrintRelocs, PrintTraps};
 use crate::utils::{parse_sets_and_triple, read_to_end};
+use cranelift_codegen::binemit;
 use cranelift_codegen::print_errors::{pretty_error, pretty_verifier_error};
 use cranelift_codegen::settings::FlagsOrIsa;
 use cranelift_codegen::timing;
-use cranelift_codegen::binemit;
 use cranelift_codegen::Context;
 use cranelift_entity::EntityRef;
 use cranelift_wasm::{translate_module, DummyEnvironment, FuncIndex, ReturnMode};
@@ -105,7 +105,7 @@ fn handle_module(
         None => {
             return Err(String::from(
                 "Error: the wasm command requires an explicit isa.",
-            ))
+            ));
         }
     };
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -163,7 +163,7 @@ fn handle_module(
 
         let mut saved_sizes = None;
         let func_index = num_func_imports + def_index.index();
-        let mut mem = vec![0];
+        let mut mem = vec![];
         let mut relocs = PrintRelocs::new(flag_print);
         let mut traps = PrintTraps::new(flag_print);
         if flag_check_translation {


### PR DESCRIPTION
Both the `wasm` and `compile` commands get this new subcommand, and it defaults to false.  This means that test runs with `wasm` can request disassembly (the main reason I am doing this) while test runs with `compile` now must request it, this changes current behavior.  Discuss.