### PR TITLE
[meta] bind() should be a {Bound,}Instruction method and not a static func

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -1,5 +1,5 @@
 use crate::cdsl::formats::FormatRegistry;
-use crate::cdsl::inst::{ApplyTarget, Instruction, InstructionPredicate};
+use crate::cdsl::inst::{InstSpec, Instruction, InstructionPredicate};
 use crate::cdsl::operands::{OperandKind, OperandKindFields};
 use crate::cdsl::types::ValueType;
 use crate::cdsl::typevar::{TypeSetBuilder, TypeVar};
@@ -375,10 +375,10 @@ pub struct Apply {
 }
 
 impl Apply {
-    pub fn new(target: ApplyTarget, args: Vec<Expr>) -> Self {
+    pub fn new(target: InstSpec, args: Vec<Expr>) -> Self {
         let (inst, value_types) = match target.into() {
-            ApplyTarget::Inst(inst) => (inst, Vec::new()),
-            ApplyTarget::Bound(bound_inst) => (bound_inst.inst, bound_inst.value_types),
+            InstSpec::Inst(inst) => (inst, Vec::new()),
+            InstSpec::Bound(bound_inst) => (bound_inst.inst, bound_inst.value_types),
         };
 
         // Basic check on number of arguments.
@@ -520,7 +520,7 @@ impl Apply {
 pub enum DummyExpr {
     Var(DummyVar),
     Literal(Literal),
-    Apply(ApplyTarget, Vec<DummyExpr>),
+    Apply(InstSpec, Vec<DummyExpr>),
 }
 
 #[derive(Clone)]
@@ -553,7 +553,7 @@ pub struct ExprBuilder {
 }
 
 impl ExprBuilder {
-    pub fn apply(inst: ApplyTarget, args: Vec<DummyExpr>) -> Self {
+    pub fn apply(inst: InstSpec, args: Vec<DummyExpr>) -> Self {
         let expr = DummyExpr::Apply(inst, args);
         Self { expr }
     }

--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -1,7 +1,7 @@
 use crate::cdsl::formats::FormatRegistry;
-use crate::cdsl::inst::{BoundInstruction, Instruction, InstructionPredicate};
+use crate::cdsl::inst::{ApplyTarget, Instruction, InstructionPredicate};
 use crate::cdsl::operands::{OperandKind, OperandKindFields};
-use crate::cdsl::types::{LaneType, ValueType};
+use crate::cdsl::types::ValueType;
 use crate::cdsl::typevar::{TypeSetBuilder, TypeVar};
 
 use cranelift_entity::{entity_impl, PrimaryMap};
@@ -362,62 +362,6 @@ impl VarPool {
     pub fn create(&mut self, name: &'static str) -> VarIndex {
         self.pool.push(Var::new(name))
     }
-}
-
-pub enum ApplyTarget {
-    Inst(Instruction),
-    Bound(BoundInstruction),
-}
-
-impl ApplyTarget {
-    pub fn inst(&self) -> &Instruction {
-        match &self {
-            ApplyTarget::Inst(inst) => inst,
-            ApplyTarget::Bound(bound_inst) => &bound_inst.inst,
-        }
-    }
-}
-
-impl Into<ApplyTarget> for &Instruction {
-    fn into(self) -> ApplyTarget {
-        ApplyTarget::Inst(self.clone())
-    }
-}
-
-impl Into<ApplyTarget> for BoundInstruction {
-    fn into(self) -> ApplyTarget {
-        ApplyTarget::Bound(self)
-    }
-}
-
-pub fn bind(target: impl Into<ApplyTarget>, lane_type: impl Into<LaneType>) -> BoundInstruction {
-    let value_type = ValueType::from(lane_type.into());
-
-    let (inst, value_types) = match target.into() {
-        ApplyTarget::Inst(inst) => (inst, vec![value_type]),
-        ApplyTarget::Bound(bound_inst) => {
-            let mut new_value_types = bound_inst.value_types;
-            new_value_types.push(value_type);
-            (bound_inst.inst, new_value_types)
-        }
-    };
-
-    match &inst.polymorphic_info {
-        Some(poly) => {
-            assert!(
-                value_types.len() <= 1 + poly.other_typevars.len(),
-                format!("trying to bind too many types for {}", inst.name)
-            );
-        }
-        None => {
-            panic!(format!(
-                "trying to bind a type for {} which is not a polymorphic instruction",
-                inst.name
-            ));
-        }
-    }
-
-    BoundInstruction { inst, value_types }
 }
 
 /// Apply an instruction to arguments.

--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -574,7 +574,7 @@ macro_rules! def_rhs {
 
     // inst.type(a, b, c)
     ($inst:ident.$type:ident($($src:expr),*)) => {
-        ExprBuilder::apply(bind($inst, $type).into(), vec![$($src.clone().into()),*])
+        ExprBuilder::apply($inst.bind($type).into(), vec![$($src.clone().into()),*])
     };
 }
 

--- a/cranelift-codegen/meta/src/cdsl/inst.rs
+++ b/cranelift-codegen/meta/src/cdsl/inst.rs
@@ -599,38 +599,39 @@ impl InstructionPredicate {
     }
 }
 
-pub enum ApplyTarget {
+/// An instruction specification, containing an instruction that has bound types or not.
+pub enum InstSpec {
     Inst(Instruction),
     Bound(BoundInstruction),
 }
 
-impl ApplyTarget {
+impl InstSpec {
     pub fn inst(&self) -> &Instruction {
         match &self {
-            ApplyTarget::Inst(inst) => inst,
-            ApplyTarget::Bound(bound_inst) => &bound_inst.inst,
+            InstSpec::Inst(inst) => inst,
+            InstSpec::Bound(bound_inst) => &bound_inst.inst,
         }
     }
 }
 
-impl Into<ApplyTarget> for &Instruction {
-    fn into(self) -> ApplyTarget {
-        ApplyTarget::Inst(self.clone())
+impl Into<InstSpec> for &Instruction {
+    fn into(self) -> InstSpec {
+        InstSpec::Inst(self.clone())
     }
 }
 
-impl Into<ApplyTarget> for BoundInstruction {
-    fn into(self) -> ApplyTarget {
-        ApplyTarget::Bound(self)
+impl Into<InstSpec> for BoundInstruction {
+    fn into(self) -> InstSpec {
+        InstSpec::Bound(self)
     }
 }
 
-pub fn bind(target: impl Into<ApplyTarget>, lane_type: impl Into<LaneType>) -> BoundInstruction {
+pub fn bind(target: impl Into<InstSpec>, lane_type: impl Into<LaneType>) -> BoundInstruction {
     let value_type = ValueType::from(lane_type.into());
 
     let (inst, value_types) = match target.into() {
-        ApplyTarget::Inst(inst) => (inst, vec![value_type]),
-        ApplyTarget::Bound(bound_inst) => {
+        InstSpec::Inst(inst) => (inst, vec![value_type]),
+        InstSpec::Bound(bound_inst) => {
             let mut new_value_types = bound_inst.value_types;
             new_value_types.push(value_type);
             (bound_inst.inst, new_value_types)

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -1,5 +1,5 @@
 use crate::cdsl::ast::{var, ExprBuilder, Literal};
-use crate::cdsl::inst::{bind, InstructionGroup};
+use crate::cdsl::inst::InstructionGroup;
 use crate::cdsl::xform::TransformGroupBuilder;
 
 use crate::shared::types::Int::{I32, I64};

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -1,5 +1,5 @@
-use crate::cdsl::ast::{bind, var, ExprBuilder, Literal};
-use crate::cdsl::inst::InstructionGroup;
+use crate::cdsl::ast::{var, ExprBuilder, Literal};
+use crate::cdsl::inst::{bind, InstructionGroup};
 use crate::cdsl::xform::TransformGroupBuilder;
 
 use crate::shared::types::Int::{I32, I64};

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -1,5 +1,5 @@
 use crate::cdsl::ast::{var, ExprBuilder, Literal};
-use crate::cdsl::inst::{bind, Instruction, InstructionGroup};
+use crate::cdsl::inst::{Instruction, InstructionGroup};
 use crate::cdsl::xform::{TransformGroupBuilder, TransformGroups};
 
 use crate::shared::OperandKinds;
@@ -352,7 +352,7 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
     for &extend_op in &[uextend, sextend] {
         // The sign extension operators have two typevars: the result has one and controls the
         // instruction, then the input has one.
-        let bound = bind(bind(extend_op, I16), I8);
+        let bound = extend_op.bind(I16).bind(I8);
         widen.legalize(
             def!(a = bound(b)),
             vec![def!(c = extend_op.I32(b)), def!(a = ireduce(c))],
@@ -520,7 +520,7 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
     // group.
     for &dest_ty in &[F32, F64] {
         for &src_ty in &[I8, I16] {
-            let bound_inst = bind(bind(fcvt_from_uint, dest_ty), src_ty);
+            let bound_inst = fcvt_from_uint.bind(dest_ty).bind(src_ty);
             expand.legalize(
                 def!(a = bound_inst(b)),
                 vec![
@@ -529,7 +529,7 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
                 ],
             );
 
-            let bound_inst = bind(bind(fcvt_from_sint, dest_ty), src_ty);
+            let bound_inst = fcvt_from_sint.bind(dest_ty).bind(src_ty);
             expand.legalize(
                 def!(a = bound_inst(b)),
                 vec![

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -1,5 +1,5 @@
-use crate::cdsl::ast::{bind, var, ExprBuilder, Literal};
-use crate::cdsl::inst::{Instruction, InstructionGroup};
+use crate::cdsl::ast::{var, ExprBuilder, Literal};
+use crate::cdsl::inst::{bind, Instruction, InstructionGroup};
 use crate::cdsl::xform::{TransformGroupBuilder, TransformGroups};
 
 use crate::shared::OperandKinds;


### PR DESCRIPTION
It's neater and avoids the extra `bind` import when it's needed. @nbp I think you wanted something like this when we looked at a previous PR, so asking you for review please :)