### PR TITLE
Generalize information about compiled code

### DIFF
--- a/cranelift-codegen/src/binemit/mod.rs
+++ b/cranelift-codegen/src/binemit/mod.rs
@@ -33,6 +33,8 @@ pub enum Reloc {
     Abs8,
     /// x86 PC-relative 4-byte
     X86PCRel4,
+    /// x86 PC-relative 4-byte offset to trailing rodata
+    X86PCRelRodata4,
     /// x86 call to PC-relative 4-byte
     X86CallPCRel4,
     /// x86 call to PLT-relative 4-byte
@@ -55,11 +57,44 @@ impl fmt::Display for Reloc {
             Reloc::Abs4 => write!(f, "Abs4"),
             Reloc::Abs8 => write!(f, "Abs8"),
             Reloc::X86PCRel4 => write!(f, "PCRel4"),
+            Reloc::X86PCRelRodata4 => write!(f, "PCRelRodata4"),
             Reloc::X86CallPCRel4 => write!(f, "CallPCRel4"),
             Reloc::X86CallPLTRel4 => write!(f, "CallPLTRel4"),
             Reloc::X86GOTPCRel4 => write!(f, "GOTPCRel4"),
             Reloc::Arm32Call | Reloc::Arm64Call | Reloc::RiscvCall => write!(f, "Call"),
         }
+    }
+}
+
+/// Container for information about a vector of compiled code and its supporting read-only data.
+///
+/// The code starts at offset 0 and is followed optionally by relocatable jump tables and copyable
+/// (raw binary) read-only data.  Any padding between sections is always part of the section that
+/// precedes the boundary between the sections.
+#[derive(PartialEq)]
+pub struct CodeInfo {
+    /// Number of bytes of machine code (the code starts at offset 0).
+    pub code_size: CodeOffset,
+
+    /// Number of bytes of jumptables.
+    pub jumptables_size: CodeOffset,
+
+    /// Number of bytes of rodata.
+    pub rodata_size: CodeOffset,
+
+    /// Number of bytes in total.
+    pub total_size: CodeOffset,
+}
+
+impl CodeInfo {
+    /// Offset of any relocatable jump tables, or equal to rodata if there are no jump tables.
+    pub fn jumptables(&self) -> CodeOffset {
+        self.code_size
+    }
+
+    /// Offset of any copyable read-only data, or equal to total_size if there are no rodata.
+    pub fn rodata(&self) -> CodeOffset {
+        self.code_size + self.jumptables_size
     }
 }
 
@@ -95,8 +130,14 @@ pub trait CodeSink {
     /// Add trap information for the current offset.
     fn trap(&mut self, _: TrapCode, _: SourceLoc);
 
-    /// Code output is complete, read-only data may follow.
+    /// Machine code output is complete, jump table data may follow.
+    fn begin_jumptables(&mut self);
+
+    /// Jump table output is complete, raw read-only data may follow.
     fn begin_rodata(&mut self);
+
+    /// Read-only data output is complete, we're done.
+    fn end_codegen(&mut self);
 }
 
 /// Report a bad encoding error.
@@ -127,7 +168,7 @@ where
         }
     }
 
-    sink.begin_rodata();
+    sink.begin_jumptables();
 
     // output jump tables
     for (jt, jt_data) in func.jump_tables.iter() {
@@ -137,4 +178,9 @@ where
             sink.put4(rel_offset as u32)
         }
     }
+
+    sink.begin_rodata();
+    // TODO: No read-only data (constant pools) at this time.
+
+    sink.end_codegen();
 }

--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -10,7 +10,7 @@
 //! single ISA instance.
 
 use crate::binemit::{
-    relax_branches, shrink_instructions, CodeOffset, MemoryCodeSink, RelocSink, TrapSink,
+    relax_branches, shrink_instructions, CodeInfo, MemoryCodeSink, RelocSink, TrapSink,
 };
 use crate::dce::do_dce;
 use crate::dominator_tree::DominatorTree;
@@ -93,20 +93,21 @@ impl Context {
     /// This function calls `compile` and `emit_to_memory`, taking care to resize `mem` as
     /// needed, so it provides a safe interface.
     ///
-    /// Returns the size of the function's code and the size of the read-only data.
+    /// Returns information about the function's code and read-only data.
     pub fn compile_and_emit(
         &mut self,
         isa: &TargetIsa,
         mem: &mut Vec<u8>,
         relocs: &mut RelocSink,
         traps: &mut TrapSink,
-    ) -> CodegenResult<(CodeOffset, CodeOffset)> {
-        let total_size = self.compile(isa)?;
+    ) -> CodegenResult<CodeInfo> {
+        let info = self.compile(isa)?;
         let old_len = mem.len();
-        mem.resize(old_len + total_size as usize, 0);
-        let code_size =
+        mem.resize(old_len + info.total_size as usize, 0);
+        let new_info =
             unsafe { self.emit_to_memory(isa, mem.as_mut_ptr().add(old_len), relocs, traps) };
-        Ok((code_size, total_size - code_size))
+        debug_assert!(new_info == info);
+        Ok(info)
     }
 
     /// Compile the function.
@@ -115,8 +116,8 @@ impl Context {
     /// represented by `isa`. This does not include the final step of emitting machine code into a
     /// code sink.
     ///
-    /// Returns the size of the function's code and read-only data.
-    pub fn compile(&mut self, isa: &TargetIsa) -> CodegenResult<CodeOffset> {
+    /// Returns information about the function's code and read-only data.
+    pub fn compile(&mut self, isa: &TargetIsa) -> CodegenResult<CodeInfo> {
         let _tt = timing::compile();
         self.verify_if(isa)?;
 
@@ -160,18 +161,18 @@ impl Context {
     /// This function is unsafe since it does not perform bounds checking on the memory buffer,
     /// and it can't guarantee that the `mem` pointer is valid.
     ///
-    /// Returns the size of the function's code.
+    /// Returns information about the emitted code and data.
     pub unsafe fn emit_to_memory(
         &self,
         isa: &TargetIsa,
         mem: *mut u8,
         relocs: &mut RelocSink,
         traps: &mut TrapSink,
-    ) -> CodeOffset {
+    ) -> CodeInfo {
         let _tt = timing::binemit();
         let mut sink = MemoryCodeSink::new(mem, relocs, traps);
         isa.emit_function_to_memory(&self.func, &mut sink);
-        sink.code_size as CodeOffset
+        sink.info
     }
 
     /// Run the verifier on the function.
@@ -325,12 +326,13 @@ impl Context {
         Ok(())
     }
 
-    /// Run the branch relaxation pass and return the final code size.
-    pub fn relax_branches(&mut self, isa: &TargetIsa) -> CodegenResult<CodeOffset> {
-        let code_size = relax_branches(&mut self.func, isa)?;
+    /// Run the branch relaxation pass and return information about the function's code and
+    /// read-only data.
+    pub fn relax_branches(&mut self, isa: &TargetIsa) -> CodegenResult<CodeInfo> {
+        let info = relax_branches(&mut self.func, isa)?;
         self.verify_if(isa)?;
         self.verify_locations_if(isa)?;
-        Ok(code_size)
+        Ok(info)
     }
 
     /// Builds ranges and location for specified value labels.

--- a/cranelift-codegen/src/isa/x86/binemit.rs
+++ b/cranelift-codegen/src/isa/x86/binemit.rs
@@ -339,4 +339,5 @@ fn disp4<CS: CodeSink + ?Sized>(destination: Ebb, func: &Function, sink: &mut CS
 fn jt_disp4<CS: CodeSink + ?Sized>(jt: JumpTable, func: &Function, sink: &mut CS) {
     let delta = func.jt_offsets[jt].wrapping_sub(sink.offset() + 4);
     sink.put4(delta);
+    sink.reloc_jt(Reloc::X86PCRelRodata4, jt);
 }

--- a/cranelift-faerie/src/backend.rs
+++ b/cranelift-faerie/src/backend.rs
@@ -138,9 +138,9 @@ impl Backend for FaerieBackend {
         name: &str,
         ctx: &cranelift_codegen::Context,
         namespace: &ModuleNamespace<Self>,
-        code_size: u32,
+        total_size: u32,
     ) -> ModuleResult<FaerieCompiledFunction> {
-        let mut code: Vec<u8> = vec![0; code_size as usize];
+        let mut code: Vec<u8> = vec![0; total_size as usize];
 
         // Non-lexical lifetimes would obviate the braces here.
         {
@@ -153,7 +153,7 @@ impl Backend for FaerieBackend {
             };
 
             if let Some(ref mut trap_manifest) = self.trap_manifest {
-                let mut trap_sink = FaerieTrapSink::new(name, code_size);
+                let mut trap_sink = FaerieTrapSink::new(name, total_size);
                 unsafe {
                     ctx.emit_to_memory(
                         &*self.isa,

--- a/filetests/isa/x86/binary64.clif
+++ b/filetests/isa/x86/binary64.clif
@@ -1424,8 +1424,8 @@ function %I64_JT(i64 [%rdi]) {
 ebb0(v0: i64 [%rdi]):
     ; Note: The next two lines will need to change whenever instructions are
     ;        added or removed from this test.
-    [-, %rax]           v1 = jump_table_base.i64 jt0    ; bin: 48 8d 05 00000039
-    [-, %r10]           v2 = jump_table_base.i64 jt0    ; bin: 4c 8d 15 00000032
+    [-, %rax]           v1 = jump_table_base.i64 jt0    ; bin: 48 8d 05 00000039 PCRelRodata4(jt0)
+    [-, %r10]           v2 = jump_table_base.i64 jt0    ; bin: 4c 8d 15 00000032 PCRelRodata4(jt0)
 
     [-, %rbx]           v10 = iconst.i64 1
     [-, %r13]           v11 = iconst.i64 2

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -65,7 +65,7 @@ fn handle_module(
         let mut mem = vec![];
 
         // Compile and encode the result to machine code.
-        let (code_size, rodata_size) = context
+        let code_info = context
             .compile_and_emit(isa, &mut mem, &mut relocs, &mut traps)
             .map_err(|err| pretty_error(&context.func, Some(isa), err))?;
 
@@ -74,7 +74,14 @@ fn handle_module(
         }
 
         if flag_disasm {
-            print_all(isa, &mem, code_size, rodata_size, &relocs, &traps)?;
+            print_all(
+                isa,
+                &mem,
+                code_info.code_size,
+                code_info.jumptables_size + code_info.rodata_size,
+                &relocs,
+                &traps,
+            )?;
         }
     }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -176,16 +176,16 @@ fn handle_module(
                 return Err(pretty_verifier_error(&context.func, fisa.isa, None, errors));
             }
         } else {
-            let (code_size, rodata_size) = context
+            let code_info = context
                 .compile_and_emit(isa, &mut mem, &mut relocs, &mut traps)
                 .map_err(|err| pretty_error(&context.func, fisa.isa, err))?;
 
             if flag_print_size {
                 println!(
                     "Function #{} code size: {} bytes",
-                    func_index, code_size + rodata_size
+                    func_index, code_info.total_size,
                 );
-                total_module_code_size += code_size + rodata_size;
+                total_module_code_size += code_info.total_size;
                 println!(
                     "Function #{} bytecode size: {} bytes",
                     func_index,
@@ -194,7 +194,7 @@ fn handle_module(
             }
 
             if flag_print_disasm {
-                saved_sizes = Some((code_size, rodata_size));
+                saved_sizes = Some((code_info.code_size, code_info.jumptables_size + code_info.rodata_size));
             }
         }
 


### PR DESCRIPTION
This patch generalizes the information that is available about the compiled-code vector in the following ways:

- it records the offsets to and sizes of the different sections of the compiled-code vector
  (machine code, jump tables, raw bits)
- it records (by means of the existing reloc system) the locations in the code portion that need to be
  fixed up if the jump tables or raw bits are moved relative to the code.
- it propagates a new structure, CodeOffsets, around where needed as a generalization of the
  existing ad-hoc system for code_size / total_size.

(At the moment, there are no "raw bits" but we keep talking about needing constant pools, so I put in the trivial bits to support this, to suggest the way forward.  There are two remaining TODO comments that would need to be dealt with for full support.  Discuss.)

The context here is that SpiderMonkey needs to move the jump tables out of the way to make space for its epilogue (https://bugzilla.mozilla.org/show_bug.cgi?id=1547752).  One alternative solution requires SpiderMonkey to create IR nodes for its prologue/epilogue so that their sizes can be accounted for properly, but this is hard because the prologue/epilogue can't be emitted until the rest of the code has been generated.  Simply splitting the code vector is easier.