### PR TITLE
Mark the jump_table_entry Instruction as loading

### DIFF
--- a/cranelift-codegen/meta-python/base/instructions.py
+++ b/cranelift-codegen/meta-python/base/instructions.py
@@ -164,7 +164,7 @@ jump_table_entry = Instruction(
     Currently, the only type supported is entries which are relative to the
     base of the jump table.
     """,
-    ins=(x, addr, Size, JT), outs=entry)
+    ins=(x, addr, Size, JT), outs=entry, can_load=True)
 
 jump_table_base = Instruction(
     'jump_table_base', r"""

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -309,7 +309,8 @@ pub fn define(
     "#,
         )
         .operands_in(vec![x, addr, Size, JT])
-        .operands_out(vec![entry]),
+        .operands_out(vec![entry])
+        .can_load(true),
     );
 
     ig.push(

--- a/filetests/licm/jump-table-entry.clif
+++ b/filetests/licm/jump-table-entry.clif
@@ -1,0 +1,29 @@
+test licm
+
+target x86_64
+
+function %dont_hoist_jump_table_entry_during_licm() {
+    jt0 = jump_table [ebb1, ebb1]
+
+ebb0:
+    fallthrough ebb1
+
+ebb1: ; the loop!
+    v2 = iconst.i32 42
+    v3 = ifcmp_imm v2, 0
+    brif uge v3, ebb1
+    fallthrough ebb2
+
+ebb2:
+    v1 = iconst.i32 -14
+    v8 = ifcmp_imm v1, 2
+    brif uge v8, ebb1
+    v5 = jump_table_base.i64 jt0
+    v6 = jump_table_entry.i64 v1, v5, 4, jt0
+    v7 = iadd v5, v6
+    indirect_jump_table_br v7, jt0
+; check: ebb2:
+; nextln: v8 = ifcmp_imm.i32 v1, 2
+; nextln: brif uge v8, ebb1
+; nextln: jump_table_entry.i64
+}


### PR DESCRIPTION
The Cranelift instruction `jump_table_entry` loads the jump table entry based on a user-controlled index value that's passed. It's possible to have LICM hoist these instructions above a loop, since they're not considered dangerous in any way. The thing is that the jump table bounds check (`brif` as generated/optimized) is not tied in any way to the `jump_table_entry` instruction, so it's not hoisted at the same time as the jump_table_entry. As a matter of fact, the entry loading may be hoisted (with the user controlled value) before the bounds check is carried out.

This PR marks "jump_table_entry" instructions as loading instructions, since they actually load from memory based on a user-controlled index, thus LICM considers them more dangerous.