### PR TITLE
Remove rex-prefixed recipes for x86_64 e9 and eb jumps

### DIFF
--- a/cranelift-codegen/meta-python/isa/x86/encodings.py
+++ b/cranelift-codegen/meta-python/isa/x86/encodings.py
@@ -481,8 +481,10 @@ X86_64.enc(base.x_return, *r.ret(0xc3))
 #
 # Branches
 #
-enc_both(base.jump, r.jmpb, 0xeb)
-enc_both(base.jump, r.jmpd, 0xe9)
+X86_32.enc(base.jump, *r.jmpb(0xeb))
+X86_64.enc(base.jump, *r.jmpb(0xeb))
+X86_32.enc(base.jump, *r.jmpd(0xe9))
+X86_64.enc(base.jump, *r.jmpd(0xe9))
 
 enc_both(base.brif, r.brib, 0x70)
 enc_both(base.brif, r.brid, 0x0f, 0x80)

--- a/filetests/isa/x86/legalize-br-icmp.clif
+++ b/filetests/isa/x86/legalize-br-icmp.clif
@@ -17,7 +17,7 @@ ebb1:
 ; nextln: [RexOp1pu_id#b8]                    v1 = iconst.i64 0
 ; nextln: [RexOp1icscc#8039]                  v2 = icmp eq v0, v1
 ; nextln: [RexOp1t8jccb#75]                   brnz v2, ebb1
-; nextln: [RexOp1jmpb#eb]                     jump ebb1
+; nextln: [Op1jmpb#eb]                        jump ebb1
 ; nextln: 
 ; nextln:                                 ebb1:
 ; nextln: [Op1ret#c3]                         return
@@ -39,7 +39,7 @@ ebb1(v2: i64):
 ; nextln: [RexOp1pu_id#b8]                    v1 = iconst.i64 0
 ; nextln: [RexOp1icscc#8039]                  v3 = icmp eq v0, v1
 ; nextln: [RexOp1t8jccb#75]                   brnz v3, ebb1(v0)
-; nextln: [RexOp1jmpb#eb]                     jump ebb1(v0)
+; nextln: [Op1jmpb#eb]                        jump ebb1(v0)
 ; nextln: 
 ; nextln:                                 ebb1(v2: i64):
 ; nextln: [Op1ret#c3]                         return

--- a/filetests/isa/x86/relax_branch.clif
+++ b/filetests/isa/x86/relax_branch.clif
@@ -103,7 +103,7 @@ function u0:2691(i32 [%rdi], i32 [%rsi], i64 vmctx [%r14]) -> i64 uext [%rax] ba
 [Op1umr#89,%rdx]                    v100 = copy v79
 @00a4 [RexOp1rmov#89]               regmove v100, %rdx -> %rdi
 @00a4 [RexOp1rmov#89]               regmove v99, %rcx -> %rsi
-@00a4 [RexOp1jmpd#e9]               jump ebb3(v100, v99); bin: 40 e9 ffffff2c
+@00a4 [Op1jmpd#e9]                  jump ebb3(v100, v99); bin: e9 ffffff2d
 
                                 ebb9:
 @00a7 [-]                           fallthrough ebb4

--- a/filetests/regalloc/coloring-227.clif
+++ b/filetests/regalloc/coloring-227.clif
@@ -9,10 +9,10 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 [RexOp1pu_id#b8]              v5 = iconst.i32 0
 [RexOp1pu_id#b8]              v6 = iconst.i32 0
 [RexOp1tjccb#74]              brz v6, ebb10
-[RexOp1jmpb#eb]               jump ebb3(v5, v5, v5, v5, v5, v5, v0, v1, v2, v3)
+[Op1jmpb#eb]                  jump ebb3(v5, v5, v5, v5, v5, v5, v0, v1, v2, v3)
 
                           ebb3(v15: i32, v17: i32, v25: i32, v31: i32, v40: i32, v47: i32, v54: i32, v61: i32, v68: i32, v75: i32):
-[RexOp1jmpb#eb]               jump ebb6
+[Op1jmpb#eb]                  jump ebb6
 
                           ebb6:
 [RexOp1pu_id#b8]              v8 = iconst.i32 0
@@ -23,7 +23,7 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 [RexOp2urm_noflags#4b6]       v13 = bint.i32 v12
 [RexOp1rr#21]                 v14 = band v9, v13
 [RexOp1tjccb#75]              brnz v14, ebb6
-[RexOp1jmpb#eb]               jump ebb7
+[Op1jmpb#eb]                  jump ebb7
 
                           ebb7:
 [RexOp1tjccb#74]              brz.i32 v17, ebb8
@@ -35,30 +35,30 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 [RexOp1ld#808b]               v81 = load.i64 v80
 [RexOp1rr#8001]               v22 = iadd v81, v79
 [RexMp1st#189]                istore16 v21, v22
-[RexOp1jmpb#eb]               jump ebb9
+[Op1jmpb#eb]                  jump ebb9
 
                           ebb9:
-[RexOp1jmpb#eb]               jump ebb8
+[Op1jmpb#eb]                  jump ebb8
 
                           ebb8:
 [RexOp1pu_id#b8]              v27 = iconst.i32 3
 [RexOp1pu_id#b8]              v28 = iconst.i32 4
 [RexOp1rr#09]                 v35 = bor.i32 v31, v13
 [RexOp1tjccb#75]              brnz v35, ebb15(v27)
-[RexOp1jmpb#eb]               jump ebb15(v28)
+[Op1jmpb#eb]                  jump ebb15(v28)
 
                           ebb15(v36: i32):
-[RexOp1jmpb#eb]               jump ebb3(v25, v36, v25, v31, v40, v47, v54, v61, v68, v75)
+[Op1jmpb#eb]                  jump ebb3(v25, v36, v25, v31, v40, v47, v54, v61, v68, v75)
 
                           ebb5:
-[RexOp1jmpb#eb]               jump ebb4
+[Op1jmpb#eb]                  jump ebb4
 
                           ebb4:
-[RexOp1jmpb#eb]               jump ebb2(v40, v47, v54, v61, v68, v75)
+[Op1jmpb#eb]                  jump ebb2(v40, v47, v54, v61, v68, v75)
 
                           ebb10:
 [RexOp1pu_id#b8]              v43 = iconst.i32 0
-[RexOp1jmpb#eb]               jump ebb2(v43, v5, v0, v1, v2, v3)
+[Op1jmpb#eb]                  jump ebb2(v43, v5, v0, v1, v2, v3)
 
                           ebb2(v7: i32, v45: i32, v52: i32, v59: i32, v66: i32, v73: i32):
 [RexOp1pu_id#b8]              v44 = iconst.i32 0
@@ -76,10 +76,10 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 [RexOp1rr#8001]               v64 = iadd v87, v85
 [RexOp1st#88]                 istore8 v59, v64
 [RexOp1pu_id#b8]              v65 = iconst.i32 0
-[RexOp1jmpb#eb]               jump ebb13(v65)
+[Op1jmpb#eb]                  jump ebb13(v65)
 
                           ebb14:
-[RexOp1jmpb#eb]               jump ebb13(v66)
+[Op1jmpb#eb]                  jump ebb13(v66)
 
                           ebb13(v51: i32):
 [RexOp1umr#89]                v88 = uextend.i64 v45
@@ -87,13 +87,13 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 [RexOp1ld#808b]               v90 = load.i64 v89
 [RexOp1rr#8001]               v71 = iadd v90, v88
 [RexOp1st#89]                 store v51, v71
-[RexOp1jmpb#eb]               jump ebb12
+[Op1jmpb#eb]                  jump ebb12
 
                           ebb12:
-[RexOp1jmpb#eb]               jump ebb11
+[Op1jmpb#eb]                  jump ebb11
 
                           ebb11:
-[RexOp1jmpb#eb]               jump ebb1
+[Op1jmpb#eb]                  jump ebb1
 
                           ebb1:
 [Op1ret#c3]                   return


### PR DESCRIPTION
this is a pretty small change, and only affects codegen for opt levels below `Best`, but there's no reason I'm aware of outside padding to emit rex prefixes here even in those modes.