### PR TITLE
[wasm] Have the WasmError::User member be a String

### DIFF
--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -27,7 +27,7 @@ target-lexicon = "0.4.0"
 
 [features]
 default = ["std"]
-std = ["cranelift-codegen/std", "cranelift-frontend/std", "wasmparser/std", "failure/std"]
+std = ["cranelift-codegen/std", "cranelift-frontend/std", "wasmparser/std"]
 core = ["hashmap_core", "cranelift-codegen/core", "cranelift-frontend/core", "wasmparser/core"]
 
 [badges]

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -68,17 +68,9 @@ pub enum WasmError {
     #[fail(display = "Implementation limit exceeded")]
     ImplLimitExceeded,
 
-    /// Any user-defined error. Requires an std build, where failure::Error is defined.
-    #[cfg(feature = "std")]
+    /// Any user-defined error.
     #[fail(display = "User error: {}", _0)]
-    User(failure::Error),
-}
-
-#[cfg(feature = "std")]
-impl From<failure::Error> for WasmError {
-    fn from(err: failure::Error) -> Self {
-        WasmError::User(err)
-    }
+    User(std::string::String),
 }
 
 impl From<BinaryReaderError> for WasmError {


### PR DESCRIPTION
As said on IRC, using `failure::Error` requires to have the `failure/std` feature set, which adds an old version of `backtrace` as a crate dependency. In addition to supplementary compilation cost (the build is longer!), it also means that some platforms won't quite work: windows aarch64 in particular doesn't plain work.

A few options I've considered:

- go the hard, open-source way, and update `backtrace` in `failure` etc. This would be my preferred way to do things, but that implies a lot of reliance on external factors (`failure` accepting the pull request, releasing a new version etc.) and our work (on Spidermonkey) is unfortunately blocked by this. So I've removed the one use of the `failure::Error` in the code, and the `failure/std` dependency.
- instead of having a `failure::Error`, this could be a `Box<failure::Fail>` or `Box<error::Error + Sync + Send>`.
- or a plain `String`, which also works in non-std builds. I've chosen this path since our use cases don't indicate a clear preference over one way or the other (so I've concluded that the simplest would be best), but I'm open to other opinions.

Anyway, I'd be happy to hear people's thoughts about this.