### PR TITLE
[meta] TypeVar/TypeSet tests

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/types.rs
+++ b/cranelift-codegen/meta/src/cdsl/types.rs
@@ -21,13 +21,13 @@ static LANE_BASE: u8 = 0x70;
 // Rust name prefix used for the `rust_name` method.
 static _RUST_NAME_PREFIX: &'static str = "ir::types::";
 
-// ValueType variants (i8, i32, ...) are provided in `base::types.rs`.
+// ValueType variants (i8, i32, ...) are provided in `shared::types.rs`.
 
 /// A concrete SSA value type.
 ///
 /// All SSA values have a type that is described by an instance of `ValueType`
 /// or one of its subclasses.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ValueType {
     BV(BVType),
     Lane(LaneType),
@@ -147,7 +147,7 @@ impl From<VectorType> for ValueType {
 }
 
 /// A concrete scalar type that can appear as a vector lane too.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum LaneType {
     BoolType(shared_types::Bool),
     FloatType(shared_types::Float),
@@ -327,7 +327,7 @@ impl Iterator for LaneTypeIterator {
 ///
 /// A vector type has a lane type which is an instance of `LaneType`,
 /// and a positive number of lanes.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct VectorType {
     base: LaneType,
     lanes: u64,
@@ -393,7 +393,7 @@ impl fmt::Debug for VectorType {
 }
 
 /// A flat bitvector type. Used for semantics description only.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct BVType {
     bits: u64,
 }

--- a/cranelift-codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift-codegen/meta/src/cdsl/typevar.rs
@@ -690,6 +690,111 @@ fn test_typevar_builder_inverted_bounds_panic() {
 }
 
 #[test]
+fn test_as_bool() {
+    let a = TypeSetBuilder::new()
+        .simd_lanes(2..8)
+        .ints(8..8)
+        .floats(32..32)
+        .finish();
+    assert_eq!(
+        a.lane_of(),
+        TypeSetBuilder::new().ints(8..8).floats(32..32).finish()
+    );
+
+    // Test as_bool with disjoint intervals.
+    let mut a_as_bool = TypeSetBuilder::new().simd_lanes(2..8).finish();
+    a_as_bool.bools = num_set![8, 32];
+    assert_eq!(a.as_bool(), a_as_bool);
+
+    let b = TypeSetBuilder::new()
+        .simd_lanes(1..8)
+        .ints(8..8)
+        .floats(32..32)
+        .finish();
+    let mut b_as_bool = TypeSetBuilder::new().simd_lanes(1..8).finish();
+    b_as_bool.bools = num_set![1, 8, 32];
+    assert_eq!(b.as_bool(), b_as_bool);
+}
+
+#[test]
+fn test_forward_images() {
+    let empty_set = TypeSetBuilder::new().finish();
+
+    // Half vector.
+    assert_eq!(
+        TypeSetBuilder::new()
+            .simd_lanes(1..32)
+            .finish()
+            .half_vector(),
+        TypeSetBuilder::new().simd_lanes(1..16).finish()
+    );
+
+    // Double vector.
+    assert_eq!(
+        TypeSetBuilder::new()
+            .simd_lanes(1..32)
+            .finish()
+            .double_vector(),
+        TypeSetBuilder::new().simd_lanes(2..64).finish()
+    );
+    assert_eq!(
+        TypeSetBuilder::new()
+            .simd_lanes(128..256)
+            .finish()
+            .double_vector(),
+        TypeSetBuilder::new().simd_lanes(256..256).finish()
+    );
+
+    // Half width.
+    assert_eq!(
+        TypeSetBuilder::new().ints(8..32).finish().half_width(),
+        TypeSetBuilder::new().ints(8..16).finish()
+    );
+    assert_eq!(
+        TypeSetBuilder::new().floats(32..32).finish().half_width(),
+        empty_set
+    );
+    assert_eq!(
+        TypeSetBuilder::new().floats(32..64).finish().half_width(),
+        TypeSetBuilder::new().floats(32..32).finish()
+    );
+    assert_eq!(
+        TypeSetBuilder::new().bools(1..8).finish().half_width(),
+        empty_set
+    );
+    assert_eq!(
+        TypeSetBuilder::new().bools(1..32).finish().half_width(),
+        TypeSetBuilder::new().bools(8..16).finish()
+    );
+
+    // Double width.
+    assert_eq!(
+        TypeSetBuilder::new().ints(8..32).finish().double_width(),
+        TypeSetBuilder::new().ints(16..64).finish()
+    );
+    assert_eq!(
+        TypeSetBuilder::new().ints(32..64).finish().double_width(),
+        TypeSetBuilder::new().ints(64..64).finish()
+    );
+    assert_eq!(
+        TypeSetBuilder::new().floats(32..32).finish().double_width(),
+        TypeSetBuilder::new().floats(64..64).finish()
+    );
+    assert_eq!(
+        TypeSetBuilder::new().floats(32..64).finish().double_width(),
+        TypeSetBuilder::new().floats(64..64).finish()
+    );
+    assert_eq!(
+        TypeSetBuilder::new().bools(1..16).finish().double_width(),
+        TypeSetBuilder::new().bools(16..32).finish()
+    );
+    assert_eq!(
+        TypeSetBuilder::new().bools(32..64).finish().double_width(),
+        TypeSetBuilder::new().bools(64..64).finish()
+    );
+}
+
+#[test]
 fn test_singleton() {
     use crate::cdsl::types::VectorType;
     use crate::shared::types as shared_types;

--- a/cranelift-codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift-codegen/meta/src/cdsl/typevar.rs
@@ -117,7 +117,7 @@ impl TypeVar {
 
     /// Create a type variable that is a function of another.
     fn derived(&self, derived_func: DerivedFunc) -> TypeVar {
-        let ts = self.content.type_set.clone();
+        let ts = self.get_typeset();
 
         // Safety checks to avoid over/underflows.
         assert!(ts.specials.len() == 0, "can't derive from special types");
@@ -169,7 +169,7 @@ impl TypeVar {
 
         return TypeVar {
             content: Rc::new(TypeVarContent {
-                name: "".into(), // XXX Python passes None to these two fields
+                name: format!("{}({})", derived_func.name(), self.name),
                 doc: "".into(),
                 type_set: ts,
                 base: Some(TypeVarParent {
@@ -840,6 +840,23 @@ fn test_typeset_singleton() {
             .get_singleton(),
         LaneType::from(shared_types::Int::I32).by(4)
     );
+}
+
+#[test]
+fn test_typevar_functions() {
+    let x = TypeVar::new(
+        "x",
+        "i16 and up",
+        TypeSetBuilder::new().ints(16..64).finish(),
+    );
+    assert_eq!(x.half_width().name, "half_width(x)");
+    assert_eq!(
+        x.half_width().double_width().name,
+        "double_width(half_width(x))"
+    );
+
+    let x = TypeVar::new("x", "up to i32", TypeSetBuilder::new().ints(8..32).finish());
+    assert_eq!(x.double_width().name, "double_width(x)");
 }
 
 #[test]

--- a/cranelift-codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift-codegen/meta/src/cdsl/typevar.rs
@@ -795,7 +795,55 @@ fn test_forward_images() {
 }
 
 #[test]
-fn test_singleton() {
+#[should_panic]
+fn test_typeset_singleton_panic_nonsingleton_types() {
+    TypeSetBuilder::new()
+        .ints(8..8)
+        .floats(32..32)
+        .finish()
+        .get_singleton();
+}
+
+#[test]
+#[should_panic]
+fn test_typeset_singleton_panic_nonsingleton_lanes() {
+    TypeSetBuilder::new()
+        .simd_lanes(1..2)
+        .floats(32..32)
+        .finish()
+        .get_singleton();
+}
+
+#[test]
+fn test_typeset_singleton() {
+    use crate::shared::types as shared_types;
+    assert_eq!(
+        TypeSetBuilder::new().ints(16..16).finish().get_singleton(),
+        ValueType::Lane(shared_types::Int::I16.into())
+    );
+    assert_eq!(
+        TypeSetBuilder::new()
+            .floats(64..64)
+            .finish()
+            .get_singleton(),
+        ValueType::Lane(shared_types::Float::F64.into())
+    );
+    assert_eq!(
+        TypeSetBuilder::new().bools(1..1).finish().get_singleton(),
+        ValueType::Lane(shared_types::Bool::B1.into())
+    );
+    assert_eq!(
+        TypeSetBuilder::new()
+            .simd_lanes(4..4)
+            .ints(32..32)
+            .finish()
+            .get_singleton(),
+        LaneType::from(shared_types::Int::I32).by(4)
+    );
+}
+
+#[test]
+fn test_typevar_singleton() {
     use crate::cdsl::types::VectorType;
     use crate::shared::types as shared_types;
 

--- a/cranelift-codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift-codegen/meta/src/isa/x86/instructions.rs
@@ -4,7 +4,7 @@ use crate::cdsl::formats::FormatRegistry;
 use crate::cdsl::inst::{InstructionBuilder as Inst, InstructionGroup};
 use crate::cdsl::operands::{create_operand as operand, create_operand_doc as operand_doc};
 use crate::cdsl::types::ValueType;
-use crate::cdsl::typevar::{Interval, TypeVar, TypeVarBuilder};
+use crate::cdsl::typevar::{Interval, TypeSetBuilder, TypeVar};
 use crate::shared::types;
 
 pub fn define(format_registry: &FormatRegistry) -> InstructionGroup {
@@ -12,9 +12,11 @@ pub fn define(format_registry: &FormatRegistry) -> InstructionGroup {
 
     let iflags: &TypeVar = &ValueType::Special(types::Flag::IFlags.into()).into();
 
-    let iWord = &TypeVarBuilder::new("iWord", "A scalar integer machine word")
-        .ints(32..64)
-        .finish();
+    let iWord = &TypeVar::new(
+        "iWord",
+        "A scalar integer machine word",
+        TypeSetBuilder::new().ints(32..64).finish(),
+    );
     let nlo = &operand_doc("nlo", iWord, "Low part of numerator");
     let nhi = &operand_doc("nhi", iWord, "High part of numerator");
     let d = &operand_doc("d", iWord, "Denominator");
@@ -96,14 +98,22 @@ pub fn define(format_registry: &FormatRegistry) -> InstructionGroup {
         .finish(format_registry),
     );
 
-    let Float = &TypeVarBuilder::new("Float", "A scalar or vector floating point number")
-        .floats(Interval::All)
-        .simd_lanes(Interval::All)
-        .finish();
-    let IntTo = &TypeVarBuilder::new("IntTo", "An integer type with the same number of lanes")
-        .ints(32..64)
-        .simd_lanes(Interval::All)
-        .finish();
+    let Float = &TypeVar::new(
+        "Float",
+        "A scalar or vector floating point number",
+        TypeSetBuilder::new()
+            .floats(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
+    let IntTo = &TypeVar::new(
+        "IntTo",
+        "An integer type with the same number of lanes",
+        TypeSetBuilder::new()
+            .ints(32..64)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
     let x = &operand("x", Float);
     let a = &operand("a", IntTo);
 

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -5,7 +5,7 @@ use crate::cdsl::inst::{InstructionBuilder as Inst, InstructionGroup};
 use crate::cdsl::operands::{create_operand as operand, create_operand_doc as operand_doc};
 use crate::cdsl::type_inference::Constraint::WiderOrEq;
 use crate::cdsl::types::{LaneType, ValueType};
-use crate::cdsl::typevar::{Interval, TypeVar, TypeVarBuilder};
+use crate::cdsl::typevar::{Interval, TypeSetBuilder, TypeVar};
 use crate::shared::{types, OperandKinds};
 
 pub fn define(
@@ -47,59 +47,88 @@ pub fn define(
     let f64_: &TypeVar = &ValueType::from(LaneType::from(types::Float::F64)).into();
 
     // Starting definitions.
-    let Int = &TypeVarBuilder::new("Int", "A scalar or vector integer type")
-        .ints(Interval::All)
-        .simd_lanes(Interval::All)
-        .finish();
+    let Int = &TypeVar::new(
+        "Int",
+        "A scalar or vector integer type",
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
 
-    let Bool = &TypeVarBuilder::new("Bool", "A scalar or vector boolean type")
-        .bools(Interval::All)
-        .simd_lanes(Interval::All)
-        .finish();
+    let Bool = &TypeVar::new(
+        "Bool",
+        "A scalar or vector boolean type",
+        TypeSetBuilder::new()
+            .bools(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
 
-    let iB = &TypeVarBuilder::new("iB", "A scalar integer type")
-        .ints(Interval::All)
-        .finish();
+    let iB = &TypeVar::new(
+        "iB",
+        "A scalar integer type",
+        TypeSetBuilder::new().ints(Interval::All).finish(),
+    );
 
-    let iAddr = &TypeVarBuilder::new("iAddr", "An integer address type")
-        .ints(32..64)
-        .finish();
+    let iAddr = &TypeVar::new(
+        "iAddr",
+        "An integer address type",
+        TypeSetBuilder::new().ints(32..64).finish(),
+    );
 
-    let Testable = &TypeVarBuilder::new("Testable", "A scalar boolean or integer type")
-        .ints(Interval::All)
-        .bools(Interval::All)
-        .finish();
+    let Testable = &TypeVar::new(
+        "Testable",
+        "A scalar boolean or integer type",
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .bools(Interval::All)
+            .finish(),
+    );
 
-    let TxN = &TypeVarBuilder::new("TxN", "A SIMD vector type")
-        .ints(Interval::All)
-        .floats(Interval::All)
-        .bools(Interval::All)
-        .simd_lanes(Interval::All)
-        .includes_scalars(false)
-        .finish();
+    let TxN = &TypeVar::new(
+        "TxN",
+        "A SIMD vector type",
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .floats(Interval::All)
+            .bools(Interval::All)
+            .simd_lanes(Interval::All)
+            .includes_scalars(false)
+            .finish(),
+    );
 
-    let Any = &TypeVarBuilder::new(
+    let Any = &TypeVar::new(
         "Any",
         "Any integer, float, or boolean scalar or vector type",
-    )
-    .ints(Interval::All)
-    .floats(Interval::All)
-    .bools(Interval::All)
-    .simd_lanes(Interval::All)
-    .includes_scalars(true)
-    .finish();
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .floats(Interval::All)
+            .bools(Interval::All)
+            .simd_lanes(Interval::All)
+            .includes_scalars(true)
+            .finish(),
+    );
 
-    let Mem = &TypeVarBuilder::new("Mem", "Any type that can be stored in memory")
-        .ints(Interval::All)
-        .floats(Interval::All)
-        .simd_lanes(Interval::All)
-        .finish();
+    let Mem = &TypeVar::new(
+        "Mem",
+        "Any type that can be stored in memory",
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .floats(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
 
-    let MemTo = &TypeVarBuilder::new("MemTo", "Any type that can be stored in memory")
-        .ints(Interval::All)
-        .floats(Interval::All)
-        .simd_lanes(Interval::All)
-        .finish();
+    let MemTo = &TypeVar::new(
+        "MemTo",
+        "Any type that can be stored in memory",
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .floats(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
 
     let addr = &operand("addr", iAddr);
     let c = &operand_doc("c", Testable, "Controlling value to test");
@@ -233,9 +262,11 @@ pub fn define(
 
     let x = &operand_doc("x", iB, "index into jump table");
 
-    let Entry = &TypeVarBuilder::new("Entry", "A scalar integer type")
-        .ints(Interval::All)
-        .finish();
+    let Entry = &TypeVar::new(
+        "Entry",
+        "A scalar integer type",
+        TypeSetBuilder::new().ints(Interval::All).finish(),
+    );
 
     let entry = &operand_doc("entry", Entry, "entry of jump table");
     let JT = &operand("JT", jump_table);
@@ -578,9 +609,11 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let iExt8 = &TypeVarBuilder::new("iExt8", "An integer type with more than 8 bits")
-        .ints(16..64)
-        .finish();
+    let iExt8 = &TypeVar::new(
+        "iExt8",
+        "An integer type with more than 8 bits",
+        TypeSetBuilder::new().ints(16..64).finish(),
+    );
     let x = &operand("x", iExt8);
     let a = &operand("a", iExt8);
 
@@ -672,9 +705,11 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let iExt16 = &TypeVarBuilder::new("iExt16", "An integer type with more than 16 bits")
-        .ints(32..64)
-        .finish();
+    let iExt16 = &TypeVar::new(
+        "iExt16",
+        "An integer type with more than 16 bits",
+        TypeSetBuilder::new().ints(32..64).finish(),
+    );
     let x = &operand("x", iExt16);
     let a = &operand("a", iExt16);
 
@@ -766,9 +801,11 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let iExt32 = &TypeVarBuilder::new("iExt32", "An integer type with more than 32 bits")
-        .ints(64..64)
-        .finish();
+    let iExt32 = &TypeVar::new(
+        "iExt32",
+        "An integer type with more than 32 bits",
+        TypeSetBuilder::new().ints(64..64).finish(),
+    );
     let x = &operand("x", iExt32);
     let a = &operand("a", iExt32);
 
@@ -945,9 +982,11 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let HeapOffset = &TypeVarBuilder::new("HeapOffset", "An unsigned heap offset")
-        .ints(32..64)
-        .finish();
+    let HeapOffset = &TypeVar::new(
+        "HeapOffset",
+        "An unsigned heap offset",
+        TypeSetBuilder::new().ints(32..64).finish(),
+    );
 
     let H = &operand("H", heap);
     let p = &operand("p", HeapOffset);
@@ -973,9 +1012,11 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let TableOffset = &TypeVarBuilder::new("TableOffset", "An unsigned table offset")
-        .ints(32..64)
-        .finish();
+    let TableOffset = &TypeVar::new(
+        "TableOffset",
+        "An unsigned table offset",
+        TypeSetBuilder::new().ints(32..64).finish(),
+    );
     let T = &operand("T", table);
     let p = &operand("p", TableOffset);
     let Offset = &operand_doc("Offset", offset32, "Byte offset from element address");
@@ -1342,13 +1383,17 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let Any128 = &TypeVarBuilder::new("Any128", "Any scalar or vector type with as most 128 lanes")
-        .ints(Interval::All)
-        .floats(Interval::All)
-        .bools(Interval::All)
-        .simd_lanes(1..128)
-        .includes_scalars(true)
-        .finish();
+    let Any128 = &TypeVar::new(
+        "Any128",
+        "Any scalar or vector type with as most 128 lanes",
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .floats(Interval::All)
+            .bools(Interval::All)
+            .simd_lanes(1..128)
+            .includes_scalars(true)
+            .finish(),
+    );
 
     let x = &operand_doc("x", Any128, "Low-numbered lanes");
     let y = &operand_doc("y", Any128, "High-numbered lanes");
@@ -1935,16 +1980,17 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let bits = &TypeVarBuilder::new(
+    let bits = &TypeVar::new(
         "bits",
         "Any integer, float, or boolean scalar or vector type",
-    )
-    .ints(Interval::All)
-    .floats(Interval::All)
-    .bools(Interval::All)
-    .simd_lanes(Interval::All)
-    .includes_scalars(true)
-    .finish();
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .floats(Interval::All)
+            .bools(Interval::All)
+            .simd_lanes(Interval::All)
+            .includes_scalars(true)
+            .finish(),
+    );
     let x = &operand("x", bits);
     let y = &operand("y", bits);
     let a = &operand("a", bits);
@@ -2331,10 +2377,14 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let Float = &TypeVarBuilder::new("Float", "A scalar or vector floating point number")
-        .floats(Interval::All)
-        .simd_lanes(Interval::All)
-        .finish();
+    let Float = &TypeVar::new(
+        "Float",
+        "A scalar or vector floating point number",
+        TypeSetBuilder::new()
+            .floats(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
     let Cond = &operand("Cond", floatcc);
     let x = &operand("x", Float);
     let y = &operand("y", Float);
@@ -2703,18 +2753,23 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let Bool = &TypeVarBuilder::new("Bool", "A scalar or vector boolean type")
-        .bools(Interval::All)
-        .simd_lanes(Interval::All)
-        .finish();
+    let Bool = &TypeVar::new(
+        "Bool",
+        "A scalar or vector boolean type",
+        TypeSetBuilder::new()
+            .bools(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
 
-    let BoolTo = &TypeVarBuilder::new(
+    let BoolTo = &TypeVar::new(
         "BoolTo",
         "A smaller boolean type with the same number of lanes",
-    )
-    .bools(Interval::All)
-    .simd_lanes(Interval::All)
-    .finish();
+        TypeSetBuilder::new()
+            .bools(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
 
     let x = &operand("x", Bool);
     let a = &operand("a", BoolTo);
@@ -2736,13 +2791,14 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let BoolTo = &TypeVarBuilder::new(
+    let BoolTo = &TypeVar::new(
         "BoolTo",
         "A larger boolean type with the same number of lanes",
-    )
-    .bools(Interval::All)
-    .simd_lanes(Interval::All)
-    .finish();
+        TypeSetBuilder::new()
+            .bools(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
     let x = &operand("x", Bool);
     let a = &operand("a", BoolTo);
 
@@ -2763,10 +2819,14 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let IntTo = &TypeVarBuilder::new("IntTo", "An integer type with the same number of lanes")
-        .ints(Interval::All)
-        .simd_lanes(Interval::All)
-        .finish();
+    let IntTo = &TypeVar::new(
+        "IntTo",
+        "An integer type with the same number of lanes",
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
     let x = &operand("x", Bool);
     let a = &operand("a", IntTo);
 
@@ -2800,18 +2860,23 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let Int = &TypeVarBuilder::new("Int", "A scalar or vector integer type")
-        .ints(Interval::All)
-        .simd_lanes(Interval::All)
-        .finish();
+    let Int = &TypeVar::new(
+        "Int",
+        "A scalar or vector integer type",
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
 
-    let IntTo = &TypeVarBuilder::new(
+    let IntTo = &TypeVar::new(
         "IntTo",
         "A smaller integer type with the same number of lanes",
-    )
-    .ints(Interval::All)
-    .simd_lanes(Interval::All)
-    .finish();
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
     let x = &operand("x", Int);
     let a = &operand("a", IntTo);
 
@@ -2836,13 +2901,14 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let IntTo = &TypeVarBuilder::new(
+    let IntTo = &TypeVar::new(
         "IntTo",
         "A larger integer type with the same number of lanes",
-    )
-    .ints(Interval::All)
-    .simd_lanes(Interval::All)
-    .finish();
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
     let x = &operand("x", Int);
     let a = &operand("a", IntTo);
 
@@ -2888,10 +2954,14 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let FloatTo = &TypeVarBuilder::new("FloatTo", "A scalar or vector floating point number")
-        .floats(Interval::All)
-        .simd_lanes(Interval::All)
-        .finish();
+    let FloatTo = &TypeVar::new(
+        "FloatTo",
+        "A scalar or vector floating point number",
+        TypeSetBuilder::new()
+            .floats(Interval::All)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
     let x = &operand("x", Float);
     let a = &operand("a", FloatTo);
 
@@ -3046,10 +3116,14 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let WideInt = &TypeVarBuilder::new("WideInt", "An integer type with lanes from `i16` upwards")
-        .ints(16..64)
-        .simd_lanes(Interval::All)
-        .finish();
+    let WideInt = &TypeVar::new(
+        "WideInt",
+        "An integer type with lanes from `i16` upwards",
+        TypeSetBuilder::new()
+            .ints(16..64)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
     let x = &operand("x", WideInt);
     let lo = &operand_doc("lo", &WideInt.half_width(), "The low bits of `x`");
     let hi = &operand_doc("hi", &WideInt.half_width(), "The high bits of `x`");
@@ -3073,10 +3147,14 @@ pub fn define(
         .finish(format_registry),
     );
 
-    let NarrowInt = &TypeVarBuilder::new("NarrowInt", "An integer type with lanes type to `i32`")
-        .ints(8..32)
-        .simd_lanes(Interval::All)
-        .finish();
+    let NarrowInt = &TypeVar::new(
+        "NarrowInt",
+        "An integer type with lanes type to `i32`",
+        TypeSetBuilder::new()
+            .ints(8..32)
+            .simd_lanes(Interval::All)
+            .finish(),
+    );
 
     let lo = &operand("lo", NarrowInt);
     let hi = &operand("hi", NarrowInt);


### PR DESCRIPTION
  This does a few things:

- add a `num_set!` macro to avoid repeating `NumSet::from_iter(vec![...])`.
- Move the TypeSet building code from the TypeVarBuilder into its own TypeSetBuilder structure. This doesn't change the all behavior, while it moves some code around.
- next commits add more tests, some of them were passing, but one of them helped identify two issues (that I saw when porting the legalization actions!):
  - the name of derived type variables wasn't computed correctly
  - nor was the type set, resulting in weird assertions triggering (e.g. when doing `TypeSet(ints=32..64).half_width().double_width()`)

I'm also pretty sure I found a bug in `gen_instr.py` which directly reads `type_set` from some typevars (it might need to use `get_typeset()` instead; this doesn't change behavior in the Python case, because none of the type variables which we read the type sets are derived). Since I'm not sure other Python generators rely on this behavior, I haven't changed/fixed it yet. That might happen later.