### PR TITLE
Change Postion's default method into one from Default trait

### DIFF
--- a/cranelift-codegen/src/ir/function.rs
+++ b/cranelift-codegen/src/ir/function.rs
@@ -222,22 +222,13 @@ impl Function {
 }
 
 /// Additional annotations for function display.
+#[derive(Default)]
 pub struct DisplayFunctionAnnotations<'a> {
     /// Enable ISA annotations.
     pub isa: Option<&'a dyn TargetIsa>,
 
     /// Enable value labels annotations.
     pub value_ranges: Option<&'a ValueLabelsRanges>,
-}
-
-impl<'a> DisplayFunctionAnnotations<'a> {
-    /// Create a DisplayFunctionAnnotations with all fields set to None.
-    pub fn default() -> Self {
-        DisplayFunctionAnnotations {
-            isa: None,
-            value_ranges: None,
-        }
-    }
 }
 
 impl<'a> From<Option<&'a dyn TargetIsa>> for DisplayFunctionAnnotations<'a> {

--- a/cranelift-frontend/src/frontend.rs
+++ b/cranelift-frontend/src/frontend.rs
@@ -46,6 +46,7 @@ struct EbbData {
     user_param_count: usize,
 }
 
+#[derive(Default)]
 struct Position {
     ebb: PackedOption<Ebb>,
     basic_block: PackedOption<Block>,
@@ -56,13 +57,6 @@ impl Position {
         Self {
             ebb: PackedOption::from(ebb),
             basic_block: PackedOption::from(basic_block),
-        }
-    }
-
-    fn default() -> Self {
-        Self {
-            ebb: PackedOption::default(),
-            basic_block: PackedOption::default(),
         }
     }
 


### PR DESCRIPTION
Hello!

Apologies about the trivial commit; just happened to see this code and thought I'd send a PR.  As far as I'm aware, there are no downsides to using the `Default` trait here (`Position::default()` still works), and it's more 'standard' in my mind.

from a quick grep there are other instances of `default` methods, if they're also just calling default, then we can do the same thing more widely.  If that's something you all are interested in I can add more to this PR tonight