### PR TITLE
Legal - part 1: a few small changes

### DIFF
--- a/cranelift-codegen/meta-python/cdsl/ast.py
+++ b/cranelift-codegen/meta-python/cdsl/ast.py
@@ -162,19 +162,19 @@ class Var(Atom):
         Values that are defined only in the destination pattern.
     """
 
-    def __init__(self, name, typevar=None):
-        # type: (str, TypeVar) -> None
+    def __init__(self, name):
+        # type: (str) -> None
         self.name = name
         # The `Def` defining this variable in a source pattern.
         self.src_def = None  # type: Def
         # The `Def` defining this variable in a destination pattern.
         self.dst_def = None  # type: Def
         # TypeVar representing the type of this variable.
-        self.typevar = typevar  # type: TypeVar
+        self.typevar = None  # type: TypeVar
         # The original 'typeof(x)' type variable that was created for this Var.
         # This one doesn't change. `self.typevar` above may be changed to
         # another typevar by type inference.
-        self.original_typevar = self.typevar  # type: TypeVar
+        self.original_typevar = None  # type: TypeVar
 
     def __str__(self):
         # type: () -> str

--- a/cranelift-codegen/meta/src/cdsl/formats.rs
+++ b/cranelift-codegen/meta/src/cdsl/formats.rs
@@ -10,10 +10,6 @@ use cranelift_entity::{entity_impl, PrimaryMap};
 ///
 /// This corresponds to a single member of a variant of the `InstructionData`
 /// data type.
-///
-/// :param iform: Parent `InstructionFormat`.
-/// :param kind: Immediate Operand kind.
-/// :param member: Member name in `InstructionData` variant.
 #[derive(Debug)]
 pub struct FormatField {
     /// Immediate operand number in parent.
@@ -22,39 +18,36 @@ pub struct FormatField {
     /// Immediate operand kind.
     pub kind: OperandKind,
 
-    /// Member name in InstructionDate variant.
+    /// Member name in InstructionData variant.
     pub member: &'static str,
 }
 
-/// Every instruction opcode has a corresponding instruction format which
-/// determines the number of operands and their kinds. Instruction formats are
-/// identified structurally, i.e., the format of an instruction is derived from
-/// the kinds of operands used in its declaration.
+/// Every instruction opcode has a corresponding instruction format which determines the number of
+/// operands and their kinds. Instruction formats are identified structurally, i.e., the format of
+/// an instruction is derived from the kinds of operands used in its declaration.
 ///
-/// The instruction format stores two separate lists of operands: Immediates
-/// and values. Immediate operands (including entity references) are
-/// represented as explicit members in the `InstructionData` variants. The
-/// value operands are stored differently, depending on how many there are.
-/// Beyond a certain point, instruction formats switch to an external value
-/// list for storing value arguments. Value lists can hold an arbitrary number
-/// of values.
+/// The instruction format stores two separate lists of operands: Immediates and values. Immediate
+/// operands (including entity references) are represented as explicit members in the
+/// `InstructionData` variants. The value operands are stored differently, depending on how many
+/// there are.  Beyond a certain point, instruction formats switch to an external value list for
+/// storing value arguments. Value lists can hold an arbitrary number of values.
 ///
-/// All instruction formats must be predefined in the meta shared/formats module.
-///
-/// :param kinds: List of `OperandKind` objects describing the operands.
-/// :param name: Instruction format name in CamelCase. This is used as a Rust
-///     variant name in both the `InstructionData` and `InstructionFormat`
-///     enums.
-/// :param typevar_operand: Index of the value input operand that is used to
-///     infer the controlling type variable. By default, this is `0`, the first
-///     `value` operand. The index is relative to the values only, ignoring
-///     immediate operands.
+/// All instruction formats must be predefined in the meta shared/formats.rs module.
 #[derive(Debug)]
 pub struct InstructionFormat {
+    /// Instruction format name in CamelCase. This is used as a Rust variant name in both the
+    /// `InstructionData` and `InstructionFormat` enums.
     pub name: &'static str,
+
     pub num_value_operands: usize,
+
     pub has_value_list: bool,
+
     pub imm_fields: Vec<FormatField>,
+
+    /// Index of the value input operand that is used to infer the controlling type variable. By
+    /// default, this is `0`, the first `value` operand. The index is relative to the values only,
+    /// ignoring immediate operands.
     pub typevar_operand: Option<usize>,
 }
 
@@ -162,7 +155,7 @@ impl InstructionFormatBuilder {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct InstructionFormatIndex(u32);
 entity_impl!(InstructionFormatIndex);
 

--- a/cranelift-codegen/meta/src/shared/immediates.rs
+++ b/cranelift-codegen/meta/src/shared/immediates.rs
@@ -71,10 +71,10 @@ pub fn define() -> Vec<OperandKind> {
     let mut intcc_values = HashMap::new();
     intcc_values.insert("eq", "Equal");
     intcc_values.insert("ne", "NotEqual");
-    intcc_values.insert("sge", "UnsignedGreaterThanOrEqual");
-    intcc_values.insert("sgt", "UnsignedGreaterThan");
-    intcc_values.insert("sle", "UnsignedLessThanOrEqual");
-    intcc_values.insert("slt", "UnsignedLessThan");
+    intcc_values.insert("sge", "SignedGreaterThanOrEqual");
+    intcc_values.insert("sgt", "SignedGreaterThan");
+    intcc_values.insert("sle", "SignedLessThanOrEqual");
+    intcc_values.insert("slt", "SignedLessThan");
     intcc_values.insert("uge", "UnsignedGreaterThanOrEqual");
     intcc_values.insert("ugt", "UnsignedGreaterThan");
     intcc_values.insert("ule", "UnsignedLessThanOrEqual");

--- a/cranelift-codegen/meta/src/srcgen.rs
+++ b/cranelift-codegen/meta/src/srcgen.rs
@@ -80,9 +80,9 @@ impl Formatter {
     /// Get a string containing whitespace outdented one level. Used for
     /// lines of code that are inside a single indented block.
     fn _get_outdent(&mut self) -> String {
-        self.indent_push();
-        let s = self.get_indent();
         self.indent_pop();
+        let s = self.get_indent();
+        self.indent_push();
         s
     }
 
@@ -99,7 +99,7 @@ impl Formatter {
 
     /// Emit a line outdented one level.
     pub fn _outdented_line(&mut self, s: &str) {
-        let new_line = format!("{}{}", self._get_outdent(), s);
+        let new_line = format!("{}{}\n", self._get_outdent(), s);
         self.lines.push(new_line);
     }
 


### PR DESCRIPTION
This simple PR:

- fixes a bad copy/pasto in the definition of condition codes immediates.
- makes the Var class constructor simpler in the Python code (it was merely to understand more if it was needed, and to make sure that tests were still passing without it).
- wraps/adds comments in `cdsl/formats.rs`
- fix outended_line in srcgen.rs, which was inverted.