### PR TITLE
Add x86 encoding for rotr_imm and rotl_imm.

### DIFF
--- a/cranelift-codegen/meta-python/isa/x86/encodings.py
+++ b/cranelift-codegen/meta-python/isa/x86/encodings.py
@@ -233,6 +233,8 @@ for inst,           rrr in [
     X86_64.enc(inst.i32.any, *r.rc(0xd3, rrr=rrr))
 
 for inst,           rrr in [
+        (base.rotl_imm, 0),
+        (base.rotr_imm, 1),
         (base.ishl_imm, 4),
         (base.ushr_imm, 5),
         (base.sshr_imm, 7)]:

--- a/filetests/isa/x86/binary32.clif
+++ b/filetests/isa/x86/binary32.clif
@@ -432,6 +432,12 @@ ebb0:
     ; asm: shrl $8, %esi
     [-,%rsi]             v515 = ushr_imm v2, 8    ; bin: c1 ee 08
 
+    ; Rotate immediates
+    ; asm: rolq $12, %esi
+    [-,%rsi]             v5101 = rotl_imm v2, 12   ; bin: c1 c6 0c
+    ; asm: rorq $5, %esi
+    [-,%rsi]             v5103 = rotr_imm v2, 5    ; bin: c1 ce 05
+
     ; Load Complex
     [-,%rax]            v521 = iconst.i32 1
     [-,%rbx]            v522 = iconst.i32 1

--- a/filetests/isa/x86/binary64.clif
+++ b/filetests/isa/x86/binary64.clif
@@ -602,6 +602,17 @@ ebb0:
     [-,%r8]              v520 = ushr_imm v4, 63   ; bin: 49 c1 e8 3f
 
 
+    ; Rotate immediates
+    ; asm: rolq $12, %rsi
+    [-,%rsi]             v5101 = rotl_imm v2, 12   ; bin: 48 c1 c6 0c
+    ; asm: rolq $13, %r8
+    [-,%r8]              v5102 = rotl_imm v4, 13   ; bin: 49 c1 c0 0d
+    ; asm: rorq $32, %rsi
+    [-,%rsi]             v5103 = rotr_imm v2, 32   ; bin: 48 c1 ce 20
+    ; asm: rorq $33, %r8
+    [-,%r8]              v5104 = rotr_imm v4, 33   ; bin: 49 c1 c8 21
+
+
     ; Load Complex
     [-,%rax]            v521 = iconst.i64 1
     [-,%rbx]            v522 = iconst.i64 1

--- a/filetests/isa/x86/legalize-rotate.clif
+++ b/filetests/isa/x86/legalize-rotate.clif
@@ -1,0 +1,35 @@
+test compile
+target x86_64
+
+; regex: V=v\d+
+; regex: R=%[a-z0-9]+
+
+function %i32_rotr(i32, i32) -> i32 fast {
+ebb0(v0: i32, v1: i32):
+    ; check: regmove v1, $R -> %rcx
+    ; check: v2 = rotr v0, v1
+    v2 = rotr v0, v1
+    return v2
+}
+
+function %i32_rotr_imm_1(i32) -> i32 fast {
+ebb0(v0: i32):
+    ; check: $V = rotr_imm v0, 1
+    v2 = rotr_imm v0, 1
+    return v2
+}
+
+function %i32_rotl(i32, i32) -> i32 fast {
+ebb0(v0: i32, v1: i32):
+    ; check: regmove v1, $R -> %rcx
+    ; check: v2 = rotl v0, v1
+    v2 = rotl v0, v1
+    return v2
+}
+
+function %i32_rotl_imm_1(i32) -> i32 fast {
+ebb0(v0: i32):
+    ; check: $V = rotl_imm v0, 1
+    v2 = rotl_imm v0, 1
+    return v2
+}


### PR DESCRIPTION
While looking at #526, I noticed that x86 encoding does not exists for rotation with immediate values.
This pull request is adding encoding for left and right rotation with immediate value, as well as test cases to check that we legalize & generate the expected bytes.

However, I have no idea if the current python rules for encoding have any checks for the validity of the immediate value range.
