### PR TITLE
Update the Rust version badge to match what's tested in CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ into executable machine code.
 [![Travis Status](https://travis-ci.org/CraneStation/cranelift.svg?branch=master)](https://travis-ci.org/CraneStation/cranelift)
 [![Appveyor Status](https://ci.appveyor.com/api/projects/status/oub7wrrb59utuv8x?svg=true)](https://ci.appveyor.com/project/CraneStation/cranelift)
 [![Gitter chat](https://badges.gitter.im/CraneStation/CraneStation.svg)](https://gitter.im/CraneStation/Lobby)
-![Minimum rustc 1.33](https://img.shields.io/badge/rustc-1.33+-green.svg)
+![Minimum rustc 1.34](https://img.shields.io/badge/rustc-1.34+-green.svg)
 
 For more information, see [the
 documentation](https://cranelift.readthedocs.io/en/latest/?badge=latest).


### PR DESCRIPTION
Travis CI is testing 1.34, so update the README.md to match.