### PR TITLE
Serialize ValueLabel and StackSlots

### DIFF
--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -69,6 +69,7 @@ entity_impl!(Inst, "inst");
 
 /// An opaque reference to a stack slot.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct StackSlot(u32);
 entity_impl!(StackSlot, "ss");
 

--- a/cranelift-codegen/src/ir/mod.rs
+++ b/cranelift-codegen/src/ir/mod.rs
@@ -23,6 +23,9 @@ mod trapcode;
 pub mod types;
 mod valueloc;
 
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
+
 pub use crate::ir::builder::{InsertBuilder, InstBuilder, InstBuilderBase, InstInserterBase};
 pub use crate::ir::dfg::{DataFlowGraph, ValueDef};
 pub use crate::ir::entities::{
@@ -74,6 +77,7 @@ pub type SourceLocs = SecondaryMap<Inst, SourceLoc>;
 
 /// Marked with a label value.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct ValueLabel(u32);
 entity_impl!(ValueLabel, "val");
 

--- a/cranelift-codegen/src/ir/stackslot.rs
+++ b/cranelift-codegen/src/ir/stackslot.rs
@@ -13,6 +13,9 @@ use core::slice;
 use core::str::FromStr;
 use std::vec::Vec;
 
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
+
 /// The size of an object on the stack, or the size of a stack frame.
 ///
 /// We don't use `usize` to represent object sizes on the target platform because Cranelift supports
@@ -38,6 +41,7 @@ fn spill_size(ty: Type) -> StackSize {
 
 /// The kind of a stack slot.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum StackSlotKind {
     /// A spill slot. This is a stack slot created by the register allocator.
     SpillSlot,
@@ -98,6 +102,7 @@ impl fmt::Display for StackSlotKind {
 
 /// Contents of a stack slot.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct StackSlotData {
     /// The kind of stack slot.
     pub kind: StackSlotKind,
@@ -150,6 +155,7 @@ impl fmt::Display for StackSlotData {
 ///
 /// Keep track of all the stack slots used by a function.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct StackSlots {
     /// All allocated stack slots.
     slots: PrimaryMap<StackSlot, StackSlotData>,

--- a/cranelift-codegen/src/ir/valueloc.rs
+++ b/cranelift-codegen/src/ir/valueloc.rs
@@ -7,8 +7,12 @@ use crate::ir::StackSlot;
 use crate::isa::{RegInfo, RegUnit};
 use core::fmt;
 
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
+
 /// Value location.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum ValueLoc {
     /// This value has not been assigned to a location yet.
     Unassigned,

--- a/cranelift-codegen/src/value_label.rs
+++ b/cranelift-codegen/src/value_label.rs
@@ -8,8 +8,12 @@ use std::ops::Bound::*;
 use std::ops::Deref;
 use std::vec::Vec;
 
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
+
 /// Value location range.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct ValueLocRange {
     /// The ValueLoc containing a ValueLabel during this range.
     pub loc: ValueLoc,


### PR DESCRIPTION
While rebasing https://github.com/CraneStation/wasmtime/pull/63, found that ValueLabel and StackSlots are not marked for serialization -- this patch addresses that.

/cc @Mrowqa