### PR TITLE
Fix a calculation error for rodata_size in memsink

### DIFF
--- a/cranelift-codegen/src/binemit/memorysink.rs
+++ b/cranelift-codegen/src/binemit/memorysink.rs
@@ -142,7 +142,7 @@ impl<'a> CodeSink for MemoryCodeSink<'a> {
     }
 
     fn end_codegen(&mut self) {
-        self.info.rodata_size = self.offset() - self.info.jumptables_size;
+        self.info.rodata_size = self.offset() - (self.info.jumptables_size + self.info.code_size);
         self.info.total_size = self.offset();
     }
 }


### PR DESCRIPTION
The calculation for rodata_size subtraced only the jump table size from the current offset, but had to subtract the sum of all the previous sections, including the code.