### PR TITLE
Use aliasing instead of copying in simple_preopt

### DIFF
--- a/filetests/simple_preopt/div_by_const_indirect.clif
+++ b/filetests/simple_preopt/div_by_const_indirect.clif
@@ -13,8 +13,8 @@ ebb0(v0: i32):
     ; check: isub v0, v4
     ; check: ushr_imm v5, 1
     ; check: iadd v6, v4
-    ; check: ushr_imm v7, 2
-    ; check: copy v8
+    ; check: v8 = ushr_imm v7, 2
+    ; check: v2 -> v8
     return v2
 }
 
@@ -27,8 +27,8 @@ ebb0(v0: i32):
     ; check: smulhi v0, v3
     ; check: sshr_imm v4, 3
     ; check: ushr_imm v5, 31
-    ; check: iadd v5, v6
-    ; check: copy v7
+    ; check: v7 = iadd v5, v6
+    ; check: v2 -> v7
     return v2
 }
 
@@ -39,8 +39,8 @@ ebb0(v0: i64):
     ; check: iconst.i64 1337
     ; check: iconst.i64 0xc411_9d95_2866_a139
     ; check: umulhi v0, v3
-    ; check: ushr_imm v4, 10
-    ; check: copy v5
+    ; check: v5 = ushr_imm v4, 10
+    ; check: v2 -> v5
     return v2
 }
 
@@ -53,7 +53,7 @@ ebb0(v0: i64):
     ; check: smulhi v0, v3
     ; check: sshr_imm v4, 14
     ; check: ushr_imm v5, 63
-    ; check: iadd v5, v6
-    ; check: copy v7
+    ; check: v7 = iadd v5, v6
+    ; check: v2 -> v7
     return v2
 }

--- a/filetests/simple_preopt/div_by_const_non_power_of_2.clif
+++ b/filetests/simple_preopt/div_by_const_non_power_of_2.clif
@@ -12,8 +12,8 @@ ebb0(v0: i32):
     ; check: isub v0, v3
     ; check: ushr_imm v4, 1
     ; check: iadd v5, v3
-    ; check: ushr_imm v6, 2
-    ; check: copy v7
+    ; check: v7 = ushr_imm v6, 2
+    ; check: v1 -> v7
     return v1
 }
 
@@ -23,8 +23,8 @@ ebb0(v0: i32):
     v1 = udiv_imm v0, 125
     ; check: iconst.i32 0x1062_4dd3
     ; check: umulhi v0, v2
-    ; check: ushr_imm v3, 3
-    ; check: copy v4
+    ; check: v4 = ushr_imm v3, 3
+    ; check: v1 -> v4
     return v1
 }
 
@@ -33,8 +33,8 @@ function %t_udiv32_p641(i32) -> i32 {
 ebb0(v0: i32):
     v1 = udiv_imm v0, 641
     ; check: iconst.i32 0x0066_3d81
-    ; check: umulhi v0, v2
-    ; check: copy v3
+    ; check: v3 = umulhi v0, v2
+    ; check: v1 -> v3
     return v1
 }
 
@@ -48,8 +48,8 @@ ebb0(v0: i32):
     ; check: iconst.i32 0xffff_ffff_d555_5555
     ; check: smulhi v0, v2
     ; check: ushr_imm v3, 31
-    ; check: iadd v3, v4
-    ; check: copy v5
+    ; check: v5 = iadd v3, v4
+    ; check: v1 -> v5
     return v1
 }
 
@@ -61,8 +61,8 @@ ebb0(v0: i32):
     ; check: smulhi v0, v2
     ; check: sshr_imm v3, 1
     ; check: ushr_imm v4, 31
-    ; check: iadd v4, v5
-    ; check: copy v6
+    ; check: v6 = iadd v4, v5
+    ; check: v1 -> v6
     return v1
 }
 
@@ -75,8 +75,8 @@ ebb0(v0: i32):
     ; check: isub v3, v0
     ; check: sshr_imm v4, 1
     ; check: ushr_imm v5, 31
-    ; check: iadd v5, v6
-    ; check: copy v7
+    ; check: v7 = iadd v5, v6
+    ; check: v1 -> v7
     return v1
 }
 
@@ -87,8 +87,8 @@ ebb0(v0: i32):
     ; check: iconst.i32 0x2aaa_aaab
     ; check: smulhi v0, v2
     ; check: ushr_imm v3, 31
-    ; check: iadd v3, v4
-    ; check: copy v5
+    ; check: v5 = iadd v3, v4
+    ; check: v1 -> v5
     return v1
 }
 
@@ -101,8 +101,8 @@ ebb0(v0: i32):
     ; check: iadd v3, v0
     ; check: sshr_imm v4, 2
     ; check: ushr_imm v5, 31
-    ; check: iadd v5, v6
-    ; check: copy v7
+    ; check: v7 = iadd v5, v6
+    ; check: v1 -> v7
     return v1
 }
 
@@ -114,8 +114,8 @@ ebb0(v0: i32):
     ; check: smulhi v0, v2
     ; check: sshr_imm v3, 8
     ; check: ushr_imm v4, 31
-    ; check: iadd v4, v5
-    ; check: copy v6
+    ; check: v6 = iadd v4, v5
+    ; check: v1 -> v6
     return v1
 }
 
@@ -131,8 +131,8 @@ ebb0(v0: i64):
     ; check: isub v0, v3
     ; check: ushr_imm v4, 1
     ; check: iadd v5, v3
-    ; check: ushr_imm v6, 2
-    ; check: copy v7
+    ; check: v7 = ushr_imm v6, 2
+    ; check: v1 -> v7
     return v1
 }
 
@@ -142,8 +142,8 @@ ebb0(v0: i64):
     v1 = udiv_imm v0, 9
     ; check: iconst.i64 0xe38e_38e3_8e38_e38f
     ; check: umulhi v0, v2
-    ; check: ushr_imm v3, 3
-    ; check: copy v4
+    ; check: v4 = ushr_imm v3, 3
+    ; check: v1 -> v4
     return v1
 }
 
@@ -156,8 +156,8 @@ ebb0(v0: i64):
     ; check: isub v0, v3
     ; check: ushr_imm v4, 1
     ; check: iadd v5, v3
-    ; check: ushr_imm v6, 6
-    ; check: copy v7
+    ; check: v7 = ushr_imm v6, 6
+    ; check: v1 -> v7
     return v1
 }
 
@@ -166,8 +166,8 @@ function %t_udiv64_p274177(i64) -> i64 {
 ebb0(v0: i64):
     v1 = udiv_imm v0, 274177
     ; check: iconst.i64 0x3d30_f19c_d101
-    ; check: umulhi v0, v2
-    ; check: copy v3
+    ; check: v3 = umulhi v0, v2
+    ; check: v1 -> v3
     return v1
 }
 
@@ -182,8 +182,8 @@ ebb0(v0: i64):
     ; check: smulhi v0, v2
     ; check: sshr_imm v3, 7
     ; check: ushr_imm v4, 63
-    ; check: iadd v4, v5
-    ; check: copy v6
+    ; check: v6 = iadd v4, v5
+    ; check: v1 -> v6
     return v1
 }
 
@@ -194,8 +194,8 @@ ebb0(v0: i64):
     ; check: iconst.i64 0xd555_5555_5555_5555
     ; check: smulhi v0, v2
     ; check: ushr_imm v3, 63
-    ; check: iadd v3, v4
-    ; check: copy v5
+    ; check: v5 = iadd v3, v4
+    ; check: v1 -> v5
     return v1
 }
 
@@ -207,8 +207,8 @@ ebb0(v0: i64):
     ; check: smulhi v0, v2
     ; check: sshr_imm v3, 1
     ; check: ushr_imm v4, 63
-    ; check: iadd v4, v5
-    ; check: copy v6
+    ; check: v6 = iadd v4, v5
+    ; check: v1 -> v6
     return v1
 }
 
@@ -221,8 +221,8 @@ ebb0(v0: i64):
     ; check: isub v3, v0
     ; check: sshr_imm v4, 1
     ; check: ushr_imm v5, 63
-    ; check: iadd v5, v6
-    ; check: copy v7
+    ; check: v7 = iadd v5, v6
+    ; check: v1 -> v7
     return v1
 }
 
@@ -233,8 +233,8 @@ ebb0(v0: i64):
     ; check: iconst.i64 0x2aaa_aaaa_aaaa_aaab
     ; check: smulhi v0, v2
     ; check: ushr_imm v3, 63
-    ; check: iadd v3, v4
-    ; check: copy v5
+    ; check: v5 = iadd v3, v4
+    ; check: v1 -> v5
     return v1
 }
 
@@ -247,8 +247,8 @@ ebb0(v0: i64):
     ; check: iadd v3, v0
     ; check: sshr_imm v4, 3
     ; check: ushr_imm v5, 63
-    ; check: iadd v5, v6
-    ; check: copy v7
+    ; check: v7 = iadd v5, v6
+    ; check: v1 -> v7
     return v1
 }
 
@@ -260,7 +260,7 @@ ebb0(v0: i64):
     ; check: smulhi v0, v2
     ; check: sshr_imm v3, 7
     ; check: ushr_imm v4, 63
-    ; check: iadd v4, v5
-    ; check: copy v6
+    ; check: v6 = iadd v4, v5
+    ; check: v1 -> v6
     return v1
 }

--- a/filetests/simple_preopt/div_by_const_power_of_2.clif
+++ b/filetests/simple_preopt/div_by_const_power_of_2.clif
@@ -104,7 +104,7 @@ ebb0(v0: i32):
     ; check: ushr_imm v0, 31
     ; check: iadd v0, v2
     ; check: sshr_imm v3, 1
-    ; check: copy v4
+    ; check: v1 -> v4
     return v1
 }
 
@@ -126,8 +126,8 @@ ebb0(v0: i32):
     ; check: v2 = sshr_imm v0, 1
     ; check: ushr_imm v2, 30
     ; check: iadd v0, v3
-    ; check: sshr_imm v4, 2
-    ; check: copy v5
+    ; check: v5 = sshr_imm v4, 2
+    ; check: v1 -> v5
 
     return v1
 }
@@ -151,8 +151,8 @@ ebb0(v0: i32):
     ; check: sshr_imm v0, 29
     ; check: ushr_imm v2, 2
     ; check: iadd v0, v3
-    ; check: sshr_imm v4, 30
-    ; check: copy v5
+    ; check: v5 = sshr_imm v4, 30
+    ; check: v1 -> v5
     return v1
 }
 
@@ -214,8 +214,8 @@ ebb0(v0: i64):
     v1 = sdiv_imm v0, 2
     ; check: ushr_imm v0, 63
     ; check: iadd v0, v2
-    ; check: sshr_imm v3, 1
-    ; check: copy v4
+    ; check: v4 = sshr_imm v3, 1
+    ; check: v1 -> v4
     return v1
 }
 
@@ -237,8 +237,8 @@ ebb0(v0: i64):
     ; check: sshr_imm v0, 1
     ; check: ushr_imm v2, 62
     ; check: iadd v0, v3
-    ; check: sshr_imm v4, 2
-    ; check: copy v5
+    ; check: v5 = sshr_imm v4, 2
+    ; check: v1 -> v5
     return v1
 }
 
@@ -261,8 +261,8 @@ ebb0(v0: i64):
     ; check: sshr_imm v0, 61
     ; check: ushr_imm v2, 2
     ; check: iadd v0, v3
-    ; check: sshr_imm v4, 62
-    ; check: copy v5
+    ; check: v5 = sshr_imm v4, 62
+    ; check: v1 -> v5
     return v1
 }
 


### PR DESCRIPTION
As discussed by emails, this replaces copies in simple_preopt to use more aliasing instead. There's another `replace_with_aliases` method in the DFG data structure, but it doesn't exactly do what we want (it replaces the results of one instruction by the results of another). Arguably, this could be put in the DFG data structure too, with a different name.