### PR TITLE
[codegen] Make scalar_to_vector's output type a lane of its input type

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1679,9 +1679,7 @@ pub fn define(
     // to the Intel manual: "When the destination operand is an XMM register, the source operand is
     // written to the low doubleword of the register and the regiser is zero-extended to 128 bits."
     for ty in ValueType::all_lane_types().filter(|t| t.lane_bits() >= 8) {
-        let instruction = scalar_to_vector
-            .bind_vector_from_lane(ty, sse_vector_size)
-            .bind(ty);
+        let instruction = scalar_to_vector.bind_vector_from_lane(ty, sse_vector_size);
         let template = rec_frurm.opcodes(vec![0x66, 0x0f, 0x6e]); // MOVD/MOVQ
         if ty.lane_bits() < 64 {
             // no 32-bit encodings for 64-bit widths

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -112,16 +112,6 @@ pub fn define(
             .build(),
     );
 
-    let Scalar = &TypeVar::new(
-        "scalar",
-        "Any scalar value that can be used as a lane in a vector",
-        TypeSetBuilder::new()
-            .bools(Interval::All)
-            .ints(Interval::All)
-            .floats(Interval::All)
-            .build(),
-    );
-
     let Any = &TypeVar::new(
         "Any",
         "Any integer, float, boolean, or reference scalar or vector type",
@@ -406,7 +396,7 @@ pub fn define(
             "resumable_trap",
             r#"
         A resumable trap.
-        
+
         This instruction allows non-conditional traps to be used as non-terminal instructions.
         "#,
         )
@@ -2722,8 +2712,8 @@ pub fn define(
         .operands_out(vec![a]),
     );
 
-    let s = &operand_doc("s", Scalar, "A scalar value");
-    let a = &operand_doc("a", TxN, "A vector value (i.e. held in an XMM register)");
+    let a = &operand_doc("a", TxN, "A vector value");
+    let s = &operand_doc("s", &TxN.lane_of(), "A scalar value");
 
     ig.push(
         Inst::new(

--- a/filetests/verifier/scalar-to-vector.clif
+++ b/filetests/verifier/scalar-to-vector.clif
@@ -1,0 +1,10 @@
+test verifier
+set enable_simd=true
+target x86_64
+
+function %scalar_to_vector() {
+ebb0:
+    v0 = iconst.i32 42
+    v1 = scalar_to_vector.f32x4 v0 ; error: arg 0 (v0) has type i32, expected f32
+    return
+}


### PR DESCRIPTION
This makes the scalar_to_vector instruction type sane: it expects the input value to be a lane of the output value. Also removed the reference to XMM registers, because this is a shared instruction for all platforms.

cc @abrown FYI