### PR TITLE
Generate basic blocks for Wasm `br_if` statements.

### DIFF
--- a/cranelift-frontend/src/frontend.rs
+++ b/cranelift-frontend/src/frontend.rs
@@ -41,8 +41,17 @@ pub struct FunctionBuilder<'a> {
 
 #[derive(Clone, Default)]
 struct EbbData {
-    filled: bool,
+    /// An Ebb is "pristine" iff no instructions have been added since the last
+    /// call to `switch_to_block()`.
     pristine: bool,
+
+    /// An Ebb is "filled" iff a terminator instruction has been inserted since
+    /// the last call to `switch_to_block()`.
+    ///
+    /// A filled block cannot be pristine.
+    filled: bool,
+
+    /// Count of parameters not supplied implicitly by the SSABuilder.
     user_param_count: usize,
 }
 

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -31,6 +31,9 @@ std = ["cranelift-codegen/std", "cranelift-frontend/std", "wasmparser/std"]
 core = ["hashmap_core", "cranelift-codegen/core", "cranelift-frontend/core", "wasmparser/core"]
 enable-serde = ["serde"]
 
+# Temporary feature that enforces basic block semantics.
+basic-blocks = ["cranelift-codegen/basic-blocks", "cranelift-frontend/basic-blocks"]
+
 [badges]
 maintenance = { status = "experimental" }
 travis-ci = { repository = "CraneStation/cranelift" }

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -1244,6 +1244,14 @@ fn translate_br_if(
     let val = state.pop1();
     let (br_destination, inputs) = translate_br_if_args(relative_depth, state);
     builder.ins().brnz(val, br_destination, inputs);
+
+    #[cfg(feature = "basic-blocks")]
+    {
+        let next_ebb = builder.create_ebb();
+        builder.ins().jump(next_ebb, &[]);
+        builder.seal_block(next_ebb); // The only predecessor is the current block.
+        builder.switch_to_block(next_ebb);
+    }
 }
 
 fn translate_br_if_args(

--- a/cranelift-wasm/src/func_translator.rs
+++ b/cranelift-wasm/src/func_translator.rs
@@ -89,7 +89,8 @@ impl FuncTranslator {
         let entry_block = builder.create_ebb();
         builder.append_ebb_params_for_function_params(entry_block);
         builder.switch_to_block(entry_block); // This also creates values for the arguments.
-        builder.seal_block(entry_block);
+        builder.seal_block(entry_block); // Declare all predecessors known.
+
         // Make sure the entry block is inserted in the layout before we make any callbacks to
         // `environ`. The callback functions may need to insert things in the entry block.
         builder.ensure_inserted_ebb();


### PR DESCRIPTION
This is a very simple transformation. Most of the work was just getting a pipeline set up so that I could actually check that the changes were working. I included some other commits, which also make error messages significantly more useful.

This changes:
```
...
@00b3 [RexOp2urm_noflags#4b6,%rcx]  v13 = bint.i32 v12
@00b6 [RexOp1r_ib#4083,%rcx]        v15 = band_imm v13, 1
@00b8 [RexOp1tjccb#74]              brz v15, ebb3 *****
@00bc [RexOp1pu_id#b8,%rcx]         v18 = iconst.i32 7
@00be [RexOp1umr#89,%rdx]           v29 = uextend.i64 v7
@00be [RexOp1ld#808b,%rbx]          v30 = load.i64 notrap aligned readonly v1
@00be [RexOp1stWithIndexDisp8#89]   store_complex v18, v30+v29+12
@00c1 [Op1jmpb#eb]                  jump ebb2
...
```

Into:
```
...
@00c9 [RexOp2urm_noflags#4b6,%rcx]  v13 = bint.i32 v12
@00d4 [RexOp1r_ib#4083,%rcx]        v15 = band_imm v13, 1
@00de [RexOp1tjccb#74]              brz v15, ebb3
@00de [-]                           fallthrough ebb4

                                ebb4:
@00e0 [RexOp1pu_id#b8,%rcx]         v18 = iconst.i32 7
@00e8 [RexOp1umr#89,%rdx]           v29 = uextend.i64 v7
@00e8 [RexOp1ld#808b,%rbx]          v30 = load.i64 notrap aligned readonly v1
@00e8 [RexOp1stWithIndexDisp8#89]   store_complex v18, v30+v29+12
@00eb [Op1jmpb#eb]                  jump ebb2
...
```

Should be very easy to review. I kept it feature-gated because we haven't determined the effect on the various codegen passes yet.