### PR TITLE
I128

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -8,6 +8,7 @@ use cranelift_entity::{entity_impl, PrimaryMap};
 
 use std::fmt;
 
+#[derive(Debug)]
 pub enum Expr {
     Var(VarIndex),
     Literal(Literal),
@@ -363,6 +364,7 @@ impl VarPool {
 ///
 /// An `Apply` AST expression is created by using function call syntax on instructions. This
 /// applies to both bound and unbound polymorphic instructions.
+#[derive(Debug)]
 pub struct Apply {
     pub inst: Instruction,
     pub args: Vec<Expr>,

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -79,12 +79,14 @@ impl InstructionGroup {
     }
 }
 
+#[derive(Debug)]
 pub struct PolymorphicInfo {
     pub use_typevar_operand: bool,
     pub ctrl_typevar: TypeVar,
     pub other_typevars: Vec<TypeVar>,
 }
 
+#[derive(Debug)]
 pub struct InstructionContent {
     /// Instruction mnemonic, also becomes opcode name.
     pub name: String,
@@ -139,7 +141,7 @@ pub struct InstructionContent {
     pub writes_cpu_flags: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Instruction {
     content: Rc<InstructionContent>,
 }

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -1127,6 +1127,11 @@ fn bind_vector(
     mut value_types: Vec<ValueTypeOrAny>,
 ) -> BoundInstruction {
     let num_lanes = vector_size_in_bits / lane_type.lane_bits();
+    assert!(
+        num_lanes >= 2,
+        "Minimum lane number for bind_vector is 2, found {}.",
+        num_lanes,
+    );
     let vector_type = ValueType::Vector(VectorType::new(lane_type, num_lanes));
     value_types.push(ValueTypeOrAny::ValueType(vector_type));
     verify_polymorphic_binding(&inst, &value_types);

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -14,7 +14,7 @@ use crate::cdsl::type_inference::Constraint;
 use crate::cdsl::types::{LaneType, ReferenceType, ValueType, VectorType};
 use crate::cdsl::typevar::TypeVar;
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct OpcodeNumber(u32);
 entity_impl!(OpcodeNumber);
 

--- a/cranelift-codegen/meta/src/cdsl/type_inference.rs
+++ b/cranelift-codegen/meta/src/cdsl/type_inference.rs
@@ -4,7 +4,7 @@ use crate::cdsl::typevar::{DerivedFunc, TypeSet, TypeVar};
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 
-#[derive(Hash, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq)]
 pub enum Constraint {
     /// Constraint specifying that a type var tv1 must be wider than or equal to type var tv2 at
     /// runtime. This requires that:

--- a/cranelift-codegen/meta/src/cdsl/types.rs
+++ b/cranelift-codegen/meta/src/cdsl/types.rs
@@ -215,13 +215,14 @@ impl LaneType {
                 LaneType::BoolType(shared_types::Bool::B16) => 2,
                 LaneType::BoolType(shared_types::Bool::B32) => 3,
                 LaneType::BoolType(shared_types::Bool::B64) => 4,
-                LaneType::IntType(shared_types::Int::I8) => 5,
-                LaneType::IntType(shared_types::Int::I16) => 6,
-                LaneType::IntType(shared_types::Int::I32) => 7,
-                LaneType::IntType(shared_types::Int::I64) => 8,
-                LaneType::IntType(shared_types::Int::I128) => 9,
-                LaneType::FloatType(shared_types::Float::F32) => 10,
-                LaneType::FloatType(shared_types::Float::F64) => 11,
+                LaneType::BoolType(shared_types::Bool::B128) => 5,
+                LaneType::IntType(shared_types::Int::I8) => 6,
+                LaneType::IntType(shared_types::Int::I16) => 7,
+                LaneType::IntType(shared_types::Int::I32) => 8,
+                LaneType::IntType(shared_types::Int::I64) => 9,
+                LaneType::IntType(shared_types::Int::I128) => 10,
+                LaneType::FloatType(shared_types::Float::F32) => 11,
+                LaneType::FloatType(shared_types::Float::F64) => 12,
             }
     }
 
@@ -232,6 +233,7 @@ impl LaneType {
             16 => shared_types::Bool::B16,
             32 => shared_types::Bool::B32,
             64 => shared_types::Bool::B64,
+            128 => shared_types::Bool::B128,
             _ => unreachable!("unxpected num bits for bool"),
         })
     }

--- a/cranelift-codegen/meta/src/cdsl/types.rs
+++ b/cranelift-codegen/meta/src/cdsl/types.rs
@@ -219,8 +219,9 @@ impl LaneType {
                 LaneType::IntType(shared_types::Int::I16) => 6,
                 LaneType::IntType(shared_types::Int::I32) => 7,
                 LaneType::IntType(shared_types::Int::I64) => 8,
-                LaneType::FloatType(shared_types::Float::F32) => 9,
-                LaneType::FloatType(shared_types::Float::F64) => 10,
+                LaneType::IntType(shared_types::Int::I128) => 9,
+                LaneType::FloatType(shared_types::Float::F32) => 10,
+                LaneType::FloatType(shared_types::Float::F64) => 11,
             }
     }
 
@@ -241,6 +242,7 @@ impl LaneType {
             16 => shared_types::Int::I16,
             32 => shared_types::Int::I32,
             64 => shared_types::Int::I64,
+            128 => shared_types::Int::I128,
             _ => unreachable!("unxpected num bits for int"),
         })
     }

--- a/cranelift-codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift-codegen/meta/src/cdsl/typevar.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use crate::cdsl::types::{BVType, LaneType, ReferenceType, SpecialType, ValueType};
 
 const MAX_LANES: u16 = 256;
-const MAX_BITS: u16 = 64;
+const MAX_BITS: u16 = 128;
 const MAX_BITVEC: u16 = MAX_BITS * MAX_LANES;
 
 /// Type variables can be used in place of concrete types when defining

--- a/cranelift-codegen/meta/src/cdsl/xform.rs
+++ b/cranelift-codegen/meta/src/cdsl/xform.rs
@@ -183,7 +183,12 @@ fn rewrite_expr(
     assert_eq!(
         apply_target.inst().operands_in.len(),
         dummy_args.len(),
-        "number of arguments in instruction is incorrect"
+        "number of arguments in instruction {} is incorrect\nexpected: {:?}",
+        apply_target.inst().name,
+        apply_target.inst().operands_in
+            .iter()
+            .map(|operand| format!("{}: {}", operand.name, operand.kind.name))
+            .collect::<Vec<_>>(),
     );
 
     let mut args = Vec::new();

--- a/cranelift-codegen/meta/src/cdsl/xform.rs
+++ b/cranelift-codegen/meta/src/cdsl/xform.rs
@@ -185,7 +185,9 @@ fn rewrite_expr(
         dummy_args.len(),
         "number of arguments in instruction {} is incorrect\nexpected: {:?}",
         apply_target.inst().name,
-        apply_target.inst().operands_in
+        apply_target
+            .inst()
+            .operands_in
             .iter()
             .map(|operand| format!("{}: {}", operand.name, operand.kind.name))
             .collect::<Vec<_>>(),

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -61,10 +61,10 @@ fn unwrap_inst(
             fmtln!(fmt, "{},", field.member);
         }
 
-        if iform.num_value_operands == 1 {
-            fmt.line("arg,");
-        } else if iform.has_value_list || iform.num_value_operands > 1 {
+        if iform.has_value_list || iform.num_value_operands > 1 {
             fmt.line("ref args,");
+        } else if iform.num_value_operands == 1 {
+            fmt.line("arg,");
         }
 
         fmt.line("..");
@@ -87,6 +87,11 @@ fn unwrap_inst(
                 } else if op.is_value() {
                     let n = inst.value_opnums.iter().position(|&i| i == op_num).unwrap();
                     fmtln!(fmt, "func.dfg.resolve_aliases(args[{}]),", n);
+                } else if op.is_varargs() {
+                    let n = inst.imm_opnums.iter().chain(inst.value_opnums.iter()).max().map(|n| n + 1).unwrap_or(0);
+                    fmtln!(fmt, "\
+                        args.iter().skip({}).map(|&arg| func.dfg.resolve_aliases(arg)).collect::<Vec<_>>(),\
+                    ", n);
                 }
             }
 
@@ -103,6 +108,14 @@ fn unwrap_inst(
         fmt.line(r#"unreachable!("bad instruction format")"#);
     });
     fmtln!(fmt, "};");
+
+    assert_eq!(inst.operands_in.len(), apply.args.len());
+    for (i, op) in inst.operands_in.iter().enumerate() {
+        if op.is_varargs() {
+            let name = var_pool.get(apply.args[i].maybe_var().expect("vararg without name")).name;
+            fmtln!(fmt, "let {} = &{};", name, name);
+        }
+    }
 
     for &op_num in &inst.value_opnums {
         let arg = &apply.args[op_num];

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -112,7 +112,9 @@ fn unwrap_inst(
     assert_eq!(inst.operands_in.len(), apply.args.len());
     for (i, op) in inst.operands_in.iter().enumerate() {
         if op.is_varargs() {
-            let name = var_pool.get(apply.args[i].maybe_var().expect("vararg without name")).name;
+            let name = var_pool
+                .get(apply.args[i].maybe_var().expect("vararg without name"))
+                .name;
             fmtln!(fmt, "let {} = &{};", name, name);
         }
     }

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -415,6 +415,11 @@ fn gen_transform<'a>(
             fmt.line("let removed = pos.remove_inst();");
             fmt.line("debug_assert_eq!(removed, inst);");
         }
+
+        if transform.def_pool.get(transform.src).apply.inst.is_branch {
+            fmt.line("cfg.recompute_ebb(pos.func, pos.current_ebb().unwrap());");
+        }
+
         fmt.line("return true;");
     });
     fmt.line("}");

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1776,7 +1776,7 @@ pub(crate) fn define(
     insertlane_mapping.insert(32, (vec![0x66, 0x0f, 0x3a, 0x22], Some(use_sse41_simd))); // PINSRD
     insertlane_mapping.insert(64, (vec![0x66, 0x0f, 0x3a, 0x22], Some(use_sse41_simd))); // PINSRQ, only x86_64
 
-    for ty in ValueType::all_lane_types() {
+    for ty in ValueType::all_lane_types().filter(allowed_simd_type) {
         if let Some((opcode, isap)) = insertlane_mapping.get(&ty.lane_bits()) {
             let instruction = insertlane.bind_vector_from_lane(ty, sse_vector_size);
             let template = rec_r_ib_unsigned_r.opcodes(opcode.clone());
@@ -1797,7 +1797,7 @@ pub(crate) fn define(
     extractlane_mapping.insert(32, (vec![0x66, 0x0f, 0x3a, 0x16], Some(use_sse41_simd))); // PEXTRD
     extractlane_mapping.insert(64, (vec![0x66, 0x0f, 0x3a, 0x16], Some(use_sse41_simd))); // PEXTRQ, only x86_64
 
-    for ty in ValueType::all_lane_types() {
+    for ty in ValueType::all_lane_types().filter(allowed_simd_type) {
         if let Some((opcode, isap)) = extractlane_mapping.get(&ty.lane_bits()) {
             let instruction = extractlane.bind_vector_from_lane(ty, sse_vector_size);
             let template = rec_r_ib_unsigned_gpr.opcodes(opcode.clone());

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -3143,7 +3143,7 @@ pub(crate) fn define(
         "WideInt",
         "An integer type with lanes from `i16` upwards",
         TypeSetBuilder::new()
-            .ints(16..64)
+            .ints(16..128)
             .simd_lanes(Interval::All)
             .build(),
     );
@@ -3171,9 +3171,9 @@ pub(crate) fn define(
 
     let NarrowInt = &TypeVar::new(
         "NarrowInt",
-        "An integer type with lanes type to `i32`",
+        "An integer type with lanes type to `i64`",
         TypeSetBuilder::new()
-            .ints(8..32)
+            .ints(8..64)
             .simd_lanes(Interval::All)
             .build(),
     );

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -207,7 +207,7 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
         ],
     );
 
-    for &bin_op in &[band, bor, bxor] {
+    for &bin_op in &[band, bor, bxor, band_not, bor_not, bxor_not] {
         narrow.legalize(
             def!(a = bin_op(x, y)),
             vec![
@@ -219,6 +219,16 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
             ],
         );
     }
+
+    narrow.legalize(
+        def!(a = bnot(x)),
+        vec![
+            def!((xl, xh) = isplit(x)),
+            def!(al = bnot(xl)),
+            def!(ah = bnot(xh)),
+            def!(a = iconcat(al, ah)),
+        ],
+    );
 
     narrow.legalize(
         def!(a = select(c, x, y)),

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -185,6 +185,9 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
     let offset = var("off");
     let vararg = var("vararg");
 
+    narrow.custom_legalize(load, "narrow_load");
+    narrow.custom_legalize(store, "narrow_store");
+
     narrow.legalize(
         def!(a = iadd(x, y)),
         vec![
@@ -270,30 +273,6 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
             def!((xl, xh) = isplit(x)),
             def!(brnz(xl, ebb, vararg)),
             def!(brnz(xh, ebb, vararg)),
-        ],
-    );
-
-    // FIXME generalize to any offset once offset+8 can be represented
-    narrow.legalize(
-        def!(a = load.I128(flags, ptr, Literal::constant(&imm.offset32, 0))),
-        vec![
-            def!(al = load.I64(flags, ptr, Literal::constant(&imm.offset32, 0))),
-            def!(ah = load.I64(flags, ptr, Literal::constant(&imm.offset32, 8))),
-            // `iconcat` expects the same byte order as stored in memory,
-            // so no need to swap depending on endianness.
-            def!(a = iconcat(al, ah)),
-        ],
-    );
-
-    // FIXME generalize to any offset once offset+8 can be represented
-    narrow.legalize(
-        def!(store.I128(flags, a, ptr, Literal::constant(&imm.offset32, 0))),
-        vec![
-            // `isplit` gives the same byte order as stored in memory,
-            // so no need to swap depending on endianness.
-            def!((al, ah) = isplit(a)),
-            def!(store.I64(flags, al, ptr, Literal::constant(&imm.offset32, 0))),
-            def!(store.I64(flags, ah, ptr, Literal::constant(&imm.offset32, 8))),
         ],
     );
 

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -4,7 +4,7 @@ use crate::cdsl::xform::{TransformGroupBuilder, TransformGroups};
 
 use crate::shared::immediates::Immediates;
 use crate::shared::types::Float::{F32, F64};
-use crate::shared::types::Int::{I16, I128, I32, I64, I8};
+use crate::shared::types::Int::{I128, I16, I32, I64, I8};
 
 pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGroups {
     let mut narrow = TransformGroupBuilder::new(
@@ -245,8 +245,20 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
         def!(brz.I128(x, ebb, vararg)),
         vec![
             def!((xl, xh) = isplit(x)),
-            def!(a = icmp_imm(Literal::enumerator_for(intcc, "eq"), xl, Literal::constant(imm64, 0))),
-            def!(b = icmp_imm(Literal::enumerator_for(intcc, "eq"), xh, Literal::constant(imm64, 0))),
+            def!(
+                a = icmp_imm(
+                    Literal::enumerator_for(intcc, "eq"),
+                    xl,
+                    Literal::constant(imm64, 0)
+                )
+            ),
+            def!(
+                b = icmp_imm(
+                    Literal::enumerator_for(intcc, "eq"),
+                    xh,
+                    Literal::constant(imm64, 0)
+                )
+            ),
             def!(c = band(a, b)),
             def!(brz(c, ebb, vararg)),
         ],

--- a/cranelift-codegen/meta/src/shared/types.rs
+++ b/cranelift-codegen/meta/src/shared/types.rs
@@ -51,6 +51,8 @@ pub enum Int {
     I32 = 32,
     /// 64-bit int.
     I64 = 64,
+    /// 128-bit int.
+    I128 = 128,
 }
 
 /// This provides an iterator through all of the supported int variants.
@@ -72,6 +74,7 @@ impl Iterator for IntIterator {
             1 => Some(Int::I16),
             2 => Some(Int::I32),
             3 => Some(Int::I64),
+            4 => Some(Int::I128),
             _ => return None,
         };
         self.index += 1;
@@ -199,6 +202,7 @@ mod iter_tests {
         assert_eq!(int_iter.next(), Some(Int::I16));
         assert_eq!(int_iter.next(), Some(Int::I32));
         assert_eq!(int_iter.next(), Some(Int::I64));
+        assert_eq!(int_iter.next(), Some(Int::I128));
         assert_eq!(int_iter.next(), None);
     }
 

--- a/cranelift-codegen/meta/src/shared/types.rs
+++ b/cranelift-codegen/meta/src/shared/types.rs
@@ -12,6 +12,8 @@ pub enum Bool {
     B32 = 32,
     /// 64-bit bool.
     B64 = 64,
+    /// 128-bit bool.
+    B128 = 128,
 }
 
 /// This provides an iterator through all of the supported bool variants.
@@ -34,6 +36,7 @@ impl Iterator for BoolIterator {
             2 => Some(Bool::B16),
             3 => Some(Bool::B32),
             4 => Some(Bool::B64),
+            5 => Some(Bool::B128),
             _ => return None,
         };
         self.index += 1;
@@ -192,6 +195,7 @@ mod iter_tests {
         assert_eq!(bool_iter.next(), Some(Bool::B16));
         assert_eq!(bool_iter.next(), Some(Bool::B32));
         assert_eq!(bool_iter.next(), Some(Bool::B64));
+        assert_eq!(bool_iter.next(), Some(Bool::B128));
         assert_eq!(bool_iter.next(), None);
     }
 

--- a/cranelift-codegen/src/ir/types.rs
+++ b/cranelift-codegen/src/ir/types.rs
@@ -10,7 +10,7 @@ use target_lexicon::{PointerWidth, Triple};
 /// field is present put no type is needed, such as the controlling type variable for a
 /// non-polymorphic instruction.
 ///
-/// Basic integer types: `I8`, `I16`, `I32`, and `I64`. These types are sign-agnostic.
+/// Basic integer types: `I8`, `I16`, `I32`, `I64`, and `I128`. These types are sign-agnostic.
 ///
 /// Basic floating point types: `F32` and `F64`. IEEE single and double precision.
 ///

--- a/cranelift-codegen/src/ir/types.rs
+++ b/cranelift-codegen/src/ir/types.rs
@@ -14,7 +14,7 @@ use target_lexicon::{PointerWidth, Triple};
 ///
 /// Basic floating point types: `F32` and `F64`. IEEE single and double precision.
 ///
-/// Boolean types: `B1`, `B8`, `B16`, `B32`, and `B64`. These all encode 'true' or 'false'. The
+/// Boolean types: `B1`, `B8`, `B16`, `B32`, `B64`, and `B128`. These all encode 'true' or 'false'. The
 /// larger types use redundant bits.
 ///
 /// SIMD vector types have power-of-two lanes, up to 256. Lanes can be any int/float/bool type.
@@ -63,7 +63,7 @@ impl Type {
             B16 | I16 => 4,
             B32 | I32 | F32 | R32 => 5,
             B64 | I64 | F64 | R64 => 6,
-            I128 => 7,
+            B128 | I128 => 7,
             _ => 0,
         }
     }
@@ -76,7 +76,7 @@ impl Type {
             B16 | I16 => 16,
             B32 | I32 | F32 | R32 => 32,
             B64 | I64 | F64 | R64 => 64,
-            I128 => 128,
+            B128 | I128 => 128,
             _ => 0,
         }
     }
@@ -112,6 +112,7 @@ impl Type {
             B32 | I32 | F32 => B32,
             B64 | I64 | F64 => B64,
             R32 | R64 => panic!("Reference types should not convert to bool"),
+            B128 | I128 => B128,
             _ => B1,
         })
     }
@@ -140,6 +141,7 @@ impl Type {
             B16 => B8,
             B32 => B16,
             B64 => B32,
+            B128 => B64,
             _ => return None,
         }))
     }
@@ -156,6 +158,7 @@ impl Type {
             B8 => B16,
             B16 => B32,
             B32 => B64,
+            B64 => B128,
             _ => return None,
         }))
     }
@@ -187,7 +190,7 @@ impl Type {
     /// Is this a scalar boolean type?
     pub fn is_bool(self) -> bool {
         match self {
-            B1 | B8 | B16 | B32 | B64 => true,
+            B1 | B8 | B16 | B32 | B64 | B128 => true,
             _ => false,
         }
     }
@@ -375,6 +378,7 @@ mod tests {
         assert_eq!(B16, B16.lane_type());
         assert_eq!(B32, B32.lane_type());
         assert_eq!(B64, B64.lane_type());
+        assert_eq!(B128, B128.lane_type());
         assert_eq!(I8, I8.lane_type());
         assert_eq!(I16, I16.lane_type());
         assert_eq!(I32, I32.lane_type());
@@ -396,6 +400,7 @@ mod tests {
         assert_eq!(B16.lane_bits(), 16);
         assert_eq!(B32.lane_bits(), 32);
         assert_eq!(B64.lane_bits(), 64);
+        assert_eq!(B128.lane_bits(), 128);
         assert_eq!(I8.lane_bits(), 8);
         assert_eq!(I16.lane_bits(), 16);
         assert_eq!(I32.lane_bits(), 32);
@@ -417,6 +422,7 @@ mod tests {
         assert_eq!(B16.half_width(), Some(B8));
         assert_eq!(B32.half_width(), Some(B16));
         assert_eq!(B64.half_width(), Some(B32));
+        assert_eq!(B128.half_width(), Some(B64));
         assert_eq!(I8.half_width(), None);
         assert_eq!(I16.half_width(), Some(I8));
         assert_eq!(I32.half_width(), Some(I16));
@@ -433,7 +439,8 @@ mod tests {
         assert_eq!(B8.double_width(), Some(B16));
         assert_eq!(B16.double_width(), Some(B32));
         assert_eq!(B32.double_width(), Some(B64));
-        assert_eq!(B64.double_width(), None);
+        assert_eq!(B64.double_width(), Some(B128));
+        assert_eq!(B128.double_width(), None);
         assert_eq!(I8.double_width(), Some(I16));
         assert_eq!(I16.double_width(), Some(I32));
         assert_eq!(I32.double_width(), Some(I64));
@@ -470,6 +477,7 @@ mod tests {
         assert_eq!(B16.to_string(), "b16");
         assert_eq!(B32.to_string(), "b32");
         assert_eq!(B64.to_string(), "b64");
+        assert_eq!(B128.to_string(), "b128");
         assert_eq!(I8.to_string(), "i8");
         assert_eq!(I16.to_string(), "i16");
         assert_eq!(I32.to_string(), "i32");

--- a/cranelift-codegen/src/ir/types.rs
+++ b/cranelift-codegen/src/ir/types.rs
@@ -63,6 +63,7 @@ impl Type {
             B16 | I16 => 4,
             B32 | I32 | F32 | R32 => 5,
             B64 | I64 | F64 | R64 => 6,
+            I128 => 7,
             _ => 0,
         }
     }
@@ -75,6 +76,7 @@ impl Type {
             B16 | I16 => 16,
             B32 | I32 | F32 | R32 => 32,
             B64 | I64 | F64 | R64 => 64,
+            I128 => 128,
             _ => 0,
         }
     }
@@ -86,6 +88,7 @@ impl Type {
             16 => Some(I16),
             32 => Some(I32),
             64 => Some(I64),
+            128 => Some(I128),
             _ => None,
         }
     }
@@ -132,6 +135,7 @@ impl Type {
             I16 => I8,
             I32 => I16,
             I64 => I32,
+            I128 => I64,
             F64 => F32,
             B16 => B8,
             B32 => B16,
@@ -147,6 +151,7 @@ impl Type {
             I8 => I16,
             I16 => I32,
             I32 => I64,
+            I64 => I128,
             F32 => F64,
             B8 => B16,
             B16 => B32,
@@ -190,7 +195,7 @@ impl Type {
     /// Is this a scalar integer type?
     pub fn is_int(self) -> bool {
         match self {
-            I8 | I16 | I32 | I64 => true,
+            I8 | I16 | I32 | I64 | I128 => true,
             _ => false,
         }
     }
@@ -374,6 +379,7 @@ mod tests {
         assert_eq!(I16, I16.lane_type());
         assert_eq!(I32, I32.lane_type());
         assert_eq!(I64, I64.lane_type());
+        assert_eq!(I128, I128.lane_type());
         assert_eq!(F32, F32.lane_type());
         assert_eq!(F64, F64.lane_type());
         assert_eq!(B1, B1.by(8).unwrap().lane_type());
@@ -394,6 +400,7 @@ mod tests {
         assert_eq!(I16.lane_bits(), 16);
         assert_eq!(I32.lane_bits(), 32);
         assert_eq!(I64.lane_bits(), 64);
+        assert_eq!(I128.lane_bits(), 128);
         assert_eq!(F32.lane_bits(), 32);
         assert_eq!(F64.lane_bits(), 64);
         assert_eq!(R32.lane_bits(), 32);
@@ -415,6 +422,7 @@ mod tests {
         assert_eq!(I32.half_width(), Some(I16));
         assert_eq!(I32X4.half_width(), Some(I16X4));
         assert_eq!(I64.half_width(), Some(I32));
+        assert_eq!(I128.half_width(), Some(I64));
         assert_eq!(F32.half_width(), None);
         assert_eq!(F64.half_width(), Some(F32));
 
@@ -430,7 +438,8 @@ mod tests {
         assert_eq!(I16.double_width(), Some(I32));
         assert_eq!(I32.double_width(), Some(I64));
         assert_eq!(I32X4.double_width(), Some(I64X4));
-        assert_eq!(I64.double_width(), None);
+        assert_eq!(I64.double_width(), Some(I128));
+        assert_eq!(I128.double_width(), None);
         assert_eq!(F32.double_width(), Some(F64));
         assert_eq!(F64.double_width(), None);
     }
@@ -465,6 +474,7 @@ mod tests {
         assert_eq!(I16.to_string(), "i16");
         assert_eq!(I32.to_string(), "i32");
         assert_eq!(I64.to_string(), "i64");
+        assert_eq!(I128.to_string(), "i128");
         assert_eq!(F32.to_string(), "f32");
         assert_eq!(F64.to_string(), "f64");
         assert_eq!(R32.to_string(), "r32");

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -61,10 +61,7 @@ fn legalize_inst(
         pos.use_srcloc(inst);
 
         let arg = match pos.func.dfg[inst] {
-            ir::InstructionData::Unary {
-                arg,
-                ..
-            } => pos.func.dfg.resolve_aliases(arg),
+            ir::InstructionData::Unary { arg, .. } => pos.func.dfg.resolve_aliases(arg),
             _ => panic!("Expected isplit: {}", pos.func.dfg.display_inst(inst, None)),
         };
 

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -72,8 +72,11 @@ fn legalize_inst(
         };
 
         match pos.func.dfg.value_def(arg) {
-            ir::ValueDef::Result(inst, num) => {
-                if let ir::InstructionData::Binary { opcode, args, .. } = pos.func.dfg[inst] {
+            ir::ValueDef::Result(inst, _num) => {
+                if let ir::InstructionData::Binary {
+                    opcode, args: _, ..
+                } = pos.func.dfg[inst]
+                {
                     if opcode != ir::Opcode::Iconcat {
                         return LegalizeInstResult::SplitLegalizePending;
                     }
@@ -84,7 +87,7 @@ fn legalize_inst(
                     return LegalizeInstResult::SplitLegalizePending;
                 }
             }
-            ir::ValueDef::Param(ebb, num) => {}
+            ir::ValueDef::Param(_ebb, _num) => {}
         }
 
         let res = pos.func.dfg.inst_results(inst).to_vec();

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -91,13 +91,9 @@ fn legalize_inst(
         assert_eq!(res.len(), 2);
         let (resl, resh) = (res[0], res[1]); // Prevent borrowck error
 
-        dbg!(pos.position());
-
         // Remove old isplit
         pos.func.dfg.clear_results(inst);
         pos.remove_inst();
-
-        dbg!(pos.position());
 
         let curpos = pos.position();
         let srcloc = pos.srcloc();
@@ -105,8 +101,6 @@ fn legalize_inst(
 
         pos.func.dfg.change_to_alias(resl, xl);
         pos.func.dfg.change_to_alias(resh, xh);
-
-        dbg!(&pos.func);
 
         return LegalizeInstResult::Legalized;
     }

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -174,6 +174,10 @@ pub fn legalize_function(func: &mut ir::Function, cfg: &mut ControlFlowGraph, is
         }
     }
 
+    while let Some(ebb) = pos.next_ebb() {
+        split::split_ebb_params(pos.func, cfg, ebb);
+    }
+
     // Try legalizing `isplit` and `vsplit` instructions, which could not previously be legalized.
     for inst in pending_splits {
         //pos.goto_inst(inst);

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -84,7 +84,7 @@ fn legalize_inst(
                     return LegalizeInstResult::SplitLegalizePending;
                 }
             }
-            ir::ValueDef::Param(ebb, num) => {},
+            ir::ValueDef::Param(ebb, num) => {}
         }
 
         let res = pos.func.dfg.inst_results(inst).to_vec();

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -174,8 +174,8 @@ pub fn legalize_function(func: &mut ir::Function, cfg: &mut ControlFlowGraph, is
 
     // Try legalizing `isplit` and `vsplit` instructions, which could not previously be legalized.
     for inst in pending_splits {
-        //pos.goto_inst(inst);
-        //legalize_inst(inst, &mut pos, cfg, isa);
+        pos.goto_inst(inst);
+        legalize_inst(inst, &mut pos, cfg, isa);
     }
 
     // Now that we've lowered all br_tables, we don't need the jump tables anymore.

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -588,9 +588,12 @@ fn narrow_load(
         _ => panic!("Expected load: {}", pos.func.dfg.display_inst(inst, None)),
     };
 
-    let al = pos.ins().load(ir::types::I64, flags, ptr, offset);
+    let res_ty = pos.func.dfg.ctrl_typevar(inst);
+    let small_ty = res_ty.half_width().expect("Can't narrow load");
+
+    let al = pos.ins().load(small_ty, flags, ptr, offset);
     let ah = pos.ins().load(
-        ir::types::I64,
+        small_ty,
         flags,
         ptr,
         offset.try_add_i64(8).expect("load offset overflow"),
@@ -618,7 +621,7 @@ fn narrow_store(
         _ => panic!("Expected store: {}", pos.func.dfg.display_inst(inst, None)),
     };
 
-    let (al, ah) = pos.func.dfg.replace(inst).isplit(val);
+    let (al, ah) = pos.ins().isplit(val);
     pos.ins().store(flags, al, ptr, offset);
     pos.ins().store(
         flags,
@@ -626,4 +629,5 @@ fn narrow_store(
         ptr,
         offset.try_add_i64(8).expect("store offset overflow"),
     );
+    pos.remove_inst();
 }

--- a/cranelift-codegen/src/legalizer/split.rs
+++ b/cranelift-codegen/src/legalizer/split.rs
@@ -129,15 +129,18 @@ fn split_any(
     result
 }
 
-pub fn split_ebb_params(
-    func: &mut ir::Function,
-    cfg: &ControlFlowGraph,
-    ebb: Ebb,
-) {
+pub fn split_ebb_params(func: &mut ir::Function, cfg: &ControlFlowGraph, ebb: Ebb) {
     let mut repairs = Vec::new();
     let pos = &mut FuncCursor::new(func).at_top(ebb);
 
-    for (num, ebb_param) in pos.func.dfg.ebb_params(ebb).to_vec().into_iter().enumerate() {
+    for (num, ebb_param) in pos
+        .func
+        .dfg
+        .ebb_params(ebb)
+        .to_vec()
+        .into_iter()
+        .enumerate()
+    {
         let ty = pos.func.dfg.value_type(ebb_param);
         if ty != ir::types::I128 {
             continue;
@@ -149,11 +152,7 @@ pub fn split_ebb_params(
     perform_repairs(pos, cfg, repairs);
 }
 
-fn perform_repairs(
-    pos: &mut FuncCursor,
-    cfg: &ControlFlowGraph,
-    mut repairs: Vec<Repair>,
-) {
+fn perform_repairs(pos: &mut FuncCursor, cfg: &ControlFlowGraph, mut repairs: Vec<Repair>) {
     // We have split the value requested, and now we may need to fix some EBB predecessors.
     while let Some(repair) = repairs.pop() {
         for BasicBlock { inst, .. } in cfg.pred_iter(repair.ebb) {

--- a/cranelift-codegen/src/regalloc/reload.rs
+++ b/cranelift-codegen/src/regalloc/reload.rs
@@ -233,7 +233,7 @@ impl<'a> Context<'a> {
                             let dst_ty = self.cur.func.dfg.value_type(dst_val);
                             debug_assert!(src_ty == dst_ty);
                             // This limits the transformation to copies of the
-                            // types: I64 I32 I16 I8 F64 and F32, since that's
+                            // types: I128 I64 I32 I16 I8 F64 and F32, since that's
                             // the set of `copy_nop` encodings available.
                             src_ty.is_int() || src_ty.is_float()
                         }

--- a/cranelift-reader/src/lexer.rs
+++ b/cranelift-reader/src/lexer.rs
@@ -373,6 +373,7 @@ impl<'a> Lexer<'a> {
             "b16" => types::B16,
             "b32" => types::B32,
             "b64" => types::B64,
+            "b128" => types::B128,
             "r32" => types::R32,
             "r64" => types::R64,
             _ => return None,

--- a/cranelift-reader/src/lexer.rs
+++ b/cranelift-reader/src/lexer.rs
@@ -365,6 +365,7 @@ impl<'a> Lexer<'a> {
             "i16" => types::I16,
             "i32" => types::I32,
             "i64" => types::I64,
+            "i128" => types::I128,
             "f32" => types::F32,
             "f64" => types::F64,
             "b1" => types::B1,

--- a/filetests/isa/x86/br-i128.clif
+++ b/filetests/isa/x86/br-i128.clif
@@ -1,0 +1,24 @@
+test compile
+target x86_64
+
+function u0:0(i128) -> i8 fast {
+ebb0(v0: i128):
+    brz v0, ebb1
+    v1 = iconst.i8 0
+    return v1
+
+ebb1:
+    v2 = iconst.i8 1
+    return v2
+}
+
+function u0:1(i128) -> i8 fast {
+ebb0(v0: i128):
+    brnz v0, ebb1
+    v1 = iconst.i8 0
+    return v1
+
+ebb1:
+    v2 = iconst.i8 1
+    return v2
+}

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -28,19 +28,19 @@ ebb0(v0: i128):
 }
 
 function u0:2(i64, i128) fast {
-; check: ebb0(v0: i64 [%rdi], v2: i64 [%rsi], v3: i64 [%rdx], v4: i64 [%rbp]):
+; check: ebb0(v0: i64 [%rdi], v2: i64 [%rsi], v3: i64 [%rdx], v6: i64 [%rbp]):
 ebb0(v0: i64, v1: i128):
-    ; check: store v2, v0
-    ; check: store v3, v0+8
-    store v1, v0
+    ; check: store v2, v0+8
+    ; check: store v3, v0+16
+    store v1, v0+8
     return
 }
 
 function u0:3(i64) -> i128 fast {
 ebb0(v0: i64):
-    ; check: v2 = load.i64 v0
-    ; check: v3 = load.i64 v0+8
-    v1 = load.i128 v0
+    ; check: v2 = load.i64 v0+8
+    ; check: v3 = load.i64 v0+16
+    v1 = load.i128 v0+8
     ; check: return v2, v3, v5
     return v1
 }

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -5,9 +5,9 @@ function u0:0(i128) -> i128 fast {
 ebb0(v0: i128):
     v1 = iconst.i64 0
     v2 = iconst.i64 42
-    v3 = iconcat.i64 v1, v2
+    v3 = iconcat.i64 v2, v1
     return v3
     ; check: v1 = iconst.i64 0
     ; check: v2 = iconst.i64 42
-    ; check: return v1, v2, v7
+    ; check: return v2, v1, v7
 }

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -1,0 +1,13 @@
+test compile
+target x86_64
+
+function u0:0(i128) -> i128 fast {
+ebb0(v0: i128):
+    v1 = iconst.i64 0
+    v2 = iconst.i64 42
+    v3 = iconcat.i64 v1, v2
+    return v3
+    ; check: v1 = iconst.i64 0
+    ; check: v2 = iconst.i64 42
+    ; check: return v1, v2, v7
+}

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -1,13 +1,28 @@
 test compile
 target x86_64
 
-function u0:0(i128) -> i128 fast {
+function u0:0(i64, i64) -> i128 fast {
+ebb0(v0: i64, v1: i64):
+;check: ebb0(v0: i64 [%rdi], v1: i64 [%rsi], v3: i64 [%rbp]):
+
+    v2 = iconcat.i64 v0, v1
+    ; check: regmove v0, %rdi -> %rax
+    ; check: regmove v1, %rsi -> %rdx
+
+    return v2
+    ; check: v4 = x86_pop.i64
+    ; check: return v0, v1, v4
+}
+
+function u0:1(i128) -> i64, i64 fast {
 ebb0(v0: i128):
-    v1 = iconst.i64 0
-    v2 = iconst.i64 42
-    v3 = iconcat.i64 v2, v1
-    return v3
-    ; check: v1 = iconst.i64 0
-    ; check: v2 = iconst.i64 42
-    ; check: return v2, v1, v7
+; check: ebb0(v3: i64 [%rdi], v4: i64 [%rsi], v5: i64 [%rbp]):
+
+    v1, v2 = isplit v0
+    ; check: regmove v3, %rdi -> %rax
+    ; check: regmove v4, %rsi -> %rdx
+
+    return v1, v2
+    ; check: v6 = x86_pop.i64
+    ; check: return v3, v4, v6
 }

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -27,7 +27,7 @@ ebb0(v0: i128):
     ; check: return v3, v4, v6
 }
 
-function u0:1(i64, i128) fast {
+function u0:2(i64, i128) fast {
 ; check: ebb0(v0: i64 [%rdi], v2: i64 [%rsi], v3: i64 [%rdx], v4: i64 [%rbp]):
 ebb0(v0: i64, v1: i128):
     ; check: store v2, v0
@@ -36,7 +36,7 @@ ebb0(v0: i64, v1: i128):
     return
 }
 
-function u0:1(i64) -> i128 fast {
+function u0:3(i64) -> i128 fast {
 ebb0(v0: i64):
     ; check: v2 = load.i64 v0
     ; check: v3 = load.i64 v0+8

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -26,3 +26,21 @@ ebb0(v0: i128):
     ; check: v6 = x86_pop.i64
     ; check: return v3, v4, v6
 }
+
+function u0:1(i64, i128) fast {
+; check: ebb0(v0: i64 [%rdi], v2: i64 [%rsi], v3: i64 [%rdx], v4: i64 [%rbp]):
+ebb0(v0: i64, v1: i128):
+    ; check: store v2, v0
+    ; check: store v3, v0+8
+    store v1, v0
+    return
+}
+
+function u0:1(i64) -> i128 fast {
+ebb0(v0: i64):
+    ; check: v2 = load.i64 v0
+    ; check: v3 = load.i64 v0+8
+    v1 = load.i128 v0
+    ; check: return v2, v3, v5
+    return v1
+}

--- a/filetests/isa/x86/isplit-not-legalized-twice.clif
+++ b/filetests/isa/x86/isplit-not-legalized-twice.clif
@@ -1,0 +1,20 @@
+test compile
+target x86_64
+
+function u0:0(i64, i64) -> i128 system_v {
+ebb0(v0: i64, v1: i64):
+    trap user0
+
+ebb30:
+    v245 = iconst.i64 0
+    v246 = iconcat v245, v245
+    ; The next instruction used to be legalized twice, causing a panic the second time.
+    v250, v251 = isplit.i128 v370
+    v252, v253 = isplit v246
+    trap user0
+
+ebb45:
+    v369 = iconst.i64 0
+    v370 = load.i128 v369
+    trap user0
+}

--- a/filetests/isa/x86/jump_i128_param_unused.clif
+++ b/filetests/isa/x86/jump_i128_param_unused.clif
@@ -1,0 +1,10 @@
+test compile
+target x86_64
+
+function u0:0(i128) system_v {
+ebb0(v0: i128):
+    jump ebb1(v0)
+
+ebb1(v1: i128):
+    return
+}

--- a/filetests/isa/x86/legalize-isplit-backwards.clif
+++ b/filetests/isa/x86/legalize-isplit-backwards.clif
@@ -1,0 +1,24 @@
+test compile
+target x86_64
+
+function u0:0(i128) -> i64, i64 fast {
+; check: ebb0(v4: i64 [%rdi], v5: i64 [%rsi], v8: i64 [%rbp]):
+ebb0(v0: i128):
+    jump ebb2
+
+ebb1:
+    ; When this `isplit` is legalized, the bnot below is not yet legalized,
+    ; so there isn't a corresponding `iconcat` yet. We should try legalization
+    ; for this `isplit` again once all instrucions have been legalized.
+    v2, v3 = isplit.i128 v1
+    ; return v6, v7
+    return v2, v3
+
+ebb2:
+    ; check: v6 = bnot.i64 v4
+    ; check: v2 -> v6
+    ; check: v7 = bnot.i64 v5
+    ; check: v3 -> v7
+    v1 = bnot.i128 v0
+    jump ebb1
+}

--- a/filetests/isa/x86/load-store-narrow.clif
+++ b/filetests/isa/x86/load-store-narrow.clif
@@ -1,0 +1,16 @@
+test compile
+target i686
+
+function u0:0(i64, i32) system_v {
+ebb0(v0: i64, v1: i32):
+    v2 = bor v0, v0
+    store v2, v1
+    return
+}
+
+function u0:1(i32) -> i64 system_v {
+ebb0(v1: i32):
+    v0 = load.i64 v1
+    v2 = bor v0, v0
+    return v2
+}


### PR DESCRIPTION
cc #354

This adds a i128 type. While only `iconcat` and `isplit` support them, this makes it easier `cg_clif` to handle 128 bit integers, as the low and high bits are bundled together. `cg_clif` would need a bigger change to special case `i128` as not consisting of just one `Value`. It also makes it easier to inspect the ir generated by `cg_clif`, as there is no need to think about which two values together represent the `i128`.

You can create an `i128` value by using `iconcat` with two `i64` values: first the lsb, then the msb (on little endian)

## TODO

* [x] Fix isplit i128 -> i64,i64