### PR TITLE
[meta] Legalization fixes and small improvements

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -654,36 +654,32 @@ impl FormatPredicateNode {
     fn rust_predicate(&self) -> String {
         match &self.kind {
             FormatPredicateKind::IsEqual(arg) => {
-                format!("crate::predicates::is_equal({}, {})", self.member_name, arg)
+                format!("predicates::is_equal({}, {})", self.member_name, arg)
             }
             FormatPredicateKind::IsSignedInt(width, scale) => format!(
-                "crate::predicates::is_signed_int({}, {}, {})",
+                "predicates::is_signed_int({}, {}, {})",
                 self.member_name, width, scale
             ),
             FormatPredicateKind::IsUnsignedInt(width, scale) => format!(
-                "crate::predicates::is_unsigned_int({}, {}, {})",
+                "predicates::is_unsigned_int({}, {}, {})",
                 self.member_name, width, scale
             ),
-            FormatPredicateKind::IsZero32BitFloat => format!(
-                "crate::predicates::is_zero_32_bit_float({})",
-                self.member_name
-            ),
-            FormatPredicateKind::IsZero64BitFloat => format!(
-                "crate::predicates::is_zero_64_bit_float({})",
-                self.member_name
-            ),
+            FormatPredicateKind::IsZero32BitFloat => {
+                format!("predicates::is_zero_32_bit_float({})", self.member_name)
+            }
+            FormatPredicateKind::IsZero64BitFloat => {
+                format!("predicates::is_zero_64_bit_float({})", self.member_name)
+            }
             FormatPredicateKind::LengthEquals(num) => format!(
-                "crate::predicates::has_length_of({}, {}, func)",
+                "predicates::has_length_of({}, {}, func)",
                 self.member_name, num
             ),
-            FormatPredicateKind::IsColocatedFunc => format!(
-                "crate::predicates::is_colocated_func({}, func)",
-                self.member_name,
-            ),
-            FormatPredicateKind::IsColocatedData => format!(
-                "crate::predicates::is_colocated_data({}, func)",
-                self.member_name
-            ),
+            FormatPredicateKind::IsColocatedFunc => {
+                format!("predicates::is_colocated_func({}, func)", self.member_name,)
+            }
+            FormatPredicateKind::IsColocatedData => {
+                format!("predicates::is_colocated_data({}, func)", self.member_name)
+            }
         }
     }
 }

--- a/cranelift-codegen/meta/src/cdsl/type_inference.rs
+++ b/cranelift-codegen/meta/src/cdsl/type_inference.rs
@@ -364,7 +364,6 @@ impl TypeEnvironment {
 
             // Sanity check: translated constraints should refer only to real variables.
             for arg in constraint.typevar_args() {
-                assert!(vars_tv.contains(arg));
                 let arg_free_tv = arg.free_typevar();
                 assert!(arg_free_tv.is_none() || vars_tv.contains(&arg_free_tv.unwrap()));
             }

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -134,6 +134,21 @@ fn unwrap_inst(
                     .get(var_pool.get(def.defined_vars[0]).dst_def.unwrap())
                     .to_comment_string(var_pool)
             ));
+
+            fmt.line("let results = pos.func.dfg.inst_results(inst);");
+            for (i, &var_index) in def.defined_vars.iter().enumerate() {
+                let var = var_pool.get(var_index);
+                fmtln!(fmt, "let {} = &results[{}];", var.name, i);
+                if var.has_free_typevar() {
+                    fmtln!(
+                        fmt,
+                        "let typeof_{} = pos.func.dfg.value_type(*{});",
+                        var.name,
+                        var.name
+                    );
+                }
+            }
+
             replace_inst = true;
         } else {
             // Boring case: Detach the result values, capture them in locals.

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -51,7 +51,7 @@ fn unwrap_inst(
 
     fmtln!(
         fmt,
-        "let ({}, predicate) = if let crate::ir::InstructionData::{} {{",
+        "let ({}, predicate) = if let ir::InstructionData::{} {{",
         arg_names,
         iform.name
     );
@@ -407,17 +407,16 @@ fn gen_transform_group<'a>(
     // Function arguments.
     fmtln!(fmt, "pub fn {}(", group.name);
     fmt.indent(|fmt| {
-        fmt.line("inst: crate::ir::Inst,");
-        fmt.line("func: &mut crate::ir::Function,");
-        fmt.line("cfg: &mut crate::flowgraph::ControlFlowGraph,");
-        fmt.line("isa: &dyn crate::isa::TargetIsa,");
+        fmt.line("inst: ir::Inst,");
+        fmt.line("func: &mut ir::Function,");
+        fmt.line("cfg: &mut ControlFlowGraph,");
+        fmt.line("isa: &dyn TargetIsa,");
     });
     fmtln!(fmt, ") -> bool {");
 
     // Function body.
     fmt.indent(|fmt| {
-        fmt.line("use crate::ir::InstBuilder;");
-        fmt.line("use crate::cursor::{Cursor, FuncCursor};");
+        fmt.line("use ir::InstBuilder;");
         fmt.line("let mut pos = FuncCursor::new(func).at_inst(inst);");
         fmt.line("pos.use_srcloc(inst);");
 

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -290,8 +290,7 @@ fn emit_dst_inst(def: &Def, def_pool: &DefPool, var_pool: &VarPool, fmt: &mut Fo
             // Unwrapping would have left the results intact.  Replace the whole instruction.
             fmtln!(
                 fmt,
-                "let {} = pos.func.dfg.replace(inst).{};",
-                defined_vars,
+                "pos.func.dfg.replace(inst).{};",
                 def.apply.rust_builder(&def.defined_vars, var_pool)
             );
 

--- a/cranelift-codegen/src/ir/instructions.rs
+++ b/cranelift-codegen/src/ir/instructions.rs
@@ -498,7 +498,7 @@ enum OperandConstraint {
     /// This operand is the same type as the controlling type variable.
     Same,
 
-    /// This operand is `ctrlType.lane_type()`.
+    /// This operand is `ctrlType.lane_of()`.
     LaneOf,
 
     /// This operand is `ctrlType.as_bool()`.
@@ -527,7 +527,7 @@ impl OperandConstraint {
             Concrete(t) => Bound(t),
             Free(vts) => ResolvedConstraint::Free(TYPE_SETS[vts as usize]),
             Same => Bound(ctrl_type),
-            LaneOf => Bound(ctrl_type.lane_type()),
+            LaneOf => Bound(ctrl_type.lane_of()),
             AsBool => Bound(ctrl_type.as_bool()),
             HalfWidth => Bound(ctrl_type.half_width().expect("invalid type for half_width")),
             DoubleWidth => Bound(

--- a/cranelift-codegen/src/ir/types.rs
+++ b/cranelift-codegen/src/ir/types.rs
@@ -44,8 +44,15 @@ impl Type {
         if self.0 < VECTOR_BASE {
             self
         } else {
-            Type(LANE_BASE | (self.0 & 0x0f))
+            Self(LANE_BASE | (self.0 & 0x0f))
         }
+    }
+
+    /// The type transformation that returns the lane type of a type variable; it is just a
+    /// renaming of lane_type() to be used in context where we think in terms of type variable
+    /// transformations.
+    pub fn lane_of(self) -> Self {
+        self.lane_type()
     }
 
     /// Get log_2 of the number of bits in a lane.

--- a/cranelift-codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift-codegen/src/isa/x86/enc_tables.rs
@@ -6,12 +6,13 @@ use crate::cursor::{Cursor, FuncCursor};
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir::condcodes::{FloatCC, IntCC};
 use crate::ir::{self, Function, Inst, InstBuilder};
-use crate::isa;
 use crate::isa::constraints::*;
 use crate::isa::enc_tables::*;
 use crate::isa::encoding::base_size;
 use crate::isa::encoding::RecipeSizing;
 use crate::isa::RegUnit;
+use crate::isa::{self, TargetIsa};
+use crate::predicates;
 use crate::regalloc::RegDiversions;
 
 include!(concat!(env!("OUT_DIR"), "/encoding-x86.rs"));
@@ -115,7 +116,7 @@ fn expand_sdivrem(
     inst: ir::Inst,
     func: &mut ir::Function,
     cfg: &mut ControlFlowGraph,
-    isa: &dyn isa::TargetIsa,
+    isa: &dyn TargetIsa,
 ) {
     let (x, y, is_srem) = match func.dfg[inst] {
         ir::InstructionData::Binary {
@@ -225,7 +226,7 @@ fn expand_udivrem(
     inst: ir::Inst,
     func: &mut ir::Function,
     _cfg: &mut ControlFlowGraph,
-    isa: &dyn isa::TargetIsa,
+    isa: &dyn TargetIsa,
 ) {
     let (x, y, is_urem) = match func.dfg[inst] {
         ir::InstructionData::Binary {
@@ -278,7 +279,7 @@ fn expand_minmax(
     inst: ir::Inst,
     func: &mut ir::Function,
     cfg: &mut ControlFlowGraph,
-    _isa: &dyn isa::TargetIsa,
+    _isa: &dyn TargetIsa,
 ) {
     let (x, y, x86_opc, bitwise_opc) = match func.dfg[inst] {
         ir::InstructionData::Binary {
@@ -370,7 +371,7 @@ fn expand_fcvt_from_uint(
     inst: ir::Inst,
     func: &mut ir::Function,
     cfg: &mut ControlFlowGraph,
-    _isa: &dyn isa::TargetIsa,
+    _isa: &dyn TargetIsa,
 ) {
     let x;
     match func.dfg[inst] {
@@ -441,7 +442,7 @@ fn expand_fcvt_to_sint(
     inst: ir::Inst,
     func: &mut ir::Function,
     cfg: &mut ControlFlowGraph,
-    _isa: &dyn isa::TargetIsa,
+    _isa: &dyn TargetIsa,
 ) {
     use crate::ir::immediates::{Ieee32, Ieee64};
 
@@ -536,7 +537,7 @@ fn expand_fcvt_to_sint_sat(
     inst: ir::Inst,
     func: &mut ir::Function,
     cfg: &mut ControlFlowGraph,
-    _isa: &dyn isa::TargetIsa,
+    _isa: &dyn TargetIsa,
 ) {
     use crate::ir::immediates::{Ieee32, Ieee64};
 
@@ -655,7 +656,7 @@ fn expand_fcvt_to_uint(
     inst: ir::Inst,
     func: &mut ir::Function,
     cfg: &mut ControlFlowGraph,
-    _isa: &dyn isa::TargetIsa,
+    _isa: &dyn TargetIsa,
 ) {
     use crate::ir::immediates::{Ieee32, Ieee64};
 
@@ -736,7 +737,7 @@ fn expand_fcvt_to_uint_sat(
     inst: ir::Inst,
     func: &mut ir::Function,
     cfg: &mut ControlFlowGraph,
-    _isa: &dyn isa::TargetIsa,
+    _isa: &dyn TargetIsa,
 ) {
     use crate::ir::immediates::{Ieee32, Ieee64};
 

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -19,6 +19,7 @@ use crate::flowgraph::ControlFlowGraph;
 use crate::ir::types::I32;
 use crate::ir::{self, InstBuilder, MemFlags};
 use crate::isa::TargetIsa;
+use crate::predicates;
 use crate::timing;
 
 mod boundary;


### PR DESCRIPTION
When debugging together the generation of splat with @abrown, I've found a few issues in the generation of legalization.

- a spurious assert I added, which doesn't hold when you have a test on a dependent type: `splat` has a test on `some_type_var.lane_of()` which must be equal to something else, and `some_type_var.lane_of` can't belong to the original set of variables, because it's not a free variable in the first place.
- second commit adds a simple alias for `ir::Types::lane_type()`, which was unused so far by the meta code, but should have been named `lane_of()` for type variable constraints. I think it makes sense to keep both names, since each has a useful meaning in different contexts.
- third commit emits type variables variables (sigh... "Rust variables for type variables"), in the case where we can reuse the results of an instruction. (It was already done in the case where we don't reuse the results but create new ones.) I assume it wasn't needed so far, so splat on x86 would be the first user. This actually makes legalization much more powerful, because now we don't need to bind the controlling type anymore in transforms; legalization will just check more things (type variables equality checks). I haven't ported any existing transform to use this, but we should do it in the future.