### PR TITLE
Fixes #716: Stub out parse_x86_cpuid in the non-x86 case

### DIFF
--- a/cranelift-native/src/lib.rs
+++ b/cranelift-native/src/lib.rs
@@ -88,6 +88,11 @@ fn parse_x86_cpuid(isa_builder: &mut isa::Builder) -> Result<(), &'static str> {
     Ok(())
 }
 
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn parse_x86_cpuid(_isa_builder: &mut isa::Builder) -> Result<(), &'static str> {
+    unreachable!();
+}
+
 #[cfg(test)]
 mod tests {
     use super::builder;


### PR DESCRIPTION
See #716 for discussion; an alternative solution is to add the dependency `cfg-if` and use `cfg_if!` here.