### PR TITLE
clif-wasm: adding `deterministic` feature

### DIFF
--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -30,6 +30,7 @@ default = ["std"]
 std = ["cranelift-codegen/std", "cranelift-frontend/std", "wasmparser/std"]
 core = ["hashmap_core", "cranelift-codegen/core", "cranelift-frontend/core", "wasmparser/core"]
 enable-serde = ["serde"]
+deterministic = ["wasmparser/deterministic"]
 
 # Temporary feature that enforces basic block semantics.
 basic-blocks = ["cranelift-codegen/basic-blocks", "cranelift-frontend/basic-blocks"]


### PR DESCRIPTION
clift-wasm: adding `deterministic` feature.
(leveraging the `wasmparser` deterministic` feature)

relevant `wasmparser` merged PR:
https://github.com/yurydelendik/wasmparser.rs/pull/121