### PR TITLE
Continuous fuzzing

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -97,6 +97,30 @@ jobs:
         RUST_BACKTRACE: 1
       condition: and(succeeded(), eq(variables['toolchain'], 'nightly'))
 
+- job: Fuzz_regression
+  displayName: Fuzz regression
+  pool:
+    vmImage: "ubuntu-16.04"
+  variables:
+    toolchain: nightly
+  steps:
+    - template: ci/azure-install-rust.yml
+    - bash: cargo install cargo-fuzz
+    - bash: ci/fuzzit.sh local-regression
+
+- job: Fuzz
+  condition: ne(variables['Build.Reason'], 'PullRequest')
+  pool:
+    vmImage: "ubuntu-16.04"
+  variables:
+    toolchain: nightly
+  steps:
+    - template: ci/azure-install-rust.yml
+    - bash: cargo install cargo-fuzz
+    - bash: ci/fuzzit.sh fuzzing
+      env:
+        FUZZIT_API_KEY: $(FUZZIT_API_KEY)
+
 - job: Build
   strategy:
     matrix:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ into executable machine code.
 
 [![Documentation Status](https://readthedocs.org/projects/cranelift/badge/?version=latest)](https://cranelift.readthedocs.io/en/latest/?badge=latest)
 [![Travis Status](https://travis-ci.org/CraneStation/cranelift.svg?branch=master)](https://travis-ci.org/CraneStation/cranelift)
+[![Fuzzit Status](https://app.fuzzit.dev/badge?org_id=CraneStation)](https://app.fuzzit.dev/orgs/CraneStation/dashboard)
 [![Gitter chat](https://badges.gitter.im/CraneStation/CraneStation.svg)](https://gitter.im/CraneStation/Lobby)
 ![Minimum rustc 1.37](https://img.shields.io/badge/rustc-1.37+-green.svg)
 

--- a/ci/fuzzit.sh
+++ b/ci/fuzzit.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -xe
+
+# Validate arguments
+if [ "$#" -ne 1 ]; then
+    cat << EOF
+Usage: $0 <type>
+
+Types are:
+local-regression - Run corpus and past crashes locally to catch regressions.
+fuzzing - Submit for long run fuzzing on Fuzzit.
+EOF
+    exit 1
+fi
+
+# Configure
+set -xe
+NAME=cranelift
+TYPE=$1
+FUZZIT_VERSION=2.4.46
+
+# Setup
+if [[ ! -f fuzzit || ! `./fuzzit --version` =~ $FUZZIT_VERSION$ ]]; then
+    wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v$FUZZIT_VERSION/fuzzit_Linux_x86_64
+    chmod a+x fuzzit
+fi
+./fuzzit --version
+
+# Fuzz
+function fuzz {
+    FUZZER=$1
+    TARGET=$2
+    cargo fuzz run $FUZZER -- -runs=0
+    ./fuzzit --version
+    ./fuzzit create job --type $TYPE $NAME/$TARGET ./fuzz/target/x86_64-unknown-linux-gnu/debug/$FUZZER
+}
+fuzz fuzz_translate_module translate-module
+fuzz fuzz_reader_parse_test reader-parse

--- a/fuzz/fuzz_reader_parse_test.rs
+++ b/fuzz/fuzz_reader_parse_test.rs
@@ -6,6 +6,7 @@ use std::str;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = str::from_utf8(data) {
-        let _ = cranelift_reader::parse_test(s, None, None);
+        let options = cranelift_reader::ParseOptions::default();
+        let _ = cranelift_reader::parse_test(s, options);
     }
 });


### PR DESCRIPTION
Proposing to enable continuous fuzzing of the good fuzzing targets. I see this was mentioned in #306 as a possible future improvement.

This patch runs both existing targets on [Fuzzit](https://fuzzit.dev/). There's [a build](https://travis-ci.org/bookmoons/cranelift/builds/577307862) under my Travis account I'm expecting to succeed.

The PR build will fail due to missing an API key. Setup is like this:
* In Fuzzit create targets `cranelift-translate-module` `cranelift-reader-parse`
* In Fuzzit settings grab an API key. In repo settings in [Travis](https://travis-ci.org/) paste it to envvar `FUZZIT_API_KEY`.

Thank you for considering.