### PR TITLE
Use BB-like EBB for test cases. 

### DIFF
--- a/docs/callex.clif
+++ b/docs/callex.clif
@@ -4,10 +4,13 @@ function %gcd(i32 uext, i32 uext) -> i32 uext system_v {
     fn0 = %divmod(i32 uext, i32 uext) -> i32 uext, i32 uext
 
 ebb1(v0: i32, v1: i32):
-    brz v1, ebb2
+    brz v1, ebb3
+    jump ebb2
+
+ebb2:
     v2, v3 = call fn0(v0, v1)
     return v2
 
-ebb2:
+ebb3:
     return v0
 }

--- a/docs/example.clif
+++ b/docs/example.clif
@@ -6,11 +6,14 @@ function %average(i32, i32) -> f32 system_v {
 ebb1(v0: i32, v1: i32):
     v2 = f64const 0x0.0
     stack_store v2, ss0
-    brz v1, ebb3                  ; Handle count == 0.
-    v3 = iconst.i32 0
-    jump ebb2(v3)
+    brz v1, ebb5                  ; Handle count == 0.
+    jump ebb2
 
-ebb2(v4: i32):
+ebb2:
+    v3 = iconst.i32 0
+    jump ebb3(v3)
+
+ebb3(v4: i32):
     v5 = imul_imm v4, 4
     v6 = iadd v0, v5
     v7 = load.f32 v6              ; array[i]
@@ -20,14 +23,17 @@ ebb2(v4: i32):
     stack_store v10, ss0
     v11 = iadd_imm v4, 1
     v12 = icmp ult v11, v1
-    brnz v12, ebb2(v11)           ; Loop backedge.
+    brnz v12, ebb3(v11)           ; Loop backedge.
+    jump ebb4
+
+ebb4:
     v13 = stack_load.f64 ss0
     v14 = fcvt_from_uint.f64 v1
     v15 = fdiv v13, v14
     v16 = fdemote.f32 v15
     return v16
 
-ebb3:
+ebb5:
     v100 = f32const +NaN
     return v100
 }

--- a/filetests/cfg/loop.clif
+++ b/filetests/cfg/loop.clif
@@ -5,13 +5,16 @@ test verifier
 function %nonsense(i32, i32) -> f32 {
 ; check: digraph "%nonsense" {
 ; regex: I=\binst\d+\b
-; check: label="{ebb0 | <$(BRZ=$I)>brz ebb2 | <$(JUMP=$I)>jump ebb1}"]
+; check: label="{ebb0 | <$(BRZ=$I)>brz ebb2 | <$(JUMP=$I)>jump ebb3}"]
 
 ebb0(v1: i32, v2: i32):
     v3 = f64const 0x0.0
     brz v2, ebb2            ; unordered: ebb0:$BRZ -> ebb2
+    jump ebb3               ; unordered: ebb0:$JUMP -> ebb3
+
+ebb3:
     v4 = iconst.i32 0
-    jump ebb1(v4)           ; unordered: ebb0:$JUMP -> ebb1
+    jump ebb1(v4)           ; unordered: ebb3:inst4 -> ebb1
 
 ebb1(v5: i32):
     v6 = imul_imm v5, 4
@@ -22,7 +25,10 @@ ebb1(v5: i32):
     v11 = fadd v9, v10
     v12 = iadd_imm v5, 1
     v13 = icmp ult v12, v2
-    brnz v13, ebb1(v12)     ; unordered: ebb1:inst12 -> ebb1
+    brnz v13, ebb1(v12)     ; unordered: ebb1:inst13 -> ebb1
+    jump ebb4               ; unordered: ebb1:inst14 -> ebb4
+
+ebb4:
     v14 = f64const 0.0
     v15 = f64const 0.0
     v16 = fdiv v14, v15

--- a/filetests/domtree/loops.clif
+++ b/filetests/domtree/loops.clif
@@ -16,6 +16,8 @@ function %test(i32) {
         jump ebb5
     ebb5:
         brz v0, ebb4
+        jump ebb6     ; dominates: ebb6
+    ebb6:
         return
 }
 ; Fall-through-first, prune-at-source DFT:
@@ -28,7 +30,9 @@ function %test(i32) {
 ;                 ebb2:brz v3, ebb1 -
 ;                 ebb2:brz v4, ebb4 {
 ;                     ebb2: jump ebb5 {
-;                         ebb5 {}
+;                         ebb5: jump ebb6 {
+;                             ebb6 {}
+;                         }
 ;                     }
 ;                     ebb4 {}
 ;                 }
@@ -43,6 +47,7 @@ function %test(i32) {
 ; } ebb0
 ;
 ; check: cfg_postorder:
+; sameln: ebb6
 ; sameln: ebb5
 ; sameln: ebb3
 ; sameln: ebb4
@@ -56,7 +61,8 @@ function %test(i32) {
 ; nextln: ebb2:
 ; nextln: ebb4:
 ; nextln: ebb3:
-; nextln: ebb5:
+; nextln: ebb5: ebb6
+; nextln: ebb6:
 ; nextln: }
 
 function %loop2(i32) system_v {
@@ -72,10 +78,14 @@ function %loop2(i32) system_v {
         jump ebb4
     ebb4:
         brz v0, ebb3
+        jump ebb8       ; dominates: ebb8
+    ebb8:
         brnz v0, ebb5
         jump ebb6       ; dominates: ebb6
     ebb5:
         brz v0, ebb4
+        jump ebb9       ; dominates: ebb9
+    ebb9:
         trap user0
     ebb6:
         jump ebb7       ; dominates: ebb7
@@ -83,9 +93,11 @@ function %loop2(i32) system_v {
         return
 }
 ; check: cfg_postorder:
+; sameln: ebb9
 ; sameln: ebb5
 ; sameln: ebb7
 ; sameln: ebb6
+; sameln: ebb8
 ; sameln: ebb3
 ; sameln: ebb4
 ; sameln: ebb2
@@ -96,9 +108,11 @@ function %loop2(i32) system_v {
 ; nextln: ebb0: ebb1 ebb2 ebb4 ebb3 ebb5
 ; nextln: ebb1:
 ; nextln: ebb2:
-; nextln: ebb4: ebb6
+; nextln: ebb4: ebb8
+; nextln: ebb8: ebb6
 ; nextln: ebb6: ebb7
 ; nextln: ebb7:
 ; nextln: ebb3:
-; nextln: ebb5:
+; nextln: ebb5: ebb9
+; nextln: ebb9:
 ; nextln: }

--- a/filetests/domtree/loops2.clif
+++ b/filetests/domtree/loops2.clif
@@ -3,6 +3,8 @@ test domtree
 function %loop1(i32) {
     ebb0(v0: i32):
         brz v0, ebb1    ; dominates: ebb1 ebb6
+        jump ebb10      ; dominates: ebb10
+    ebb10:
         brnz v0, ebb2   ; dominates: ebb2 ebb9
         jump ebb3       ; dominates: ebb3
     ebb1:
@@ -14,10 +16,14 @@ function %loop1(i32) {
         jump ebb9
     ebb4:
         brz v0, ebb4
+        jump ebb11      ; dominates: ebb11
+    ebb11:
         brnz v0, ebb6
         jump ebb7
     ebb5:
         brz v0, ebb7
+        jump ebb12      ; dominates: ebb12
+    ebb12:
         brnz v0, ebb8
         jump ebb9
     ebb6:
@@ -31,16 +37,19 @@ function %loop1(i32) {
 }
 
 ; check: domtree_preorder {
-; nextln: ebb0: ebb1 ebb2 ebb6 ebb3 ebb9
+; nextln: ebb0: ebb1 ebb10 ebb6
 ; nextln: ebb1:
+; nextln: ebb10: ebb2 ebb3 ebb9
 ; nextln: ebb2: ebb4 ebb5 ebb7 ebb8
-; nextln: ebb4:
-; nextln: ebb5:
+; nextln: ebb4: ebb11
+; nextln: ebb11:
+; nextln: ebb5: ebb12
+; nextln: ebb12:
 ; nextln: ebb7:
 ; nextln: ebb8:
-; nextln: ebb6:
 ; nextln: ebb3:
 ; nextln: ebb9:
+; nextln: ebb6:
 ; nextln: }
 
 function %loop2(i32) system_v {
@@ -59,9 +68,12 @@ function %loop2(i32) system_v {
         jump ebb5
     ebb5:
         brz v0, ebb4
+        jump ebb6       ; dominates: ebb6
+    ebb6:
         return
 }
 ; check: cfg_postorder:
+; sameln: ebb6
 ; sameln: ebb5
 ; sameln: ebb3
 ; sameln: ebb4
@@ -75,5 +87,6 @@ function %loop2(i32) system_v {
 ; nextln: ebb2:
 ; nextln: ebb4:
 ; nextln: ebb3:
-; nextln: ebb5:
+; nextln: ebb5: ebb6
+; nextln: ebb6:
 ; nextln: }

--- a/filetests/domtree/tall-tree.clif
+++ b/filetests/domtree/tall-tree.clif
@@ -3,6 +3,8 @@ test domtree
 function %test(i32) {
     ebb0(v0: i32):
         brz v0, ebb1    ; dominates: ebb1
+        jump ebb12      ; dominates: ebb12
+    ebb12:
         brnz v0, ebb2   ; dominates: ebb2 ebb5
         jump ebb3       ; dominates: ebb3
     ebb1:
@@ -18,6 +20,8 @@ function %test(i32) {
         return
     ebb6:
         brz v0, ebb8    ; dominates: ebb11 ebb8
+        jump ebb13      ; dominates: ebb13
+    ebb13:
         brnz v0, ebb9   ; dominates: ebb9
         jump ebb10
     ebb7:
@@ -33,15 +37,17 @@ function %test(i32) {
 }
 
 ; check: domtree_preorder {
-; nextln: ebb0: ebb1 ebb2 ebb3 ebb5
+; nextln: ebb0: ebb1 ebb12
 ; nextln: ebb1: ebb4
 ; nextln: ebb4: ebb6 ebb7 ebb10
-; nextln: ebb6: ebb8 ebb9 ebb11
+; nextln: ebb6: ebb8 ebb13 ebb11
 ; nextln: ebb8:
+; nextln: ebb13: ebb9
 ; nextln: ebb9:
 ; nextln: ebb11:
 ; nextln: ebb7:
 ; nextln: ebb10:
+; nextln: ebb12: ebb2 ebb3 ebb5
 ; nextln: ebb2:
 ; nextln: ebb3:
 ; nextln: ebb5:

--- a/filetests/domtree/wide-tree.clif
+++ b/filetests/domtree/wide-tree.clif
@@ -6,8 +6,14 @@ function %test(i32) {
         jump ebb1       ; dominates: ebb1
     ebb1:
         brz v0, ebb2    ; dominates: ebb2 ebb7
+        jump ebb20      ; dominates: ebb20
+    ebb20:
         brnz v0, ebb3   ; dominates: ebb3
+        jump ebb21      ; dominates: ebb21
+    ebb21:
         brz v0, ebb4    ; dominates: ebb4
+        jump ebb22      ; dominates: ebb22
+    ebb22:
         brnz v0, ebb5   ; dominates: ebb5
         jump ebb6       ; dominates: ebb6
     ebb2:
@@ -22,7 +28,11 @@ function %test(i32) {
         jump ebb7
     ebb7:
         brnz v0, ebb8   ; dominates: ebb8 ebb12
+        jump ebb23      ; dominates: ebb23
+    ebb23:
         brz v0, ebb9    ; dominates: ebb9
+        jump ebb24      ; dominates: ebb24
+    ebb24:
         brnz v0, ebb10  ; dominates: ebb10
         jump ebb11      ; dominates: ebb11
     ebb8:
@@ -43,16 +53,21 @@ function %test(i32) {
 ; check: domtree_preorder {
 ; nextln: ebb0: ebb13 ebb1
 ; nextln: ebb13:
-; nextln: ebb1: ebb2 ebb3 ebb4 ebb5 ebb6 ebb7
+; nextln: ebb1: ebb2 ebb20 ebb7
 ; nextln: ebb2:
+; nextln: ebb20: ebb3 ebb21
 ; nextln: ebb3:
+; nextln: ebb21: ebb4 ebb22
 ; nextln: ebb4:
+; nextln: ebb22: ebb5 ebb6
 ; nextln: ebb5:
 ; nextln: ebb6:
-; nextln: ebb7: ebb8 ebb9 ebb10 ebb12 ebb11
+; nextln: ebb7: ebb8 ebb23 ebb12
 ; nextln: ebb8:
+; nextln: ebb23: ebb9 ebb24
 ; nextln: ebb9:
+; nextln: ebb24: ebb10 ebb11
 ; nextln: ebb10:
-; nextln: ebb12:
 ; nextln: ebb11:
+; nextln: ebb12:
 ; nextln: }

--- a/filetests/isa/riscv/binary32.clif
+++ b/filetests/isa/riscv/binary32.clif
@@ -95,36 +95,77 @@ ebb0(v9999: i32):
     call_indirect sig0, v2()                    ; bin: 000a80e7
 
     brz v1, ebb3
-    brnz v1, ebb1
+    fallthrough ebb4
 
+ebb4:
+    brnz v1, ebb1
+    fallthrough ebb5
+
+ebb5:
     ; jalr %x0, %x1, 0
     return v9999                        ; bin: 00008067
 
 ebb1:
     ; beq 0x000
     br_icmp eq v1, v2, ebb1             ; bin: 01550063
+    fallthrough ebb100
+
+ebb100:
     ; bne 0xffc
     br_icmp ne v1, v2, ebb1             ; bin: ff551ee3
+    fallthrough ebb101
+
+ebb101:
     ; blt 0xff8
     br_icmp slt v1, v2, ebb1            ; bin: ff554ce3
+    fallthrough ebb102
+
+ebb102:
     ; bge 0xff4
     br_icmp sge v1, v2, ebb1            ; bin: ff555ae3
+    fallthrough ebb103
+
+ebb103:
     ; bltu 0xff0
     br_icmp ult v1, v2, ebb1            ; bin: ff5568e3
+    fallthrough ebb104
+
+ebb104:
     ; bgeu 0xfec
     br_icmp uge v1, v2, ebb1            ; bin: ff5576e3
+    fallthrough ebb105
+
+ebb105:
 
     ; Forward branches.
+    fallthrough ebb106
+
+ebb106:
     ; beq 0x018
     br_icmp eq v2, v1, ebb2             ; bin: 00aa8c63
+    fallthrough ebb107
+
+ebb107:
     ; bne 0x014
     br_icmp ne v2, v1, ebb2             ; bin: 00aa9a63
+    fallthrough ebb108
+
+ebb108:
     ; blt 0x010
     br_icmp slt v2, v1, ebb2            ; bin: 00aac863
+    fallthrough ebb109
+
+ebb109:
     ; bge 0x00c
     br_icmp sge v2, v1, ebb2            ; bin: 00aad663
+    fallthrough ebb110
+
+ebb110:
     ; bltu 0x008
     br_icmp ult v2, v1, ebb2            ; bin: 00aae463
+    fallthrough ebb111
+
+ebb111:
     ; bgeu 0x004
     br_icmp uge v2, v1, ebb2            ; bin: 00aaf263
 
@@ -137,6 +178,9 @@ ebb2:
 ebb3:
     ; beq x, %x0
     brz v1, ebb3                        ; bin: 00050063
+    fallthrough ebb6
+
+ebb6:
     ; bne x, %x0
     brnz v1, ebb3                       ; bin: fe051ee3
 

--- a/filetests/isa/x86/binary32-float.clif
+++ b/filetests/isa/x86/binary32-float.clif
@@ -481,21 +481,44 @@ ebb0(v0: f32 [%xmm0]):
 ebb1:
     ; asm: jnp ebb1
     brff ord v1, ebb1                                           ; bin: 7b fe
+    jump ebb2
+
+ebb2:
     ; asm: jp ebb1
     brff uno v1, ebb1                                           ; bin: 7a fc
+    jump ebb3
+
+ebb3:
     ; asm: jne ebb1
     brff one v1, ebb1                                           ; bin: 75 fa
+    jump ebb4
+
+ebb4:
     ; asm: je ebb1
     brff ueq v1, ebb1                                           ; bin: 74 f8
+    jump ebb5
+
+ebb5:
     ; asm: ja ebb1
     brff gt v1, ebb1                                            ; bin: 77 f6
+    jump ebb6
+
+ebb6:
     ; asm: jae ebb1
     brff ge v1, ebb1                                            ; bin: 73 f4
+    jump ebb7
+
+ebb7:
     ; asm: jb ebb1
     brff ult v1, ebb1                                           ; bin: 72 f2
+    jump ebb8
+
+ebb8:
     ; asm: jbe ebb1
     brff ule v1, ebb1                                           ; bin: 76 f0
+    jump ebb9
 
+ebb9:
     ; asm: jp .+4; ud2
     trapff ord v1, user0                                        ; bin: 7a 02 user0 0f 0b
     ; asm: jnp .+4; ud2

--- a/filetests/isa/x86/binary32.clif
+++ b/filetests/isa/x86/binary32.clif
@@ -472,12 +472,21 @@ ebb0:
     ; asm: testl %ecx, %ecx
     ; asm: je ebb1
     brz v1, ebb1                                ; bin: 85 c9 74 0e
+    fallthrough ebb3
+
+ebb3:
     ; asm: testl %esi, %esi
     ; asm: je ebb1
     brz v2, ebb1                                ; bin: 85 f6 74 0a
+    fallthrough ebb4
+
+ebb4:
     ; asm: testl %ecx, %ecx
     ; asm: jne ebb1
     brnz v1, ebb1                               ; bin: 85 c9 75 06
+    fallthrough ebb5
+
+ebb5:
     ; asm: testl %esi, %esi
     ; asm: jne ebb1
     brnz v2, ebb1                               ; bin: 85 f6 75 02
@@ -506,16 +515,27 @@ ebb0:
     ; asm: testl $0xff, %edi
     ; asm: je ebb1
     brz v3, ebb1                                ; bin: f7 c7 000000ff 0f 84 00000015
+    fallthrough ebb2
+
+ebb2:
     ; asm: testb %bl, %bl
     ; asm: je ebb1
     brz v4, ebb1                                ; bin: 84 db 74 11
+    fallthrough ebb3
+
+ebb3:
     ; asm: testl $0xff, %edi
     ; asm: jne ebb1
     brnz v3, ebb1                               ; bin: f7 c7 000000ff 0f 85 00000005
+    fallthrough ebb4
+
+ebb4:
     ; asm: testb %bl, %bl
     ; asm: jne ebb1
     brnz v4, ebb1                               ; bin: 84 db 75 01
+    fallthrough ebb5
 
+ebb5:
     return
 
 ebb1:
@@ -537,24 +557,54 @@ ebb1:
 
     ; asm: je ebb1
     brif eq v11, ebb1                           ; bin: 74 fa
+    jump ebb2
+
+ebb2:
     ; asm: jne ebb1
     brif ne v11, ebb1                           ; bin: 75 f8
+    jump ebb3
+
+ebb3:
     ; asm: jl ebb1
     brif slt v11, ebb1                          ; bin: 7c f6
+    jump ebb4
+
+ebb4:
     ; asm: jge ebb1
     brif sge v11, ebb1                          ; bin: 7d f4
+    jump ebb5
+
+ebb5:
     ; asm: jg ebb1
     brif sgt v11, ebb1                          ; bin: 7f f2
+    jump ebb6
+
+ebb6:
     ; asm: jle ebb1
     brif sle v11, ebb1                          ; bin: 7e f0
+    jump ebb7
+
+ebb7:
     ; asm: jb ebb1
     brif ult v11, ebb1                          ; bin: 72 ee
+    jump ebb8
+
+ebb8:
     ; asm: jae ebb1
     brif uge v11, ebb1                          ; bin: 73 ec
+    jump ebb9
+
+ebb9:
     ; asm: ja ebb1
     brif ugt v11, ebb1                          ; bin: 77 ea
+    jump ebb10
+
+ebb10:
     ; asm: jbe ebb1
     brif ule v11, ebb1                          ; bin: 76 e8
+    jump ebb11
+
+ebb11:
 
     ; asm: sete %bl
     [-,%rbx]            v20 = trueif eq v11                           ; bin: 0f 94 c3

--- a/filetests/isa/x86/binary64-float.clif
+++ b/filetests/isa/x86/binary64-float.clif
@@ -542,21 +542,44 @@ ebb0(v0: f32 [%xmm0]):
 ebb1:
     ; asm: jnp ebb1
     brff ord v1, ebb1                                           ; bin: 7b fe
+    jump ebb2
+
+ebb2:
     ; asm: jp ebb1
     brff uno v1, ebb1                                           ; bin: 7a fc
+    jump ebb3
+
+ebb3:
     ; asm: jne ebb1
     brff one v1, ebb1                                           ; bin: 75 fa
+    jump ebb4
+
+ebb4:
     ; asm: je ebb1
     brff ueq v1, ebb1                                           ; bin: 74 f8
+    jump ebb5
+
+ebb5:
     ; asm: ja ebb1
     brff gt v1, ebb1                                            ; bin: 77 f6
+    jump ebb6
+
+ebb6:
     ; asm: jae ebb1
     brff ge v1, ebb1                                            ; bin: 73 f4
+    jump ebb7
+
+ebb7:
     ; asm: jb ebb1
     brff ult v1, ebb1                                           ; bin: 72 f2
+    jump ebb8
+
+ebb8:
     ; asm: jbe ebb1
     brff ule v1, ebb1                                           ; bin: 76 f0
+    jump ebb9
 
+ebb9:
     ; asm: jp .+4; ud2
     trapff ord v1, user0                                        ; bin: 7a 02 user0 0f 0b
     ; asm: jnp .+4; ud2

--- a/filetests/isa/x86/binary64.clif
+++ b/filetests/isa/x86/binary64.clif
@@ -690,18 +690,33 @@ ebb0:
     ; asm: testq %rcx, %rcx
     ; asm: je ebb1
     brz v1, ebb1                                ; bin: 48 85 c9 74 1b
+    fallthrough ebb3
+
+ebb3:
     ; asm: testq %rsi, %rsi
     ; asm: je ebb1
     brz v2, ebb1                                ; bin: 48 85 f6 74 16
+    fallthrough ebb4
+
+ebb4:
     ; asm: testq %r10, %r10
     ; asm: je ebb1
     brz v3, ebb1                                ; bin: 4d 85 d2 74 11
+    fallthrough ebb5
+
+ebb5:
     ; asm: testq %rcx, %rcx
     ; asm: jne ebb1
     brnz v1, ebb1                               ; bin: 48 85 c9 75 0c
+    fallthrough ebb6
+
+ebb6:
     ; asm: testq %rsi, %rsi
     ; asm: jne ebb1
     brnz v2, ebb1                               ; bin: 48 85 f6 75 07
+    fallthrough ebb7
+
+ebb7:
     ; asm: testq %r10, %r10
     ; asm: jne ebb1
     brnz v3, ebb1                               ; bin: 4d 85 d2 75 02
@@ -733,24 +748,54 @@ ebb1:
 
     ; asm: je ebb1
     brif eq v11, ebb1                           ; bin: 74 f8
+    jump ebb2
+
+ebb2:
     ; asm: jne ebb1
     brif ne v11, ebb1                           ; bin: 75 f6
+    jump ebb3
+
+ebb3:
     ; asm: jl ebb1
     brif slt v11, ebb1                          ; bin: 7c f4
+    jump ebb4
+
+ebb4:
     ; asm: jge ebb1
     brif sge v11, ebb1                          ; bin: 7d f2
+    jump ebb5
+
+ebb5:
     ; asm: jg ebb1
     brif sgt v11, ebb1                          ; bin: 7f f0
+    jump ebb6
+
+ebb6:
     ; asm: jle ebb1
     brif sle v11, ebb1                          ; bin: 7e ee
+    jump ebb7
+
+ebb7:
     ; asm: jb ebb1
     brif ult v11, ebb1                          ; bin: 72 ec
+    jump ebb8
+
+ebb8:
     ; asm: jae ebb1
     brif uge v11, ebb1                          ; bin: 73 ea
+    jump ebb9
+
+ebb9:
     ; asm: ja ebb1
     brif ugt v11, ebb1                          ; bin: 77 e8
+    jump ebb10
+
+ebb10:
     ; asm: jbe ebb1
     brif ule v11, ebb1                          ; bin: 76 e6
+    jump ebb11
+
+ebb11:
 
     ; asm: sete %bl
     [-,%rbx]            v20 = trueif eq v11                           ; bin: 0f 94 c3
@@ -1248,18 +1293,33 @@ ebb0:
     ; asm: testl %ecx, %ecx
     ; asm: je ebb1x
     brz v1, ebb1                                ; bin: 85 c9 74 18
+    fallthrough ebb3
+
+ebb3:
     ; asm: testl %esi, %esi
     ; asm: je ebb1x
     brz v2, ebb1                                ; bin: 85 f6 74 14
+    fallthrough ebb4
+
+ebb4:
     ; asm: testl %r10d, %r10d
     ; asm: je ebb1x
     brz v3, ebb1                                ; bin: 45 85 d2 74 0f
+    fallthrough ebb5
+
+ebb5:
     ; asm: testl %ecx, %ecx
     ; asm: jne ebb1x
     brnz v1, ebb1                               ; bin: 85 c9 75 0b
+    fallthrough ebb6
+
+ebb6:
     ; asm: testl %esi, %esi
     ; asm: jne ebb1x
     brnz v2, ebb1                               ; bin: 85 f6 75 07
+    fallthrough ebb7
+
+ebb7:
     ; asm: testl %r10d, %r10d
     ; asm: jne ebb1x
     brnz v3, ebb1                               ; bin: 45 85 d2 75 02

--- a/filetests/isa/x86/prologue-epilogue.clif
+++ b/filetests/isa/x86/prologue-epilogue.clif
@@ -213,20 +213,23 @@ function %divert(i32) -> i32 system_v {
 ebb0(v0: i32):
     v2 = iconst.i32 0
     v3 = iconst.i32 1
-    jump ebb3(v0, v3, v2)
+    jump ebb1(v0, v3, v2)
 
-ebb3(v4: i32, v5: i32, v6: i32):
-    brz v4, ebb4
+ebb1(v4: i32, v5: i32, v6: i32):
+    brz v4, ebb3
+    fallthrough ebb2
+
+ebb2:
     v7 = iadd v5, v6
     v8 = iadd_imm v4, -1
-    jump ebb3(v8, v7, v5)
+    jump ebb1(v8, v7, v5)
 
-ebb4:
+ebb3:
     return v5
 }
 
 ; check: function %divert
-; check: regmove v5, %rcx -> %rbx
+; check: regmove.i32 v5, %rcx -> %rbx
 ; check: [Op1popq#58,%rbx]                   v15 = x86_pop.i64
 
 ; Stack limit checking

--- a/filetests/isa/x86/prologue-epilogue.clif
+++ b/filetests/isa/x86/prologue-epilogue.clif
@@ -217,7 +217,7 @@ ebb0(v0: i32):
 
 ebb1(v4: i32, v5: i32, v6: i32):
     brz v4, ebb3
-    fallthrough ebb2
+    jump ebb2
 
 ebb2:
     v7 = iadd v5, v6

--- a/filetests/isa/x86/relax_branch.clif
+++ b/filetests/isa/x86/relax_branch.clif
@@ -55,6 +55,9 @@ function u0:2691(i32 [%rdi], i32 [%rsi], i64 vmctx [%r14]) -> i64 uext [%rax] ba
 @004c [Op1r_id#4081,%rcx]           v37 = band_imm v35, 255
 [Op1rcmp_ib#7083,%rflags]           v97 = ifcmp_imm v37, 26
 @0050 [Op1brib#70]                  brif sge v97, ebb6
+@0050 [-]                           fallthrough ebb10
+
+                                ebb10:
 [Op1umr#89,%rcx]                    v101 = copy v18
 @0054 [Op1jmpb#eb]                  jump ebb5(v18, v101)
 
@@ -82,6 +85,9 @@ function u0:2691(i32 [%rdi], i32 [%rsi], i64 vmctx [%r14]) -> i64 uext [%rax] ba
 [Op1rcmp_ib#7083,%rflags]           v98 = ifcmp_imm v63, 26
 @0084 [RexOp1rmov#89]               regmove v47, %rdi -> %rbx
 @0084 [Op1brib#70]                  brif sge v98, ebb8
+@0084 [-]                           fallthrough ebb11
+
+                                ebb11:
 [RexOp1umr#89,%rdx]                 v103 = copy.i32 v29
 @0088 [Op1jmpb#eb]                  jump ebb7(v29, v10, v21, v103)
 
@@ -99,6 +105,9 @@ function u0:2691(i32 [%rdi], i32 [%rsi], i64 vmctx [%r14]) -> i64 uext [%rax] ba
 @0098 [Op2urm_noflags_abcd#4b6,%rbx] v77 = bint.i32 v76
 @0099 [RexOp1rr#21,%r10]            v78 = band.i32 v50, v77
 @009a [RexOp1tjccb#74]              brz v78, ebb9
+@009a [-]                           fallthrough ebb12
+
+                                ebb12:
 [RexOp1umr#89,%rcx]                 v99 = copy v81
 [Op1umr#89,%rdx]                    v100 = copy v79
 @00a4 [RexOp1rmov#89]               regmove v100, %rdx -> %rdi

--- a/filetests/isa/x86/shrink-multiple-uses.clif
+++ b/filetests/isa/x86/shrink-multiple-uses.clif
@@ -8,7 +8,7 @@ ebb0(v0: i32 [%rdi]):
 [Op2seti_abcd#490,%rax]             v1 = trueif eq v3
 [RexOp2urm_noflags#4b6,%rax]        v2 = bint.i32 v1
 [Op1brib#70]                        brif eq v3, ebb1
-[-]                                 fallthrough ebb2
+[Op1jmpb#eb]                        jump ebb2
 
 ebb2:
 [Op1ret#c3]                         return v2

--- a/filetests/isa/x86/shrink-multiple-uses.clif
+++ b/filetests/isa/x86/shrink-multiple-uses.clif
@@ -8,6 +8,9 @@ ebb0(v0: i32 [%rdi]):
 [Op2seti_abcd#490,%rax]             v1 = trueif eq v3
 [RexOp2urm_noflags#4b6,%rax]        v2 = bint.i32 v1
 [Op1brib#70]                        brif eq v3, ebb1
+[-]                                 fallthrough ebb2
+
+ebb2:
 [Op1ret#c3]                         return v2
 
 ebb1:

--- a/filetests/licm/basic.clif
+++ b/filetests/licm/basic.clif
@@ -10,11 +10,14 @@ ebb1(v1: i32):
     v2 = iconst.i32 1
     v3 = iconst.i32 2
     v4 = iadd v2, v3
-    brz v1, ebb2(v1)
+    brz v1, ebb3(v1)
+    jump ebb2
+
+ebb2:
     v5 = isub v1, v2
     jump ebb1(v5)
 
-ebb2(v6: i32):
+ebb3(v6: i32):
     return v6
 
 }
@@ -26,10 +29,13 @@ ebb2(v6: i32):
 ; nextln:     jump ebb1(v0)
 ; nextln: 
 ; nextln: ebb1(v1: i32):
-; nextln:     brz v1, ebb2(v1)
-; nextln:     v5 = isub v1, v2
+; nextln:     brz v1, ebb3(v1)
+; nextln:     jump ebb2
+; nextln: 
+; nextln: ebb2:
+; nextln:     v5 = isub.i32 v1, v2
 ; nextln:     jump ebb1(v5)
 ; nextln: 
-; nextln: ebb2(v6: i32):
+; nextln: ebb3(v6: i32):
 ; nextln:     return v6
 ; nextln: }

--- a/filetests/licm/complex.clif
+++ b/filetests/licm/complex.clif
@@ -39,7 +39,7 @@ ebb0(v0: i32):
             v19 = iadd v18, v2
             v20 = iadd.i32 v2, v3
 [SBzero#18] brz.i32 v1, ebb1(v20)
-            fallthrough ebb7
+[UJ#1b]     jump ebb7
 
          ebb7:
 [Iret#19]   return v19
@@ -89,7 +89,7 @@ ebb0(v0: i32):
 ; nextln: ebb6(v18: i32):
 ; nextln:     v19 = iadd v18, v2
 ; nextln:     brz.i32 v1, ebb1(v20)
-; nextln:     fallthrough ebb7
+; nextln:     jump ebb7
 ; nextln: 
 ; nextln: ebb7:
 ; nextln:     return v19

--- a/filetests/licm/complex.clif
+++ b/filetests/licm/complex.clif
@@ -39,6 +39,9 @@ ebb0(v0: i32):
             v19 = iadd v18, v2
             v20 = iadd.i32 v2, v3
 [SBzero#18] brz.i32 v1, ebb1(v20)
+            fallthrough ebb7
+
+         ebb7:
 [Iret#19]   return v19
 }
 
@@ -53,10 +56,10 @@ ebb0(v0: i32):
 ; nextln: 
 ; nextln: ebb1(v1: i32):
 ; nextln:     v4 = iadd.i32 v2, v1
-; nextln:     brz v1, ebb7(v2)
-; nextln:     jump ebb8(v4)
+; nextln:     brz v1, ebb8(v2)
+; nextln:     jump ebb9(v4)
 ; nextln: 
-; nextln: ebb7(v21: i32):
+; nextln: ebb8(v21: i32):
 ; nextln:     v8 = iadd.i32 v6, v1
 ; nextln:     v11 = iadd.i32 v1, v4
 ; nextln:     jump ebb2(v21)
@@ -70,7 +73,7 @@ ebb0(v0: i32):
 ; nextln:     brz.i32 v1, ebb2(v9)
 ; nextln:     jump ebb6(v10)
 ; nextln: 
-; nextln: ebb8(v22: i32):
+; nextln: ebb9(v22: i32):
 ; nextln:     v15 = iadd.i32 v4, v13
 ; nextln:     jump ebb4(v22)
 ; nextln: 
@@ -86,5 +89,8 @@ ebb0(v0: i32):
 ; nextln: ebb6(v18: i32):
 ; nextln:     v19 = iadd v18, v2
 ; nextln:     brz.i32 v1, ebb1(v20)
+; nextln:     fallthrough ebb7
+; nextln: 
+; nextln: ebb7:
 ; nextln:     return v19
 ; nextln: }

--- a/filetests/licm/critical-edge.clif
+++ b/filetests/licm/critical-edge.clif
@@ -7,7 +7,7 @@ function %critical_edge(i32, i32) -> i32 {
 
             ebb0(v0: i32, v7: i32):
 [SBzero#38]   brnz v7, ebb2(v0)
-[-]           fallthrough ebb1
+[UJ#1b]       jump ebb1
 
             ebb1:
 [Iret#19]     return v0
@@ -30,7 +30,7 @@ function %critical_edge(i32, i32) -> i32 {
 ; sameln: function %critical_edge
 ; nextln: ebb0(v0: i32, v7: i32):
 ; nextln:     brnz v7, ebb5(v0)
-; nextln:     fallthrough ebb1
+; nextln:     jump ebb1
 ; nextln: 
 ; nextln: ebb1:
 ; nextln:     return v0

--- a/filetests/licm/critical-edge.clif
+++ b/filetests/licm/critical-edge.clif
@@ -6,37 +6,49 @@ target riscv32
 function %critical_edge(i32, i32) -> i32 {
 
             ebb0(v0: i32, v7: i32):
-[SBzero#38]   brnz v7, ebb1(v0)
+[SBzero#38]   brnz v7, ebb2(v0)
+[-]           fallthrough ebb1
+
+            ebb1:
 [Iret#19]     return v0
 
-            ebb1(v1: i32):
+            ebb2(v1: i32):
               v2 = iconst.i32 1
               v3 = iconst.i32 2
               v4 = iadd v2, v3
-[SBzero#18]   brz v1, ebb2(v1)
-              v5 = isub v1, v2
-[UJ#1b]       jump ebb1(v5)
+[SBzero#18]   brz v1, ebb4(v1)
+[UJ#1b]       jump ebb3
 
-            ebb2(v6: i32):
+            ebb3:
+              v5 = isub v1, v2
+[UJ#1b]       jump ebb2(v5)
+
+            ebb4(v6: i32):
 [Iret#19]     return v6
 
 }
 ; sameln: function %critical_edge
 ; nextln: ebb0(v0: i32, v7: i32):
-; nextln:     brnz v7, ebb3(v0)
+; nextln:     brnz v7, ebb5(v0)
+; nextln:     fallthrough ebb1
+; nextln: 
+; nextln: ebb1:
 ; nextln:     return v0
 ; nextln: 
-; nextln: ebb3(v8: i32):
+; nextln: ebb5(v8: i32):
 ; nextln:     v2 = iconst.i32 1
 ; nextln:     v3 = iconst.i32 2
 ; nextln:     v4 = iadd v2, v3
-; nextln:     jump ebb1(v8)
+; nextln:     jump ebb2(v8)
 ; nextln: 
-; nextln: ebb1(v1: i32):
-; nextln:     brz v1, ebb2(v1)
-; nextln:     v5 = isub v1, v2
-; nextln:     jump ebb1(v5)
+; nextln: ebb2(v1: i32):
+; nextln:     brz v1, ebb4(v1)
+; nextln:     jump ebb3
 ; nextln: 
-; nextln: ebb2(v6: i32):
+; nextln: ebb3:
+; nextln:     v5 = isub.i32 v1, v2
+; nextln:     jump ebb2(v5)
+; nextln: 
+; nextln: ebb4(v6: i32):
 ; nextln:     return v6
 ; nextln: }

--- a/filetests/licm/encoding.clif
+++ b/filetests/licm/encoding.clif
@@ -11,11 +11,14 @@ function %simple_loop(i32) -> i32 {
 [Iz#04,%x0]   v2 = iconst.i32 1
 [Iz#04,%x1]   v3 = iconst.i32 2
 [R#0c,%x2]    v4 = iadd v2, v3
-[SBzero#18]   brz v1, ebb2(v1)
+[SBzero#18]   brz v1, ebb3(v1)
+[UJ#1b]       jump ebb2
+
+            ebb2:
 [R#200c,%x5]  v5 = isub v1, v2
 [UJ#1b]       jump ebb1(v5)
 
-            ebb2(v6: i32):
+            ebb3(v6: i32):
 [Iret#19]     return v6
 }
 
@@ -27,10 +30,13 @@ function %simple_loop(i32) -> i32 {
 ; nextln: [UJ#1b]                             jump ebb1(v0)
 ; nextln: 
 ; nextln:                                 ebb1(v1: i32):
-; nextln: [SBzero#18]                         brz v1, ebb2(v1)
-; nextln: [R#200c,%x5]                        v5 = isub v1, v2
+; nextln: [SBzero#18]                         brz v1, ebb3(v1)
+; nextln: [UJ#1b]                             jump ebb2
+; nextln: 
+; nextln:                                 ebb2:
+; nextln: [R#200c,%x5]                        v5 = isub.i32 v1, v2
 ; nextln: [UJ#1b]                             jump ebb1(v5)
 ; nextln: 
-; nextln:                                 ebb2(v6: i32):
+; nextln:                                 ebb3(v6: i32):
 ; nextln: [Iret#19]                           return v6
 ; nextln: }

--- a/filetests/licm/load_readonly_notrap.clif
+++ b/filetests/licm/load_readonly_notrap.clif
@@ -18,11 +18,14 @@ ebb1(v2: i32, v3: i64):
     v5 = heap_addr.i64 heap0, v4, 1
     v6 = load.i32 notrap aligned readonly v5
     v7 = iadd v2, v6
-    brz v2, ebb2(v2)
+    brz v2, ebb3(v2)
+    jump ebb2
+
+ebb2:
     v8 = isub v2, v4
     jump ebb1(v8, v3)
 
-ebb2(v9: i32):
+ebb3(v9: i32):
     return v9
 }
 
@@ -39,10 +42,13 @@ ebb2(v9: i32):
 ; nextln: 
 ; nextln: ebb1(v2: i32, v3: i64):
 ; nextln:    v7 = iadd v2, v6
-; nextln:    brz v2, ebb2(v2)
-; nextln:    v8 = isub v2, v4
+; nextln:    brz v2, ebb3(v2)
+; nextln:     jump ebb2
+; nextln: 
+; nextln: ebb2:
+; nextln:    v8 = isub.i32 v2, v4
 ; nextln:    jump ebb1(v8, v3)
 ; nextln: 
-; nextln: ebb2(v9: i32):
+; nextln: ebb3(v9: i32):
 ; nextln:    return v9
 ; nextln: }

--- a/filetests/licm/multiple-blocks.clif
+++ b/filetests/licm/multiple-blocks.clif
@@ -10,16 +10,22 @@ ebb1(v10: i32):
     v11 = iconst.i32 1
     v12 = iconst.i32 2
     v13 = iadd v11, v12
-    brz v10, ebb2(v10)
+    brz v10, ebb4(v10)
+    jump ebb2
+
+ebb2:
     v15 = isub v10, v11
-    brz v15, ebb3(v15)
+    brz v15, ebb5(v15)
+    jump ebb3
+
+ebb3:
     v14 = isub v10, v11
     jump ebb1(v14)
 
-ebb2(v20: i32):
+ebb4(v20: i32):
     return v20
 
-ebb3(v30: i32):
+ebb5(v30: i32):
     v31 = iadd v11, v13
     jump ebb1(v30)
 
@@ -33,15 +39,21 @@ ebb3(v30: i32):
 ; nextln:     jump ebb1(v0)
 ; nextln: 
 ; nextln: ebb1(v10: i32):
-; nextln:     brz v10, ebb2(v10)
-; nextln:     v15 = isub v10, v11
-; nextln:     brz v15, ebb3(v15)
-; nextln:     v14 = isub v10, v11
+; nextln:     brz v10, ebb4(v10)
+; nextln:     jump ebb2
+; nextln: 
+; nextln: ebb2:
+; nextln:     v15 = isub.i32 v10, v11
+; nextln:     brz v15, ebb5(v15)
+; nextln:     jump ebb3
+; nextln: 
+; nextln: ebb3:
+; nextln:     v14 = isub.i32 v10, v11
 ; nextln:     jump ebb1(v14)
 ; nextln: 
-; nextln: ebb2(v20: i32):
+; nextln: ebb4(v20: i32):
 ; nextln:     return v20
 ; nextln: 
-; nextln: ebb3(v30: i32):
+; nextln: ebb5(v30: i32):
 ; nextln:     jump ebb1(v30)
 ; nextln: }

--- a/filetests/licm/nested_loops.clif
+++ b/filetests/licm/nested_loops.clif
@@ -14,17 +14,20 @@ ebb1(v1: i32):
     jump ebb2(v5, v5)
 
 ebb2(v10: i32, v11: i32):
-    brz v11, ebb3(v10)
+    brz v11, ebb4(v10)
+    jump ebb3
+
+ebb3:
     v12 = iconst.i32 1
     v15 = iadd v12, v5
     v13 = isub v11, v12
     jump ebb2(v10,v13)
 
-ebb3(v20: i32):
-    brz v20, ebb4(v20)
+ebb4(v20: i32):
+    brz v20, ebb5(v20)
     jump ebb1(v20)
 
-ebb4(v30: i32):
+ebb5(v30: i32):
     return v30
 
 }
@@ -43,14 +46,17 @@ ebb4(v30: i32):
 ; nextln:     jump ebb2(v5, v5)
 ; nextln: 
 ; nextln: ebb2(v10: i32, v11: i32):
-; nextln:     brz v11, ebb3(v10)
-; nextln:     v13 = isub v11, v12
+; nextln:     brz v11, ebb4(v10)
+; nextln:     jump ebb3
+; nextln: 
+; nextln: ebb3:
+; nextln:     v13 = isub.i32 v11, v12
 ; nextln:     jump ebb2(v10, v13)
 ; nextln: 
-; nextln: ebb3(v20: i32):
-; nextln:     brz v20, ebb4(v20)
+; nextln: ebb4(v20: i32):
+; nextln:     brz v20, ebb5(v20)
 ; nextln:     jump ebb1(v20)
 ; nextln: 
-; nextln: ebb4(v30: i32):
+; nextln: ebb5(v30: i32):
 ; nextln:     return v30
 ; nextln: }

--- a/filetests/licm/reject.clif
+++ b/filetests/licm/reject.clif
@@ -11,11 +11,14 @@ ebb1(v1: i32):
 ; check: ebb1(v1: i32):
 ; check: regmove.i32 v0, %x10 -> %x20
     v2 = iconst.i32 1
-    brz v1, ebb2(v1)
+    brz v1, ebb3(v1)
+    jump ebb2
+
+ebb2:
     v5 = isub v1, v2
     jump ebb1(v5)
 
-ebb2(v6: i32):
+ebb3(v6: i32):
     return v6
 
 }
@@ -31,12 +34,15 @@ ebb1(v2: i32, v3: i32):
 ; check: ifcmp.i32 v0, v1
 ; check: v5 = selectif.i32 eq v4, v2, v3
     v8 = iconst.i32 1
-    brz v1, ebb2(v1)
+    brz v1, ebb3(v1)
+    jump ebb2
+
+ebb2:
     v9 = isub v1, v8
     v10 = iadd v1, v8
     jump ebb1(v9, v10)
 
-ebb2(v6: i32):
+ebb3(v6: i32):
     return v6
 }
 
@@ -53,11 +59,14 @@ ebb1(v3: i32, v4: i32):
 ; check: v5 = spill.i32 v1
 ; check: v6 = fill.i32 v2
 ; check: v7 = fill v5
-    brz v1, ebb2(v1)
+    brz v1, ebb3(v1)
+    jump ebb2
+
+ebb2:
     v9 = isub v1, v4
     jump ebb1(v9, v3)
 
-ebb2(v10: i32):
+ebb3(v10: i32):
     return v10
 }
 
@@ -72,11 +81,14 @@ ebb1(v1: i32):
     v2 = iadd v8, v9
 ; check: ebb1(v1: i32):
 ; check: v2 = iadd v8, v9
-    brz v1, ebb2(v1)
+    brz v1, ebb3(v1)
+    jump ebb2
+
+ebb2:
     v5 = isub v1, v2
     jump ebb1(v5)
 
-ebb2(v6: i32):
+ebb3(v6: i32):
     return v6
 
 }

--- a/filetests/licm/reject_load_notrap.clif
+++ b/filetests/licm/reject_load_notrap.clif
@@ -19,11 +19,14 @@ ebb0(v0: i32, v1: i64):
 ebb1(v2: i32, v3: i64):
     v6 = load.i32 notrap aligned v5
     v7 = iadd v2, v6
-    brz v2, ebb2(v2)
+    brz v2, ebb3(v2)
+    jump ebb2
+
+ebb2:
     v8 = isub v2, v4
     jump ebb1(v8, v3)
 
-ebb2(v9: i32):
+ebb3(v9: i32):
     return v9
 }
 
@@ -40,10 +43,13 @@ ebb2(v9: i32):
 ; nextln: ebb1(v2: i32, v3: i64):
 ; nextln:    v6 = load.i32 notrap aligned v5
 ; nextln:    v7 = iadd v2, v6
-; nextln:    brz v2, ebb2(v2)
-; nextln:    v8 = isub v2, v4
+; nextln:    brz v2, ebb3(v2)
+; nextln:    jump ebb2
+; nextln: 
+; nextln: ebb2:
+; nextln:    v8 = isub.i32 v2, v4
 ; nextln:    jump ebb1(v8, v3)
 ; nextln: 
-; nextln: ebb2(v9: i32):
+; nextln: ebb3(v9: i32):
 ; nextln:    return v9
 ; nextln: }

--- a/filetests/licm/reject_load_readonly.clif
+++ b/filetests/licm/reject_load_readonly.clif
@@ -19,11 +19,14 @@ ebb1(v2: i32, v3: i64):
     v5 = heap_addr.i64 heap0, v4, 1
     v6 = load.i32 aligned readonly v5
     v7 = iadd v2, v6
-    brz v2, ebb2(v2)
+    brz v2, ebb3(v2)
+    jump ebb2
+
+ebb2:
     v8 = isub v2, v4
     jump ebb1(v8, v3)
 
-ebb2(v9: i32):
+ebb3(v9: i32):
     return v9
 }
 
@@ -40,10 +43,13 @@ ebb2(v9: i32):
 ; nextln: ebb1(v2: i32, v3: i64):
 ; nextln:    v6 = load.i32 aligned readonly v5
 ; nextln:    v7 = iadd v2, v6
-; nextln:    brz v2, ebb2(v2)
-; nextln:    v8 = isub v2, v4
+; nextln:    brz v2, ebb3(v2)
+; nextln:    jump ebb2
+; nextln: 
+; nextln: ebb2:
+; nextln:    v8 = isub.i32 v2, v4
 ; nextln:    jump ebb1(v8, v3)
 ; nextln: 
-; nextln: ebb2(v9: i32):
+; nextln: ebb3(v9: i32):
 ; nextln:    return v9
 ; nextln: }

--- a/filetests/parser/flags.clif
+++ b/filetests/parser/flags.clif
@@ -5,11 +5,20 @@ function %iflags(i32) {
 ebb200(v0: i32):
     v1 = ifcmp_imm v0, 17
     brif eq v1, ebb201
+    jump ebb400
+
+ebb400:
     brif ugt v1, ebb202
+    jump ebb401
+
+ebb401:
     v2 = iconst.i32 34
     v3 = ifcmp v0, v2
     v4 = trueif eq v3
     brnz v4, ebb202
+    jump ebb402
+
+ebb402:
     return
 
 ebb201:
@@ -21,7 +30,7 @@ ebb202:
 ; check: v1 = ifcmp_imm v0, 17
 ; check: brif eq v1, ebb201
 ; check: brif ugt v1, ebb202
-; check: v3 = ifcmp v0, v2
+; check: v3 = ifcmp.i32 v0, v2
 ; check: v4 = trueif eq v3
 
 function %fflags(f32) {
@@ -29,9 +38,18 @@ ebb200(v0: f32):
     v1 = f32const 0x34.0p0
     v2 = ffcmp v0, v1
     brff eq v2, ebb201
+    jump ebb400
+
+ebb400:
     brff ord v2, ebb202
+    jump ebb401
+
+ebb401:
     v3 = trueff gt v2
     brnz v3, ebb202
+    jump ebb402
+
+ebb402:
     return
 
 ebb201:

--- a/filetests/postopt/basic.clif
+++ b/filetests/postopt/basic.clif
@@ -7,6 +7,9 @@ function %br_icmp(i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32):
 [Op1icscc#39,%rdx]  v2 = icmp slt v0, v1
 [Op1t8jccd_long#85] brnz v2, ebb1
+[-]                 fallthrough ebb2
+
+ebb2:
 [Op1ret#c3]         return v1
 
 ebb1:
@@ -18,6 +21,9 @@ ebb1:
 ; nextln:    v9 = ifcmp v0, v1
 ; nextln:    v2 = trueif slt v9
 ; nextln:    brif slt v9, ebb1
+; nextln:    fallthrough ebb2
+; nextln: 
+; nextln: ebb2:
 ; nextln:    return v1
 ; nextln: 
 ; nextln: ebb1:
@@ -31,6 +37,9 @@ function %br_icmp_inverse(i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32):
 [Op1icscc#39,%rdx]  v2 = icmp slt v0, v1
 [Op1t8jccd_long#84] brz v2, ebb1
+[-]                 fallthrough ebb2
+
+ebb2:
 [Op1ret#c3]         return v1
 
 ebb1:
@@ -42,6 +51,9 @@ ebb1:
 ; nextln:    v9 = ifcmp v0, v1
 ; nextln:    v2 = trueif slt v9
 ; nextln:    brif sge v9, ebb1
+; nextln:    fallthrough ebb2
+; nextln: 
+; nextln: ebb2:
 ; nextln:    return v1
 ; nextln: 
 ; nextln: ebb1:
@@ -55,6 +67,9 @@ function %br_icmp_imm(i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32):
 [Op1icscc_ib#7083]  v2 = icmp_imm slt v0, 2
 [Op1t8jccd_long#84] brz v2, ebb1
+[-]                 fallthrough ebb2
+
+ebb2:
 [Op1ret#c3]         return v1
 
 ebb1:
@@ -66,6 +81,9 @@ ebb1:
 ; nextln:    v9 = ifcmp_imm v0, 2
 ; nextln:    v2 = trueif slt v9
 ; nextln:    brif sge v9, ebb1
+; nextln:    fallthrough ebb2
+; nextln: 
+; nextln: ebb2:
 ; nextln:    return v1
 ; nextln: 
 ; nextln: ebb1:
@@ -79,6 +97,9 @@ function %br_fcmp(f32, f32) -> f32 {
 ebb0(v0: f32, v1: f32):
 [Op2fcscc#42e,%rdx] v2 = fcmp gt v0, v1
 [Op1t8jccd_long#84] brz v2, ebb1
+[-]                 fallthrough ebb2
+
+ebb2:
 [Op1ret#c3]         return v1
 
 ebb1:
@@ -91,6 +112,9 @@ ebb1:
 ; nextln:    v19 = ffcmp v0, v1
 ; nextln:    v2 = trueff gt v19
 ; nextln:    brff ule v19, ebb1
+; nextln:    fallthrough ebb2
+; nextln: 
+; nextln: ebb2:
 ; nextln:    return v1
 ; nextln: 
 ; nextln: ebb1:

--- a/filetests/postopt/basic.clif
+++ b/filetests/postopt/basic.clif
@@ -7,7 +7,7 @@ function %br_icmp(i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32):
 [Op1icscc#39,%rdx]  v2 = icmp slt v0, v1
 [Op1t8jccd_long#85] brnz v2, ebb1
-[-]                 fallthrough ebb2
+[Op1jmpb#eb]        jump ebb2
 
 ebb2:
 [Op1ret#c3]         return v1
@@ -21,7 +21,7 @@ ebb1:
 ; nextln:    v9 = ifcmp v0, v1
 ; nextln:    v2 = trueif slt v9
 ; nextln:    brif slt v9, ebb1
-; nextln:    fallthrough ebb2
+; nextln:    jump ebb2
 ; nextln: 
 ; nextln: ebb2:
 ; nextln:    return v1
@@ -37,7 +37,7 @@ function %br_icmp_inverse(i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32):
 [Op1icscc#39,%rdx]  v2 = icmp slt v0, v1
 [Op1t8jccd_long#84] brz v2, ebb1
-[-]                 fallthrough ebb2
+[Op1jmpb#eb]        jump ebb2
 
 ebb2:
 [Op1ret#c3]         return v1
@@ -51,7 +51,7 @@ ebb1:
 ; nextln:    v9 = ifcmp v0, v1
 ; nextln:    v2 = trueif slt v9
 ; nextln:    brif sge v9, ebb1
-; nextln:    fallthrough ebb2
+; nextln:    jump ebb2
 ; nextln: 
 ; nextln: ebb2:
 ; nextln:    return v1
@@ -67,7 +67,7 @@ function %br_icmp_imm(i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32):
 [Op1icscc_ib#7083]  v2 = icmp_imm slt v0, 2
 [Op1t8jccd_long#84] brz v2, ebb1
-[-]                 fallthrough ebb2
+[Op1jmpb#eb]        jump ebb2
 
 ebb2:
 [Op1ret#c3]         return v1
@@ -81,7 +81,7 @@ ebb1:
 ; nextln:    v9 = ifcmp_imm v0, 2
 ; nextln:    v2 = trueif slt v9
 ; nextln:    brif sge v9, ebb1
-; nextln:    fallthrough ebb2
+; nextln:    jump ebb2
 ; nextln: 
 ; nextln: ebb2:
 ; nextln:    return v1
@@ -97,7 +97,7 @@ function %br_fcmp(f32, f32) -> f32 {
 ebb0(v0: f32, v1: f32):
 [Op2fcscc#42e,%rdx] v2 = fcmp gt v0, v1
 [Op1t8jccd_long#84] brz v2, ebb1
-[-]                 fallthrough ebb2
+[Op1jmpb#eb]        jump ebb2
 
 ebb2:
 [Op1ret#c3]         return v1
@@ -112,7 +112,7 @@ ebb1:
 ; nextln:    v19 = ffcmp v0, v1
 ; nextln:    v2 = trueff gt v19
 ; nextln:    brff ule v19, ebb1
-; nextln:    fallthrough ebb2
+; nextln:    jump ebb2
 ; nextln: 
 ; nextln: ebb2:
 ; nextln:    return v1

--- a/filetests/regalloc/coalesce.clif
+++ b/filetests/regalloc/coalesce.clif
@@ -12,7 +12,7 @@ ebb0(v0: i32):
     ; not: copy
     ; v0 is used by the branch and passed as an arg - that's no conflict.
     brnz v0, ebb1(v0)
-    fallthrough ebb2
+    jump ebb2
 
 ebb2:
     ; v0 is live across the branch above. That's no conflict.
@@ -29,7 +29,7 @@ ebb0(v0: i32):
     ; check: $(cp1=$V) = copy v0
     ; nextln: brnz v0, ebb1($cp1)
     brnz v0, ebb1(v0)
-    fallthrough ebb2
+    jump ebb2
 
 ebb2:
     ; not: copy
@@ -48,7 +48,7 @@ ebb0(v0: i32):
     ; check: $(cp1=$V) = copy v0
     ; nextln: brnz v0, ebb1($cp1, v0)
     brnz v0, ebb1(v0, v0)
-    fallthrough ebb2
+    jump ebb2
 
 ebb2:
     v1 = iadd_imm v0, 7
@@ -68,7 +68,7 @@ ebb0(v0: i32):
     ; not: copy
     ; check: brnz v0, ebb1($cp0)
     brnz v0, ebb1(v0)
-    fallthrough ebb2
+    jump ebb2
 
 ebb2:
     v1 = iadd_imm v0, 7
@@ -101,7 +101,7 @@ ebb1(v10: i32, v11: i32):
     ; not: copy
     ; check: brnz v13, ebb1($nv11b, v12)
     brnz v13, ebb1(v11, v12)
-    fallthrough ebb2
+    jump ebb2
 
 ebb2:
     return v12
@@ -131,12 +131,12 @@ ebb0(v0: i32):
 
 ebb2(v3: i32, v4: i32):
     brnz v3, ebb2(v3, v4)
-    fallthrough ebb3
+    jump ebb3
 
 ebb3:
     v5 = iconst.i32 1
     brnz v3, ebb2(v2, v5)
-    fallthrough ebb4
+    jump ebb4
 
 ebb4:
     return

--- a/filetests/regalloc/coalesce.clif
+++ b/filetests/regalloc/coalesce.clif
@@ -12,6 +12,9 @@ ebb0(v0: i32):
     ; not: copy
     ; v0 is used by the branch and passed as an arg - that's no conflict.
     brnz v0, ebb1(v0)
+    fallthrough ebb2
+
+ebb2:
     ; v0 is live across the branch above. That's no conflict.
     v1 = iadd_imm v0, 7
     jump ebb1(v1)
@@ -26,6 +29,9 @@ ebb0(v0: i32):
     ; check: $(cp1=$V) = copy v0
     ; nextln: brnz v0, ebb1($cp1)
     brnz v0, ebb1(v0)
+    fallthrough ebb2
+
+ebb2:
     ; not: copy
     v1 = iadd_imm v0, 7
     jump ebb1(v1)
@@ -42,6 +48,9 @@ ebb0(v0: i32):
     ; check: $(cp1=$V) = copy v0
     ; nextln: brnz v0, ebb1($cp1, v0)
     brnz v0, ebb1(v0, v0)
+    fallthrough ebb2
+
+ebb2:
     v1 = iadd_imm v0, 7
     v2 = iadd_imm v1, 56
     jump ebb1(v1, v2)
@@ -59,6 +68,9 @@ ebb0(v0: i32):
     ; not: copy
     ; check: brnz v0, ebb1($cp0)
     brnz v0, ebb1(v0)
+    fallthrough ebb2
+
+ebb2:
     v1 = iadd_imm v0, 7
     ; v1 and v0 interfere here:
     v2 = iadd_imm v0, 8
@@ -89,6 +101,9 @@ ebb1(v10: i32, v11: i32):
     ; not: copy
     ; check: brnz v13, ebb1($nv11b, v12)
     brnz v13, ebb1(v11, v12)
+    fallthrough ebb2
+
+ebb2:
     return v12
 }
 
@@ -116,7 +131,13 @@ ebb0(v0: i32):
 
 ebb2(v3: i32, v4: i32):
     brnz v3, ebb2(v3, v4)
+    fallthrough ebb3
+
+ebb3:
     v5 = iconst.i32 1
     brnz v3, ebb2(v2, v5)
+    fallthrough ebb4
+
+ebb4:
     return
 }

--- a/filetests/regalloc/coalescing-207.clif
+++ b/filetests/regalloc/coalescing-207.clif
@@ -22,6 +22,9 @@ ebb0(v0: i64, v1: i32, v2: i32):
     v6 = iconst.i32 0x4ffe
     v7 = icmp uge v5, v6
     brz v7, ebb1
+    fallthrough ebb100
+
+ebb100:
     trap heap_oob
 
 ebb1:
@@ -35,6 +38,9 @@ ebb1:
     v15 = iconst.i32 0x4ffe
     v16 = icmp.i32 uge v4, v15
     brz v16, ebb2
+    fallthrough ebb101
+
+ebb101:
     trap heap_oob
 
 ebb2:
@@ -46,6 +52,9 @@ ebb2:
     v21 = iconst.i32 0x4ffe
     v22 = icmp.i32 uge v2, v21
     brz v22, ebb3
+    fallthrough ebb102
+
+ebb102:
     trap heap_oob
 
 ebb3:
@@ -60,15 +69,24 @@ ebb3:
     v31 = icmp eq v29, v30
     v32 = bint.i32 v31
     brnz v32, ebb90(v14, v1)
+    fallthrough ebb103
+
+ebb103:
     v33 = call fn0(v0, v1, v27)
     v34 = iconst.i32 0
     v35 = iconst.i32 0
     v36 = icmp eq v33, v35
     v37 = bint.i32 v36
     brnz v37, ebb90(v14, v34)
+    fallthrough ebb104
+
+ebb104:
     v38 = iconst.i32 0x4ffe
     v39 = icmp.i32 uge v2, v38
     brz v39, ebb4
+    fallthrough ebb105
+
+ebb105:
     trap heap_oob
 
 ebb4:
@@ -81,9 +99,15 @@ ebb4:
     v46 = icmp eq v44, v45
     v47 = bint.i32 v46
     brnz v47, ebb56(v33, v14)
+    fallthrough ebb106
+
+ebb106:
     v48 = iconst.i32 0x4ffe
     v49 = icmp.i32 uge v33, v48
     brz v49, ebb5
+    fallthrough ebb107
+
+ebb107:
     trap heap_oob
 
 ebb5:
@@ -96,9 +120,15 @@ ebb5:
     v56 = icmp eq v54, v55
     v57 = bint.i32 v56
     brnz v57, ebb90(v14, v34)
+    fallthrough ebb108
+
+ebb108:
     v58 = iconst.i32 0x4ffe
     v59 = icmp.i32 uge v2, v58
     brz v59, ebb6
+    fallthrough ebb109
+
+ebb109:
     trap heap_oob
 
 ebb6:
@@ -111,9 +141,15 @@ ebb6:
     v66 = icmp eq v64, v65
     v67 = bint.i32 v66
     brnz v67, ebb42
+    fallthrough ebb110
+
+ebb110:
     v68 = iconst.i32 0x4ffe
     v69 = icmp.i32 uge v33, v68
     brz v69, ebb7
+    fallthrough ebb111
+
+ebb111:
     trap heap_oob
 
 ebb7:
@@ -126,9 +162,15 @@ ebb7:
     v76 = icmp eq v74, v75
     v77 = bint.i32 v76
     brnz v77, ebb90(v14, v34)
+    fallthrough ebb112
+
+ebb112:
     v78 = iconst.i32 0x4ffe
     v79 = icmp.i32 uge v2, v78
     brz v79, ebb8
+    fallthrough ebb113
+
+ebb113:
     trap heap_oob
 
 ebb8:
@@ -141,9 +183,15 @@ ebb8:
     v86 = icmp eq v84, v85
     v87 = bint.i32 v86
     brnz v87, ebb46
+    fallthrough ebb114
+
+ebb114:
     v88 = iconst.i32 0x4ffe
     v89 = icmp.i32 uge v33, v88
     brz v89, ebb9
+    fallthrough ebb115
+
+ebb115:
     trap heap_oob
 
 ebb9:
@@ -156,9 +204,15 @@ ebb9:
     v96 = icmp eq v94, v95
     v97 = bint.i32 v96
     brnz v97, ebb90(v14, v34)
+    fallthrough ebb116
+
+ebb116:
     v98 = iconst.i32 0x4ffe
     v99 = icmp.i32 uge v2, v98
     brz v99, ebb10
+    fallthrough ebb117
+
+ebb117:
     trap heap_oob
 
 ebb10:
@@ -171,6 +225,9 @@ ebb10:
     v106 = icmp eq v104, v105
     v107 = bint.i32 v106
     brnz v107, ebb54
+    fallthrough ebb118
+
+ebb118:
     v108 = iconst.i32 1
     v109 = iadd.i32 v2, v108
     v110 = iconst.i32 1048
@@ -179,6 +236,9 @@ ebb10:
     v113 = iconst.i32 0x4ffe
     v114 = icmp uge v111, v113
     brz v114, ebb11
+    fallthrough ebb119
+
+ebb119:
     trap heap_oob
 
 ebb11:
@@ -193,6 +253,9 @@ ebb11:
     v122 = iconst.i32 0x4ffe
     v123 = icmp uge v120, v122
     brz v123, ebb12
+    fallthrough ebb120
+
+ebb120:
     trap heap_oob
 
 ebb12:
@@ -205,6 +268,9 @@ ebb12:
     v129 = iconst.i32 0x4ffe
     v130 = icmp.i32 uge v14, v129
     brz v130, ebb13
+    fallthrough ebb121
+
+ebb121:
     trap heap_oob
 
 ebb13:
@@ -217,6 +283,9 @@ ebb13:
     v136 = iconst.i32 0x4ffe
     v137 = icmp.i32 uge v14, v136
     brz v137, ebb14
+    fallthrough ebb122
+
+ebb122:
     trap heap_oob
 
 ebb14:
@@ -235,6 +304,9 @@ ebb15(v143: i32, v144: i32):
     v148 = iconst.i32 0x4ffe
     v149 = icmp uge v147, v148
     brz v149, ebb16
+    fallthrough ebb123
+
+ebb123:
     trap heap_oob
 
 ebb16:
@@ -247,6 +319,9 @@ ebb16:
     v156 = icmp eq v154, v155
     v157 = bint.i32 v156
     brnz v157, ebb89(v14)
+    fallthrough ebb124
+
+ebb124:
     v158 = iconst.i32 255
     v159 = band.i32 v144, v158
     v160 = iconst.i32 2
@@ -257,6 +332,9 @@ ebb16:
     v165 = iconst.i32 0x4ffe
     v166 = icmp uge v162, v165
     brz v166, ebb17
+    fallthrough ebb125
+
+ebb125:
     trap heap_oob
 
 ebb17:
@@ -275,6 +353,9 @@ ebb17:
     v178 = iconst.i32 0x4ffe
     v179 = icmp uge v177, v178
     brz v179, ebb18
+    fallthrough ebb126
+
+ebb126:
     trap heap_oob
 
 ebb18:
@@ -291,6 +372,9 @@ ebb18:
     v190 = iconst.i32 0x4ffe
     v191 = icmp.i32 uge v177, v190
     brz v191, ebb19
+    fallthrough ebb127
+
+ebb127:
     trap heap_oob
 
 ebb19:
@@ -307,6 +391,9 @@ ebb19:
     v201 = iconst.i32 0x4ffe
     v202 = icmp uge v200, v201
     brz v202, ebb20
+    fallthrough ebb128
+
+ebb128:
     trap heap_oob
 
 ebb20:
@@ -329,6 +416,9 @@ ebb21:
     v215 = icmp ult v213, v214
     v216 = bint.i32 v215
     brnz v216, ebb38(v2, v211, v209, v210, v208, v198, v213, v33, v14)
+    fallthrough ebb129
+
+ebb129:
     v217 = iconst.i32 -1
     v218 = iconst.i32 0
     v219 = iconst.i32 1
@@ -344,6 +434,9 @@ ebb22(v223: i32, v224: i32, v225: i32, v226: i32, v227: i32, v228: i32, v229: i3
     v237 = iconst.i32 0x4ffe
     v238 = icmp uge v236, v237
     brz v238, ebb23
+    fallthrough ebb130
+
+ebb130:
     trap heap_oob
 
 ebb23:
@@ -357,9 +450,15 @@ ebb23:
     v246 = icmp ne v243, v245
     v247 = bint.i32 v246
     brnz v247, ebb24
+    fallthrough ebb131
+
+ebb131:
     v248 = icmp.i32 ne v224, v226
     v249 = bint.i32 v248
     brnz v249, ebb25
+    fallthrough ebb132
+
+ebb132:
     v250 = iadd.i32 v227, v226
     v251 = iconst.i32 1
     jump ebb27(v251, v250, v223, v226)
@@ -368,6 +467,9 @@ ebb24:
     v252 = icmp.i32 ule v243, v245
     v253 = bint.i32 v252
     brnz v253, ebb26
+    fallthrough ebb133
+
+ebb133:
     v254 = isub.i32 v234, v223
     v255 = iconst.i32 1
     jump ebb27(v255, v234, v223, v254)
@@ -391,10 +493,16 @@ ebb27(v264: i32, v265: i32, v266: i32, v267: i32):
     v269 = icmp uge v268, v229
     v270 = bint.i32 v269
     brnz v270, ebb29
+    fallthrough ebb134
+
+ebb134:
     v271 = iadd.i32 v2, v268
     v272 = iconst.i32 0x4ffe
     v273 = icmp uge v271, v272
     brz v273, ebb28
+    fallthrough ebb135
+
+ebb135:
     trap heap_oob
 
 ebb28:
@@ -424,6 +532,9 @@ ebb31(v285: i32, v286: i32, v287: i32, v288: i32, v289: i32, v290: i32, v291: i3
     v300 = iconst.i32 0x4ffe
     v301 = icmp uge v299, v300
     brz v301, ebb32
+    fallthrough ebb136
+
+ebb136:
     trap heap_oob
 
 ebb32:
@@ -437,9 +548,15 @@ ebb32:
     v309 = icmp ne v306, v308
     v310 = bint.i32 v309
     brnz v310, ebb33
+    fallthrough ebb137
+
+ebb137:
     v311 = icmp.i32 ne v286, v288
     v312 = bint.i32 v311
     brnz v312, ebb34
+    fallthrough ebb138
+
+ebb138:
     v313 = iadd.i32 v289, v288
     v314 = iconst.i32 1
     jump ebb36(v314, v313, v285, v288)
@@ -448,6 +565,9 @@ ebb33:
     v315 = icmp.i32 uge v306, v308
     v316 = bint.i32 v315
     brnz v316, ebb35
+    fallthrough ebb139
+
+ebb139:
     v317 = isub.i32 v297, v285
     v318 = iconst.i32 1
     jump ebb36(v318, v297, v285, v317)
@@ -471,10 +591,16 @@ ebb36(v327: i32, v328: i32, v329: i32, v330: i32):
     v332 = icmp uge v331, v291
     v333 = bint.i32 v332
     brnz v333, ebb38(v2, v330, v292, v329, v293, v294, v291, v295, v296)
+    fallthrough ebb140
+
+ebb140:
     v334 = iadd.i32 v2, v331
     v335 = iconst.i32 0x4ffe
     v336 = icmp uge v334, v335
     brz v336, ebb37
+    fallthrough ebb141
+
+ebb141:
     trap heap_oob
 
 ebb37:
@@ -494,12 +620,18 @@ ebb38(v343: i32, v344: i32, v345: i32, v346: i32, v347: i32, v348: i32, v349: i3
     v356 = icmp ugt v353, v355
     v357 = bint.i32 v356
     brnz v357, ebb39(v344)
+    fallthrough ebb142
+
+ebb142:
     v358 = copy v345
     jump ebb39(v358)
 
 ebb39(v359: i32):
     v360 = iadd.i32 v343, v359
     brnz.i32 v357, ebb40(v346)
+    fallthrough ebb143
+
+ebb143:
     v361 = copy.i32 v347
     jump ebb40(v361)
 
@@ -511,6 +643,9 @@ ebb40(v362: i32):
     v367 = icmp eq v365, v366
     v368 = bint.i32 v367
     brnz v368, ebb63
+    fallthrough ebb144
+
+ebb144:
     v369 = iconst.i32 1
     v370 = iadd v362, v369
     v371 = isub.i32 v348, v370
@@ -520,6 +655,9 @@ ebb40(v362: i32):
     v375 = bint.i32 v374
     v376 = copy v362
     brnz v375, ebb41(v376)
+    fallthrough ebb145
+
+ebb145:
     v377 = copy v373
     jump ebb41(v377)
 
@@ -536,6 +674,9 @@ ebb42:
     v385 = iconst.i32 0x4ffe
     v386 = icmp.i32 uge v33, v385
     brz v386, ebb43
+    fallthrough ebb146
+
+ebb146:
     trap heap_oob
 
 ebb43:
@@ -557,6 +698,9 @@ ebb44(v392: i32, v393: i32, v394: i32):
     v402 = icmp eq v401, v384
     v403 = bint.i32 v402
     brnz v403, ebb56(v394, v14)
+    fallthrough ebb147
+
+ebb147:
     v404 = iconst.i32 2
     v405 = iadd v394, v404
     v406 = iconst.i32 1
@@ -564,6 +708,9 @@ ebb44(v392: i32, v393: i32, v394: i32):
     v408 = iconst.i32 0x4ffe
     v409 = icmp uge v405, v408
     brz v409, ebb45
+    fallthrough ebb148
+
+ebb148:
     trap heap_oob
 
 ebb45:
@@ -584,6 +731,9 @@ ebb46:
     v420 = iconst.i32 0x4ffe
     v421 = icmp.i32 uge v33, v420
     brz v421, ebb47
+    fallthrough ebb149
+
+ebb149:
     trap heap_oob
 
 ebb47:
@@ -616,6 +766,9 @@ ebb48(v440: i32, v441: i32):
     v446 = iconst.i32 0x4ffe
     v447 = icmp uge v445, v446
     brz v447, ebb49
+    fallthrough ebb150
+
+ebb150:
     trap heap_oob
 
 ebb49:
@@ -628,6 +781,9 @@ ebb49:
     v454 = icmp eq v452, v453
     v455 = bint.i32 v454
     brnz v455, ebb51(v14)
+    fallthrough ebb151
+
+ebb151:
     v456 = bor.i32 v441, v452
     v457 = iconst.i32 8
     v458 = ishl v456, v457
@@ -647,6 +803,9 @@ ebb51(v462: i32):
     v466 = iconst.i32 0x4ffe
     v467 = icmp uge v463, v466
     brz v467, ebb52
+    fallthrough ebb152
+
+ebb152:
     trap heap_oob
 
 ebb52:
@@ -657,6 +816,9 @@ ebb52:
     store.i32 v465, v471+4
     v472 = iconst.i32 0
     brnz.i32 v452, ebb53(v443)
+    fallthrough ebb153
+
+ebb153:
     v473 = copy v472
     jump ebb53(v473)
 
@@ -673,6 +835,9 @@ ebb54:
     v481 = iconst.i32 0x4ffe
     v482 = icmp.i32 uge v33, v481
     brz v482, ebb55
+    fallthrough ebb154
+
+ebb154:
     trap heap_oob
 
 ebb55:
@@ -713,6 +878,9 @@ ebb58(v505: i32, v506: i32):
     v511 = iconst.i32 0x4ffe
     v512 = icmp uge v508, v511
     brz v512, ebb59
+    fallthrough ebb155
+
+ebb155:
     trap heap_oob
 
 ebb59:
@@ -725,6 +893,9 @@ ebb59:
     v519 = icmp eq v517, v518
     v520 = bint.i32 v519
     brnz v520, ebb61(v14)
+    fallthrough ebb156
+
+ebb156:
     v521 = iconst.i32 8
     v522 = ishl.i32 v506, v521
     v523 = bor v522, v517
@@ -739,6 +910,9 @@ ebb60:
 ebb61(v526: i32):
     v527 = iconst.i32 0
     brnz.i32 v517, ebb62(v510)
+    fallthrough ebb157
+
+ebb157:
     v528 = copy v527
     jump ebb62(v528)
 
@@ -772,9 +946,15 @@ ebb65(v547: i32, v548: i32, v549: i32, v550: i32, v551: i32, v552: i32, v553: i3
     v564 = icmp uge v563, v549
     v565 = bint.i32 v564
     brnz v565, ebb67(v547)
+    fallthrough ebb158
+
+ebb158:
     v566 = iconst.i32 0
     v567 = call fn2(v0, v547, v566, v550)
     brnz v567, ebb66
+    fallthrough ebb159
+
+ebb159:
     v568 = iadd v547, v550
     jump ebb67(v568)
 
@@ -783,6 +963,9 @@ ebb66:
     v570 = icmp ult v569, v549
     v571 = bint.i32 v570
     brnz v571, ebb89(v552)
+    fallthrough ebb160
+
+ebb160:
     v572 = copy.i32 v567
     jump ebb67(v572)
 
@@ -792,6 +975,9 @@ ebb67(v573: i32):
     v576 = iconst.i32 0x4ffe
     v577 = icmp uge v575, v576
     brz v577, ebb68
+    fallthrough ebb161
+
+ebb161:
     trap heap_oob
 
 ebb68:
@@ -813,6 +999,9 @@ ebb68:
     v593 = iconst.i32 0x4ffe
     v594 = icmp uge v592, v593
     brz v594, ebb69
+    fallthrough ebb162
+
+ebb162:
     trap heap_oob
 
 ebb69:
@@ -826,12 +1015,18 @@ ebb69:
     v602 = icmp eq v600, v601
     v603 = bint.i32 v602
     brnz v603, ebb74
+    fallthrough ebb163
+
+ebb163:
     v604 = iconst.i32 2
     v605 = ishl.i32 v582, v604
     v606 = iadd.i32 v552, v605
     v607 = iconst.i32 0x4ffe
     v608 = icmp uge v606, v607
     brz v608, ebb70
+    fallthrough ebb164
+
+ebb164:
     trap heap_oob
 
 ebb70:
@@ -845,12 +1040,18 @@ ebb70:
     v616 = icmp eq v614, v615
     v617 = bint.i32 v616
     brnz v617, ebb75
+    fallthrough ebb165
+
+ebb165:
     v618 = iconst.i32 1
     v619 = iadd v614, v618
     v620 = icmp ult v619, v554
     v621 = bint.i32 v620
     v622 = copy.i32 v553
     brnz v621, ebb71(v622)
+    fallthrough ebb166
+
+ebb166:
     v623 = copy v619
     jump ebb71(v623)
 
@@ -879,6 +1080,9 @@ ebb75:
     v634 = bint.i32 v633
     v635 = copy.i32 v558
     brnz v634, ebb76(v635)
+    fallthrough ebb167
+
+ebb167:
     v636 = copy.i32 v555
     jump ebb76(v636)
 
@@ -887,6 +1091,9 @@ ebb76(v637: i32):
     v639 = iconst.i32 0x4ffe
     v640 = icmp uge v638, v639
     brz v640, ebb77
+    fallthrough ebb168
+
+ebb168:
     trap heap_oob
 
 ebb77:
@@ -899,6 +1106,9 @@ ebb77:
     v647 = icmp eq v645, v646
     v648 = bint.i32 v647
     brnz v648, ebb82(v548, v549, v551, v552)
+    fallthrough ebb169
+
+ebb169:
     v649 = iadd.i32 v548, v637
     v650 = iadd.i32 v559, v637
     v651 = iadd.i32 v560, v637
@@ -910,6 +1120,9 @@ ebb78(v652: i32, v653: i32, v654: i32, v655: i32):
     v658 = iconst.i32 0x4ffe
     v659 = icmp uge v653, v658
     brz v659, ebb79
+    fallthrough ebb170
+
+ebb170:
     trap heap_oob
 
 ebb79:
@@ -923,6 +1136,9 @@ ebb79:
     v667 = copy.i32 v554
     v668 = copy.i32 v562
     brnz v666, ebb87(v548, v654, v573, v549, v550, v551, v552, v553, v667, v668, v557, v558, v559, v560, v561)
+    fallthrough ebb171
+
+ebb171:
     v669 = iconst.i32 1
     v670 = iadd.i32 v653, v669
     v671 = iconst.i32 1
@@ -930,6 +1146,9 @@ ebb79:
     v673 = iconst.i32 0x4ffe
     v674 = icmp.i32 uge v655, v673
     brz v674, ebb80
+    fallthrough ebb172
+
+ebb172:
     trap heap_oob
 
 ebb80:
@@ -950,6 +1169,9 @@ ebb82(v682: i32, v683: i32, v684: i32, v685: i32):
     v686 = icmp.i32 ule v558, v555
     v687 = bint.i32 v686
     brnz v687, ebb90(v685, v682)
+    fallthrough ebb173
+
+ebb173:
     v688 = copy.i32 v561
     jump ebb83(v688)
 
@@ -958,6 +1180,9 @@ ebb83(v689: i32):
     v691 = iconst.i32 0x4ffe
     v692 = icmp uge v690, v691
     brz v692, ebb84
+    fallthrough ebb174
+
+ebb174:
     trap heap_oob
 
 ebb84:
@@ -970,6 +1195,9 @@ ebb84:
     v699 = iconst.i32 0x4ffe
     v700 = icmp uge v698, v699
     brz v700, ebb85
+    fallthrough ebb175
+
+ebb175:
     trap heap_oob
 
 ebb85:
@@ -981,6 +1209,9 @@ ebb85:
     v706 = icmp.i32 ne v697, v705
     v707 = bint.i32 v706
     brnz v707, ebb86
+    fallthrough ebb176
+
+ebb176:
     v708 = icmp.i32 ule v689, v555
     v709 = bint.i32 v708
     v710 = iconst.i32 -1
@@ -1019,6 +1250,9 @@ ebb90(v756: i32, v757: i32):
     v761 = iconst.i32 0x4ffe
     v762 = icmp uge v758, v761
     brz v762, ebb91
+    fallthrough ebb177
+
+ebb177:
     trap heap_oob
 
 ebb91:
@@ -1073,6 +1307,9 @@ ebb0(v0: f64, v1: i64):
     v24 = icmp ult v22, v23
     v25 = bint.i32 v24
     brnz v25, ebb10
+    fallthrough ebb178
+
+ebb178:
     v26 = iconst.i64 0x7fff_ffff_ffff_ffff
     v27 = band v14, v26
     v28 = iconst.i64 0x7ff0_0000_0000_0000
@@ -1086,10 +1323,16 @@ ebb10:
     v32 = icmp.i32 ult v22, v31
     v33 = bint.i32 v32
     brnz v33, ebb8
+    fallthrough ebb179
+
+ebb179:
     v34 = iconst.i32 0x3ff0_a2b2
     v35 = icmp.i32 uge v22, v34
     v36 = bint.i32 v35
     brnz v36, ebb6
+    fallthrough ebb180
+
+ebb180:
     v37 = iconst.i32 1
     v38 = bxor.i32 v17, v37
     v39 = isub v38, v17
@@ -1106,6 +1349,9 @@ ebb9:
     v44 = bint.i32 v43
     v45 = bor v42, v44
     brnz v45, ebb7
+    fallthrough ebb181
+
+ebb181:
     v141 = iconst.i64 0x7fe0_0000_0000_0000
     v46 = bitcast.f64 v141
     v47 = fmul.f64 v0, v46
@@ -1116,6 +1362,9 @@ ebb8:
     v49 = icmp.i32 ule v22, v48
     v50 = bint.i32 v49
     brnz v50, ebb3
+    fallthrough ebb182
+
+ebb182:
     v51 = iconst.i32 0
     v142 = iconst.i64 0
     v52 = bitcast.f64 v142
@@ -1129,6 +1378,9 @@ ebb7:
     v55 = bint.i32 v54
     v56 = bor v55, v44
     brnz v56, ebb6
+    fallthrough ebb183
+
+ebb183:
     v144 = iconst.i64 0xb6a0_0000_0000_0000
     v57 = bitcast.f64 v144
     v58 = fdiv v57, v0
@@ -1165,8 +1417,14 @@ ebb6:
     v158 = iconst.i32 0x8000_0000
     v154 = icmp ne v76, v158
     brnz v154, ebb11
+    fallthrough ebb184
+
+ebb184:
     v155 = fcmp uno v75, v75
     brz v155, ebb12
+    fallthrough ebb185
+
+ebb185:
     trap bad_toint
 
 ebb12:
@@ -1174,6 +1432,9 @@ ebb12:
     v156 = bitcast.f64 v159
     v157 = fcmp ge v156, v75
     brz v157, ebb13
+    fallthrough ebb186
+
+ebb186:
     trap int_ovf
 
 ebb13:
@@ -1230,6 +1491,9 @@ ebb4(v86: f64, v87: f64, v108: f64, v113: i32):
     v114 = icmp eq v113, v169
     v115 = bint.i32 v114
     brnz v115, ebb2(v12, v112)
+    fallthrough ebb187
+
+ebb187:
     v116 = call fn0(v112, v113, v1)
     jump ebb2(v12, v116)
 

--- a/filetests/regalloc/coalescing-207.clif
+++ b/filetests/regalloc/coalescing-207.clif
@@ -22,7 +22,7 @@ ebb0(v0: i64, v1: i32, v2: i32):
     v6 = iconst.i32 0x4ffe
     v7 = icmp uge v5, v6
     brz v7, ebb1
-    fallthrough ebb100
+    jump ebb100
 
 ebb100:
     trap heap_oob
@@ -38,7 +38,7 @@ ebb1:
     v15 = iconst.i32 0x4ffe
     v16 = icmp.i32 uge v4, v15
     brz v16, ebb2
-    fallthrough ebb101
+    jump ebb101
 
 ebb101:
     trap heap_oob
@@ -52,7 +52,7 @@ ebb2:
     v21 = iconst.i32 0x4ffe
     v22 = icmp.i32 uge v2, v21
     brz v22, ebb3
-    fallthrough ebb102
+    jump ebb102
 
 ebb102:
     trap heap_oob
@@ -69,7 +69,7 @@ ebb3:
     v31 = icmp eq v29, v30
     v32 = bint.i32 v31
     brnz v32, ebb90(v14, v1)
-    fallthrough ebb103
+    jump ebb103
 
 ebb103:
     v33 = call fn0(v0, v1, v27)
@@ -78,13 +78,13 @@ ebb103:
     v36 = icmp eq v33, v35
     v37 = bint.i32 v36
     brnz v37, ebb90(v14, v34)
-    fallthrough ebb104
+    jump ebb104
 
 ebb104:
     v38 = iconst.i32 0x4ffe
     v39 = icmp.i32 uge v2, v38
     brz v39, ebb4
-    fallthrough ebb105
+    jump ebb105
 
 ebb105:
     trap heap_oob
@@ -99,13 +99,13 @@ ebb4:
     v46 = icmp eq v44, v45
     v47 = bint.i32 v46
     brnz v47, ebb56(v33, v14)
-    fallthrough ebb106
+    jump ebb106
 
 ebb106:
     v48 = iconst.i32 0x4ffe
     v49 = icmp.i32 uge v33, v48
     brz v49, ebb5
-    fallthrough ebb107
+    jump ebb107
 
 ebb107:
     trap heap_oob
@@ -120,13 +120,13 @@ ebb5:
     v56 = icmp eq v54, v55
     v57 = bint.i32 v56
     brnz v57, ebb90(v14, v34)
-    fallthrough ebb108
+    jump ebb108
 
 ebb108:
     v58 = iconst.i32 0x4ffe
     v59 = icmp.i32 uge v2, v58
     brz v59, ebb6
-    fallthrough ebb109
+    jump ebb109
 
 ebb109:
     trap heap_oob
@@ -141,13 +141,13 @@ ebb6:
     v66 = icmp eq v64, v65
     v67 = bint.i32 v66
     brnz v67, ebb42
-    fallthrough ebb110
+    jump ebb110
 
 ebb110:
     v68 = iconst.i32 0x4ffe
     v69 = icmp.i32 uge v33, v68
     brz v69, ebb7
-    fallthrough ebb111
+    jump ebb111
 
 ebb111:
     trap heap_oob
@@ -162,13 +162,13 @@ ebb7:
     v76 = icmp eq v74, v75
     v77 = bint.i32 v76
     brnz v77, ebb90(v14, v34)
-    fallthrough ebb112
+    jump ebb112
 
 ebb112:
     v78 = iconst.i32 0x4ffe
     v79 = icmp.i32 uge v2, v78
     brz v79, ebb8
-    fallthrough ebb113
+    jump ebb113
 
 ebb113:
     trap heap_oob
@@ -183,13 +183,13 @@ ebb8:
     v86 = icmp eq v84, v85
     v87 = bint.i32 v86
     brnz v87, ebb46
-    fallthrough ebb114
+    jump ebb114
 
 ebb114:
     v88 = iconst.i32 0x4ffe
     v89 = icmp.i32 uge v33, v88
     brz v89, ebb9
-    fallthrough ebb115
+    jump ebb115
 
 ebb115:
     trap heap_oob
@@ -204,13 +204,13 @@ ebb9:
     v96 = icmp eq v94, v95
     v97 = bint.i32 v96
     brnz v97, ebb90(v14, v34)
-    fallthrough ebb116
+    jump ebb116
 
 ebb116:
     v98 = iconst.i32 0x4ffe
     v99 = icmp.i32 uge v2, v98
     brz v99, ebb10
-    fallthrough ebb117
+    jump ebb117
 
 ebb117:
     trap heap_oob
@@ -225,7 +225,7 @@ ebb10:
     v106 = icmp eq v104, v105
     v107 = bint.i32 v106
     brnz v107, ebb54
-    fallthrough ebb118
+    jump ebb118
 
 ebb118:
     v108 = iconst.i32 1
@@ -236,7 +236,7 @@ ebb118:
     v113 = iconst.i32 0x4ffe
     v114 = icmp uge v111, v113
     brz v114, ebb11
-    fallthrough ebb119
+    jump ebb119
 
 ebb119:
     trap heap_oob
@@ -253,7 +253,7 @@ ebb11:
     v122 = iconst.i32 0x4ffe
     v123 = icmp uge v120, v122
     brz v123, ebb12
-    fallthrough ebb120
+    jump ebb120
 
 ebb120:
     trap heap_oob
@@ -268,7 +268,7 @@ ebb12:
     v129 = iconst.i32 0x4ffe
     v130 = icmp.i32 uge v14, v129
     brz v130, ebb13
-    fallthrough ebb121
+    jump ebb121
 
 ebb121:
     trap heap_oob
@@ -283,7 +283,7 @@ ebb13:
     v136 = iconst.i32 0x4ffe
     v137 = icmp.i32 uge v14, v136
     brz v137, ebb14
-    fallthrough ebb122
+    jump ebb122
 
 ebb122:
     trap heap_oob
@@ -304,7 +304,7 @@ ebb15(v143: i32, v144: i32):
     v148 = iconst.i32 0x4ffe
     v149 = icmp uge v147, v148
     brz v149, ebb16
-    fallthrough ebb123
+    jump ebb123
 
 ebb123:
     trap heap_oob
@@ -319,7 +319,7 @@ ebb16:
     v156 = icmp eq v154, v155
     v157 = bint.i32 v156
     brnz v157, ebb89(v14)
-    fallthrough ebb124
+    jump ebb124
 
 ebb124:
     v158 = iconst.i32 255
@@ -332,7 +332,7 @@ ebb124:
     v165 = iconst.i32 0x4ffe
     v166 = icmp uge v162, v165
     brz v166, ebb17
-    fallthrough ebb125
+    jump ebb125
 
 ebb125:
     trap heap_oob
@@ -353,7 +353,7 @@ ebb17:
     v178 = iconst.i32 0x4ffe
     v179 = icmp uge v177, v178
     brz v179, ebb18
-    fallthrough ebb126
+    jump ebb126
 
 ebb126:
     trap heap_oob
@@ -372,7 +372,7 @@ ebb18:
     v190 = iconst.i32 0x4ffe
     v191 = icmp.i32 uge v177, v190
     brz v191, ebb19
-    fallthrough ebb127
+    jump ebb127
 
 ebb127:
     trap heap_oob
@@ -391,7 +391,7 @@ ebb19:
     v201 = iconst.i32 0x4ffe
     v202 = icmp uge v200, v201
     brz v202, ebb20
-    fallthrough ebb128
+    jump ebb128
 
 ebb128:
     trap heap_oob
@@ -416,7 +416,7 @@ ebb21:
     v215 = icmp ult v213, v214
     v216 = bint.i32 v215
     brnz v216, ebb38(v2, v211, v209, v210, v208, v198, v213, v33, v14)
-    fallthrough ebb129
+    jump ebb129
 
 ebb129:
     v217 = iconst.i32 -1
@@ -434,7 +434,7 @@ ebb22(v223: i32, v224: i32, v225: i32, v226: i32, v227: i32, v228: i32, v229: i3
     v237 = iconst.i32 0x4ffe
     v238 = icmp uge v236, v237
     brz v238, ebb23
-    fallthrough ebb130
+    jump ebb130
 
 ebb130:
     trap heap_oob
@@ -450,13 +450,13 @@ ebb23:
     v246 = icmp ne v243, v245
     v247 = bint.i32 v246
     brnz v247, ebb24
-    fallthrough ebb131
+    jump ebb131
 
 ebb131:
     v248 = icmp.i32 ne v224, v226
     v249 = bint.i32 v248
     brnz v249, ebb25
-    fallthrough ebb132
+    jump ebb132
 
 ebb132:
     v250 = iadd.i32 v227, v226
@@ -467,7 +467,7 @@ ebb24:
     v252 = icmp.i32 ule v243, v245
     v253 = bint.i32 v252
     brnz v253, ebb26
-    fallthrough ebb133
+    jump ebb133
 
 ebb133:
     v254 = isub.i32 v234, v223
@@ -493,14 +493,14 @@ ebb27(v264: i32, v265: i32, v266: i32, v267: i32):
     v269 = icmp uge v268, v229
     v270 = bint.i32 v269
     brnz v270, ebb29
-    fallthrough ebb134
+    jump ebb134
 
 ebb134:
     v271 = iadd.i32 v2, v268
     v272 = iconst.i32 0x4ffe
     v273 = icmp uge v271, v272
     brz v273, ebb28
-    fallthrough ebb135
+    jump ebb135
 
 ebb135:
     trap heap_oob
@@ -532,7 +532,7 @@ ebb31(v285: i32, v286: i32, v287: i32, v288: i32, v289: i32, v290: i32, v291: i3
     v300 = iconst.i32 0x4ffe
     v301 = icmp uge v299, v300
     brz v301, ebb32
-    fallthrough ebb136
+    jump ebb136
 
 ebb136:
     trap heap_oob
@@ -548,13 +548,13 @@ ebb32:
     v309 = icmp ne v306, v308
     v310 = bint.i32 v309
     brnz v310, ebb33
-    fallthrough ebb137
+    jump ebb137
 
 ebb137:
     v311 = icmp.i32 ne v286, v288
     v312 = bint.i32 v311
     brnz v312, ebb34
-    fallthrough ebb138
+    jump ebb138
 
 ebb138:
     v313 = iadd.i32 v289, v288
@@ -565,7 +565,7 @@ ebb33:
     v315 = icmp.i32 uge v306, v308
     v316 = bint.i32 v315
     brnz v316, ebb35
-    fallthrough ebb139
+    jump ebb139
 
 ebb139:
     v317 = isub.i32 v297, v285
@@ -591,14 +591,14 @@ ebb36(v327: i32, v328: i32, v329: i32, v330: i32):
     v332 = icmp uge v331, v291
     v333 = bint.i32 v332
     brnz v333, ebb38(v2, v330, v292, v329, v293, v294, v291, v295, v296)
-    fallthrough ebb140
+    jump ebb140
 
 ebb140:
     v334 = iadd.i32 v2, v331
     v335 = iconst.i32 0x4ffe
     v336 = icmp uge v334, v335
     brz v336, ebb37
-    fallthrough ebb141
+    jump ebb141
 
 ebb141:
     trap heap_oob
@@ -620,7 +620,7 @@ ebb38(v343: i32, v344: i32, v345: i32, v346: i32, v347: i32, v348: i32, v349: i3
     v356 = icmp ugt v353, v355
     v357 = bint.i32 v356
     brnz v357, ebb39(v344)
-    fallthrough ebb142
+    jump ebb142
 
 ebb142:
     v358 = copy v345
@@ -629,7 +629,7 @@ ebb142:
 ebb39(v359: i32):
     v360 = iadd.i32 v343, v359
     brnz.i32 v357, ebb40(v346)
-    fallthrough ebb143
+    jump ebb143
 
 ebb143:
     v361 = copy.i32 v347
@@ -643,7 +643,7 @@ ebb40(v362: i32):
     v367 = icmp eq v365, v366
     v368 = bint.i32 v367
     brnz v368, ebb63
-    fallthrough ebb144
+    jump ebb144
 
 ebb144:
     v369 = iconst.i32 1
@@ -655,7 +655,7 @@ ebb144:
     v375 = bint.i32 v374
     v376 = copy v362
     brnz v375, ebb41(v376)
-    fallthrough ebb145
+    jump ebb145
 
 ebb145:
     v377 = copy v373
@@ -674,7 +674,7 @@ ebb42:
     v385 = iconst.i32 0x4ffe
     v386 = icmp.i32 uge v33, v385
     brz v386, ebb43
-    fallthrough ebb146
+    jump ebb146
 
 ebb146:
     trap heap_oob
@@ -698,7 +698,7 @@ ebb44(v392: i32, v393: i32, v394: i32):
     v402 = icmp eq v401, v384
     v403 = bint.i32 v402
     brnz v403, ebb56(v394, v14)
-    fallthrough ebb147
+    jump ebb147
 
 ebb147:
     v404 = iconst.i32 2
@@ -708,7 +708,7 @@ ebb147:
     v408 = iconst.i32 0x4ffe
     v409 = icmp uge v405, v408
     brz v409, ebb45
-    fallthrough ebb148
+    jump ebb148
 
 ebb148:
     trap heap_oob
@@ -731,7 +731,7 @@ ebb46:
     v420 = iconst.i32 0x4ffe
     v421 = icmp.i32 uge v33, v420
     brz v421, ebb47
-    fallthrough ebb149
+    jump ebb149
 
 ebb149:
     trap heap_oob
@@ -766,7 +766,7 @@ ebb48(v440: i32, v441: i32):
     v446 = iconst.i32 0x4ffe
     v447 = icmp uge v445, v446
     brz v447, ebb49
-    fallthrough ebb150
+    jump ebb150
 
 ebb150:
     trap heap_oob
@@ -781,7 +781,7 @@ ebb49:
     v454 = icmp eq v452, v453
     v455 = bint.i32 v454
     brnz v455, ebb51(v14)
-    fallthrough ebb151
+    jump ebb151
 
 ebb151:
     v456 = bor.i32 v441, v452
@@ -803,7 +803,7 @@ ebb51(v462: i32):
     v466 = iconst.i32 0x4ffe
     v467 = icmp uge v463, v466
     brz v467, ebb52
-    fallthrough ebb152
+    jump ebb152
 
 ebb152:
     trap heap_oob
@@ -816,7 +816,7 @@ ebb52:
     store.i32 v465, v471+4
     v472 = iconst.i32 0
     brnz.i32 v452, ebb53(v443)
-    fallthrough ebb153
+    jump ebb153
 
 ebb153:
     v473 = copy v472
@@ -835,7 +835,7 @@ ebb54:
     v481 = iconst.i32 0x4ffe
     v482 = icmp.i32 uge v33, v481
     brz v482, ebb55
-    fallthrough ebb154
+    jump ebb154
 
 ebb154:
     trap heap_oob
@@ -878,7 +878,7 @@ ebb58(v505: i32, v506: i32):
     v511 = iconst.i32 0x4ffe
     v512 = icmp uge v508, v511
     brz v512, ebb59
-    fallthrough ebb155
+    jump ebb155
 
 ebb155:
     trap heap_oob
@@ -893,7 +893,7 @@ ebb59:
     v519 = icmp eq v517, v518
     v520 = bint.i32 v519
     brnz v520, ebb61(v14)
-    fallthrough ebb156
+    jump ebb156
 
 ebb156:
     v521 = iconst.i32 8
@@ -910,7 +910,7 @@ ebb60:
 ebb61(v526: i32):
     v527 = iconst.i32 0
     brnz.i32 v517, ebb62(v510)
-    fallthrough ebb157
+    jump ebb157
 
 ebb157:
     v528 = copy v527
@@ -946,13 +946,13 @@ ebb65(v547: i32, v548: i32, v549: i32, v550: i32, v551: i32, v552: i32, v553: i3
     v564 = icmp uge v563, v549
     v565 = bint.i32 v564
     brnz v565, ebb67(v547)
-    fallthrough ebb158
+    jump ebb158
 
 ebb158:
     v566 = iconst.i32 0
     v567 = call fn2(v0, v547, v566, v550)
     brnz v567, ebb66
-    fallthrough ebb159
+    jump ebb159
 
 ebb159:
     v568 = iadd v547, v550
@@ -963,7 +963,7 @@ ebb66:
     v570 = icmp ult v569, v549
     v571 = bint.i32 v570
     brnz v571, ebb89(v552)
-    fallthrough ebb160
+    jump ebb160
 
 ebb160:
     v572 = copy.i32 v567
@@ -975,7 +975,7 @@ ebb67(v573: i32):
     v576 = iconst.i32 0x4ffe
     v577 = icmp uge v575, v576
     brz v577, ebb68
-    fallthrough ebb161
+    jump ebb161
 
 ebb161:
     trap heap_oob
@@ -999,7 +999,7 @@ ebb68:
     v593 = iconst.i32 0x4ffe
     v594 = icmp uge v592, v593
     brz v594, ebb69
-    fallthrough ebb162
+    jump ebb162
 
 ebb162:
     trap heap_oob
@@ -1015,7 +1015,7 @@ ebb69:
     v602 = icmp eq v600, v601
     v603 = bint.i32 v602
     brnz v603, ebb74
-    fallthrough ebb163
+    jump ebb163
 
 ebb163:
     v604 = iconst.i32 2
@@ -1024,7 +1024,7 @@ ebb163:
     v607 = iconst.i32 0x4ffe
     v608 = icmp uge v606, v607
     brz v608, ebb70
-    fallthrough ebb164
+    jump ebb164
 
 ebb164:
     trap heap_oob
@@ -1040,7 +1040,7 @@ ebb70:
     v616 = icmp eq v614, v615
     v617 = bint.i32 v616
     brnz v617, ebb75
-    fallthrough ebb165
+    jump ebb165
 
 ebb165:
     v618 = iconst.i32 1
@@ -1049,7 +1049,7 @@ ebb165:
     v621 = bint.i32 v620
     v622 = copy.i32 v553
     brnz v621, ebb71(v622)
-    fallthrough ebb166
+    jump ebb166
 
 ebb166:
     v623 = copy v619
@@ -1080,7 +1080,7 @@ ebb75:
     v634 = bint.i32 v633
     v635 = copy.i32 v558
     brnz v634, ebb76(v635)
-    fallthrough ebb167
+    jump ebb167
 
 ebb167:
     v636 = copy.i32 v555
@@ -1091,7 +1091,7 @@ ebb76(v637: i32):
     v639 = iconst.i32 0x4ffe
     v640 = icmp uge v638, v639
     brz v640, ebb77
-    fallthrough ebb168
+    jump ebb168
 
 ebb168:
     trap heap_oob
@@ -1106,7 +1106,7 @@ ebb77:
     v647 = icmp eq v645, v646
     v648 = bint.i32 v647
     brnz v648, ebb82(v548, v549, v551, v552)
-    fallthrough ebb169
+    jump ebb169
 
 ebb169:
     v649 = iadd.i32 v548, v637
@@ -1120,7 +1120,7 @@ ebb78(v652: i32, v653: i32, v654: i32, v655: i32):
     v658 = iconst.i32 0x4ffe
     v659 = icmp uge v653, v658
     brz v659, ebb79
-    fallthrough ebb170
+    jump ebb170
 
 ebb170:
     trap heap_oob
@@ -1136,7 +1136,7 @@ ebb79:
     v667 = copy.i32 v554
     v668 = copy.i32 v562
     brnz v666, ebb87(v548, v654, v573, v549, v550, v551, v552, v553, v667, v668, v557, v558, v559, v560, v561)
-    fallthrough ebb171
+    jump ebb171
 
 ebb171:
     v669 = iconst.i32 1
@@ -1146,7 +1146,7 @@ ebb171:
     v673 = iconst.i32 0x4ffe
     v674 = icmp.i32 uge v655, v673
     brz v674, ebb80
-    fallthrough ebb172
+    jump ebb172
 
 ebb172:
     trap heap_oob
@@ -1169,7 +1169,7 @@ ebb82(v682: i32, v683: i32, v684: i32, v685: i32):
     v686 = icmp.i32 ule v558, v555
     v687 = bint.i32 v686
     brnz v687, ebb90(v685, v682)
-    fallthrough ebb173
+    jump ebb173
 
 ebb173:
     v688 = copy.i32 v561
@@ -1180,7 +1180,7 @@ ebb83(v689: i32):
     v691 = iconst.i32 0x4ffe
     v692 = icmp uge v690, v691
     brz v692, ebb84
-    fallthrough ebb174
+    jump ebb174
 
 ebb174:
     trap heap_oob
@@ -1195,7 +1195,7 @@ ebb84:
     v699 = iconst.i32 0x4ffe
     v700 = icmp uge v698, v699
     brz v700, ebb85
-    fallthrough ebb175
+    jump ebb175
 
 ebb175:
     trap heap_oob
@@ -1209,7 +1209,7 @@ ebb85:
     v706 = icmp.i32 ne v697, v705
     v707 = bint.i32 v706
     brnz v707, ebb86
-    fallthrough ebb176
+    jump ebb176
 
 ebb176:
     v708 = icmp.i32 ule v689, v555
@@ -1250,7 +1250,7 @@ ebb90(v756: i32, v757: i32):
     v761 = iconst.i32 0x4ffe
     v762 = icmp uge v758, v761
     brz v762, ebb91
-    fallthrough ebb177
+    jump ebb177
 
 ebb177:
     trap heap_oob
@@ -1307,7 +1307,7 @@ ebb0(v0: f64, v1: i64):
     v24 = icmp ult v22, v23
     v25 = bint.i32 v24
     brnz v25, ebb10
-    fallthrough ebb178
+    jump ebb178
 
 ebb178:
     v26 = iconst.i64 0x7fff_ffff_ffff_ffff
@@ -1323,14 +1323,14 @@ ebb10:
     v32 = icmp.i32 ult v22, v31
     v33 = bint.i32 v32
     brnz v33, ebb8
-    fallthrough ebb179
+    jump ebb179
 
 ebb179:
     v34 = iconst.i32 0x3ff0_a2b2
     v35 = icmp.i32 uge v22, v34
     v36 = bint.i32 v35
     brnz v36, ebb6
-    fallthrough ebb180
+    jump ebb180
 
 ebb180:
     v37 = iconst.i32 1
@@ -1349,7 +1349,7 @@ ebb9:
     v44 = bint.i32 v43
     v45 = bor v42, v44
     brnz v45, ebb7
-    fallthrough ebb181
+    jump ebb181
 
 ebb181:
     v141 = iconst.i64 0x7fe0_0000_0000_0000
@@ -1362,7 +1362,7 @@ ebb8:
     v49 = icmp.i32 ule v22, v48
     v50 = bint.i32 v49
     brnz v50, ebb3
-    fallthrough ebb182
+    jump ebb182
 
 ebb182:
     v51 = iconst.i32 0
@@ -1378,7 +1378,7 @@ ebb7:
     v55 = bint.i32 v54
     v56 = bor v55, v44
     brnz v56, ebb6
-    fallthrough ebb183
+    jump ebb183
 
 ebb183:
     v144 = iconst.i64 0xb6a0_0000_0000_0000
@@ -1417,12 +1417,12 @@ ebb6:
     v158 = iconst.i32 0x8000_0000
     v154 = icmp ne v76, v158
     brnz v154, ebb11
-    fallthrough ebb184
+    jump ebb184
 
 ebb184:
     v155 = fcmp uno v75, v75
     brz v155, ebb12
-    fallthrough ebb185
+    jump ebb185
 
 ebb185:
     trap bad_toint
@@ -1432,7 +1432,7 @@ ebb12:
     v156 = bitcast.f64 v159
     v157 = fcmp ge v156, v75
     brz v157, ebb13
-    fallthrough ebb186
+    jump ebb186
 
 ebb186:
     trap int_ovf
@@ -1491,7 +1491,7 @@ ebb4(v86: f64, v87: f64, v108: f64, v113: i32):
     v114 = icmp eq v113, v169
     v115 = bint.i32 v114
     brnz v115, ebb2(v12, v112)
-    fallthrough ebb187
+    jump ebb187
 
 ebb187:
     v116 = call fn0(v112, v113, v1)

--- a/filetests/regalloc/coalescing-216.clif
+++ b/filetests/regalloc/coalescing-216.clif
@@ -14,15 +14,27 @@ ebb0(v0: i32, v1: i64):
 ebb4(v11: i64, v29: i64):
     v6 = iconst.i32 0
     brz v6, ebb14
+    fallthrough ebb15
+
+ebb15:
     v9 = iconst.i32 -17
     v12 = iconst.i32 0xffff_ffff_ffff_8000
     jump ebb9(v12)
 
 ebb9(v10: i32):
     brnz v10, ebb8(v9, v11, v11)
+    fallthrough ebb16
+
+ebb16:
     brz.i32 v9, ebb13
+    fallthrough ebb17
+
+ebb17:
     v13 = iconst.i32 0
     brnz v13, ebb6(v11, v11)
+    fallthrough ebb18
+
+ebb18:
     v14 = iconst.i32 0
     brz v14, ebb12
     jump ebb11
@@ -40,6 +52,9 @@ ebb13:
 ebb10(v21: i64):
     v16 = iconst.i32 0
     brnz v16, ebb6(v21, v11)
+    fallthrough ebb19
+
+ebb19:
     v17 = iconst.i32 0xffff_ffff_ffff_9f35
     jump ebb8(v17, v21, v11)
 

--- a/filetests/regalloc/coalescing-216.clif
+++ b/filetests/regalloc/coalescing-216.clif
@@ -14,7 +14,7 @@ ebb0(v0: i32, v1: i64):
 ebb4(v11: i64, v29: i64):
     v6 = iconst.i32 0
     brz v6, ebb14
-    fallthrough ebb15
+    jump ebb15
 
 ebb15:
     v9 = iconst.i32 -17
@@ -23,16 +23,16 @@ ebb15:
 
 ebb9(v10: i32):
     brnz v10, ebb8(v9, v11, v11)
-    fallthrough ebb16
+    jump ebb16
 
 ebb16:
     brz.i32 v9, ebb13
-    fallthrough ebb17
+    jump ebb17
 
 ebb17:
     v13 = iconst.i32 0
     brnz v13, ebb6(v11, v11)
-    fallthrough ebb18
+    jump ebb18
 
 ebb18:
     v14 = iconst.i32 0
@@ -52,7 +52,7 @@ ebb13:
 ebb10(v21: i64):
     v16 = iconst.i32 0
     brnz v16, ebb6(v21, v11)
-    fallthrough ebb19
+    jump ebb19
 
 ebb19:
     v17 = iconst.i32 0xffff_ffff_ffff_9f35

--- a/filetests/regalloc/coloring-227.clif
+++ b/filetests/regalloc/coloring-227.clif
@@ -17,6 +17,9 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
                           ebb6:
 [RexOp1pu_id#b8]              v8 = iconst.i32 0
 [RexOp1tjccb#75]              brnz v8, ebb5
+[-]                           fallthrough ebb20
+
+                          ebb20:
 [RexOp1pu_id#b8]              v9 = iconst.i32 0
 [RexOp1pu_id#b8]              v11 = iconst.i32 0
 [RexOp1icscc#39]              v12 = icmp.i32 eq v15, v11
@@ -27,8 +30,14 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 
                           ebb7:
 [RexOp1tjccb#74]              brz.i32 v17, ebb8
+[-]                           fallthrough ebb17
+
+                          ebb17:
 [RexOp1pu_id#b8]              v18 = iconst.i32 0
 [RexOp1tjccb#74]              brz v18, ebb9
+[-]                           fallthrough ebb16
+
+                          ebb16:
 [RexOp1pu_id#b8]              v21 = iconst.i32 0
 [RexOp1umr#89]                v79 = uextend.i64 v5
 [RexOp1r_ib#8083]             v80 = iadd_imm.i64 v4, 0
@@ -63,8 +72,14 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
                           ebb2(v7: i32, v45: i32, v52: i32, v59: i32, v66: i32, v73: i32):
 [RexOp1pu_id#b8]              v44 = iconst.i32 0
 [RexOp1tjccb#74]              brz v44, ebb12
+[-]                           fallthrough ebb18
+
+                          ebb18:
 [RexOp1pu_id#b8]              v50 = iconst.i32 11
 [RexOp1tjccb#74]              brz v50, ebb14
+[-]                           fallthrough ebb19
+
+                          ebb19:
 [RexOp1umr#89]                v82 = uextend.i64 v52
 [RexOp1r_ib#8083]             v83 = iadd_imm.i64 v4, 0
 [RexOp1ld#808b]               v84 = load.i64 v83

--- a/filetests/regalloc/coloring-227.clif
+++ b/filetests/regalloc/coloring-227.clif
@@ -17,7 +17,7 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
                           ebb6:
 [RexOp1pu_id#b8]              v8 = iconst.i32 0
 [RexOp1tjccb#75]              brnz v8, ebb5
-[-]                           fallthrough ebb20
+[Op1jmpb#eb]                  jump ebb20
 
                           ebb20:
 [RexOp1pu_id#b8]              v9 = iconst.i32 0
@@ -30,12 +30,12 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 
                           ebb7:
 [RexOp1tjccb#74]              brz.i32 v17, ebb8
-[-]                           fallthrough ebb17
+[Op1jmpb#eb]                  jump ebb17
 
                           ebb17:
 [RexOp1pu_id#b8]              v18 = iconst.i32 0
 [RexOp1tjccb#74]              brz v18, ebb9
-[-]                           fallthrough ebb16
+[Op1jmpb#eb]                  jump ebb16
 
                           ebb16:
 [RexOp1pu_id#b8]              v21 = iconst.i32 0
@@ -72,12 +72,12 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
                           ebb2(v7: i32, v45: i32, v52: i32, v59: i32, v66: i32, v73: i32):
 [RexOp1pu_id#b8]              v44 = iconst.i32 0
 [RexOp1tjccb#74]              brz v44, ebb12
-[-]                           fallthrough ebb18
+[Op1jmpb#eb]                  jump ebb18
 
                           ebb18:
 [RexOp1pu_id#b8]              v50 = iconst.i32 11
 [RexOp1tjccb#74]              brz v50, ebb14
-[-]                           fallthrough ebb19
+[Op1jmpb#eb]                  jump ebb19
 
                           ebb19:
 [RexOp1umr#89]                v82 = uextend.i64 v52

--- a/filetests/regalloc/ghost-param.clif
+++ b/filetests/regalloc/ghost-param.clif
@@ -20,6 +20,9 @@ ebb5(v9: f64):
     v6 = iconst.i32 0
     v7 = iconst.i32 1
     brnz v7, ebb4(v6)
+    fallthrough ebb8
+
+ebb8:
     v8 = iconst.i32 0
     jump ebb7(v8)
 

--- a/filetests/regalloc/ghost-param.clif
+++ b/filetests/regalloc/ghost-param.clif
@@ -20,7 +20,7 @@ ebb5(v9: f64):
     v6 = iconst.i32 0
     v7 = iconst.i32 1
     brnz v7, ebb4(v6)
-    fallthrough ebb8
+    jump ebb8
 
 ebb8:
     v8 = iconst.i32 0

--- a/filetests/regalloc/global-constraints.clif
+++ b/filetests/regalloc/global-constraints.clif
@@ -14,6 +14,9 @@ ebb0(v0: i32):
     v4 = icmp_imm ne v0, 4
     v5 = icmp_imm sge v0, 5
     brnz v5, ebb1
+    fallthrough ebb2
+
+ebb2:
     return
 
 ebb1:

--- a/filetests/regalloc/global-constraints.clif
+++ b/filetests/regalloc/global-constraints.clif
@@ -14,7 +14,7 @@ ebb0(v0: i32):
     v4 = icmp_imm ne v0, 4
     v5 = icmp_imm sge v0, 5
     brnz v5, ebb1
-    fallthrough ebb2
+    jump ebb2
 
 ebb2:
     return

--- a/filetests/regalloc/iterate.clif
+++ b/filetests/regalloc/iterate.clif
@@ -20,6 +20,9 @@ ebb0(v0: i64, v1: f32, v2: f64, v3: i32, v4: i32, v5: i64):
     v44 = iconst.i64 0
     v37 = icmp slt v0, v44
     brnz v37, ebb2
+    fallthrough ebb11
+
+ebb11:
     v38 = fcvt_from_sint.f64 v0
     jump ebb3(v38)
 
@@ -41,6 +44,9 @@ ebb3(v15: f64):
     v54 = iconst.i64 0
     v47 = icmp.i64 slt v13, v54
     brnz v47, ebb4
+    fallthrough ebb12
+
+ebb12:
     v48 = fcvt_from_sint.f64 v13
     jump ebb5(v48)
 
@@ -57,6 +63,9 @@ ebb5(v20: f64):
     v63 = iconst.i64 0
     v56 = icmp.i64 slt v7, v63
     brnz v56, ebb6
+    fallthrough ebb13
+
+ebb13:
     v57 = fcvt_from_sint.f64 v7
     jump ebb7(v57)
 
@@ -82,8 +91,14 @@ ebb7(v21: f64):
     v69 = iconst.i64 0x8000_0000_0000_0000
     v65 = icmp ne v30, v69
     brnz v65, ebb8
+    fallthrough ebb15
+
+ebb15:
     v66 = fcmp uno v29, v29
     brz v66, ebb9
+    fallthrough ebb16
+
+ebb16:
     trap bad_toint
 
 ebb9:
@@ -91,6 +106,9 @@ ebb9:
     v67 = bitcast.f64 v70
     v68 = fcmp gt v67, v29
     brz v68, ebb10
+    fallthrough ebb17
+
+ebb17:
     trap int_ovf
 
 ebb10:
@@ -118,6 +136,9 @@ ebb0(v0: i64):
     v7 = icmp uge v3, v6
     ; If we're unlucky, there are no ABCD registers available for v7 at this branch.
     brz v7, ebb2
+    fallthrough ebb4
+
+ebb4:
     trap oob
 
 ebb2:
@@ -128,6 +149,9 @@ ebb2:
     v11 = iadd v8, v10
     v12 = load.i64 v11
     brnz v12, ebb3
+    fallthrough ebb5
+
+ebb5:
     trap icall_null
 
 ebb3:

--- a/filetests/regalloc/iterate.clif
+++ b/filetests/regalloc/iterate.clif
@@ -20,7 +20,7 @@ ebb0(v0: i64, v1: f32, v2: f64, v3: i32, v4: i32, v5: i64):
     v44 = iconst.i64 0
     v37 = icmp slt v0, v44
     brnz v37, ebb2
-    fallthrough ebb11
+    jump ebb11
 
 ebb11:
     v38 = fcvt_from_sint.f64 v0
@@ -44,7 +44,7 @@ ebb3(v15: f64):
     v54 = iconst.i64 0
     v47 = icmp.i64 slt v13, v54
     brnz v47, ebb4
-    fallthrough ebb12
+    jump ebb12
 
 ebb12:
     v48 = fcvt_from_sint.f64 v13
@@ -63,7 +63,7 @@ ebb5(v20: f64):
     v63 = iconst.i64 0
     v56 = icmp.i64 slt v7, v63
     brnz v56, ebb6
-    fallthrough ebb13
+    jump ebb13
 
 ebb13:
     v57 = fcvt_from_sint.f64 v7
@@ -91,12 +91,12 @@ ebb7(v21: f64):
     v69 = iconst.i64 0x8000_0000_0000_0000
     v65 = icmp ne v30, v69
     brnz v65, ebb8
-    fallthrough ebb15
+    jump ebb15
 
 ebb15:
     v66 = fcmp uno v29, v29
     brz v66, ebb9
-    fallthrough ebb16
+    jump ebb16
 
 ebb16:
     trap bad_toint
@@ -106,7 +106,7 @@ ebb9:
     v67 = bitcast.f64 v70
     v68 = fcmp gt v67, v29
     brz v68, ebb10
-    fallthrough ebb17
+    jump ebb17
 
 ebb17:
     trap int_ovf
@@ -136,7 +136,7 @@ ebb0(v0: i64):
     v7 = icmp uge v3, v6
     ; If we're unlucky, there are no ABCD registers available for v7 at this branch.
     brz v7, ebb2
-    fallthrough ebb4
+    jump ebb4
 
 ebb4:
     trap oob
@@ -149,7 +149,7 @@ ebb2:
     v11 = iadd v8, v10
     v12 = load.i64 v11
     brnz v12, ebb3
-    fallthrough ebb5
+    jump ebb5
 
 ebb5:
     trap icall_null

--- a/filetests/regalloc/reload-208.clif
+++ b/filetests/regalloc/reload-208.clif
@@ -25,7 +25,7 @@ ebb0(v0: i64):
     v20 = iconst.i32 0x4ffe
     v16 = icmp uge v2, v20
     brz v16, ebb5
-    fallthrough ebb9
+    jump ebb9
 
 ebb9:
     trap heap_oob
@@ -47,7 +47,7 @@ ebb3(v7: i32):
     v26 = iconst.i32 0x4ffe
     v22 = icmp uge v7, v26
     brz v22, ebb6
-    fallthrough ebb10
+    jump ebb10
 
 ebb10:
     trap heap_oob
@@ -71,7 +71,7 @@ ebb2:
     v31 = iconst.i32 0x4ffe
     v27 = icmp uge v10, v31
     brz v27, ebb7
-    fallthrough ebb11
+    jump ebb11
 
 ebb11:
     trap heap_oob
@@ -87,7 +87,7 @@ ebb7:
     v36 = iconst.i32 0x4ffe
     v32 = icmp uge v13, v36
     brz v32, ebb8
-    fallthrough ebb12
+    jump ebb12
 
 ebb12:
     trap heap_oob

--- a/filetests/regalloc/reload-208.clif
+++ b/filetests/regalloc/reload-208.clif
@@ -25,6 +25,9 @@ ebb0(v0: i64):
     v20 = iconst.i32 0x4ffe
     v16 = icmp uge v2, v20
     brz v16, ebb5
+    fallthrough ebb9
+
+ebb9:
     trap heap_oob
 
 ebb5:
@@ -44,6 +47,9 @@ ebb3(v7: i32):
     v26 = iconst.i32 0x4ffe
     v22 = icmp uge v7, v26
     brz v22, ebb6
+    fallthrough ebb10
+
+ebb10:
     trap heap_oob
 
 ebb6:
@@ -65,6 +71,9 @@ ebb2:
     v31 = iconst.i32 0x4ffe
     v27 = icmp uge v10, v31
     brz v27, ebb7
+    fallthrough ebb11
+
+ebb11:
     trap heap_oob
 
 ebb7:
@@ -78,6 +87,9 @@ ebb7:
     v36 = iconst.i32 0x4ffe
     v32 = icmp uge v13, v36
     brz v32, ebb8
+    fallthrough ebb12
+
+ebb12:
     trap heap_oob
 
 ebb8:

--- a/filetests/regalloc/spill.clif
+++ b/filetests/regalloc/spill.clif
@@ -151,6 +151,9 @@ ebb0(v1: i32):
     ; check: v1 = spill
     v2 = iconst.i32 1
     brnz v1, ebb1(v2, v2, v2, v2, v2, v2, v2, v2, v2, v2, v2, v2)
+    fallthrough ebb2
+
+ebb2:
     return v1
 
 ebb1(v10: i32, v11: i32, v12: i32, v13: i32, v14: i32, v15: i32, v16: i32, v17: i32, v18: i32, v19: i32, v20: i32, v21: i32):

--- a/filetests/regalloc/spill.clif
+++ b/filetests/regalloc/spill.clif
@@ -151,7 +151,7 @@ ebb0(v1: i32):
     ; check: v1 = spill
     v2 = iconst.i32 1
     brnz v1, ebb1(v2, v2, v2, v2, v2, v2, v2, v2, v2, v2, v2, v2)
-    fallthrough ebb2
+    jump ebb2
 
 ebb2:
     return v1

--- a/filetests/regress/allow-relaxation-shrink.clif
+++ b/filetests/regress/allow-relaxation-shrink.clif
@@ -30,6 +30,9 @@ ebb4:
     v19 = bint.i8 v18
     v20 = uextend.i32 v19
     brz v20, ebb6
+    jump ebb7
+
+ebb7:
     trap user0
 
 ebb5:

--- a/filetests/simple_gvn/basic.clif
+++ b/filetests/simple_gvn/basic.clif
@@ -24,6 +24,9 @@ function %redundancies_on_some_paths(i32, i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32, v2: i32):
     v3 = iadd v0, v1
     brz v3, ebb1
+    jump ebb3
+
+ebb3:
     v4 = iadd v0, v1
     jump ebb2(v4)
 ; check: jump ebb2(v3)

--- a/filetests/simple_gvn/scopes.clif
+++ b/filetests/simple_gvn/scopes.clif
@@ -5,6 +5,9 @@ ebb0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
     v5 = iconst.i32 16
     ; check: v5 = iconst.i32 16
     brz v0, ebb1
+    jump ebb5
+
+ebb5:
     v6 = iconst.i32 17
     ; check: v6 = iconst.i32 17
     v7 = iconst.i32 16
@@ -30,6 +33,9 @@ ebb2:
     v14 = iconst.i32 16
     ; not: v14 = iconst.i32 16
     brz v1, ebb3
+    jump ebb6
+
+ebb6:
     v15 = iconst.i32 20
     ; check: v15 = iconst.i32 20
     v16 = iconst.i32 19

--- a/filetests/verifier/bad_layout.clif
+++ b/filetests/verifier/bad_layout.clif
@@ -1,11 +1,13 @@
 test verifier
 
-function %test(i32) {
+function %test_1(i32) {
     ebb0(v0: i32):
-        jump ebb1       ; error: terminator
+        return          ; error: terminator
         return
-    ebb1:
-        jump ebb2
+}
+function %test_2(i32) {
+    ebb0(v0: i32):
+        jump ebb2       ; error: a terminator instruction was encountered before the end of ebb0
         brz v0, ebb3
     ebb2:
         jump ebb3
@@ -13,7 +15,7 @@ function %test(i32) {
         return
 }
 
-function %test(i32) {    ; Ok
+function %test_3(i32) { ; Ok
     ebb0(v0: i32):
         return
 }


### PR DESCRIPTION
This pull request is part of #796, and fixes all test cases such that the first failure reported is not due to the way the test case is written, but due to the way the test case is optimized.

This patch series add test suite modifications on top of #804 .
I locally verified the test suite with and without the environment variable `CRANELIFT_BB=1`. When set the following list of test cases have to be fixed:

- ./filetests/wasm/i32-arith.clif
- ./filetests/wasm/i64-arith.clif
- ./filetests/wasm/control.clif
- ./filetests/wasm/f64-arith.clif
- ./filetests/wasm/conversions.clif
- ./filetests/wasm/f32-arith.clif
- ./filetests/wasm/select.clif
- ./filetests/regalloc/coloring-227.clif
- ./filetests/regalloc/global-constraints.clif
- ./filetests/regalloc/basic.clif
- ./filetests/regalloc/x86-regres.clif
- ./filetests/regalloc/coalesce.clif
- ./filetests/regalloc/coalescing-207.clif
- ./filetests/regalloc/ghost-param.clif
- ./filetests/regalloc/coalescing-216.clif
- ./filetests/regalloc/gpr-deref-safe-335.clif
- ./filetests/legalizer/br_table_cond.clif
- ./filetests/isa/x86/legalize-memory.clif
- ./filetests/isa/x86/legalize-heaps.clif
- ./filetests/isa/x86/legalize-br-table.clif
- ./filetests/isa/x86/legalize-custom.clif
- ./filetests/isa/x86/legalize-div.clif
- ./filetests/isa/x86/legalize-div-traps.clif
- ./filetests/isa/x86/legalize-tables.clif
- ./filetests/isa/x86/legalize-fcvt_from_usint-i16.clif

The remaining failures are due to:
- the `trapz` / `br_table` / `srem` / `sdiv` / `fcvt*` instructions adding a branch.
- the register allocator adding `copy` instructions.
