### PR TITLE
Hide wasm TranslationState innards

### DIFF
--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -6,7 +6,7 @@
 //!
 //! [Wasmtime]: https://github.com/CraneStation/wasmtime
 
-use crate::state::TranslationState;
+use crate::state::VisibleTranslationState;
 use crate::translation_utils::{
     FuncIndex, Global, GlobalIndex, Memory, MemoryIndex, SignatureIndex, Table, TableIndex,
 };
@@ -263,7 +263,7 @@ pub trait FuncEnvironment {
         &mut self,
         _op: &Operator,
         _builder: &mut FunctionBuilder,
-        _state: &mut TranslationState,
+        _state: &VisibleTranslationState,
     ) -> WasmResult<()> {
         Ok(())
     }
@@ -274,7 +274,7 @@ pub trait FuncEnvironment {
         &mut self,
         _op: &Operator,
         _builder: &mut FunctionBuilder,
-        _state: &mut TranslationState,
+        _state: &VisibleTranslationState,
     ) -> WasmResult<()> {
         Ok(())
     }

--- a/cranelift-wasm/src/func_translator.rs
+++ b/cranelift-wasm/src/func_translator.rs
@@ -6,7 +6,7 @@
 
 use crate::code_translator::translate_operator;
 use crate::environ::{FuncEnvironment, ReturnMode, WasmError, WasmResult};
-use crate::state::TranslationState;
+use crate::state::{TranslationState, VisibleTranslationState};
 use crate::translation_utils::get_vmctx_value_label;
 use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir::{self, Ebb, InstBuilder, ValueLabel};
@@ -207,9 +207,9 @@ fn parse_function_body<FE: FuncEnvironment + ?Sized>(
     while !state.control_stack.is_empty() {
         builder.set_srcloc(cur_srcloc(&reader));
         let op = reader.read_operator()?;
-        environ.before_translate_operator(&op, builder, state)?;
+        environ.before_translate_operator(&op, builder, &VisibleTranslationState::new(state))?;
         translate_operator(&op, builder, state, environ)?;
-        environ.after_translate_operator(&op, builder, state)?;
+        environ.after_translate_operator(&op, builder, &VisibleTranslationState::new(state))?;
     }
 
     // The final `End` operator left us in the exit block where we need to manually add a return

--- a/cranelift-wasm/src/lib.rs
+++ b/cranelift-wasm/src/lib.rs
@@ -63,7 +63,7 @@ pub use crate::environ::{
 };
 pub use crate::func_translator::FuncTranslator;
 pub use crate::module_translator::translate_module;
-pub use crate::state::TranslationState;
+pub use crate::state::VisibleTranslationState;
 pub use crate::translation_utils::{
     get_vmctx_value_label, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex,
     DefinedTableIndex, FuncIndex, Global, GlobalIndex, GlobalInit, Memory, MemoryIndex,

--- a/cranelift-wasm/src/state.rs
+++ b/cranelift-wasm/src/state.rs
@@ -124,6 +124,28 @@ impl ControlStackFrame {
     }
 }
 
+/// VisibleTranslationState wraps a TranslationState with an interface appropriate for users
+/// outside this `cranelift-wasm`.
+///
+/// VisibleTranslationState is currently very minimal (only exposing reachability information), but
+/// is anticipated to grow in the future, with functions to inspect or modify the wasm operand
+/// stack for example.
+pub struct VisibleTranslationState<'a> {
+    state: &'a TranslationState,
+}
+
+impl<'a> VisibleTranslationState<'a> {
+    /// Build a VisibleTranslationState from an existing TranslationState
+    pub fn new(state: &'a TranslationState) -> Self {
+        VisibleTranslationState { state }
+    }
+
+    /// True if the current translation state expresses reachable code, false if it is unreachable
+    pub fn reachable(&self) -> bool {
+        self.state.reachable
+    }
+}
+
 /// Contains information passed along during the translation and that records:
 ///
 /// - The current value and control stacks.


### PR DESCRIPTION
Followup to https://github.com/CraneStation/cranelift/pull/879, to only expose what we feel is a stable API for information in `TranslationState`