### PR TITLE
Properly legalize with empty jump tables.

### DIFF
--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -295,9 +295,12 @@ fn expand_br_table_conds(
 
     // This is a poor man's jump table using just a sequence of conditional branches.
     let table_size = func.jump_tables[table].len();
-    let mut cond_failed_ebb = std::vec::Vec::with_capacity(table_size - 1);
-    for _ in 0..table_size - 1 {
-        cond_failed_ebb.push(func.dfg.make_ebb());
+    let mut cond_failed_ebb = vec![];
+    if table_size >= 1 {
+        cond_failed_ebb = std::vec::Vec::with_capacity(table_size - 1);
+        for _ in 0..table_size - 1 {
+            cond_failed_ebb.push(func.dfg.make_ebb());
+        }
     }
 
     let mut pos = FuncCursor::new(func).at_inst(inst);

--- a/filetests/legalizer/empty_br_table.clif
+++ b/filetests/legalizer/empty_br_table.clif
@@ -1,0 +1,17 @@
+test legalizer
+set probestack_enabled=false
+set jump_tables_enabled=false
+target x86_64
+
+function u0:0(i64) {
+    jt0 = jump_table []
+
+ebb0(v0: i64):
+    br_table v0, ebb1, jt0
+; check:  ebb0(v0: i64):
+; nextln:   jump ebb1
+
+ebb1:
+    return
+}
+; not: jump_table


### PR DESCRIPTION
This changes adds a test case which fails when trying to legalize the a empty jump table, and the corresponding changes make the test pass.

This should fix a wasm issue reported to me by @julian-seward1 .
