### PR TITLE
Add flags to allow SIMD instructions

### DIFF
--- a/cranelift-wasm/tests/wasm_testsuite.rs
+++ b/cranelift-wasm/tests/wasm_testsuite.rs
@@ -53,6 +53,8 @@ fn read_file(path: &Path) -> io::Result<Vec<u8>> {
 }
 
 fn handle_module(path: &Path, flags: &Flags, return_mode: ReturnMode) {
+    let mut features = Features::new();
+    features.enable_all();
     let data = match path.extension() {
         None => {
             panic!("the file extension is not wasm or wat");
@@ -61,8 +63,6 @@ fn handle_module(path: &Path, flags: &Flags, return_mode: ReturnMode) {
             Some("wasm") => read_file(path).expect("error reading wasm file"),
             Some("wat") => {
                 let wat = read_file(path).expect("error reading wat file");
-                let mut features = Features::new();
-                features.enable_all();
                 match wat2wasm_with_features(&wat, features) {
                     Ok(wasm) => wasm,
                     Err(e) => {

--- a/src/clif-util.rs
+++ b/src/clif-util.rs
@@ -104,7 +104,13 @@ fn add_print_flag<'a>() -> clap::Arg<'a, 'a> {
 fn add_debug_flag<'a>() -> clap::Arg<'a, 'a> {
     Arg::with_name("debug")
         .short("d")
-        .help("enable debug output on stderr/stdout")
+        .help("Enable debug output on stderr/stdout")
+}
+
+fn add_enable_simd_flag<'a>() -> clap::Arg<'a, 'a> {
+    Arg::with_name("enable-simd")
+        .long("enable-simd")
+        .help("Enable SIMD operations")
 }
 
 /// Returns a vector of clap value options and changes these options into a vector of strings
@@ -137,6 +143,7 @@ fn add_wasm_or_compile<'a>(cmd: &str) -> clap::App<'a, 'a> {
         .arg(add_target_flag())
         .arg(add_input_file_arg())
         .arg(add_debug_flag())
+        .arg(add_enable_simd_flag())
 }
 
 fn handle_debug_flag(debug: bool) {
@@ -296,6 +303,7 @@ fn main() {
                     rest_cmd.is_present("print-size"),
                     rest_cmd.is_present("time-passes"),
                     rest_cmd.is_present("value-ranges"),
+                    rest_cmd.is_present("enable-simd"),
                 )
             };
 

--- a/src/clif-util.rs
+++ b/src/clif-util.rs
@@ -110,7 +110,7 @@ fn add_debug_flag<'a>() -> clap::Arg<'a, 'a> {
 fn add_enable_simd_flag<'a>() -> clap::Arg<'a, 'a> {
     Arg::with_name("enable-simd")
         .long("enable-simd")
-        .help("Enable SIMD operations")
+        .help("Enable WASM's SIMD operations")
 }
 
 /// Returns a vector of clap value options and changes these options into a vector of strings


### PR DESCRIPTION
While testing out the SIMD instructions I have implemented in https://github.com/abrown/cranelift/tree/work-ahead I discovered that I needed:
 - a way to tell `wabt` that SIMD instructions are allowed--this requires updating `wabt-rs` so we can pass `Features`
 - a `--enable-simd` flag on `clif-util wasm` to allow me to set the allowed features
 - all features enabled by default when running wasmtests (I have wasmtests that could go here but cannot add them to this PR until other PRs are merged; e.g. #855, #868)