### PR TITLE
Expose function definitions, populate FaerieCompiledFunction

### DIFF
--- a/cranelift-faerie/src/backend.rs
+++ b/cranelift-faerie/src/backend.rs
@@ -96,7 +96,15 @@ pub struct FaerieBackend {
     libcall_names: Box<Fn(ir::LibCall) -> String>,
 }
 
-pub struct FaerieCompiledFunction {}
+pub struct FaerieCompiledFunction {
+    code_length: u32,
+}
+
+impl FaerieCompiledFunction {
+    pub fn code_length(&self) -> u32 {
+        self.code_length
+    }
+}
 
 pub struct FaerieCompiledData {}
 
@@ -187,10 +195,14 @@ impl Backend for FaerieBackend {
             }
         }
 
+        // because `define` will take ownership of code, this is our last chance
+        let code_length = code.len() as u32;
+
         self.artifact
             .define(name, code)
             .expect("inconsistent declaration");
-        Ok(FaerieCompiledFunction {})
+
+        Ok(FaerieCompiledFunction { code_length })
     }
 
     fn define_data(

--- a/cranelift-module/src/lib.rs
+++ b/cranelift-module/src/lib.rs
@@ -40,7 +40,8 @@ mod module;
 pub use crate::backend::Backend;
 pub use crate::data_context::{DataContext, DataDescription, Init};
 pub use crate::module::{
-    DataId, FuncId, FuncOrDataId, Linkage, Module, ModuleError, ModuleNamespace, ModuleResult,
+    DataId, FuncId, FuncOrDataId, Linkage, Module, ModuleError, ModuleFunction, ModuleNamespace,
+    ModuleResult,
 };
 
 /// Version number of this crate.

--- a/cranelift-module/src/module.rs
+++ b/cranelift-module/src/module.rs
@@ -153,14 +153,14 @@ pub enum ModuleError {
 pub type ModuleResult<T> = Result<T, ModuleError>;
 
 /// A function belonging to a `Module`.
-struct ModuleFunction<B>
+pub struct ModuleFunction<B>
 where
     B: Backend,
 {
     /// The function declaration.
-    decl: FunctionDeclaration,
+    pub decl: FunctionDeclaration,
     /// The compiled artifact, once it's available.
-    compiled: Option<B::CompiledFunction>,
+    pub compiled: Option<B::CompiledFunction>,
 }
 
 impl<B> ModuleFunction<B>
@@ -425,6 +425,11 @@ where
                 Ok(id)
             }
         }
+    }
+
+    /// An iterator over functions that have been declared in this module.
+    pub fn declared_functions(&self) -> core::slice::Iter<'_, ModuleFunction<B>> {
+        self.contents.functions.values()
     }
 
     /// Declare a data object in this module.


### PR DESCRIPTION
Hi! I'm working on some [changes](https://github.com/fastly/lucet/pull/136) for Lucet that need to get at the whole list of compiled functions after they've been translated to the target architecture.

This is a pair of changes that does that, and also populates `FaerieCompiledFunction` with the same kinds of data as `SimpleJITCompiledFunction`. I really just need function sizes, but I figure making them consistent keeping the code bytes in `FaerieCompiledFunction` too couldn't hurt.