### PR TITLE
Add Azure Pipelines CI setup

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
         toolchain: stable
       mac-earliest:
         imageName: 'macos-10.14'
-        toolchain: '1.37'
+        toolchain: '1.37.0'
       mac-stable:
         imageName: 'macos-10.14'
         toolchain: stable

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,150 @@
+name: $(Build.SourceBranch)-$(date:yyyyMMdd)$(rev:.r)
+trigger:
+  branches:
+    include:
+    - 'master'
+  tags:
+    include:
+    - '*'
+    exclude:
+      - 'dev'
+
+jobs:
+- job: rustfmt
+  pool:
+    vmImage: 'macos-10.14'
+  steps:
+  - checkout: self
+    submodules: true
+  - template: ci/azure-install-rust.yml
+  - script: rustup component add rustfmt
+    displayName: Add rustfmt
+  - script: cargo fmt --all -- --check
+    displayName: Check formatting
+  variables:
+    toolchain: stable
+
+# Smoke test to build docs on one builder, using OSX for now since it's the
+# fastest
+- job: docs
+  pool:
+    vmImage: 'macos-10.14'
+  steps:
+  - checkout: self
+    submodules: true
+  - template: ci/azure-install-rust.yml
+  - script: cargo doc
+    displayName: Build documentation
+  variables:
+    toolchain: stable
+
+- job: Test
+  strategy:
+    matrix:
+      # windows-stable:
+      #   imageName: 'vs2017-win2016'
+      #   toolchain: stable
+      linux-stable:
+        imageName: 'ubuntu-16.04'
+        toolchain: stable
+      mac-stable:
+        imageName: 'macos-10.14'
+        toolchain: stable
+      mac-beta:
+        imageName: 'macos-10.14'
+        toolchain: beta
+      mac-nightly:
+        imageName: 'macos-10.14'
+        toolchain: nightly
+
+  pool:
+    vmImage: $(imageName)
+
+  steps:
+    - checkout: self
+      submodules: true
+    - template: ci/azure-install-rust.yml
+
+    - script: cargo fetch
+      displayName: Fetch cargo dependencies
+
+    - script: cargo build
+      displayName: Cargo build
+
+    - bash: cargo test --all
+      displayName: Cargo test
+      env:
+        RUST_BACKTRACE: 1
+
+    # Ensure fuzzer works by running it with a single input
+    # Note LSAN is disabled due to https://github.com/google/sanitizers/issues/764
+    - bash: cargo install cargo-fuzz
+      displayName: Install cargo-fuzz
+      condition: and(succeeded(), eq(variables['toolchain'], 'nightly'))
+    - bash: |
+        fuzz_module="ffaefab69523eb11935a9b420d58826c8ea65c4c"
+        # ASAN_OPTIONS=detect_leaks=0 \
+        cargo fuzz run fuzz_translate_module \
+        "fuzz/corpus/fuzz_translate_module/$fuzz_module"
+      displayName: Run cargo-fuzz
+      env:
+        RUST_BACKTRACE: 1
+      condition: and(succeeded(), eq(variables['toolchain'], 'nightly'))
+
+- job: Build
+  strategy:
+    matrix:
+      # windows:
+      #   imageName: 'vs2017-win2016'
+      #   # Statically link against msvcrt to produce slightly more portable
+      #   # binaries on Windows by reducing our binary compatibility requirements.
+      #   RUSTFLAGS: -Ctarget-feature=+crt-static
+      mac:
+        imageName: 'macos-10.14'
+        # Lower the deployment target from our build image in an attempt to
+        # build more portable binaries that run on older releases. Note that
+        # 10.9 here is arbitrarily chosen and just happens to be the lowest that
+        # works at this time. Raising this is probably fine.
+        MACOSX_DEPLOYMENT_TARGET: 10.9
+  variables:
+    toolchain: stable
+  pool:
+    vmImage: $(imageName)
+  # We try to be compatible with beta and nightly, but they occasionally
+  # fail, so we don't allow them to hold up people using stable.
+  continueOnError: $[ne(variables['toolchain'], 'stable')]
+  steps:
+  - template: ci/azure-build-release.yml
+
+# Build the Linux release binary in an older Linux container (in this case
+# Centos 6)
+- job: Build_linux
+  variables:
+    toolchain: stable
+  container:
+    image: centos:6
+    options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
+  steps:
+  # We're executing in the container as non-root but `yum` requires root. We
+  # need to install `sudo` but to do that we need `sudo`. Do a bit of a weird
+  # hack where we use the host `docker` executable to re-execute in our own
+  # container with the root user to install `sudo`
+  - bash: /tmp/docker exec -t -u 0 ci-container sh -c "yum install -y sudo"
+    displayName: Configure sudo
+
+  # See https://edwards.sdsu.edu/research/c11-on-centos-6/ for where these
+  # various commands came from.
+  - bash: |
+      set -e
+      sudo yum install -y centos-release-scl cmake xz
+      sudo yum install -y devtoolset-8-gcc devtoolset-8-binutils devtoolset-8-gcc-c++
+      echo "##vso[task.prependpath]/opt/rh/devtoolset-8/root/usr/bin"
+    displayName: Install system dependencies
+
+  # Delete `libstdc++.so` to force gcc to link against `libstdc++.a` instead.
+  # This is a hack and not the right way to do this, but it ends up doing the
+  # right thing for now.
+  - bash: sudo rm -f /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++.so
+    displayName: Force a static libstdc++
+
+  - template: ci/azure-build-release.yml

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -46,9 +46,9 @@ jobs:
 - job: Test
   strategy:
     matrix:
-      # windows-stable:
-      #   imageName: 'vs2017-win2016'
-      #   toolchain: stable
+      windows-stable:
+        imageName: 'vs2017-win2016'
+        toolchain: stable
       linux-stable:
         imageName: 'ubuntu-16.04'
         toolchain: stable
@@ -100,11 +100,11 @@ jobs:
 - job: Build
   strategy:
     matrix:
-      # windows:
-      #   imageName: 'vs2017-win2016'
-      #   # Statically link against msvcrt to produce slightly more portable
-      #   # binaries on Windows by reducing our binary compatibility requirements.
-      #   RUSTFLAGS: -Ctarget-feature=+crt-static
+      windows:
+        imageName: 'vs2017-win2016'
+        # Statically link against msvcrt to produce slightly more portable
+        # binaries on Windows by reducing our binary compatibility requirements.
+        RUSTFLAGS: -Ctarget-feature=+crt-static
       mac:
         imageName: 'macos-10.14'
         # Lower the deployment target from our build image in an attempt to

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
       find ./target/doc -maxdepth 1 -type d -name "cranelift*" | xargs -I{} cargo deadlinks --dir {}
     displayName: Run cargo-deadlinks
   variables:
-    toolchain: stable
+    toolchain: nightly
 
 - job: Test
   strategy:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -46,12 +46,12 @@ jobs:
 - job: Test
   strategy:
     matrix:
-      windows-stable:
+      windows-earliest:
         imageName: 'vs2017-win2016'
-        toolchain: stable
-      linux-stable:
+        toolchain: '1.37.0'
+      linux-earliest:
         imageName: 'ubuntu-16.04'
-        toolchain: stable
+        toolchain: '1.37.0'
       mac-earliest:
         imageName: 'macos-10.14'
         toolchain: '1.37.0'
@@ -113,7 +113,7 @@ jobs:
         # works at this time. Raising this is probably fine.
         MACOSX_DEPLOYMENT_TARGET: 10.9
   variables:
-    toolchain: stable
+    toolchain: '1.37.0'
   pool:
     vmImage: $(imageName)
   # We try to be compatible with beta and nightly, but they occasionally
@@ -126,7 +126,7 @@ jobs:
 # Centos 6)
 - job: Build_linux
   variables:
-    toolchain: stable
+    toolchain: '1.37.0'
   container:
     image: centos:6
     options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: $(Build.SourceBranch)-$(date:yyyyMMdd)$(rev:.r)
+name: $(Build.SourceBranch)-$(date:yyyy-MM-dd)$(rev:.r)
 trigger:
   branches:
     include:
@@ -35,6 +35,11 @@ jobs:
   - template: ci/azure-install-rust.yml
   - script: cargo doc
     displayName: Build documentation
+  - script: cargo install cargo-deadlinks
+    displayName: Install cargo-deadlinks
+  - bash: |
+      find ./target/doc -maxdepth 1 -type d -name "cranelift*" | xargs -I{} cargo deadlinks --dir {}
+    displayName: Run cargo-deadlinks
   variables:
     toolchain: stable
 
@@ -47,6 +52,9 @@ jobs:
       linux-stable:
         imageName: 'ubuntu-16.04'
         toolchain: stable
+      mac-earliest:
+        imageName: 'macos-10.14'
+        toolchain: '1.37'
       mac-stable:
         imageName: 'macos-10.14'
         toolchain: stable
@@ -77,13 +85,11 @@ jobs:
         RUST_BACKTRACE: 1
 
     # Ensure fuzzer works by running it with a single input
-    # Note LSAN is disabled due to https://github.com/google/sanitizers/issues/764
     - bash: cargo install cargo-fuzz
       displayName: Install cargo-fuzz
       condition: and(succeeded(), eq(variables['toolchain'], 'nightly'))
     - bash: |
         fuzz_module="ffaefab69523eb11935a9b420d58826c8ea65c4c"
-        # ASAN_OPTIONS=detect_leaks=0 \
         cargo fuzz run fuzz_translate_module \
         "fuzz/corpus/fuzz_translate_module/$fuzz_module"
       displayName: Run cargo-fuzz

--- a/ci/azure-build-release.yml
+++ b/ci/azure-build-release.yml
@@ -1,0 +1,93 @@
+steps:
+- checkout: self
+  submodules: true
+
+- template: azure-install-rust.yml
+
+- bash: echo "##vso[task.setvariable variable=RUSTC_VERSION;]`rustc --version`"
+  displayName: Set rustc version string for caching
+
+# - bash: |
+#     set -e
+#     curl -Lfo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/0.2.9/sccache-0.2.9-x86_64-apple-darwin.tar.gz
+#     tar -xzf sccache.tar.gz
+#     cp sccache-*/sccache /usr/local/bin/
+#   displayName: Install sccache (OSX)
+#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+
+# - bash: |
+#     set -e
+#     curl -Lfo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/0.2.9/sccache-0.2.9-x86_64-unknown-linux-musl.tar.gz
+#     tar -xzf sccache.tar.gz
+#     sudo cp sccache-*/sccache /usr/local/bin/
+#   displayName: Install sccache (Linux)
+#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+# - script: |
+#     curl -Lfo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/0.2.9/sccache-0.2.9-x86_64-pc-windows-msvc.tar.gz
+#     tar -xzf sccache.tar.gz
+#     move sccache-* sccache
+#     echo "##vso[task.prependpath]%CD%\sccache"
+#   displayName: Install sccache (Windows)
+#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+- bash: cargo build --release
+  displayName: Cargo build
+
+# Test what we're about to release in release mode itself.
+- bash: cargo test --release --all
+  displayName: Cargo test
+  env:
+    RUST_BACKTRACE: 1
+
+# - script: sccache --show-stats
+#   displayName: post-compile sccache stats
+
+- bash: |
+    echo "##vso[task.setvariable variable=tagName;]`echo $BUILD_SOURCEBRANCH | sed -e 's|refs/tags/||'`"
+  displayName: Set tag name
+  condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+- bash: |
+    echo "##vso[task.setvariable variable=tagName;]dev"
+  displayName: Set tag name to "dev"
+  condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+
+- bash: echo "##vso[task.setvariable variable=basename;]cranelift-$(tagName)-x86_64-windows"
+  displayName: Configure basename var
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+- bash: echo "##vso[task.setvariable variable=basename;]cranelift-$(tagName)-x86_64-macos"
+  displayName: Configure basename var
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+- bash: echo "##vso[task.setvariable variable=basename;]cranelift-$(tagName)-x86_64-linux"
+  displayName: Configure basename var
+  condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
+
+- bash: |
+    set -e
+    mkdir -p $BUILD_BINARIESDIRECTORY/$BASENAME
+    if [ "$AGENT_OS" = "Windows_NT" ]; then
+      ext=.exe
+    fi
+    cp LICENSE README.md target/release/clif-util$ext $BUILD_BINARIESDIRECTORY/$BASENAME
+  displayName: Copy binaries
+
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: $(Build.BinariesDirectory)/$(basename)
+    archiveType: 'zip'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(basename).zip'
+  displayName: Archive files (Win)
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: $(Build.BinariesDirectory)/$(basename)
+    archiveType: 'tar'
+    tarCompression: 'xz'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(basename).tar.xz'
+  displayName: Archive files (Unix)
+  condition: and(succeeded(), ne(variables['Agent.OS'], 'Windows_NT'))
+- task: PublishPipelineArtifact@1
+  inputs:
+    path: $(Build.ArtifactStagingDirectory)/
+    artifactName: 'bundle-$(Agent.OS)'
+

--- a/ci/azure-build-release.yml
+++ b/ci/azure-build-release.yml
@@ -7,30 +7,6 @@ steps:
 - bash: echo "##vso[task.setvariable variable=RUSTC_VERSION;]`rustc --version`"
   displayName: Set rustc version string for caching
 
-# - bash: |
-#     set -e
-#     curl -Lfo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/0.2.9/sccache-0.2.9-x86_64-apple-darwin.tar.gz
-#     tar -xzf sccache.tar.gz
-#     cp sccache-*/sccache /usr/local/bin/
-#   displayName: Install sccache (OSX)
-#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-
-# - bash: |
-#     set -e
-#     curl -Lfo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/0.2.9/sccache-0.2.9-x86_64-unknown-linux-musl.tar.gz
-#     tar -xzf sccache.tar.gz
-#     sudo cp sccache-*/sccache /usr/local/bin/
-#   displayName: Install sccache (Linux)
-#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-
-# - script: |
-#     curl -Lfo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/0.2.9/sccache-0.2.9-x86_64-pc-windows-msvc.tar.gz
-#     tar -xzf sccache.tar.gz
-#     move sccache-* sccache
-#     echo "##vso[task.prependpath]%CD%\sccache"
-#   displayName: Install sccache (Windows)
-#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
-
 - bash: cargo build --release
   displayName: Cargo build
 
@@ -39,9 +15,6 @@ steps:
   displayName: Cargo test
   env:
     RUST_BACKTRACE: 1
-
-# - script: sccache --show-stats
-#   displayName: post-compile sccache stats
 
 - bash: |
     echo "##vso[task.setvariable variable=tagName;]`echo $BUILD_SOURCEBRANCH | sed -e 's|refs/tags/||'`"

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -1,0 +1,33 @@
+steps:
+  # Rustup is currently installed on Windows and Linux, but not macOS.
+  # It is installed in /usr/local/cargo/bin/ or C:\Program Files\Rust\.cargo\bin\
+  # This steps ensures that rustup is installed, mainly for macOS, or if the
+  # azure image changes in the future.
+  - bash: |
+      set -ex
+      if [ -x "`command -v rustup`" ]; then
+        echo `command -v rustup` `rustup -V` already installed
+        rustup self update
+      else
+        if [ "$AGENT_OS" = "Windows_NT" ]; then
+          curl -sSf -o rustup-init.exe https://win.rustup.rs
+          ./rustup-init.exe -y --default-toolchain $TOOLCHAIN
+          echo "##vso[task.prependpath]$USERPROFILE/.cargo/bin"
+        else
+          curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN
+          echo "##vso[task.prependpath]$HOME/.cargo/bin"
+        fi
+      fi
+    displayName: Install rustup
+
+  - bash: |
+      set -ex
+      rustup update $TOOLCHAIN
+      rustup default $TOOLCHAIN
+    displayName: Install rust
+
+  - bash: |
+      set -ex
+      rustc -Vv
+      cargo -V
+    displayName: Query rust and cargo versions


### PR DESCRIPTION
This should recreate what we have with Travis right now, but run in about 20-25 minutes instead of 3.5 hours.

The Windows builds are disabled right now, because [some tests currently don't work on Windows](https://dev.azure.com/tschneidereit/Cranelift/_build/results?buildId=94). We should get those enabled quickly, and then not regress Windows again :)