### PR TITLE
Fix a disasm formatting error

### DIFF
--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -131,10 +131,10 @@ cfg_if! {
                 let mut len = 0;
                 let mut first = true;
                 for b in i.bytes() {
-                    write!(&mut bytes_str, "{:02x}", b).unwrap();
                     if !first {
                         write!(&mut bytes_str, " ").unwrap();
                     }
+                    write!(&mut bytes_str, "{:02x}", b).unwrap();
                     len += 1;
                     first = false;
                 }


### PR DESCRIPTION
When I factored the disassembler I tried to be smart about how it prints spaces, in order to avoid a formatting error in an edge condition.  But I wasn't smart enough: the space should be printed conditionally before the byte value, not after.  This fixes that.