### PR TITLE
Fix broken documentation links

### DIFF
--- a/cranelift-codegen/src/binemit/memorysink.rs
+++ b/cranelift-codegen/src/binemit/memorysink.rs
@@ -80,7 +80,7 @@ pub trait RelocSink {
 /// A trait for receiving trap codes and offsets.
 ///
 /// If you don't need information about possible traps, you can use the
-/// [`NullTrapSink`](binemit/trait.TrapSink.html) implementation.
+/// [`NullTrapSink`](NullTrapSink) implementation.
 pub trait TrapSink {
     /// Add trap information for a specific offset.
     fn trap(&mut self, _: CodeOffset, _: SourceLoc, _: TrapCode);

--- a/cranelift-faerie/src/backend.rs
+++ b/cranelift-faerie/src/backend.rs
@@ -36,7 +36,7 @@ pub struct FaerieBuilder {
 impl FaerieBuilder {
     /// Create a new `FaerieBuilder` using the given Cranelift target, that
     /// can be passed to
-    /// [`Module::new`](cranelift_module/struct.Module.html#method.new].
+    /// [`Module::new`](cranelift_module::Module::new)
     ///
     /// Faerie output requires that TargetIsa have PIC (Position Independent Code) enabled.
     ///

--- a/cranelift-frontend/src/frontend.rs
+++ b/cranelift-frontend/src/frontend.rs
@@ -96,7 +96,7 @@ impl FunctionBuilderContext {
     }
 }
 
-/// Implementation of the [`InstBuilder`](../codegen/ir/builder/trait.InstBuilder.html) that has
+/// Implementation of the [`InstBuilder`](cranelift_codegen::ir::InstBuilder) that has
 /// one convenience method per Cranelift IR instruction.
 pub struct FuncInstBuilder<'short, 'long: 'short> {
     builder: &'short mut FunctionBuilder<'long>,
@@ -207,7 +207,7 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
 /// modifies with the information stored in the mutable borrowed
 /// [`FunctionBuilderContext`](struct.FunctionBuilderContext.html). The function passed in
 /// argument should be newly created with
-/// [`Function::with_name_signature()`](../function/struct.Function.html), whereas the
+/// [`Function::with_name_signature()`](Function::with_name_signature), whereas the
 /// `FunctionBuilderContext` can be kept as is between two function translations.
 ///
 /// # Errors
@@ -391,7 +391,7 @@ impl<'a> FunctionBuilder<'a> {
         self.func.create_heap(data)
     }
 
-    /// Returns an object with the [`InstBuilder`](../codegen/ir/builder/trait.InstBuilder.html)
+    /// Returns an object with the [`InstBuilder`](cranelift_codegen::ir::InstBuilder)
     /// trait that allows to conveniently append an instruction to the current `Ebb` being built.
     pub fn ins<'short>(&'short mut self) -> FuncInstBuilder<'short, 'a> {
         let ebb = self

--- a/cranelift-wasm/src/module_translator.rs
+++ b/cranelift-wasm/src/module_translator.rs
@@ -10,7 +10,7 @@ use cranelift_codegen::timing;
 use wasmparser::{ModuleReader, SectionCode};
 
 /// Translate a sequence of bytes forming a valid Wasm binary into a list of valid Cranelift IR
-/// [`Function`](../codegen/ir/function/struct.Function.html).
+/// [`Function`](cranelift_codegen::ir::Function).
 pub fn translate_module<'data>(
     data: &'data [u8],
     environ: &mut dyn ModuleEnvironment<'data>,

--- a/test-all.sh
+++ b/test-all.sh
@@ -49,7 +49,11 @@ RUST_BACKTRACE=1 cargo test --all
 
 # Make sure the documentation builds.
 banner "Rust documentation: $topdir/target/doc/cranelift/index.html"
-cargo doc
+cargo +nightly doc
+
+# Make sure the documentation doesn't have broken links.
+banner "Rust documentation link test"
+find ./target/doc -maxdepth 1 -type d -name "cranelift*" | xargs -I{} cargo deadlinks --dir {}
 
 # Ensure fuzzer works by running it with a single input
 # Note LSAN is disabled due to https://github.com/google/sanitizers/issues/764


### PR DESCRIPTION
Uses rustdoc nightly to build documentation.
Checks that documentation links aren't broken using `cargo-deadlinks`.
Installs `cargo-deadlinks` if it's not already installed.

Addresses https://github.com/CraneStation/cranelift/issues/901