### PR TITLE
Remove calling convention on FunctionRunner test

### DIFF
--- a/cranelift-filetests/src/function_runner.rs
+++ b/cranelift-filetests/src/function_runner.rs
@@ -99,7 +99,9 @@ mod test {
     #[test]
     fn nop() {
         let code = String::from(
-            "function %test() -> b8 system_v {
+            "
+            test run
+            function %test() -> b8 {
             ebb0:
                 nop
                 v1 = bconst.b8 true

--- a/src/run.rs
+++ b/src/run.rs
@@ -108,13 +108,12 @@ mod test {
     fn nop() {
         let code = String::from(
             "
-            function %test() -> b8 system_v {
+            function %test() -> b8 {
             ebb0:
                 nop
                 v1 = bconst.b8 true
                 return v1
             }
-            
             ; run
             ",
         );


### PR DESCRIPTION
For this test to run on Windows, the explicit calling convention must be removed so that the parser is free to use the host's calling convention.