### PR TITLE
Build fix: add crates::predicates to the Riscv enc_tables file

### DIFF
--- a/cranelift-codegen/src/isa/riscv/enc_tables.rs
+++ b/cranelift-codegen/src/isa/riscv/enc_tables.rs
@@ -6,6 +6,7 @@ use crate::isa;
 use crate::isa::constraints::*;
 use crate::isa::enc_tables::*;
 use crate::isa::encoding::{base_size, RecipeSizing};
+use crate::predicates;
 
 // Include the generated encoding tables:
 // - `LEVEL1_RV32`


### PR DESCRIPTION
This is an FYI: merging so this unbreaks the build.