### PR TITLE
clif-wasm version bump 0.40.01 

### DIFF
--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.40.0"
+version = "0.40.01"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 repository = "https://github.com/CraneStation/cranelift"


### PR DESCRIPTION
`clif-wasm` version bump to `0.40.01` (because of `wasmparser` version bump to `0.37.0`)

I wasn't sure what new version number to set though