### PR TITLE
Preopt: use replaced arg after having replaced BinaryImm

### DIFF
--- a/cranelift-codegen/src/simple_preopt.rs
+++ b/cranelift-codegen/src/simple_preopt.rs
@@ -585,6 +585,7 @@ fn simplify(pos: &mut FuncCursor, inst: Inst) {
         InstructionData::BinaryImm { opcode, arg, imm } => {
             let ty = pos.func.dfg.ctrl_typevar(inst);
 
+            let mut arg = arg;
             let mut imm = imm;
             match opcode {
                 Opcode::IaddImm
@@ -613,12 +614,13 @@ fn simplify(pos: &mut FuncCursor, inst: Inst) {
                                         _ => panic!("can't happen"),
                                     };
                                     let new_imm = immediates::Imm64::from(new_imm);
-                                    let arg = *prev_arg;
+                                    let new_arg = *prev_arg;
                                     pos.func
                                         .dfg
                                         .replace(inst)
-                                        .BinaryImm(opcode, ty, new_imm, arg);
+                                        .BinaryImm(opcode, ty, new_imm, new_arg);
                                     imm = new_imm;
+                                    arg = new_arg;
                                 }
                             }
                         }

--- a/filetests/simple_preopt/simplify.clif
+++ b/filetests/simple_preopt/simplify.clif
@@ -278,3 +278,16 @@ ebb0:
 ; nextln:     v2 = sextend.i64 v3
 ; nextln:     return v2
 ; nextln: }
+
+function %add_imm_fold(i32) -> i32 {
+ebb0(v0: i32):
+  v1 = iadd_imm v0, 42
+  v2 = iadd_imm v1, -42
+  return v2
+}
+; sameln: function %add_imm_fold(i32)
+; nextln: ebb0(v0: i32):
+; nextln:    v2 -> v0
+; nextln:    v1 = iadd_imm v0, 42
+; nextln:    nop
+; nextln:    return v2


### PR DESCRIPTION
when replacing BinaryImm, we use the prior arg, but later use the arg that was replaced when writing an alias if we can determine the new op is actually equivalent to a simple copy

this was found with `strlen("a")` returning 2 in some wasm downstream, but I reduced that down to the test case here.

I was surprised to see in writing the test case that runners for cases in `filetests` have a lot of variance - should `simple_preopt` and `preopt` be merged together? the cases in `preopt` ought to fail under the full `preopt` run, but are only tested with respect to only some of the constant folding done in `simple_preopt`