### PR TITLE
Enable basic block checks through a feature

### DIFF
--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -62,6 +62,9 @@ riscv = []
 # For dependent crates that want to serialize some parts of cranelift
 enable-serde = ["serde"]
 
+# Temporary feature that enforces basic block semantics.
+basic-blocks = []
+
 [badges]
 maintenance = { status = "experimental" }
 travis-ci = { repository = "CraneStation/cranelift" }


### PR DESCRIPTION
This allows prefixing BB-specific code with "#[cfg(feature = "basic-blocks")]", which avoids having to reference an environment variable across the codebase.

The easiest way to enable the feature locally is to add the arguments `features = ["basic-blocks"]` to the workspace Cargo.toml, where it defines the cranelift-codegen dependency. If you're just building cratelift-codegen, you can also use `cargo build --features="basic-blocks"`.

This makes it easier to add BB-specific logic across the codebase.