### PR TITLE
Switch from mmap to memmap to support Windows

### DIFF
--- a/cranelift-filetests/Cargo.toml
+++ b/cranelift-filetests/Cargo.toml
@@ -17,6 +17,6 @@ cranelift-preopt = { path = "../cranelift-preopt", version = "0.40.0" }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.4.0"
 log = "0.4.6"
-mmap = "0.1.1"
+memmap = "0.7.0"
 num_cpus = "1.8.0"
 region = "2.1.2"


### PR DESCRIPTION
#890 introduced a dependency on the `mmap` crate, which doesn't support Windows. A quick investigation showed mmap is not actively maintained, so [people mostly use the `memmap` crate](https://github.com/cgag/loc/issues/13#issuecomment-256178954). This PR switches to that, and seems to work without issues.