### PR TITLE
Update target-lexicon to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = "1.0.8"
 term = "0.5.1"
 capstone = { version = "0.5.0", optional = true }
 wabt = { version = "0.7.0", optional = true }
-target-lexicon = "0.3.0"
+target-lexicon = "0.4.0"
 pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.2"
 

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -18,7 +18,7 @@ cranelift-bforest = { path = "../cranelift-bforest", version = "0.30.0", default
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }
-target-lexicon = { version = "0.3.0", default-features = false }
+target-lexicon = { version = "0.4.0", default-features = false }
 log = { version = "0.4.6", default-features = false }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary

--- a/cranelift-faerie/Cargo.toml
+++ b/cranelift-faerie/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2018"
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.30.0" }
 cranelift-module = { path = "../cranelift-module", version = "0.30.0" }
-faerie = "0.9.1"
+faerie = "0.10.0"
 goblin = "0.0.21"
 failure = "0.1.2"
-target-lexicon = "0.3.0"
+target-lexicon = "0.4.0"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-frontend/Cargo.toml
+++ b/cranelift-frontend/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.30.0", default-features = false }
-target-lexicon = { version = "0.3.0", default-features = false }
+target-lexicon = { version = "0.4.0", default-features = false }
 log = { version = "0.4.6", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }
 

--- a/cranelift-native/Cargo.toml
+++ b/cranelift-native/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.30.0", default-features = false }
-target-lexicon = { version = "0.3.0", default-features = false }
+target-lexicon = { version = "0.4.0", default-features = false }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 raw-cpuid = "6.0.0"

--- a/cranelift-reader/Cargo.toml
+++ b/cranelift-reader/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.30.0" }
-target-lexicon = "0.3.0"
+target-lexicon = "0.4.0"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-simplejit/Cargo.toml
+++ b/cranelift-simplejit/Cargo.toml
@@ -16,7 +16,7 @@ cranelift-native = { path = "../cranelift-native", version = "0.30.0" }
 region = "2.0.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
-target-lexicon = { version = "0.3.0" }
+target-lexicon = { version = "0.4.0" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["winbase", "memoryapi"] }

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -23,7 +23,7 @@ cast = { version = "0.2.2", default-features = false }
 
 [dev-dependencies]
 wabt = "0.7.0"
-target-lexicon = "0.3.0"
+target-lexicon = "0.4.0"
 
 [features]
 default = ["std"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 cranelift-codegen = { path = "../cranelift-codegen" }
 cranelift-wasm = { path = "../cranelift-wasm" }
 cranelift-reader = { path = "../cranelift-reader" }
-target-lexicon = "0.3.0"
+target-lexicon = "0.4.0"
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
This depends on https://github.com/m4b/faerie/pull/73 and will require a version bump there.

Having this would be nice for Spidermonkey/Gecko, which currently uses @glandium's clone of `target-lexicon` as the Gecko dependency (so as to have support for some ARM devices I guess).

(Build will be broken until faerie is updated)