### PR TITLE
Assert BB-like every time an instruction is added

### DIFF
--- a/cranelift-codegen/src/cursor.rs
+++ b/cranelift-codegen/src/cursor.rs
@@ -635,6 +635,20 @@ impl<'c, 'f> ir::InstInserterBase<'c> for &'c mut FuncCursor<'f> {
     }
 
     fn insert_built_inst(self, inst: ir::Inst, _: ir::Type) -> &'c mut ir::DataFlowGraph {
+        // TODO: Remove this assertion once #796 is fixed.
+        assert!({
+            if let Some(curr) = self.current_inst() {
+                let curr_op = self.data_flow_graph()[curr].opcode();
+                let inst_op = self.data_flow_graph()[inst].opcode();
+                if curr_op.is_branch() && !curr_op.is_terminator() {
+                    inst_op.is_terminator()
+                } else {
+                    true
+                }
+            } else {
+                true
+            }
+        });
         self.insert_inst(inst);
         if !self.srcloc.is_default() {
             self.func.srclocs[inst] = self.srcloc;
@@ -742,6 +756,20 @@ impl<'c, 'f> ir::InstInserterBase<'c> for &'c mut EncCursor<'f> {
         inst: ir::Inst,
         ctrl_typevar: ir::Type,
     ) -> &'c mut ir::DataFlowGraph {
+        // TODO: Remove this assertion once #796 is fixed.
+        assert!({
+            if let Some(curr) = self.current_inst() {
+                let curr_op = self.data_flow_graph()[curr].opcode();
+                let inst_op = self.data_flow_graph()[inst].opcode();
+                if curr_op.is_branch() && !curr_op.is_terminator() {
+                    inst_op.is_terminator()
+                } else {
+                    true
+                }
+            } else {
+                true
+            }
+        });
         // Insert the instruction and remember the reference.
         self.insert_inst(inst);
         self.built_inst = Some(inst);

--- a/cranelift-codegen/src/cursor.rs
+++ b/cranelift-codegen/src/cursor.rs
@@ -641,9 +641,13 @@ impl<'c, 'f> ir::InstInserterBase<'c> for &'c mut FuncCursor<'f> {
                 if let Some(prev) = self.layout().prev_inst(curr) {
                     let prev_op = self.data_flow_graph()[prev].opcode();
                     let inst_op = self.data_flow_graph()[inst].opcode();
+                    let curr_op = self.data_flow_graph()[curr].opcode();
                     if prev_op.is_branch() && !prev_op.is_terminator() {
                         if !inst_op.is_terminator() {
-                            panic!("Inserting instruction {} after {}", inst_op, prev_op)
+                            panic!(
+                                "Inserting instruction {} after {}, and before {}",
+                                inst_op, prev_op, curr_op
+                            )
                         };
                     }
                 };
@@ -765,9 +769,10 @@ impl<'c, 'f> ir::InstInserterBase<'c> for &'c mut EncCursor<'f> {
                     if prev_op.is_branch() && !prev_op.is_terminator() {
                         if !inst_op.is_terminator() {
                             panic!(
-                                "Inserting instruction {} after {}",
+                                "Inserting instruction {} after {} and before {}",
                                 self.display_inst(inst),
-                                self.display_inst(prev)
+                                self.display_inst(prev),
+                                self.display_inst(curr)
                             )
                         };
                     }

--- a/cranelift-codegen/src/cursor.rs
+++ b/cranelift-codegen/src/cursor.rs
@@ -636,23 +636,27 @@ impl<'c, 'f> ir::InstInserterBase<'c> for &'c mut FuncCursor<'f> {
 
     fn insert_built_inst(self, inst: ir::Inst, _: ir::Type) -> &'c mut ir::DataFlowGraph {
         // TODO: Remove this assertion once #796 is fixed.
-        if let CursorPosition::At(_) = self.position() {
-            if let Some(curr) = self.current_inst() {
-                if let Some(prev) = self.layout().prev_inst(curr) {
-                    let prev_op = self.data_flow_graph()[prev].opcode();
-                    let inst_op = self.data_flow_graph()[inst].opcode();
-                    let curr_op = self.data_flow_graph()[curr].opcode();
-                    if prev_op.is_branch() && !prev_op.is_terminator() {
-                        if !inst_op.is_terminator() {
-                            panic!(
-                                "Inserting instruction {} after {}, and before {}",
-                                inst_op, prev_op, curr_op
-                            )
-                        };
-                    }
+        #[cfg(feature = "basic-blocks")]
+        #[cfg(debug_assertions)]
+        {
+            if let CursorPosition::At(_) = self.position() {
+                if let Some(curr) = self.current_inst() {
+                    if let Some(prev) = self.layout().prev_inst(curr) {
+                        let prev_op = self.data_flow_graph()[prev].opcode();
+                        let inst_op = self.data_flow_graph()[inst].opcode();
+                        let curr_op = self.data_flow_graph()[curr].opcode();
+                        if prev_op.is_branch() && !prev_op.is_terminator() {
+                            if !inst_op.is_terminator() {
+                                panic!(
+                                    "Inserting instruction {} after {}, and before {}",
+                                    inst_op, prev_op, curr_op
+                                )
+                            };
+                        }
+                    };
                 };
             };
-        };
+        }
         self.insert_inst(inst);
         if !self.srcloc.is_default() {
             self.func.srclocs[inst] = self.srcloc;
@@ -761,24 +765,28 @@ impl<'c, 'f> ir::InstInserterBase<'c> for &'c mut EncCursor<'f> {
         ctrl_typevar: ir::Type,
     ) -> &'c mut ir::DataFlowGraph {
         // TODO: Remove this assertion once #796 is fixed.
-        if let CursorPosition::At(_) = self.position() {
-            if let Some(curr) = self.current_inst() {
-                if let Some(prev) = self.layout().prev_inst(curr) {
-                    let prev_op = self.data_flow_graph()[prev].opcode();
-                    let inst_op = self.data_flow_graph()[inst].opcode();
-                    if prev_op.is_branch() && !prev_op.is_terminator() {
-                        if !inst_op.is_terminator() {
-                            panic!(
-                                "Inserting instruction {} after {} and before {}",
-                                self.display_inst(inst),
-                                self.display_inst(prev),
-                                self.display_inst(curr)
-                            )
-                        };
-                    }
+        #[cfg(feature = "basic-blocks")]
+        #[cfg(debug_assertions)]
+        {
+            if let CursorPosition::At(_) = self.position() {
+                if let Some(curr) = self.current_inst() {
+                    if let Some(prev) = self.layout().prev_inst(curr) {
+                        let prev_op = self.data_flow_graph()[prev].opcode();
+                        let inst_op = self.data_flow_graph()[inst].opcode();
+                        if prev_op.is_branch() && !prev_op.is_terminator() {
+                            if !inst_op.is_terminator() {
+                                panic!(
+                                    "Inserting instruction {} after {} and before {}",
+                                    self.display_inst(inst),
+                                    self.display_inst(prev),
+                                    self.display_inst(curr)
+                                )
+                            };
+                        }
+                    };
                 };
             };
-        };
+        }
         // Insert the instruction and remember the reference.
         self.insert_inst(inst);
         self.built_inst = Some(inst);


### PR DESCRIPTION
This adds an assertion similar to the verifier, except that it catches issues as soon as they are added to the graph instead of catching issues later on.

This assertion allow to stop all errors when they are introduced and would be useful for fixing the issue with the register allocator which inserts copy instruction.

I will not request a review yet, as this is at the moment just a convenient assertion while making progress, but we would want this assertion to be in place once all test pass and while we have not yet changed the data structure to be Basic Blocks instead of Extended Basic Blocks.