### PR TITLE
Add a custom section hook to `ModuleEnvironment`

### DIFF
--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -456,4 +456,14 @@ pub trait ModuleEnvironment<'data> {
         offset: usize,
         data: &'data [u8],
     ) -> WasmResult<()>;
+
+    /// Indicates that a custom section has been found in the wasm file
+    fn custom_section(
+        &mut self,
+        name: &'data str,
+        data: &'data [u8],
+    ) -> WasmResult<()> {
+        drop((name, data));
+        Ok(())
+    }
 }

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -458,11 +458,7 @@ pub trait ModuleEnvironment<'data> {
     ) -> WasmResult<()>;
 
     /// Indicates that a custom section has been found in the wasm file
-    fn custom_section(
-        &mut self,
-        name: &'data str,
-        data: &'data [u8],
-    ) -> WasmResult<()> {
+    fn custom_section(&mut self, name: &'data str, data: &'data [u8]) -> WasmResult<()> {
         drop((name, data));
         Ok(())
     }


### PR DESCRIPTION
This commit adds a hook to the `ModuleEnvironment` trait to learn when a
custom section in a wasm file is read. This hook can in theory be used
to parse and handle custom sections as they appear in the wasm file
without having to re-iterate over the wasm file after cranelift has
already parsed the wasm file.

The `translate_module` function is now less strict in that it doesn't
require sections to be in a particular order, but it's figured that the
wasm file is already validated elsewhere to verify the section order.