### PR TITLE
fix sections translator doc comment

### DIFF
--- a/cranelift-wasm/src/sections_translator.rs
+++ b/cranelift-wasm/src/sections_translator.rs
@@ -1,8 +1,8 @@
 //! Helper functions to gather information for each of the non-function sections of a
 //! WebAssembly module.
 //!
-//! The code of theses helper function is straightforward since it is only about reading metadata
-//! about linear memories, tables, globals, etc. and storing them for later use.
+//! The code of these helper functions is straightforward since they only read metadata
+//! about linear memories, tables, globals, etc. and store them for later use.
 //!
 //! The special case of the initialize expressions for table elements offsets or global variables
 //! is handled, according to the semantics of WebAssembly, to only specific expressions that are


### PR DESCRIPTION
fixes a small typo I found in the doc comment of `cranelift-wasm/src/sections_translator.rs`