### PR TITLE
Clarify that FixedTied constraints are not Tied

### DIFF
--- a/cranelift-codegen/src/isa/constraints.rs
+++ b/cranelift-codegen/src/isa/constraints.rs
@@ -105,13 +105,13 @@ pub struct RecipeConstraints {
     /// constraints must be derived from the calling convention ABI.
     pub outs: &'static [OperandConstraint],
 
-    /// Are any of the input constraints `FixedReg`?
+    /// Are any of the input constraints `FixedReg` or `FixedTied`?
     pub fixed_ins: bool,
 
-    /// Are any of the output constraints `FixedReg`?
+    /// Are any of the output constraints `FixedReg` or `FixedTied`?
     pub fixed_outs: bool,
 
-    /// Are there any tied operands?
+    /// Are any of the input/output constraints `Tied`?
     pub tied_ops: bool,
 
     /// Does this instruction clobber the CPU flags?

--- a/cranelift-codegen/src/isa/constraints.rs
+++ b/cranelift-codegen/src/isa/constraints.rs
@@ -111,7 +111,7 @@ pub struct RecipeConstraints {
     /// Are any of the output constraints `FixedReg` or `FixedTied`?
     pub fixed_outs: bool,
 
-    /// Are any of the input/output constraints `Tied`?
+    /// Are any of the input/output constraints `Tied` (but not `FixedTied`)?
     pub tied_ops: bool,
 
     /// Does this instruction clobber the CPU flags?


### PR DESCRIPTION
What I mean is, `ConstraintKind::Tied` forces the `tied_ops` flags to be true, but `ConstraintKind::FixedTied` does not - it only forces `fixed_ins` or `fixed_outs`, as the case may be.  (These appear only to be used in coloring, and `tied_ops` and `fixed_outs` are only used once each, while `fixed_ins` is not used at all.)