### PR TITLE
Use `try_from` instead of the cast crate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: rust
 rust:
     # The oldest version we currently support. See
     # CONTRIBUTING.md#rustc-version-support for details.
-    - 1.33.0
+    - 1.34.0
     - beta
     - nightly
 matrix:

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -19,7 +19,6 @@ hashmap_core = { version = "0.1.9", optional = true }
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }
 log = { version = "0.4.6", default-features = false }
-cast = { version = "0.2.2", default-features = false }
 
 [dev-dependencies]
 wabt = "0.7.0"

--- a/cranelift-wasm/src/environ/dummy.rs
+++ b/cranelift-wasm/src/environ/dummy.rs
@@ -11,7 +11,7 @@ use crate::translation_utils::{
     DefinedFuncIndex, FuncIndex, Global, GlobalIndex, Memory, MemoryIndex, SignatureIndex, Table,
     TableIndex,
 };
-use cast;
+use core::convert::TryFrom;
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::immediates::{Offset32, Uimm64};
 use cranelift_codegen::ir::types::*;
@@ -196,7 +196,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         index: GlobalIndex,
     ) -> WasmResult<GlobalVariable> {
         // Just create a dummy `vmctx` global.
-        let offset = cast::i32((index.index() * 8) + 8).unwrap().into();
+        let offset = i32::try_from((index.index() * 8) + 8).unwrap().into();
         let vmctx = func.create_global_value(ir::GlobalValueData::VMContext {});
         Ok(GlobalVariable::Memory {
             gv: vmctx,

--- a/cranelift-wasm/src/sections_translator.rs
+++ b/cranelift-wasm/src/sections_translator.rs
@@ -12,6 +12,7 @@ use crate::translation_utils::{
     type_to_type, FuncIndex, Global, GlobalIndex, GlobalInit, Memory, MemoryIndex, SignatureIndex,
     Table, TableElementType, TableIndex,
 };
+use core::convert::TryFrom;
 use cranelift_codegen::ir::{self, AbiParam, Signature};
 use cranelift_entity::EntityRef;
 use std::vec::Vec;
@@ -270,7 +271,7 @@ pub fn parse_element_section<'data>(
                 ref s => panic!("unsupported init expr in element section: {:?}", s),
             };
             let items_reader = items.get_items_reader()?;
-            let mut elems = Vec::with_capacity(cast::usize(items_reader.get_count()));
+            let mut elems = Vec::with_capacity(usize::try_from(items_reader.get_count()).unwrap());
             for item in items_reader {
                 let x = item?;
                 elems.push(FuncIndex::from_u32(x));


### PR DESCRIPTION
Now that `try_from` is in stable Rust, we can use it here.
