### PR TITLE
allow module environment to parse name section

### DIFF
--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -468,6 +468,14 @@ pub trait ModuleEnvironment<'data> {
         data: &'data [u8],
     ) -> WasmResult<()>;
 
+    /// Declares the name of a function to the environment.
+    ///
+    /// By default this does nothing, but implementations can use this to read
+    /// the function name subsection of the custom name section if desired.
+    fn declare_func_name(&mut self, _func_index: FuncIndex, _name: &'data str) -> WasmResult<()> {
+        Ok(())
+    }
+
     /// Indicates that a custom section has been found in the wasm file
     fn custom_section(&mut self, name: &'data str, data: &'data [u8]) -> WasmResult<()> {
         drop((name, data));

--- a/cranelift-wasm/src/module_translator.rs
+++ b/cranelift-wasm/src/module_translator.rs
@@ -4,10 +4,10 @@ use crate::environ::{ModuleEnvironment, WasmError, WasmResult};
 use crate::sections_translator::{
     parse_code_section, parse_data_section, parse_element_section, parse_export_section,
     parse_function_section, parse_global_section, parse_import_section, parse_memory_section,
-    parse_start_section, parse_table_section, parse_type_section,
+    parse_name_section, parse_start_section, parse_table_section, parse_type_section,
 };
 use cranelift_codegen::timing;
-use wasmparser::{ModuleReader, SectionCode};
+use wasmparser::{CustomSectionKind, ModuleReader, SectionCode};
 
 /// Translate a sequence of bytes forming a valid Wasm binary into a list of valid Cranelift IR
 /// [`Function`](cranelift_codegen::ir::Function).
@@ -81,6 +81,14 @@ pub fn translate_module<'data>(
                     message: "don't know how to handle the data count section yet",
                     offset: reader.current_position(),
                 });
+            }
+
+            SectionCode::Custom {
+                kind: CustomSectionKind::Name,
+                name: _,
+            } => {
+                let names = section.get_name_section_reader()?;
+                parse_name_section(names, environ)?;
             }
 
             SectionCode::Custom { name, kind: _ } => {

--- a/cranelift-wasm/src/sections_translator.rs
+++ b/cranelift-wasm/src/sections_translator.rs
@@ -12,7 +12,7 @@ use crate::translation_utils::{
     tabletype_to_type, type_to_type, FuncIndex, Global, GlobalIndex, GlobalInit, Memory,
     MemoryIndex, SignatureIndex, Table, TableElementType, TableIndex,
 };
-use crate::wasm_unsupported;
+use crate::{wasm_unsupported, HashMap};
 use core::convert::TryFrom;
 use cranelift_codegen::ir::{self, AbiParam, Signature};
 use cranelift_entity::EntityRef;
@@ -21,8 +21,8 @@ use wasmparser::{
     self, CodeSectionReader, Data, DataKind, DataSectionReader, Element, ElementKind,
     ElementSectionReader, Export, ExportSectionReader, ExternalKind, FuncType,
     FunctionSectionReader, GlobalSectionReader, GlobalType, ImportSectionEntryType,
-    ImportSectionReader, MemorySectionReader, MemoryType, Operator, TableSectionReader,
-    TypeSectionReader,
+    ImportSectionReader, MemorySectionReader, MemoryType, NameSectionReader, Naming, NamingReader,
+    Operator, TableSectionReader, TypeSectionReader,
 };
 
 /// Parses the Type section of the wasm module.
@@ -350,4 +350,48 @@ pub fn parse_data_section<'data>(
     }
 
     Ok(())
+}
+
+/// Parses the Name section of the wasm module.
+pub fn parse_name_section<'data>(
+    mut names: NameSectionReader<'data>,
+    environ: &mut dyn ModuleEnvironment<'data>,
+) -> WasmResult<()> {
+    while let Ok(subsection) = names.read() {
+        match subsection {
+            wasmparser::Name::Function(function_subsection) => {
+                if let Some(function_names) = function_subsection
+                    .get_map()
+                    .ok()
+                    .and_then(parse_function_name_subsection)
+                {
+                    for (index, name) in function_names {
+                        environ.declare_func_name(index, name)?;
+                    }
+                }
+                return Ok(());
+            }
+            wasmparser::Name::Local(_) | wasmparser::Name::Module(_) => {}
+        };
+    }
+    Ok(())
+}
+
+fn parse_function_name_subsection<'data>(
+    mut naming_reader: NamingReader<'data>,
+) -> Option<HashMap<FuncIndex, &str>> {
+    let mut function_names = HashMap::new();
+    for _ in 0..naming_reader.get_count() {
+        let Naming { index, name } = naming_reader.read().ok()?;
+        if function_names
+            .insert(FuncIndex::from_u32(index), name)
+            .is_some()
+        {
+            // If the function index has been previously seen, then we
+            // break out of the loop and early return `None`, because these
+            // should be unique.
+            return None;
+        }
+    }
+    return Some(function_names);
 }

--- a/cranelift-wasm/tests/wasm_testsuite.rs
+++ b/cranelift-wasm/tests/wasm_testsuite.rs
@@ -2,7 +2,7 @@ use cranelift_codegen::isa;
 use cranelift_codegen::print_errors::pretty_verifier_error;
 use cranelift_codegen::settings::{self, Flags};
 use cranelift_codegen::verifier;
-use cranelift_wasm::{translate_module, DummyEnvironment, ReturnMode};
+use cranelift_wasm::{translate_module, DummyEnvironment, FuncIndex, ReturnMode};
 use std::fs;
 use std::fs::File;
 use std::io;
@@ -10,7 +10,7 @@ use std::io::prelude::*;
 use std::path::Path;
 use std::str::FromStr;
 use target_lexicon::triple;
-use wabt::{wat2wasm_with_features, Features};
+use wabt::{wat2wasm_with_features, Features, Wat2Wasm};
 
 #[test]
 fn testsuite() {
@@ -31,17 +31,42 @@ fn testsuite() {
     let flags = Flags::new(settings::builder());
     for path in paths {
         let path = path.path();
-        handle_module(&path, &flags, ReturnMode::NormalReturns);
+        let data = read_module(&path);
+        handle_module(data, &flags, ReturnMode::NormalReturns);
     }
 }
 
 #[test]
 fn use_fallthrough_return() {
     let flags = Flags::new(settings::builder());
-    handle_module(
-        Path::new("../wasmtests/use_fallthrough_return.wat"),
-        &flags,
-        ReturnMode::FallthroughReturn,
+    let path = Path::new("../wasmtests/use_fallthrough_return.wat");
+    let data = read_module(&path);
+    handle_module(data, &flags, ReturnMode::FallthroughReturn);
+}
+
+#[test]
+fn use_name_section() {
+    let wat = r#"
+        (module $module_name
+            (func $func_name (local $loc_name i32)
+            )
+        )"#;
+    let data = Wat2Wasm::new()
+        .write_debug_names(true)
+        .convert(wat)
+        .unwrap_or_else(|e| panic!("error converting wat to wasm: {:?}", e));
+
+    let flags = Flags::new(settings::builder());
+    let triple = triple!("riscv64");
+    let isa = isa::lookup(triple).unwrap().finish(flags.clone());
+    let return_mode = ReturnMode::NormalReturns;
+    let mut dummy_environ = DummyEnvironment::new(isa.frontend_config(), return_mode, false);
+
+    translate_module(data.as_ref(), &mut dummy_environ).unwrap();
+
+    assert_eq!(
+        dummy_environ.get_func_name(FuncIndex::from_u32(0)).unwrap(),
+        "func_name"
     );
 }
 
@@ -52,10 +77,10 @@ fn read_file(path: &Path) -> io::Result<Vec<u8>> {
     Ok(buf)
 }
 
-fn handle_module(path: &Path, flags: &Flags, return_mode: ReturnMode) {
+fn read_module(path: &Path) -> Vec<u8> {
     let mut features = Features::new();
     features.enable_all();
-    let data = match path.extension() {
+    match path.extension() {
         None => {
             panic!("the file extension is not wasm or wat");
         }
@@ -72,7 +97,10 @@ fn handle_module(path: &Path, flags: &Flags, return_mode: ReturnMode) {
             }
             None | Some(&_) => panic!("the file extension for {:?} is not wasm or wat", path),
         },
-    };
+    }
+}
+
+fn handle_module(data: Vec<u8>, flags: &Flags, return_mode: ReturnMode) {
     let triple = triple!("riscv64");
     let isa = isa::lookup(triple).unwrap().finish(flags.clone());
     let mut dummy_environ = DummyEnvironment::new(isa.frontend_config(), return_mode, false);


### PR DESCRIPTION
This allows a `ModuleEnvironment` trait object to parse the name section of a wasm binary!