### PR TITLE
Add feature flags to test files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,8 @@ walkdir = "2.2"
 default = ["disas", "wasm", "cranelift-codegen/all-arch"]
 disas = ["capstone"]
 wasm = ["wabt", "cranelift-wasm"]
-basic-blocks = ["cranelift-codegen/basic-blocks", "cranelift-frontend/basic-blocks", "cranelift-wasm/basic-blocks"]
+basic-blocks = ["cranelift-codegen/basic-blocks", "cranelift-frontend/basic-blocks",
+"cranelift-wasm/basic-blocks", "cranelift-filetests/basic-blocks"]
 
 # We want debug symbols on release binaries by default since it allows profiling
 # tools to give more accurate information. We can always strip them out later if

--- a/cranelift-filetests/Cargo.toml
+++ b/cranelift-filetests/Cargo.toml
@@ -20,3 +20,6 @@ log = "0.4.6"
 memmap = "0.7.0"
 num_cpus = "1.8.0"
 region = "2.1.2"
+
+[features]
+basic-blocks = []

--- a/cranelift-reader/src/lexer.rs
+++ b/cranelift-reader/src/lexer.rs
@@ -27,6 +27,7 @@ pub enum Token<'a> {
     Dot,                  // '.'
     Colon,                // ':'
     Equal,                // '='
+    Not,                  // '!'
     Arrow,                // '->'
     Float(&'a str),       // Floating point immediate
     Integer(&'a str),     // Integer immediate
@@ -42,6 +43,7 @@ pub enum Token<'a> {
     SigRef(u32),          // sig2
     UserRef(u32),         // u345
     Name(&'a str),        // %9arbitrary_alphanum, %x3, %0, %function ...
+    String(&'a str),      // "abritrary quoted string with no escape" ...
     HexSequence(&'a str), // #89AF
     Identifier(&'a str),  // Unrecognized identifier (opcode, enumerator, ...)
     SourceLoc(&'a str),   // @00c7
@@ -401,6 +403,27 @@ impl<'a> Lexer<'a> {
         token(Token::Name(&self.source[begin..end]), loc)
     }
 
+    /// Scan for a multi-line quoted string with no escape character.
+    fn scan_string(&mut self) -> Result<LocatedToken<'a>, LocatedError> {
+        let loc = self.loc();
+        let begin = self.pos + 1;
+
+        assert_eq!(self.lookahead, Some('"'));
+
+        while let Some(c) = self.next_ch() {
+            if c == '"' {
+                break;
+            }
+        }
+
+        let end = self.pos;
+        if self.lookahead != Some('"') {
+            return error(LexError::InvalidChar, self.loc());
+        }
+        self.next_ch();
+        token(Token::String(&self.source[begin..end]), loc)
+    }
+
     fn scan_hex_sequence(&mut self) -> Result<LocatedToken<'a>, LocatedError> {
         let loc = self.loc();
         let begin = self.pos + 1;
@@ -452,6 +475,7 @@ impl<'a> Lexer<'a> {
                 Some('.') => Some(self.scan_char(Token::Dot)),
                 Some(':') => Some(self.scan_char(Token::Colon)),
                 Some('=') => Some(self.scan_char(Token::Equal)),
+                Some('!') => Some(self.scan_char(Token::Not)),
                 Some('+') => Some(self.scan_number()),
                 Some('-') => {
                     if self.looking_at("->") {
@@ -463,6 +487,7 @@ impl<'a> Lexer<'a> {
                 Some(ch) if ch.is_digit(10) => Some(self.scan_number()),
                 Some(ch) if ch.is_alphabetic() => Some(self.scan_word()),
                 Some('%') => Some(self.scan_name()),
+                Some('"') => Some(self.scan_string()),
                 Some('#') => Some(self.scan_hex_sequence()),
                 Some('@') => Some(self.scan_srcloc()),
                 Some(ch) if ch.is_whitespace() => {
@@ -631,6 +656,33 @@ mod tests {
         assert_eq!(lex.next(), token(Token::Name("v3"), 1));
         assert_eq!(lex.next(), token(Token::Name("ebb11"), 1));
         assert_eq!(lex.next(), token(Token::Name("_"), 1));
+    }
+
+    #[test]
+    fn lex_strings() {
+        let mut lex = Lexer::new(
+            r#"""  "0" "x3""function" "123 abc" "\" "start
+                    and end on
+                    different lines" "#,
+        );
+
+        assert_eq!(lex.next(), token(Token::String(""), 1));
+        assert_eq!(lex.next(), token(Token::String("0"), 1));
+        assert_eq!(lex.next(), token(Token::String("x3"), 1));
+        assert_eq!(lex.next(), token(Token::String("function"), 1));
+        assert_eq!(lex.next(), token(Token::String("123 abc"), 1));
+        assert_eq!(lex.next(), token(Token::String(r#"\"#), 1));
+        assert_eq!(
+            lex.next(),
+            token(
+                Token::String(
+                    r#"start
+                    and end on
+                    different lines"#
+                ),
+                1
+            )
+        );
     }
 
     #[test]

--- a/cranelift-reader/src/lib.rs
+++ b/cranelift-reader/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::isaspec::{parse_options, IsaSpec};
 pub use crate::parser::{parse_functions, parse_test, ParseOptions};
 pub use crate::sourcemap::SourceMap;
 pub use crate::testcommand::{TestCommand, TestOption};
-pub use crate::testfile::{Comment, Details, TestFile};
+pub use crate::testfile::{Comment, Details, Feature, TestFile};
 
 mod error;
 mod isaspec;

--- a/cranelift-reader/src/parser.rs
+++ b/cranelift-reader/src/parser.rs
@@ -5,7 +5,7 @@ use crate::isaspec;
 use crate::lexer::{LexError, Lexer, LocatedError, LocatedToken, Token};
 use crate::sourcemap::SourceMap;
 use crate::testcommand::TestCommand;
-use crate::testfile::{Comment, Details, TestFile};
+use crate::testfile::{Comment, Details, Feature, TestFile};
 use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::entities::AnyEntity;
@@ -82,6 +82,7 @@ pub fn parse_test<'a>(text: &'a str, options: ParseOptions<'a>) -> ParseResult<T
             isa_spec = parser.parse_target_specs()?;
         }
     };
+    let features = parser.parse_cranelift_features()?;
 
     // Decide between using the calling convention passed in the options or using the
     // host's calling convention--if any tests are to be run on the host we should default to the
@@ -102,6 +103,7 @@ pub fn parse_test<'a>(text: &'a str, options: ParseOptions<'a>) -> ParseResult<T
     Ok(TestFile {
         commands,
         isa_spec,
+        features,
         preamble_comments,
         functions,
     })
@@ -946,6 +948,27 @@ impl<'a> Parser<'a> {
         } else {
             Ok(isaspec::IsaSpec::Some(targets))
         }
+    }
+
+    /// Parse a list of expected features that Cranelift should be compiled with, or without.
+    pub fn parse_cranelift_features(&mut self) -> ParseResult<Vec<Feature<'a>>> {
+        let mut list = Vec::new();
+        while self.token() == Some(Token::Identifier("feature")) {
+            self.consume();
+            let has = !self.optional(Token::Not);
+            match (self.token(), has) {
+                (Some(Token::String(flag)), true) => list.push(Feature::With(flag)),
+                (Some(Token::String(flag)), false) => list.push(Feature::Without(flag)),
+                (tok, _) => {
+                    return err!(
+                        self.loc,
+                        format!("Expected feature flag string, got {:?}", tok)
+                    )
+                }
+            }
+            self.consume();
+        }
+        Ok(list)
     }
 
     /// Parse a list of function definitions.
@@ -2992,12 +3015,14 @@ mod tests {
     #[test]
     fn test_file() {
         let tf = parse_test(
-            "; before
+            r#"; before
                              test cfg option=5
                              test verify
                              set enable_float=false
+                             feature "foo"
+                             feature !"bar"
                              ; still preamble
-                             function %comment() system_v {}",
+                             function %comment() system_v {}"#,
             ParseOptions::default(),
         )
         .unwrap();
@@ -3011,6 +3036,8 @@ mod tests {
             }
             _ => panic!("unexpected ISAs"),
         }
+        assert_eq!(tf.features[0], Feature::With(&"foo"));
+        assert_eq!(tf.features[1], Feature::Without(&"bar"));
         assert_eq!(tf.preamble_comments.len(), 2);
         assert_eq!(tf.preamble_comments[0].text, "; before");
         assert_eq!(tf.preamble_comments[1].text, "; still preamble");

--- a/cranelift-reader/src/testfile.rs
+++ b/cranelift-reader/src/testfile.rs
@@ -20,6 +20,8 @@ pub struct TestFile<'a> {
     pub commands: Vec<TestCommand<'a>>,
     /// `isa bar ...` lines.
     pub isa_spec: IsaSpec,
+    /// `feature ...` lines
+    pub features: Vec<Feature<'a>>,
     /// Comments appearing before the first function.
     /// These are all tagged as 'Function' scope for lack of a better entity.
     pub preamble_comments: Vec<Comment<'a>>,
@@ -54,4 +56,18 @@ pub struct Comment<'a> {
     pub entity: AnyEntity,
     /// Text of the comment, including the leading `;`.
     pub text: &'a str,
+}
+
+/// A cranelift feature in a test file preamble.
+///
+/// This represents the expectation of the test case. Before running any of the
+/// functions of the test file, the feature set should be compared with the
+/// feature set used to compile Cranelift. If there is any differences, then the
+/// test file should be skipped.
+#[derive(PartialEq, Eq, Debug)]
+pub enum Feature<'a> {
+    /// `feature "..."` lines
+    With(&'a str),
+    /// `feature ! "..."` lines.
+    Without(&'a str),
 }


### PR DESCRIPTION
Cranelift can be compiled with feature flags which can change its output. To
accomodate changes of output related to feature flags, test file can now include
`feature "..."` and `feature ! "..."` directives in the preamble of the test
file.

The test runner would skip the test if the flag does not match the expectation
of the test case.

This PR should fix the issue #935 .
