### PR TITLE
Meta port 2: more instruction predicates + transform group mapping

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -440,7 +440,7 @@ impl Apply {
         format!("{}({})", self.inst.name, args)
     }
 
-    fn inst_predicate(
+    pub fn inst_predicate(
         &self,
         format_registry: &FormatRegistry,
         var_pool: &VarPool,
@@ -454,8 +454,8 @@ impl Apply {
                 // Ignore free variables for now.
                 continue;
             }
-            pred = pred.and(InstructionPredicate::new_is_field_equal(
-                iform.name,
+            pred = pred.and(InstructionPredicate::new_is_field_equal_ast(
+                iform,
                 &format_field,
                 arg.to_rust_code(var_pool),
             ));

--- a/cranelift-codegen/meta/src/cdsl/cpu_modes.rs
+++ b/cranelift-codegen/meta/src/cdsl/cpu_modes.rs
@@ -35,37 +35,6 @@ impl CpuMode {
             .is_none());
     }
 
-    /// Returns a deterministically ordered, deduplicated list of TransformGroupIndex for the
-    /// transitive set of TransformGroup this TargetIsa uses.
-    pub fn transitive_transform_groups(
-        &self,
-        all_groups: &TransformGroups,
-    ) -> Vec<TransformGroupIndex> {
-        let mut roots = Vec::new();
-        if let Some(i) = &self.default_legalize {
-            roots.push(*i);
-        }
-        if let Some(i) = &self.monomorphic_legalize {
-            roots.push(*i);
-        }
-        roots.extend(self.typed_legalize.values().cloned());
-
-        let mut set = HashSet::new();
-        for root in roots {
-            set.insert(root);
-            let mut base = root;
-            // Follow the chain of chain_with.
-            while let Some(chain_with) = &all_groups.get(base).chain_with {
-                set.insert(*chain_with);
-                base = *chain_with;
-            }
-        }
-
-        let mut ret = Vec::from_iter(set);
-        ret.sort();
-        ret
-    }
-
     /// Returns a deterministically ordered, deduplicated list of TransformGroupIndex for the directly
     /// reachable set of TransformGroup this TargetIsa uses.
     pub fn direct_transform_groups(&self) -> Vec<TransformGroupIndex> {

--- a/cranelift-codegen/meta/src/cdsl/formats.rs
+++ b/cranelift-codegen/meta/src/cdsl/formats.rs
@@ -67,6 +67,20 @@ impl fmt::Display for InstructionFormat {
     }
 }
 
+impl InstructionFormat {
+    pub fn imm_by_name(&self, name: &'static str) -> &FormatField {
+        self.imm_fields
+            .iter()
+            .find(|&field| field.member == name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "unexpected immediate field named {} in instruction format {}",
+                    name, self.name
+                )
+            })
+    }
+}
+
 pub struct InstructionFormatBuilder {
     name: &'static str,
     num_value_operands: usize,
@@ -198,6 +212,14 @@ impl FormatRegistry {
             .sig_to_index
             .get(&sig)
             .expect("unknown InstructionFormat; please define it in shared/formats.rs first")
+    }
+
+    pub fn by_name(&self, name: &str) -> InstructionFormatIndex {
+        self.map
+            .iter()
+            .find(|(_key, value)| value.name == name)
+            .unwrap_or_else(|| panic!("format with name '{}' doesn't exist", name))
+            .0
     }
 
     pub fn get(&self, index: InstructionFormatIndex) -> &InstructionFormat {

--- a/cranelift-codegen/meta/src/cdsl/settings.rs
+++ b/cranelift-codegen/meta/src/cdsl/settings.rs
@@ -148,6 +148,14 @@ impl SettingGroup {
         }
         panic!("Should have found bool setting by name.");
     }
+
+    pub fn predicate_by_name(&self, name: &'static str) -> SettingPredicateNumber {
+        self.predicates
+            .iter()
+            .find(|pred| pred.name == name)
+            .unwrap_or_else(|| panic!("unknown predicate {}", name))
+            .number
+    }
 }
 
 /// This is the basic information needed to track the specific parts of a setting when building
@@ -209,10 +217,12 @@ struct ProtoPredicate {
     node: PredicateNode,
 }
 
+pub type SettingPredicateNumber = u8;
+
 pub struct Predicate {
     pub name: &'static str,
     node: PredicateNode,
-    pub number: u8,
+    pub number: SettingPredicateNumber,
 }
 
 impl Predicate {

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -527,7 +527,7 @@ fn gen_isa(
         direct_groups.len()
     );
     fmt.indent(|fmt| {
-        for group_index in direct_groups {
+        for &group_index in direct_groups {
             fmtln!(fmt, "{},", transform_groups.get(group_index).rust_name());
         }
     });


### PR DESCRIPTION
This starts at 4336356 (part 1 to be merged soon)

Things that might help review:

- f69aae6b894c7c865cf6a6cb0d4af28fd86f0243 adds a mapping between global and local transform groups (= legalization transform groups) indices. That's because all the transform groups are stored within a single array (that's the "global" index into `shared_def.transform_groups`), while when they get used by an ISA, references to transform group refer to a per-ISA array (present in the per-ISA file, e.g. `legalize-x86.rs`). This mapping is used when generating the legalization files, and later when generating encodings (and mapping into the local legalization array when no encodings are found).
- the instruction predicates are unused as of now, but get used in the next commits.
- there's no way / no need to have predicates mixing AND and OR predicates, so I haven't implemented it, and I've made sure to panic when we try to do it.