### PR TITLE
Fix x86-64 encoding of uextend.i64.i8

### DIFF
--- a/cranelift-codegen/meta-python/isa/x86/encodings.py
+++ b/cranelift-codegen/meta-python/isa/x86/encodings.py
@@ -631,7 +631,7 @@ X86_64.enc(base.uextend.i32.i16, *r.urm_noflags(0x0f, 0xb7))
 
 # movzbq, encoded as movzbl because it's equivalent and shorter
 X86_64.enc(base.uextend.i64.i8, *r.urm_noflags.rex(0x0f, 0xb6))
-X86_64.enc(base.uextend.i64.i8, *r.urm_noflags(0x0f, 0xb6))
+X86_64.enc(base.uextend.i64.i8, *r.urm_noflags_abcd(0x0f, 0xb6))
 
 # movzwq, encoded as movzwl because it's equivalent and shorter
 X86_64.enc(base.uextend.i64.i16, *r.urm_noflags.rex(0x0f, 0xb7))

--- a/filetests/isa/x86/shrink.clif
+++ b/filetests/isa/x86/shrink.clif
@@ -26,3 +26,15 @@ ebb0(v0: i32 [ %r8 ]):
 [-,%r8]    v2 = isub v0, v1      ; bin: 41 29 c8
            return v2
 }
+
+function %test_not_shrinking_i8() {
+ebb0:
+[-,%rsi]   v1 = iconst.i8 1
+           ; asm: movsbl %sil,%esi
+[-,%rsi]   v2 = sextend.i32 v1   ; bin: 40 0f be f6
+           ; asm: movzbl %sil,%esi
+[-,%rsi]   v3 = uextend.i32 v1   ; bin: 40 0f b6 f6
+           ; asm: movzbl %sil,%esi
+[-,%rsi]   v4 = uextend.i64 v1   ; bin: 40 0f b6 f6
+           trap user0
+}


### PR DESCRIPTION
The non-REX encoding of movzbl requires one of the ABCD registers as input.

Fixes #664 (cc @bjorn3)

I included `sextend.i32` and `uextend.i32` in the test as well, but they were already okay. I had a bit of a look at other instructions that used i8, and they all looked okay too.