### PR TITLE
Remove all default architecture support in cranelift-codegen to allow dependencies fine-grained control

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ file-per-thread-logger = "0.1.2"
 indicatif = "0.11.0"
 
 [features]
-default = ["disas", "wasm"]
+default = ["disas", "wasm", "cranelift-codegen/all-arch"]
 disas = ["capstone"]
 wasm = ["wabt", "cranelift-wasm"]
 basic-blocks = ["cranelift-codegen/basic-blocks", "cranelift-frontend/basic-blocks", "cranelift-wasm/basic-blocks"]

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 cranelift-codegen-meta = { path = "meta", version = "0.38.0", default-features = false }
 
 [features]
-default = ["std", "x86", "arm32", "arm64", "riscv"]
+default = ["std"]
 
 # The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two
@@ -54,10 +54,19 @@ core = [
 testing_hooks = []
 
 # ISA targets for which we should build.
+# If no ISA targets are explicitly enabled, the ISA target for the host machine is enabled.
 x86 = []
 arm32 = []
 arm64 = []
 riscv = []
+
+# Option to enable all architectures.
+all-arch = [
+    "x86",
+    "arm32",
+    "arm64",
+    "riscv"
+]
 
 # For dependent crates that want to serialize some parts of cranelift
 enable-serde = ["serde"]


### PR DESCRIPTION
This is a small patch for an issue originally brought up over on the Wasmtime repository: https://github.com/CraneStation/wasmtime/issues/189

In a nutshell, `cranelift-codegen` had enabled all architecture support in its `default` feature, and, for one reason or another, it's very difficult to disable the `default` feature from within Wasmtime. This makes it hard for projects that want to pick and choose which architectures they want Wasmtime to build for.

As a result, the solution pitched was to remove all architecture support from the `default` feature and allow dependencies to enable the exact architecture support they wanted. That's what this patch hopes to achieve.

For ease of use, there is a new `all-arch` feature included that enables all architecture support -- just as `cranelift-codegen` behaved before.

One possible area for improvement: this code does not currently enforce that at least one of the architectures must be enabled. I briefly looked into using [`required-features`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-required-features-field-optional), but it seems like that wouldn't apply here. I couldn't find other solutions that might work, but I'm open to suggestions if I missed something obvious.

Tagging @npmccallum, @alexcrichton, @sunfishcode, @steveeJ for review.