### PR TITLE
Verify that FunctionBuilder blocks are basic blocks in debug mode

### DIFF
--- a/cranelift-frontend/Cargo.toml
+++ b/cranelift-frontend/Cargo.toml
@@ -21,6 +21,9 @@ default = ["std"]
 std = ["cranelift-codegen/std"]
 core = ["hashmap_core", "cranelift-codegen/core"]
 
+# Temporary feature that enforces basic block semantics.
+basic-blocks = ["cranelift-codegen/basic-blocks"]
+
 [badges]
 maintenance = { status = "experimental" }
 travis-ci = { repository = "CraneStation/cranelift" }

--- a/cranelift-frontend/src/frontend.rs
+++ b/cranelift-frontend/src/frontend.rs
@@ -470,6 +470,16 @@ impl<'a> FunctionBuilder<'a> {
             "all blocks should be filled before dropping a FunctionBuilder"
         );
 
+        // Check that all blocks are valid basic blocks.
+        #[cfg(feature = "basic-blocks")]
+        debug_assert!(
+            self.func_ctx
+                .ebbs
+                .keys()
+                .all(|ebb| self.func.is_ebb_basic(ebb).is_ok()),
+            "all blocks should be encodable as basic blocks"
+        );
+
         // Clear the state (but preserve the allocated buffers) in preparation
         // for translation another function.
         self.func_ctx.clear();
@@ -840,6 +850,7 @@ impl<'a> FunctionBuilder<'a> {
         );
     }
 
+    /// An Ebb is 'filled' when a terminator instruction is present.
     fn fill_current_block(&mut self) {
         self.func_ctx.ebbs[self.position.ebb.unwrap()].filled = true;
     }


### PR DESCRIPTION
To use, enable the "basic-blocks" feature on cranelift-frontend.

The logic defining a basic block is now shared between `cranelift-frontend` and `cranelift-codegen`, hanging off the `Function` (unfortunately there's no other great place to put it -- you need `dfg` and `layout` access).

This doesn't change the FunctionBuilder interface in any way. The first step is to enable the "basic-blocks" feature, then to make it unconditional, and finally we can remove concepts like "body blocks."