### PR TITLE
[wasm] Don't panic when seeing unexpected types but properly fail instead

### DIFF
--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -135,7 +135,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             if let Ok(ty_cre) = blocktype_to_type(ty) {
                 builder.append_ebb_param(next, ty_cre);
             }
-            state.push_block(next, num_return_values(ty));
+            state.push_block(next, num_return_values(ty)?);
         }
         Operator::Loop { ty } => {
             let loop_body = builder.create_ebb();
@@ -144,7 +144,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 builder.append_ebb_param(next, ty_cre);
             }
             builder.ins().jump(loop_body, &[]);
-            state.push_loop(loop_body, next, num_return_values(ty));
+            state.push_loop(loop_body, next, num_return_values(ty)?);
             builder.switch_to_block(loop_body);
             environ.translate_loop_header(builder.cursor())?;
         }
@@ -161,7 +161,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             if let Ok(ty_cre) = blocktype_to_type(ty) {
                 builder.append_ebb_param(if_not, ty_cre);
             }
-            state.push_if(jump_inst, if_not, num_return_values(ty));
+            state.push_if(jump_inst, if_not, num_return_values(ty)?);
         }
         Operator::Else => {
             // We take the control frame pushed by the if, use its ebb as the else body

--- a/cranelift-wasm/src/translation_utils.rs
+++ b/cranelift-wasm/src/translation_utils.rs
@@ -1,4 +1,5 @@
 //! Helper functions and structures for the translation.
+use crate::environ::{WasmError, WasmResult};
 use core::u32;
 use cranelift_codegen::entity::entity_impl;
 use cranelift_codegen::ir;
@@ -109,21 +110,36 @@ pub struct Memory {
 }
 
 /// Helper function translating wasmparser types to Cranelift types when possible.
-pub fn type_to_type(ty: wasmparser::Type) -> Result<ir::Type, ()> {
+pub fn type_to_type(ty: wasmparser::Type) -> WasmResult<ir::Type> {
     Ok(match ty {
         wasmparser::Type::I32 => ir::types::I32,
         wasmparser::Type::I64 => ir::types::I64,
         wasmparser::Type::F32 => ir::types::F32,
         wasmparser::Type::F64 => ir::types::F64,
-        _ => return Err(()),
+        _ => return Err(WasmError::Unsupported("unsupported wasm type")),
+    })
+}
+
+/// Helper function translating wasmparser possible table types to Cranelift types when possible,
+/// or None for Func tables.
+pub fn tabletype_to_type(ty: wasmparser::Type) -> WasmResult<Option<ir::Type>> {
+    Ok(match ty {
+        wasmparser::Type::I32 => Some(ir::types::I32),
+        wasmparser::Type::I64 => Some(ir::types::I64),
+        wasmparser::Type::F32 => Some(ir::types::F32),
+        wasmparser::Type::F64 => Some(ir::types::F64),
+        wasmparser::Type::AnyFunc => None,
+        _ => return Err(WasmError::Unsupported("unsupported table wasm type")),
     })
 }
 
 /// Helper function translating wasmparser block signatures to Cranelift types when possible.
-pub fn blocktype_to_type(ty: wasmparser::TypeOrFuncType) -> Result<ir::Type, ()> {
+pub fn blocktype_to_type(ty: wasmparser::TypeOrFuncType) -> WasmResult<ir::Type> {
     match ty {
         wasmparser::TypeOrFuncType::Type(ty) => type_to_type(ty),
-        wasmparser::TypeOrFuncType::FuncType(_) => unimplemented!("multi-value block signatures"),
+        wasmparser::TypeOrFuncType::FuncType(_) => {
+            Err(WasmError::Unsupported("multi-value block signatures"))
+        }
     }
 }
 
@@ -138,17 +154,19 @@ pub fn f64_translation(x: wasmparser::Ieee64) -> ir::immediates::Ieee64 {
 }
 
 /// Translate a `wasmparser` type into its `Cranelift` equivalent, when possible
-pub fn num_return_values(ty: wasmparser::TypeOrFuncType) -> usize {
+pub fn num_return_values(ty: wasmparser::TypeOrFuncType) -> WasmResult<usize> {
     match ty {
         wasmparser::TypeOrFuncType::Type(ty) => match ty {
-            wasmparser::Type::EmptyBlockType => 0,
+            wasmparser::Type::EmptyBlockType => Ok(0),
             wasmparser::Type::I32
             | wasmparser::Type::F32
             | wasmparser::Type::I64
-            | wasmparser::Type::F64 => 1,
-            _ => panic!("unsupported return value type"),
+            | wasmparser::Type::F64 => Ok(1),
+            _ => Err(WasmError::Unsupported("unsupported return value type")),
         },
-        wasmparser::TypeOrFuncType::FuncType(_) => unimplemented!("multi-value block signatures"),
+        wasmparser::TypeOrFuncType::FuncType(_) => {
+            Err(WasmError::Unsupported("multi-value block signatures"))
+        }
     }
 }
 


### PR DESCRIPTION
Panicking when seeing unexpected types is a bit harsh on embedders, instead we can properly return an Error type that can be gracefully handled by the embedder. This is for [bug 1562392](https://bugzilla.mozilla.org/show_bug.cgi?id=1562392).