### PR TITLE
Fix an assertion that wasn't doing what it said

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/recipes.rs
+++ b/cranelift-codegen/meta/src/cdsl/recipes.rs
@@ -102,7 +102,7 @@ impl Into<OperandConstraint> for Stack {
 /// The `branch_range` argument must be provided for recipes that can encode
 /// branch instructions. It is an `(origin, bits)` tuple describing the exact
 /// range that can be encoded in a branch instruction.
-#[derive(Clone, Hash)]
+#[derive(Clone)]
 pub struct EncodingRecipe {
     /// Short mnemonic name for this recipe.
     pub name: String,

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -21,7 +21,7 @@ pub struct PerCpuModeEncodings {
     pub enc32: Vec<Encoding>,
     pub enc64: Vec<Encoding>,
     pub recipes: Recipes,
-    recipes_inverse: HashMap<EncodingRecipe, EncodingRecipeNumber>,
+    recipes_by_name: HashMap<String, EncodingRecipeNumber>,
     pub inst_pred_reg: InstructionPredicateRegistry,
 }
 
@@ -31,15 +31,15 @@ impl PerCpuModeEncodings {
             enc32: Vec::new(),
             enc64: Vec::new(),
             recipes: Recipes::new(),
-            recipes_inverse: HashMap::new(),
+            recipes_by_name: HashMap::new(),
             inst_pred_reg: InstructionPredicateRegistry::new(),
         }
     }
 
     fn add_recipe(&mut self, recipe: EncodingRecipe) -> EncodingRecipeNumber {
-        if let Some(found_index) = self.recipes_inverse.get(&recipe) {
+        if let Some(found_index) = self.recipes_by_name.get(&recipe.name) {
             assert!(
-                self.recipes[*found_index].name == recipe.name,
+                self.recipes[*found_index] == recipe,
                 format!(
                     "trying to insert different recipes with a same name ({})",
                     recipe.name
@@ -47,8 +47,9 @@ impl PerCpuModeEncodings {
             );
             *found_index
         } else {
-            let index = self.recipes.push(recipe.clone());
-            self.recipes_inverse.insert(recipe, index);
+            let recipe_name = recipe.name.clone();
+            let index = self.recipes.push(recipe);
+            self.recipes_by_name.insert(recipe_name, index);
             index
         }
     }


### PR DESCRIPTION
I noticed (well, Clippy noticed) that EncodingRecipe had a default implementation of Hash, but a PartialEq implementation that didn't take name into account. So I went looking to see what made use of the Hash implementation and found a map from EncodingRecipe to EncodingRecipeNumber. It kind of looked like it was trying to detect calls to add_recipe with an equal EncodingRecipe, but a different name - except that due to the Hash implementation taking name into account, it wouldn't really have been doing that. Also, the assertion message seemed to imply that it was actually different recipes with the same name that we cared about, so I changed the code to match the assertion message.