### PR TITLE
Add EntryRegDiversions to record diversions for each block entry.

### DIFF
--- a/cranelift-codegen/src/binemit/mod.rs
+++ b/cranelift-codegen/src/binemit/mod.rs
@@ -176,7 +176,7 @@ where
 {
     let mut divert = RegDiversions::new();
     for ebb in func.layout.ebbs() {
-        divert.clear();
+        divert.at_ebb(&func.entry_diversions, ebb);
         debug_assert_eq!(func.offsets[ebb], sink.offset());
         for inst in func.layout.ebb_insts(ebb) {
             emit_inst(func, inst, &mut divert, sink, isa);

--- a/cranelift-codegen/src/binemit/relaxation.rs
+++ b/cranelift-codegen/src/binemit/relaxation.rs
@@ -74,7 +74,7 @@ pub fn relax_branches(
     {
         let mut cur = FuncCursor::new(func);
         while let Some(ebb) = cur.next_ebb() {
-            divert.clear();
+            divert.at_ebb(&cur.func.entry_diversions, ebb);
             cur.func.offsets[ebb] = offset;
             while let Some(inst) = cur.next_inst() {
                 divert.apply(&cur.func.dfg[inst]);
@@ -93,7 +93,8 @@ pub fn relax_branches(
         // Visit all instructions in layout order.
         let mut cur = FuncCursor::new(func);
         while let Some(ebb) = cur.next_ebb() {
-            divert.clear();
+            divert.at_ebb(&cur.func.entry_diversions, ebb);
+
             // Record the offset for `ebb` and make sure we iterate until offsets are stable.
             if cur.func.offsets[ebb] != offset {
                 cur.func.offsets[ebb] = offset;

--- a/cranelift-codegen/src/binemit/shrink.rs
+++ b/cranelift-codegen/src/binemit/shrink.rs
@@ -20,7 +20,9 @@ pub fn shrink_instructions(func: &mut Function, isa: &dyn TargetIsa) {
     let mut divert = RegDiversions::new();
 
     for ebb in func.layout.ebbs() {
-        divert.clear();
+        // Load diversions from predecessors.
+        divert.at_ebb(&func.entry_diversions, ebb);
+
         for inst in func.layout.ebb_insts(ebb) {
             let enc = func.encodings[inst];
             if enc.is_legal() {

--- a/cranelift-codegen/src/regalloc/coloring.rs
+++ b/cranelift-codegen/src/regalloc/coloring.rs
@@ -199,6 +199,7 @@ impl<'a> Context<'a> {
             self.domtree,
         );
 
+        self.divert.at_ebb(&self.cur.func.entry_diversions, ebb);
         if self.cur.func.layout.entry_block() == Some(ebb) {
             // Parameters on the entry block have ABI constraints.
             self.color_entry_params(tracker.live())

--- a/cranelift-codegen/src/regalloc/mod.rs
+++ b/cranelift-codegen/src/regalloc/mod.rs
@@ -20,6 +20,6 @@ mod solver;
 mod spilling;
 
 pub use self::context::Context;
-pub use self::diversion::RegDiversions;
+pub use self::diversion::{EntryRegDiversions, RegDiversions};
 pub use self::register_set::RegisterSet;
 pub use self::safepoint::emit_stackmaps;

--- a/cranelift-codegen/src/value_label.rs
+++ b/cranelift-codegen/src/value_label.rs
@@ -118,7 +118,7 @@ where
     let mut tracked_values: Vec<(Value, ValueLabel, u32, ValueLoc)> = Vec::new();
     let mut divert = RegDiversions::new();
     for ebb in ebbs {
-        divert.clear();
+        divert.at_ebb(&func.entry_diversions, ebb);
         let mut last_srcloc: Option<T> = None;
         for (offset, inst, size) in func.inst_offsets(ebb, &encinfo) {
             divert.apply(&func.dfg[inst]);

--- a/cranelift-codegen/src/verifier/locations.rs
+++ b/cranelift-codegen/src/verifier/locations.rs
@@ -51,9 +51,8 @@ impl<'a> LocationVerifier<'a> {
         let mut divert = RegDiversions::new();
 
         for ebb in self.func.layout.ebbs() {
-            // Diversions are reset at the top of each EBB. No diversions can exist across control
-            // flow edges.
-            divert.clear();
+            divert.at_ebb(&self.func.entry_diversions, ebb);
+
             for inst in self.func.layout.ebb_insts(ebb) {
                 let enc = self.func.encodings[inst];
 


### PR DESCRIPTION
This patch is a pre-requisite for #844 , which introduces `regalloc::EntryRegDiversions` as part of the `ir::Function`.

Technically we do not require `EntryRegDiversions`, but not having them implies that we would always visit all the blocks in a topological order inspired by the reverse post-order, in order to garantee that the `RegDiversions` for each basic block is recorded before the block is visited.

However, this is not possible as the order of the generated code is expected to be the same as the code within Cranelift, as implies the fact that we have `fallthrough` instructions.

Thus #844 would be changed to record the `RegDiversions` at each basic block entry on the `ir::Function::entry_diversions` field, using the `save_for_ebb` function. The `at_ebb` is used to restore the state of the `RegDiversions` as propagated by the predecessor, and the `check_ebb_entry` would be used in a mirror location as `save_for_ebb` but in the locations verifier.

Doing these changes as part of the diversions logic is the least intrusive implementation I found so far, as it only requires to replace `divert.clear()` calls by `divert.at_ebb(&func.entry_diversions, ebb)` calls.
