### PR TITLE
WIP: Add fold_redundant_jumps() pass to the branch relaxation phase.

### DIFF
--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -329,7 +329,7 @@ impl Context {
     /// Run the branch relaxation pass and return information about the function's code and
     /// read-only data.
     pub fn relax_branches(&mut self, isa: &dyn TargetIsa) -> CodegenResult<CodeInfo> {
-        let info = relax_branches(&mut self.func, isa)?;
+        let info = relax_branches(&mut self.func, &mut self.cfg, &mut self.domtree, isa)?;
         self.verify_if(isa)?;
         self.verify_locations_if(isa)?;
         Ok(info)

--- a/cranelift-codegen/src/flowgraph.rs
+++ b/cranelift-codegen/src/flowgraph.rs
@@ -31,7 +31,7 @@ use crate::timing;
 use core::mem;
 
 /// A basic block denoted by its enclosing Ebb and last instruction.
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct BasicBlock {
     /// Enclosing Ebb key.
     pub ebb: Ebb,

--- a/cranelift-codegen/src/ir/function.rs
+++ b/cranelift-codegen/src/ir/function.rs
@@ -8,7 +8,7 @@ use crate::entity::{PrimaryMap, SecondaryMap};
 use crate::ir;
 use crate::ir::{DataFlowGraph, ExternalName, Layout, Signature};
 use crate::ir::{
-    Ebb, ExtFuncData, FuncRef, GlobalValue, GlobalValueData, Heap, HeapData, JumpTable,
+    Ebb, ExtFuncData, FuncRef, GlobalValue, GlobalValueData, Heap, HeapData, Inst, JumpTable,
     JumpTableData, SigRef, StackSlot, StackSlotData, Table, TableData,
 };
 use crate::ir::{EbbOffsets, InstEncodings, SourceLocs, StackSlots, ValueLocations};
@@ -20,7 +20,7 @@ use crate::write::write_function;
 use core::fmt;
 
 #[cfg(feature = "basic-blocks")]
-use crate::ir::{Inst, Opcode};
+use crate::ir::Opcode;
 
 /// A function.
 ///
@@ -221,6 +221,15 @@ impl Function {
     /// Starts collection of debug information.
     pub fn collect_debug_info(&mut self) {
         self.dfg.collect_debug_info();
+    }
+
+    /// Changes the destination of a jump or branch instruction.
+    /// Does nothing if called with a non-jump or non-branch instruction.
+    pub fn change_branch_destination(&mut self, inst: Inst, new_dest: Ebb) {
+        match self.dfg[inst].branch_destination_mut() {
+            None => (),
+            Some(inst_dest) => *inst_dest = new_dest,
+        }
     }
 
     /// Checks that the specified EBB can be encoded as a basic block.

--- a/cranelift-codegen/src/licm.rs
+++ b/cranelift-codegen/src/licm.rs
@@ -88,7 +88,7 @@ fn create_pre_header(
     {
         // We only follow normal edges (not the back edges)
         if !domtree.dominates(header, last_inst, &func.layout) {
-            change_branch_jump_destination(last_inst, pre_header, func);
+            func.change_branch_destination(last_inst, pre_header);
         }
     }
     {
@@ -134,15 +134,6 @@ fn has_pre_header(
         }
     }
     result
-}
-
-// Change the destination of a jump or branch instruction. Does nothing if called with a non-jump
-// or non-branch instruction.
-fn change_branch_jump_destination(inst: Inst, new_ebb: Ebb, func: &mut Function) {
-    match func.dfg[inst].branch_destination_mut() {
-        None => (),
-        Some(instruction_dest) => *instruction_dest = new_ebb,
-    }
 }
 
 /// Test whether the given opcode is unsafe to even consider for LICM.

--- a/cranelift-filetests/src/test_binemit.rs
+++ b/cranelift-filetests/src/test_binemit.rs
@@ -7,6 +7,8 @@ use crate::match_directive::match_directive;
 use crate::subtest::{Context, SubTest, SubtestResult};
 use cranelift_codegen::binemit::{self, CodeInfo, CodeSink, RegDiversions};
 use cranelift_codegen::dbg::DisplayList;
+use cranelift_codegen::dominator_tree::DominatorTree;
+use cranelift_codegen::flowgraph::ControlFlowGraph;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::entities::AnyEntity;
 use cranelift_codegen::print_errors::pretty_error;
@@ -166,8 +168,11 @@ impl SubTest for TestBinEmit {
         }
 
         // Relax branches and compute EBB offsets based on the encodings.
-        let CodeInfo { total_size, .. } = binemit::relax_branches(&mut func, isa)
-            .map_err(|e| pretty_error(&func, context.isa, e))?;
+        let mut cfg = ControlFlowGraph::with_function(&func);
+        let mut domtree = DominatorTree::with_function(&func, &cfg);
+        let CodeInfo { total_size, .. } =
+            binemit::relax_branches(&mut func, &mut cfg, &mut domtree, isa)
+                .map_err(|e| pretty_error(&func, context.isa, e))?;
 
         // Collect all of the 'bin:' directives on instructions.
         let mut bins = HashMap::new();

--- a/filetests/isa/x86/binary64.clif
+++ b/filetests/isa/x86/binary64.clif
@@ -689,48 +689,48 @@ ebb0:
 
     ; asm: testq %rcx, %rcx
     ; asm: je ebb1
-    brz v1, ebb1                                ; bin: 48 85 c9 74 1b
+    brz v1, ebb1                                ; bin: 48 85 c9 74 19
     fallthrough ebb3
 
 ebb3:
     ; asm: testq %rsi, %rsi
     ; asm: je ebb1
-    brz v2, ebb1                                ; bin: 48 85 f6 74 16
+    brz v2, ebb1                                ; bin: 48 85 f6 74 14
     fallthrough ebb4
 
 ebb4:
     ; asm: testq %r10, %r10
     ; asm: je ebb1
-    brz v3, ebb1                                ; bin: 4d 85 d2 74 11
+    brz v3, ebb1                                ; bin: 4d 85 d2 74 0f
     fallthrough ebb5
 
 ebb5:
     ; asm: testq %rcx, %rcx
     ; asm: jne ebb1
-    brnz v1, ebb1                               ; bin: 48 85 c9 75 0c
+    brnz v1, ebb1                               ; bin: 48 85 c9 75 0a
     fallthrough ebb6
 
 ebb6:
     ; asm: testq %rsi, %rsi
     ; asm: jne ebb1
-    brnz v2, ebb1                               ; bin: 48 85 f6 75 07
+    brnz v2, ebb1                               ; bin: 48 85 f6 75 05
     fallthrough ebb7
 
 ebb7:
     ; asm: testq %r10, %r10
     ; asm: jne ebb1
-    brnz v3, ebb1                               ; bin: 4d 85 d2 75 02
+    brnz v3, ebb1                               ; bin: 4d 85 d2 75 00
 
     ; asm: jmp ebb2
-    jump ebb2                                   ; bin: eb 01
+    jump ebb2
 
     ; asm: ebb1:
 ebb1:
-    return                                       ; bin: c3
+    return
 
     ; asm: ebb2:
 ebb2:
-    jump ebb1                                   ; bin: eb fd
+    jump ebb1
 }
 
 ; CPU flag instructions.
@@ -1292,40 +1292,41 @@ ebb0:
 
     ; asm: testl %ecx, %ecx
     ; asm: je ebb1x
-    brz v1, ebb1                                ; bin: 85 c9 74 18
+    brz v1, ebb1                                ; bin: 85 c9 74 16
     fallthrough ebb3
 
 ebb3:
     ; asm: testl %esi, %esi
     ; asm: je ebb1x
-    brz v2, ebb1                                ; bin: 85 f6 74 14
+    brz v2, ebb1                                ; bin: 85 f6 74 12
     fallthrough ebb4
 
 ebb4:
     ; asm: testl %r10d, %r10d
     ; asm: je ebb1x
-    brz v3, ebb1                                ; bin: 45 85 d2 74 0f
+    brz v3, ebb1                                ; bin: 45 85 d2 74 0d
     fallthrough ebb5
 
 ebb5:
     ; asm: testl %ecx, %ecx
     ; asm: jne ebb1x
-    brnz v1, ebb1                               ; bin: 85 c9 75 0b
+    brnz v1, ebb1                               ; bin: 85 c9 75 09
     fallthrough ebb6
 
 ebb6:
     ; asm: testl %esi, %esi
     ; asm: jne ebb1x
-    brnz v2, ebb1                               ; bin: 85 f6 75 07
+    brnz v2, ebb1                               ; bin: 85 f6 75 05
     fallthrough ebb7
 
 ebb7:
     ; asm: testl %r10d, %r10d
     ; asm: jne ebb1x
-    brnz v3, ebb1                               ; bin: 45 85 d2 75 02
+    brnz v3, ebb1                               ; bin: 45 85 d2 75 00
 
     ; asm: jmp ebb2x
-    jump ebb2                                   ; bin: eb 01
+    ; branch relaxation translates this into `fallthrough ebb1`
+    jump ebb2
 
     ; asm: ebb1x:
 ebb1:

--- a/filetests/isa/x86/legalize-br-table.clif
+++ b/filetests/isa/x86/legalize-br-table.clif
@@ -11,9 +11,9 @@ function u0:0(i64) system_v {
 ebb0(v0: i64):
     v1 = stack_addr.i64 ss0
     v2 = load.i8 v1
-    br_table v2, ebb2, jt0
+    br_table v2, ebb1, jt0
 ; check:     $(oob=$V) = ifcmp_imm $(idx=$V), 1
-; nextln:    brif uge $oob, ebb2
+; nextln:    brif uge $oob, ebb1
 ; nextln:    fallthrough $(inb=$EBB)
 ; check:   $inb:
 ; nextln:    $(final_idx=$V) = uextend.i64 $idx
@@ -21,9 +21,6 @@ ebb0(v0: i64):
 ; nextln:    $(rel_addr=$V) = jump_table_entry $final_idx, $base, 4, jt0
 ; nextln:    $(addr=$V) = iadd $base, $rel_addr
 ; nextln:    indirect_jump_table_br $addr, jt0
-
-ebb2:
-    jump ebb1
 
 ebb1:
     return


### PR DESCRIPTION
This adds a `fold_redundant_jumps()` pass to the branch relaxation phase. Nicolas' basic-blocks regalloc patch splits critical edges: if those edges are unused by register allocation, the blocks can be folded back up. Not doing so produces weird codegen where you jump to a jump to a jump.

For example:

Before:
```
Disassembly of 22 bytes:
   0:	55                   	push	rbp
   1:	48 89 e5             	mov	rbp, rsp
   4:	b8 08 00 00 00       	mov	eax, 8
   9:	83 ff 05             	cmp	edi, 5
   c:	7f 04                	jg	0x12
   e:	89 f8                	mov	eax, edi
  10:	eb 02                	jmp	0x14
  12:	eb fc                	jmp	0x10
  14:	5d                   	pop	rbp
  15:	c3                   	ret
```

After:

```
   0:	55                   	push	rbp
   1:	48 89 e5             	mov	rbp, rsp
   4:	b8 08 00 00 00       	mov	eax, 8
   9:	83 ff 05             	cmp	edi, 5
   c:	7f 04                	jg	0x12
   e:	89 f8                	mov	eax, edi
  10:	eb 00                	jmp	0x12
  12:	5d                   	pop	rbp
  13:	c3                   	ret
```

This patch isn't done. It can fold more, and also I'm not sure if anything needs to be done about ebb parameters -- this executes after regalloc, which should already have resolved that, in theory.