### PR TITLE
[clif-util] Use a simple cfg guard instead of cfg_if for the wasm module

### DIFF
--- a/src/clif-util.rs
+++ b/src/clif-util.rs
@@ -13,14 +13,6 @@
     )
 )]
 
-use cfg_if::cfg_if;
-
-cfg_if! {
-    if #[cfg(feature = "wasm")] {
-        mod wasm;
-    }
-}
-
 use clap::{App, Arg, SubCommand};
 use cranelift_codegen::dbg::LOG_FILENAME_PREFIX;
 use cranelift_codegen::VERSION;
@@ -35,6 +27,9 @@ mod disasm;
 mod print_cfg;
 mod run;
 mod utils;
+
+#[cfg(feature = "wasm")]
+mod wasm;
 
 /// A command either succeeds or fails with an error message.
 pub type CommandResult = Result<(), String>;


### PR DESCRIPTION
I was looking at https://github.com/CraneStation/cranelift/pull/910 and was curious why this included some formatting changes; cargo fmt --all should take care of it, right? It happens that the content of macros isn't analyzed by rustfmt (for obvious good reasons!), and so that rustfmt couldn't figure out that we have a src/wasm.rs module because of this. Just using a plain and simple cfg with feature guard made Rustfmt aware of the module, and caused new formatting changes in this file.

Two things to note:

- in src/disasm.rs, a lot of code is under cfg_if!, so it's not going to be formatted either.
- running rustfmt manually on every rs file in the tree caused formatting changes to the fuzz/ directory. There's something in the fuzz's Cargo file about not messing with the parent workspace, so that might be reason. I didn't investigate further.