### PR TITLE
Avoid inserting checks during div/rem legalization

### DIFF
--- a/filetests/isa/x86/legalize-div-traps.clif
+++ b/filetests/isa/x86/legalize-div-traps.clif
@@ -19,6 +19,32 @@ ebb0(v0: i64, v1: i64):
     ; nextln: return $d
 }
 
+function %udiv_0(i64) -> i64 {
+ebb0(v0: i64):
+    ; check: ebb0(
+    v1 = iconst.i64 0
+    ; nextln: v1 = iconst.i64 0
+    v2 = udiv v0, v1
+    ; nextln: $(fz=$V) = ifcmp_imm v1, 0
+    ; nextln: trapif eq $fz, int_divz
+    ; nextln: $(hi=$V) = iconst.i64 0
+    ; nextln: $(d=$V), $(r=$V) = x86_udivmodx v0, $hi, v1
+    return v2
+    ; nextln: return $d
+}
+
+function %udiv_minus_1(i64) -> i64 {
+ebb0(v0: i64):
+    ; check: ebb0(
+    v1 = iconst.i64 -1
+    ; nextln: v1 = iconst.i64 -1
+    v2 = udiv v0, v1
+    ; nextln: $(hi=$V) = iconst.i64 0
+    ; nextln: $(d=$V), $(r=$V) = x86_udivmodx v0, $hi, v1
+    return v2
+    ; nextln: return $d
+}
+
 function %urem(i64, i64) -> i64 {
 ebb0(v0: i64, v1: i64):
     ; check: ebb0(
@@ -31,14 +57,74 @@ ebb0(v0: i64, v1: i64):
     ; nextln: return $r
 }
 
+function %urem_0(i64) -> i64 {
+ebb0(v0: i64):
+    ; check: ebb0(
+    v1 = iconst.i64 0
+    ; nextln: v1 = iconst.i64 0
+    v2 = urem v0, v1
+    ; nextln: $(fz=$V) = ifcmp_imm v1, 0
+    ; nextln: trapif eq $fz, int_divz
+    ; nextln: $(hi=$V) = iconst.i64 0
+    ; nextln: $(d=$V), $(r=$V) = x86_udivmodx v0, $hi, v1
+    return v2
+    ; nextln: return $r
+}
+
+function %urem_minus_1(i64) -> i64 {
+ebb0(v0: i64):
+    ; check: ebb0(
+    v1 = iconst.i64 -1
+    ; nextln: v1 = iconst.i64 -1
+    v2 = urem v0, v1
+    ; nextln: $(hi=$V) = iconst.i64 0
+    ; nextln: $(d=$V), $(r=$V) = x86_udivmodx v0, $hi, v1
+    return v2
+    ; nextln: return $r
+}
+
 function %sdiv(i64, i64) -> i64 {
 ebb0(v0: i64, v1: i64):
     ; check: ebb0(
     v2 = sdiv v0, v1
-    ; nextln: $(fm1=$V) = ifcmp_imm v1, -1
-    ; nextln: brif eq $fm1, $(m1=$EBB)
     ; nextln: $(fz=$V) = ifcmp_imm v1, 0
     ; nextln: trapif eq $fz, int_divz
+    ; nextln: $(fm1=$V) = ifcmp_imm v1, -1
+    ; nextln: brif eq $fm1, $(m1=$EBB)
+    ; check: $(hi=$V) = sshr_imm
+    ; nextln: $(q=$V), $(r=$V) = x86_sdivmodx v0, $hi, v1
+    ; nextln: jump $(done=$EBB)($q)
+    ; check: $m1:
+    ; nextln: $(imin=$V) = iconst.i64 0x8000_0000_0000_0000
+    ; nextln: $(fm=$V) = ifcmp.i64 v0, $imin
+    ; nextln: trapif eq $fm, int_ovf
+    ; check: $done(v2: i64):
+    return v2
+    ; nextln: return v2
+}
+
+function %sdiv_0(i64) -> i64 {
+ebb0(v0: i64):
+    ; check: ebb0(
+    v1 = iconst.i64 0
+    ; nextln: v1 = iconst.i64 0
+    v2 = sdiv v0, v1
+    ; nextln: $(fz=$V) = ifcmp_imm v1, 0
+    ; nextln: trapif eq $fz, int_divz
+    ; check: $(hi=$V) = sshr_imm
+    ; nextln: $(q=$V), $(r=$V) = x86_sdivmodx v0, $hi, v1
+    return v2
+    ; nextln: return v2
+}
+
+function %sdiv_minus_1(i64) -> i64 {
+ebb0(v0: i64):
+    ; check: ebb0(
+    v1 = iconst.i64 -1
+    ; nextln: v1 = iconst.i64 -1
+    v2 = sdiv v0, v1
+    ; nextln: $(fm1=$V) = ifcmp_imm v1, -1
+    ; nextln: brif eq $fm1, $(m1=$EBB)
     ; check: $(hi=$V) = sshr_imm
     ; nextln: $(q=$V), $(r=$V) = x86_sdivmodx v0, $hi, v1
     ; nextln: jump $(done=$EBB)($q)
@@ -56,6 +142,41 @@ ebb0(v0: i64, v1: i64):
 function %srem(i64, i64) -> i64 {
 ebb0(v0: i64, v1: i64):
     ; check: ebb0(
+    v2 = srem v0, v1
+    ; nextln: $(fz=$V) = ifcmp_imm v1, 0
+    ; nextln: trapif eq $fz, int_divz
+    ; nextln: $(fm1=$V) = ifcmp_imm v1, -1
+    ; nextln: brif eq $fm1, $(m1=$EBB)
+    ; check: $(hi=$V) = sshr_imm
+    ; nextln: $(d=$V), $(r=$V) = x86_sdivmodx v0, $hi, v1
+    ; nextln: jump $(done=$EBB)($r)
+    ; check: $m1:
+    ; nextln: $(zero=$V) = iconst.i64 0
+    ; nextln: jump $(done=$EBB)($zero)
+    ; check: $done(v2: i64):
+    return v2
+    ; nextln: return v2
+}
+
+function %srem_0(i64) -> i64 {
+ebb0(v0: i64):
+    ; check: ebb0(
+    v1 = iconst.i64 0
+    ; nextln: v1 = iconst.i64 0
+    v2 = srem v0, v1
+    ; nextln: $(fz=$V) = ifcmp_imm v1, 0
+    ; nextln: trapif eq $fz, int_divz
+    ; check: $(hi=$V) = sshr_imm
+    ; nextln: $(d=$V), $(r=$V) = x86_sdivmodx v0, $hi, v1
+    return v2
+    ; nextln: return v2
+}
+
+function %srem_minus_1(i64) -> i64 {
+ebb0(v0: i64):
+    ; check: ebb0(
+    v1 = iconst.i64 -1
+    ; nextln: v1 = iconst.i64 -1
     v2 = srem v0, v1
     ; nextln: $(fm1=$V) = ifcmp_imm v1, -1
     ; nextln: brif eq $fm1, $(m1=$EBB)


### PR DESCRIPTION
 ... when the input is a constant immediate.