### PR TITLE
Fix an outdated comment referring to `FunctionLayout` instead of `Layout`

### DIFF
--- a/cranelift-codegen/src/ir/dfg.rs
+++ b/cranelift-codegen/src/ir/dfg.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 /// instruction results or EBB parameters.
 ///
 /// The layout of EBBs in the function and of instructions in each EBB is recorded by the
-/// `FunctionLayout` data structure which form the other half of the function representation.
+/// `Layout` data structure which forms the other half of the function representation.
 ///
 #[derive(Clone)]
 pub struct DataFlowGraph {


### PR DESCRIPTION
Nothing exciting, just was reading through. Would have pushed it immediately, but didn't want to subvert the mandatory-review policy that's just a few days old.