### PR TITLE
Handle Reloc::X86PCRelRodata4 in sundry reloc_jt

### DIFF
--- a/cranelift-faerie/src/backend.rs
+++ b/cranelift-faerie/src/backend.rs
@@ -413,7 +413,15 @@ impl<'a> RelocSink for FaerieRelocSink<'a> {
             .expect("faerie relocation error");
     }
 
-    fn reloc_jt(&mut self, _offset: CodeOffset, _reloc: Reloc, _jt: ir::JumpTable) {
-        unimplemented!();
+    fn reloc_jt(&mut self, _offset: CodeOffset, reloc: Reloc, _jt: ir::JumpTable) {
+        match reloc {
+            Reloc::X86PCRelRodata4 => {
+                // Not necessary to record this unless we are going to split apart code and its
+                // jumptbl/rodata.
+            }
+            _ => {
+                panic!("Unhandled reloc");
+            }
+        }
     }
 }

--- a/cranelift-simplejit/src/backend.rs
+++ b/cranelift-simplejit/src/backend.rs
@@ -533,7 +533,15 @@ impl RelocSink for SimpleJITRelocSink {
         });
     }
 
-    fn reloc_jt(&mut self, _offset: CodeOffset, _reloc: Reloc, _jt: ir::JumpTable) {
-        unimplemented!();
+    fn reloc_jt(&mut self, _offset: CodeOffset, reloc: Reloc, _jt: ir::JumpTable) {
+        match reloc {
+            Reloc::X86PCRelRodata4 => {
+                // Not necessary to record this unless we are going to split apart code and its
+                // jumptbl/rodata.
+            }
+            _ => {
+                panic!("Unhandled reloc");
+            }
+        }
     }
 }


### PR DESCRIPTION
See issue #789: this reloc for jump table entries can be ignored by back-ends that don't need to split apart code and its rodata/jump tables.  This patch implements the ignoring for simplejit and faerie.
