### PR TITLE
Use divert apply everywhere outside the coloring phase.

### DIFF
--- a/cranelift-codegen/meta/src/gen_binemit.rs
+++ b/cranelift-codegen/meta/src/gen_binemit.rs
@@ -32,7 +32,7 @@ fn gen_recipe(formats: &FormatRegistry, recipe: &EncodingRecipe, fmt: &mut Forma
     let is_regmove = ["RegMove", "RegSpill", "RegFill"].contains(&inst_format.name);
 
     // Unpack the instruction data.
-    fmtln!(fmt, "if let InstructionData::{} {{", inst_format.name);
+    fmtln!(fmt, "if let &InstructionData::{} {{", inst_format.name);
     fmt.indent(|fmt| {
         fmt.line("opcode,");
         for f in &inst_format.imm_fields {
@@ -47,7 +47,7 @@ fn gen_recipe(formats: &FormatRegistry, recipe: &EncodingRecipe, fmt: &mut Forma
         }
         fmt.line("..");
 
-        fmt.outdented_line("} = func.dfg[inst] {");
+        fmt.outdented_line("} = data {");
 
         // Pass recipe arguments in this order: inputs, imm_fields, outputs.
         let mut args = String::new();
@@ -186,7 +186,8 @@ fn gen_isa(formats: &FormatRegistry, isa_name: &str, recipes: &Recipes, fmt: &mu
     fmt.indent(|fmt| {
         fmt.line("let encoding = func.encodings[inst];");
         fmt.line("let bits = encoding.bits();");
-        fmt.line("match func.encodings[inst].recipe() {");
+        fmt.line("let data = &func.dfg[inst];");
+        fmt.line("match encoding.recipe() {");
         fmt.indent(|fmt| {
             for (i, recipe) in recipes.iter() {
                 fmt.comment(format!("Recipe {}", recipe.name));

--- a/cranelift-codegen/meta/src/gen_binemit.rs
+++ b/cranelift-codegen/meta/src/gen_binemit.rs
@@ -47,7 +47,7 @@ fn gen_recipe(formats: &FormatRegistry, recipe: &EncodingRecipe, fmt: &mut Forma
         }
         fmt.line("..");
 
-        fmt.outdented_line("} = data {");
+        fmt.outdented_line("} = inst_data {");
 
         // Pass recipe arguments in this order: inputs, imm_fields, outputs.
         let mut args = String::new();
@@ -77,7 +77,7 @@ fn gen_recipe(formats: &FormatRegistry, recipe: &EncodingRecipe, fmt: &mut Forma
 
         // Optimization: Only update the register diversion tracker for regmove instructions.
         if is_regmove {
-            fmt.line("divert.apply(data);")
+            fmt.line("divert.apply(inst_data);")
         }
 
         match &recipe.emit {
@@ -182,7 +182,7 @@ fn gen_isa(formats: &FormatRegistry, isa_name: &str, recipes: &Recipes, fmt: &mu
     fmt.indent(|fmt| {
         fmt.line("let encoding = func.encodings[inst];");
         fmt.line("let bits = encoding.bits();");
-        fmt.line("let data = &func.dfg[inst];");
+        fmt.line("let inst_data = &func.dfg[inst];");
         fmt.line("match encoding.recipe() {");
         fmt.indent(|fmt| {
             for (i, recipe) in recipes.iter() {

--- a/cranelift-codegen/meta/src/gen_binemit.rs
+++ b/cranelift-codegen/meta/src/gen_binemit.rs
@@ -75,13 +75,9 @@ fn gen_recipe(formats: &FormatRegistry, recipe: &EncodingRecipe, fmt: &mut Forma
             args += &unwrap_values(&recipe.operands_out, "out", "results", fmt);
         }
 
-        // Special handling for regmove instructions. Update the register
-        // diversion tracker
-        match &*inst_format.name {
-            "RegMove" => fmt.line("divert.regmove(arg, src, dst);"),
-            "RegSpill" => fmt.line("divert.regspill(arg, src, dst);"),
-            "RegFill" => fmt.line("divert.regfill(arg, src, dst);"),
-            _ => {}
+        // Optimization: Only update the register diversion tracker for regmove instructions.
+        if is_regmove {
+            fmt.line("divert.apply(data);")
         }
 
         match &recipe.emit {

--- a/cranelift-codegen/src/binemit/shrink.rs
+++ b/cranelift-codegen/src/binemit/shrink.rs
@@ -33,11 +33,12 @@ pub fn shrink_instructions(func: &mut Function, isa: &dyn TargetIsa) {
                 //
                 // TODO: Eventually, we want the register allocator to avoid leaving these special
                 // instructions behind, but for now, just temporarily avoid trying to shrink them.
-                match func.dfg[inst] {
+                let inst_data = &func.dfg[inst];
+                match inst_data {
                     InstructionData::RegMove { .. }
                     | InstructionData::RegFill { .. }
                     | InstructionData::RegSpill { .. } => {
-                        divert.apply(&func.dfg[inst]);
+                        divert.apply(inst_data);
                         continue;
                     }
                     _ => (),


### PR DESCRIPTION
This is a minor change, which make use use `divert.regmove`, `divert.regspill` and `divert.regfill` only within the coloring phase of the compiler. All other phases now rely on `divert.apply`.

This is a side-effect of a change that I initially made and reverted where I attempted to split `RegDiversions` in 2, one meant to record the `EntryRegDiversions` added in #883, and another one meant to read the content of it.

The difference between the coloring phase and others, is that the coloring phase will add the `regmove` instructions, whereas others are only following what is already present in the DFG.