### PR TITLE
Bump the required rust version to 1.35.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: rust
 rust:
     # The oldest version we currently support. See
     # CONTRIBUTING.md#rustc-version-support for details.
-    - 1.34.0
+    - 1.35.0
     - beta
     - nightly
 matrix:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ into executable machine code.
 [![Travis Status](https://travis-ci.org/CraneStation/cranelift.svg?branch=master)](https://travis-ci.org/CraneStation/cranelift)
 [![Appveyor Status](https://ci.appveyor.com/api/projects/status/oub7wrrb59utuv8x?svg=true)](https://ci.appveyor.com/project/CraneStation/cranelift)
 [![Gitter chat](https://badges.gitter.im/CraneStation/CraneStation.svg)](https://gitter.im/CraneStation/Lobby)
-![Minimum rustc 1.34](https://img.shields.io/badge/rustc-1.34+-green.svg)
+![Minimum rustc 1.35](https://img.shields.io/badge/rustc-1.35+-green.svg)
 
 For more information, see [the
 documentation](https://cranelift.readthedocs.io/en/latest/?badge=latest).
@@ -53,7 +53,7 @@ needed before it would be ready for a production use case.
 
 Cranelift's APIs are not yet stable.
 
-Cranelift currently requires Rust 1.32 or later, and Python 2.7 or 3
+Cranelift currently requires Rust 1.35 or later, and Python 2.7 or 3
 to build.
 
 Planned uses


### PR DESCRIPTION
Rust 1.34 gets errors like this:

```
$ cargo +1.34.0 build --release
   Compiling cranelift-wasm v0.32.0 (cranelift/cranelift-wasm)
error[E0259]: the name `std` is defined multiple times
  |
  = note: `std` must be defined only once in the type namespace of this module

error: aborting due to previous error

For more information about this error, try `rustc --explain E0259`.
error: Could not compile `cranelift-wasm`.

To learn more, run the command again with --verbose.
```

Updating to Rust 1.35 fixes this.