### PR TITLE
Generate basic blocks for wasm if..then..else.

### DIFF
--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -152,6 +152,15 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let val = state.pop1();
             let if_not = builder.create_ebb();
             let jump_inst = builder.ins().brz(val, if_not, &[]);
+
+            #[cfg(feature = "basic-blocks")]
+            {
+                let next_ebb = builder.create_ebb();
+                builder.ins().jump(next_ebb, &[]);
+                builder.seal_block(next_ebb); // Only predecessor is the current block.
+                builder.switch_to_block(next_ebb);
+            }
+
             // Here we append an argument to an Ebb targeted by an argumentless jump instruction
             // But in fact there are two cases:
             // - either the If does not have a Else clause, in that case ty = EmptyBlock


### PR DESCRIPTION
This is a dead-simple patch. The tricky part for me was just validating it.

I was confused by [the WebAssembly specification for control instructions](https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-control) which specifies `if` blocks as `if resulttype instr* else instr* end`.

When an example of valid syntax is actually `if resulttype test then else`. For example:

```
(func $getCell (param $x i32) (param $y i32) (result i32)
  (if (result i32)
    (block (result i32)
      (i32.and
        (call $inRange
          (i32.const 0)
          (i32.const 50)
          (get_local $x)
        )
        (call $inRange
          (i32.const 0)
          (i32.const 50)
          (get_local $y)
        )
      )
    )
    (then
      (i32.const 5)
    )
    (else
      (i32.const 0)
    )
  )
)
```

The attached patch changes the generation of that code to use basic blocks (again -- the code below is after all passes have finished; the `fallthrough` instructions were emitted as `jump instructions).

Before:
```
@0040 [RexOp1call_r#20ff,%rax]      v10 = call_indirect sig0, v16(v8, v9, v21, v22)
@0042 [RexOp1fillSib32#8b,%rcx]     v23 = fill v7
@0042 [RexOp1rr#21,%rcx]            v11 = band v23, v10
@0043 [-]                           fallthrough ebb2(v11)

                                ebb2(v4: i32 [%rcx]):
@0044 [RexOp1tjccb#74]              brz v4, ebb4
@0046 [RexOp1pu_id#b8,%rax]         v13 = iconst.i32 5
@0048 [Op1jmpb#eb]                  jump ebb3(v13)

                                ebb4:
@0049 [RexOp1pu_id#b8,%rax]         v14 = iconst.i32 0
@004b [-]                           fallthrough ebb3(v14)

                                ebb3(v12: i32 [%rax]):
@004c [-]                           fallthrough ebb1(v12)
```

After:
```
@0040 [RexOp1call_r#20ff,%rax]      v10 = call_indirect sig0, v16(v8, v9, v21, v22)
@0042 [RexOp1fillSib32#8b,%rcx]     v23 = fill v7
@0042 [RexOp1rr#21,%rcx]            v11 = band v23, v10
@0043 [-]                           fallthrough ebb2(v11)

                                ebb2(v4: i32 [%rcx]):
@0044 [RexOp1tjccb#74]              brz v4, ebb5
@0044 [-]                           fallthrough ebb4

                                ebb4:
@0046 [RexOp1pu_id#b8,%rax]         v13 = iconst.i32 5
@0048 [Op1jmpb#eb]                  jump ebb3(v13)

                                ebb5:
@0049 [RexOp1pu_id#b8,%rax]         v14 = iconst.i32 0
@004b [-]                           fallthrough ebb3(v14)

                                ebb3(v12: i32 [%rax]):
@004c [-]                           fallthrough ebb1(v12)
```

Really simple patch. I think that's pretty much it for `cranelift-wasm`, given that just this and `br_if` can produce branch instructions.