### PR TITLE
Fixes #738: Check ebbs used in jump tables in the verifier

### DIFF
--- a/filetests/verifier/jump_table.clif
+++ b/filetests/verifier/jump_table.clif
@@ -1,0 +1,19 @@
+test verifier
+
+function %br_invalid_default(i64) {
+    jt0 = jump_table [ebb1, ebb1]
+
+ebb0(v0: i64):
+    br_table.i64 v0, ebb2, jt0 ; error: invalid ebb reference ebb2
+ebb1:
+    return
+}
+
+function %br(i64) {
+    jt0 = jump_table [ebb1, ebb2] ; error: invalid ebb reference ebb2
+
+ebb0(v0: i64):
+    br_table.i64 v0, ebb1, jt0
+ebb1:
+    return
+}


### PR DESCRIPTION
edit: I also found a similar issue with the default EBB in the branch_table instruction, so there's also a test for this.

@tyler mind to have a look, please? Thanks!