### PR TITLE
WIP: Re-fold basic-block split edges in regalloc

### DIFF
--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -307,7 +307,7 @@ impl Context {
     /// Run the register allocator.
     pub fn regalloc(&mut self, isa: &dyn TargetIsa) -> CodegenResult<()> {
         self.regalloc
-            .run(isa, &mut self.func, &self.cfg, &mut self.domtree)
+            .run(isa, &mut self.func, &mut self.cfg, &mut self.domtree)
     }
 
     /// Insert prologue and epilogues after computing the stack frame layout.

--- a/cranelift-codegen/src/regalloc/branch_folding.rs
+++ b/cranelift-codegen/src/regalloc/branch_folding.rs
@@ -1,0 +1,131 @@
+//! Folds redundant branches created by branch_splitting.
+//!
+//! The branch_splitting phase attempts to split possible critical edges so
+//! that the register allocator always has a unique location per conditional branch
+//! in which to insert register moves.
+//!
+//! If the register allocator decides to not use any of those blocks, they can
+//! be removed from the flowgraph.
+#![cfg(feature = "basic-blocks")]
+
+use std::vec::Vec;
+
+use crate::dominator_tree::DominatorTree;
+use crate::flowgraph::{BasicBlock, ControlFlowGraph};
+use crate::ir::{Ebb, Function, Inst, Opcode, ValueList};
+
+/// Folds an ebb if it is redundant in the CFG.
+/// Returns whether folding was performed (which invalidates the domtree).
+fn try_fold_redundant_ebb(
+    func: &mut Function,
+    cfg: &mut ControlFlowGraph,
+    ebb: Ebb
+) -> bool {
+    // Get branch information for the middle block.
+    // This block was created by regalloc, and must end with a jump or fallthrough.
+    let ebb_jump: Inst = func.layout.last_inst(ebb).expect("terminator");
+    let ebb_dest: Ebb = func.dfg[ebb_jump].branch_destination().expect("single dest");
+
+    // If there's more than just a jump in the block, the block isn't redundant.
+    if func.layout.prev_inst(ebb_jump).is_some() {
+        return false;
+    }
+
+    // Get branch information for the parent block.
+    let BasicBlock { ebb: parent, inst: parent_jump } = cfg.pred_iter(ebb).nth(0).unwrap();
+    if func.dfg[parent_jump].branch_destination().is_none() {
+        return false; // Parent jump was multi-target: avoid patching it.
+    }
+
+    // The ebb has no parameters, but its destination may have some.
+    // If it does, the parameters now need to be passed by the parent_jump.
+
+    // Get the arguments and parameters passed by the parent branch.
+    let num_fixed = func.dfg[parent_jump]
+        .opcode()
+        .constraints()
+        .num_fixed_value_arguments();
+    let (parent_jump_args, _parent_jump_params) = func.dfg[parent_jump]
+        .arguments(&func.dfg.value_lists)
+        .split_at(num_fixed);
+
+    // Get the arguments and parameters passed by the edge branch.
+    let num_fixed = func.dfg[ebb_jump]
+        .opcode()
+        .constraints()
+        .num_fixed_value_arguments();
+    let (_, ebb_jump_params) = func.dfg[ebb_jump]
+        .arguments(&func.dfg.value_lists)
+        .split_at(num_fixed);
+
+    // Pass the ebb_jump_params in the parent_jump_params.
+    // No rewriting is needed, because the edge ebb is parameterless.
+    debug_assert!(_parent_jump_params.len() == 0);
+    debug_assert!(func.dfg.num_ebb_params(ebb) == 0);
+    let args: Vec<_> = parent_jump_args
+        .iter()
+        .chain(ebb_jump_params.iter())
+        .map(|x| *x)
+        .collect();
+    let value_list = ValueList::from_slice(&args, &mut func.dfg.value_lists);
+
+    func.dfg[parent_jump].take_value_list(); // Drop the current list.
+    func.dfg[parent_jump].put_value_list(value_list); // Put the new list.
+
+    // TODO: Need to fix "livein" analysis to remove the removed ebbs,
+    // for each parameter that was passed by the edge ebb.
+
+    // Bypass the ebb's jump. This disconnects the Ebb from the CFG.
+    func.change_branch_destination(parent_jump, ebb_dest);
+    cfg.recompute_ebb(func, parent);
+
+    // The edge Ebb is now unreachable. Update the CFG.
+    debug_assert!(cfg.pred_iter(ebb).count() == 0);
+    while let Some(inst) = func.layout.first_inst(ebb) {
+        func.layout.remove_inst(inst);
+    }
+
+    // Remove the block...
+    cfg.recompute_ebb(func, ebb); // ...from predecessor lists.
+    func.layout.remove_ebb(ebb); // ...from the layout.
+
+    true
+}
+
+pub fn run(
+    func: &mut Function,
+    cfg: &mut ControlFlowGraph,
+    domtree: &mut DominatorTree,
+    split_blocks: Vec<Ebb>,
+) {
+    let mut folded = false;
+
+    for ebb in split_blocks {
+        // Ensure that each block is a well-formed split edge.
+        #[cfg(debug_assertions)]
+        {
+            // Each split edge should have exactly one predecessor.
+            debug_assert!(cfg.pred_iter(ebb).count() == 1);
+
+            // There should be a single, unconditional jump.
+            let last_inst = func.layout.last_inst(ebb).expect("terminator");
+            let opcode = func.dfg[last_inst].opcode();
+            debug_assert!(opcode == Opcode::Jump || opcode == Opcode::Fallthrough);
+
+            debug_assert!(func.dfg[last_inst].branch_destination().is_some());
+            if let Some(prev_inst) = func.layout.prev_inst(last_inst) {
+                debug_assert!(func.dfg[prev_inst].branch_destination().is_none());
+            }
+
+            // The Ebb should be parameterless.
+            debug_assert!(func.dfg.num_ebb_params(ebb) == 0);
+        }
+
+        folded |= try_fold_redundant_ebb(func, cfg, ebb);
+    }
+
+    // Folding jumps invalidates the dominator tree.
+    if folded {
+        domtree.compute(func, cfg);
+    }
+}

--- a/cranelift-codegen/src/regalloc/branch_splitting.rs
+++ b/cranelift-codegen/src/regalloc/branch_splitting.rs
@@ -3,6 +3,7 @@
 //! The `minimal` and `tree` register allocators require this. One of the reason for splitting edges
 //! is to be able to insert `copy` and `regmove` instructions between a conditional branch and the
 //! following terminator.
+#![cfg(feature = "basic-blocks")]
 
 use std::vec::Vec;
 

--- a/cranelift-codegen/src/regalloc/branch_splitting.rs
+++ b/cranelift-codegen/src/regalloc/branch_splitting.rs
@@ -1,0 +1,178 @@
+//! Split the outgoing edges of conditional branches that pass parameters.
+//!
+//! The `minimal` and `tree` register allocators require this. One of the reason for splitting edges
+//! is to be able to insert `copy` and `regmove` instructions between a conditional branch and the
+//! following terminator.
+
+use std::vec::Vec;
+
+use crate::cursor::{Cursor, EncCursor};
+use crate::dominator_tree::DominatorTree;
+use crate::flowgraph::ControlFlowGraph;
+use crate::ir::{Ebb, Function, Inst, InstBuilder, InstructionData, Opcode, ValueList};
+use crate::isa::TargetIsa;
+use crate::topo_order::TopoOrder;
+
+pub fn run(
+    isa: &TargetIsa,
+    func: &mut Function,
+    cfg: &mut ControlFlowGraph,
+    domtree: &mut DominatorTree,
+    topo: &mut TopoOrder,
+) {
+    let mut ctx = Context {
+        has_new_blocks: false,
+        cur: EncCursor::new(func, isa),
+        domtree,
+        topo,
+        cfg,
+    };
+    ctx.run()
+}
+
+struct Context<'a> {
+    /// True if new blocks were inserted.
+    has_new_blocks: bool,
+
+    /// Current instruction as well as reference to function and ISA.
+    cur: EncCursor<'a>,
+
+    /// References to contextual data structures we need.
+    domtree: &'a mut DominatorTree,
+    topo: &'a mut TopoOrder,
+    cfg: &'a mut ControlFlowGraph,
+}
+
+impl<'a> Context<'a> {
+    fn run(&mut self) {
+        // Any ebb order will do.
+        self.topo.reset(self.cur.func.layout.ebbs());
+        while let Some(ebb) = self.topo.next(&self.cur.func.layout, self.domtree) {
+            // Branches can only be at the last or second to last position in an extended basic
+            // block.
+            self.cur.goto_last_inst(ebb);
+            let terminator_inst = self.cur.current_inst().expect("terminator");
+            if let Some(inst) = self.cur.prev_inst() {
+                let opcode = self.cur.func.dfg[inst].opcode();
+                if opcode.is_branch() {
+                    self.visit_conditional_branch(inst, opcode);
+                    self.cur.goto_inst(terminator_inst);
+                    self.visit_terminator_branch(terminator_inst);
+                }
+            }
+        }
+
+        // If blocks were added the cfg and domtree are inconsistent and must be recomputed.
+        if self.has_new_blocks {
+            self.cfg.compute(&self.cur.func);
+            self.domtree.compute(&self.cur.func, self.cfg);
+        }
+    }
+
+    fn visit_conditional_branch(&mut self, branch: Inst, opcode: Opcode) {
+        // TODO: target = dfg[branch].branch_destination().expect("conditional branch");
+        let target = match self.cur.func.dfg[branch] {
+            InstructionData::Branch { destination, .. }
+            | InstructionData::BranchIcmp { destination, .. }
+            | InstructionData::BranchInt { destination, .. }
+            | InstructionData::BranchFloat { destination, .. } => destination,
+            _ => panic!("Unexpected instruction in visit_conditional_branch"),
+        };
+
+        // If there are any parameters, split the edge.
+        if self.should_split_edge(branch, target) {
+            // Create the block the branch will jump to.
+            let new_ebb = self.make_empty_ebb();
+
+            // Extract the arguments of the branch instruction, split the Ebb parameters and the
+            // branch arguments
+            let num_fixed = opcode.constraints().num_fixed_value_arguments();
+            let dfg = &mut self.cur.func.dfg;
+            let old_args: Vec<_> = {
+                let args = dfg[branch].take_value_list().expect("ebb parameters");
+                args.as_slice(&dfg.value_lists).iter().map(|x| *x).collect()
+            };
+            let (branch_args, ebb_params) = old_args.split_at(num_fixed);
+
+            // Replace the branch destination by the new Ebb created with no parameters, and restore
+            // the branch arguments, without the original Ebb parameters.
+            {
+                let branch_args = ValueList::from_slice(branch_args, &mut dfg.value_lists);
+                let data = &mut dfg[branch];
+                *data.branch_destination_mut().expect("branch") = new_ebb;
+                data.put_value_list(branch_args);
+            }
+            let ok = self.cur.func.update_encoding(branch, self.cur.isa).is_ok();
+            debug_assert!(ok);
+
+            // Insert a jump to the original target with its arguments into the new block.
+            self.cur.goto_first_insertion_point(new_ebb);
+            self.cur.ins().jump(target, ebb_params);
+
+            // Reset the cursor to point to the branch.
+            self.cur.goto_inst(branch);
+        }
+    }
+
+    fn visit_terminator_branch(&mut self, inst: Inst) {
+        let inst_data = &self.cur.func.dfg[inst];
+        let opcode = inst_data.opcode();
+        if opcode != Opcode::Jump && opcode != Opcode::Fallthrough {
+            // This opcode is ignored as it does not have any EBB parameters.
+            if opcode != Opcode::IndirectJumpTableBr {
+                debug_assert!(!opcode.is_branch())
+            }
+            return;
+        }
+
+        let target = match inst_data {
+            InstructionData::Jump { destination, .. } => destination,
+            _ => panic!(
+                "Unexpected instruction {} in visit_terminator_branch",
+                self.cur.display_inst(inst)
+            ),
+        };
+        debug_assert!(self.cur.func.dfg[inst].opcode().is_terminator());
+
+        // If there are any parameters, split the edge.
+        if self.should_split_edge(inst, *target) {
+            // Create the block the branch will jump to.
+            let new_ebb = self.cur.func.dfg.make_ebb();
+            self.has_new_blocks = true;
+
+            // Split the current block before its terminator, and insert a new jump instruction to
+            // jump to it.
+            let jump = self.cur.ins().jump(new_ebb, &[]);
+            self.cur.insert_ebb(new_ebb);
+
+            // Reset the cursor to point to new terminator of the old ebb.
+            self.cur.goto_inst(jump);
+        }
+    }
+
+    // A new ebb must be inserted before the last ebb because the last ebb may have a
+    // fallthrough_return and can't have anything after it.
+    fn make_empty_ebb(&mut self) -> Ebb {
+        let new_ebb = self.cur.func.dfg.make_ebb();
+        let last_ebb = self.cur.layout().last_ebb().unwrap();
+        self.cur.layout_mut().insert_ebb(new_ebb, last_ebb);
+        self.has_new_blocks = true;
+        new_ebb
+    }
+
+    /// Returns whether we should introduce a new branch.
+    fn should_split_edge(&self, _branch: Inst, target: Ebb) -> bool {
+        // We should split the edge if the target has any parameters.
+        if self.cur.func.dfg.ebb_params(target).len() > 0 {
+            return true;
+        };
+
+        // Or, if the target is has more than one block reaching it.
+        debug_assert!(self.cfg.pred_iter(target).next() != None);
+        if let Some(_) = self.cfg.pred_iter(target).skip(1).next() {
+            return true;
+        };
+
+        false
+    }
+}

--- a/cranelift-codegen/src/regalloc/context.rs
+++ b/cranelift-codegen/src/regalloc/context.rs
@@ -8,6 +8,7 @@ use crate::dominator_tree::DominatorTree;
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir::Function;
 use crate::isa::TargetIsa;
+#[cfg(feature = "basic-blocks")]
 use crate::regalloc::branch_splitting;
 use crate::regalloc::coalescing::Coalescing;
 use crate::regalloc::coloring::Coloring;
@@ -94,7 +95,9 @@ impl Context {
         self.tracker.clear();
 
         // Pass: Split branches, add space where to add copy & regmove instructions.
-        branch_splitting::run(isa, func, cfg, domtree, &mut self.topo);
+        #[cfg(feature = "basic-blocks")] {
+            branch_splitting::run(isa, func, cfg, domtree, &mut self.topo);
+        }
 
         // Pass: Liveness analysis.
         self.liveness.compute(isa, func, cfg);

--- a/cranelift-codegen/src/regalloc/context.rs
+++ b/cranelift-codegen/src/regalloc/context.rs
@@ -8,6 +8,7 @@ use crate::dominator_tree::DominatorTree;
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir::Function;
 use crate::isa::TargetIsa;
+use crate::regalloc::branch_splitting;
 use crate::regalloc::coalescing::Coalescing;
 use crate::regalloc::coloring::Coloring;
 use crate::regalloc::live_value_tracker::LiveValueTracker;
@@ -77,7 +78,7 @@ impl Context {
         &mut self,
         isa: &dyn TargetIsa,
         func: &mut Function,
-        cfg: &ControlFlowGraph,
+        cfg: &mut ControlFlowGraph,
         domtree: &mut DominatorTree,
     ) -> CodegenResult<()> {
         let _tt = timing::regalloc();
@@ -91,6 +92,9 @@ impl Context {
         // Tracker state (dominator live sets) is actually reused between the spilling and coloring
         // phases.
         self.tracker.clear();
+
+        // Pass: Split branches, add space where to add copy & regmove instructions.
+        branch_splitting::run(isa, func, cfg, domtree, &mut self.topo);
 
         // Pass: Liveness analysis.
         self.liveness.compute(isa, func, cfg);

--- a/cranelift-codegen/src/regalloc/mod.rs
+++ b/cranelift-codegen/src/regalloc/mod.rs
@@ -10,6 +10,7 @@ pub mod register_set;
 pub mod virtregs;
 
 mod affinity;
+mod branch_splitting;
 mod coalescing;
 mod context;
 mod diversion;

--- a/cranelift-codegen/src/regalloc/mod.rs
+++ b/cranelift-codegen/src/regalloc/mod.rs
@@ -10,6 +10,7 @@ pub mod register_set;
 pub mod virtregs;
 
 mod affinity;
+mod branch_folding;
 mod branch_splitting;
 mod coalescing;
 mod context;

--- a/filetests/regalloc/coalesce.clif
+++ b/filetests/regalloc/coalesce.clif
@@ -5,6 +5,7 @@ target riscv32
 ; regex: V=v\d+
 ; regex: WS=\s+
 ; regex: LOC=%\w+
+; regex: EBB=ebb\d+
 
 ; This function is already CSSA, so no copies should be inserted.
 function %cssa(i32) -> i32 {
@@ -26,8 +27,7 @@ ebb1(v10: i32):
 
 function %trivial(i32) -> i32 {
 ebb0(v0: i32):
-    ; check: $(cp1=$V) = copy v0
-    ; nextln: brnz v0, ebb1($cp1)
+    ; check:    brnz v0, $(splitEdge=$EBB)
     brnz v0, ebb1(v0)
     jump ebb2
 
@@ -35,6 +35,10 @@ ebb2:
     ; not: copy
     v1 = iadd_imm v0, 7
     jump ebb1(v1)
+
+    ; check:  $splitEdge:
+    ; nextln:   $(cp1=$V) = copy.i32 v0
+    ; nextln:   jump ebb1($cp1)
 
 ebb1(v10: i32):
     ; Use v0 in the destination EBB causes a conflict.
@@ -45,8 +49,7 @@ ebb1(v10: i32):
 ; A value is used as an SSA argument twice in the same branch.
 function %dualuse(i32) -> i32 {
 ebb0(v0: i32):
-    ; check: $(cp1=$V) = copy v0
-    ; nextln: brnz v0, ebb1($cp1, v0)
+    ; check:  brnz v0, $(splitEdge=$EBB)
     brnz v0, ebb1(v0, v0)
     jump ebb2
 
@@ -54,6 +57,10 @@ ebb2:
     v1 = iadd_imm v0, 7
     v2 = iadd_imm v1, 56
     jump ebb1(v1, v2)
+
+    ; check:  $splitEdge:
+    ; check:    $(cp1=$V) = copy.i32 v0
+    ; nextln:   jump ebb1($cp1, v0)
 
 ebb1(v10: i32, v11: i32):
     v12 = iadd v10, v11
@@ -64,9 +71,9 @@ ebb1(v10: i32, v11: i32):
 ; The interference can be broken with a copy at either branch.
 function %interference(i32) -> i32 {
 ebb0(v0: i32):
-    ; check: $(cp0=$V) = copy v0
-    ; not: copy
-    ; check: brnz v0, ebb1($cp0)
+    ; not:    copy
+    ; check:  brnz v0, $(splitEdge=$EBB)
+    ; not:    copy
     brnz v0, ebb1(v0)
     jump ebb2
 
@@ -74,9 +81,13 @@ ebb2:
     v1 = iadd_imm v0, 7
     ; v1 and v0 interfere here:
     v2 = iadd_imm v0, 8
-    ; not: copy
-    ; check: jump ebb1(v1)
+    ; check: $(cp0=$V) = copy v1
+    ; check: jump ebb1($cp0)
     jump ebb1(v1)
+
+    ; check:  $splitEdge:
+    ; not:      copy
+    ; nextln:   jump ebb1(v0)
 
 ebb1(v10: i32):
     ; not: copy
@@ -97,11 +108,14 @@ ebb1(v10: i32, v11: i32):
     ; check: v11 = copy $nv11a
     v12 = iadd v10, v11
     v13 = icmp ult v12, v0
-    ; check: $(nv11b=$V) = copy v11
-    ; not: copy
-    ; check: brnz v13, ebb1($nv11b, v12)
+    ; check:  brnz v13, $(splitEdge=$EBB)
     brnz v13, ebb1(v11, v12)
     jump ebb2
+
+    ; check:  $splitEdge:
+    ; check:    $(nv11b=$V) = copy.i32 v11
+    ; not:      copy
+    ; check:   jump ebb1($nv11b, v12)
 
 ebb2:
     return v12

--- a/filetests/regalloc/reload-208.clif
+++ b/filetests/regalloc/reload-208.clif
@@ -2,6 +2,7 @@ test regalloc
 target x86_64 haswell
 
 ; regex: V=v\d+
+; regex: EBB=ebb\d+
 
 ; Filed as https://github.com/CraneStation/cranelift/issues/208
 ;
@@ -59,9 +60,12 @@ ebb6:
     v8 = iadd v25, v23
     v9 = load.i32 v8+56
     ; check: v9 = spill
-    ; check: brnz $V, ebb3(v9)
+    ; check: brnz $V, $(splitEdge=$EBB)
     brnz v9, ebb3(v9)
     jump ebb4
+
+    ; check: $splitEdge:
+    ; nextln:  jump ebb3(v9)
 
 ebb4:
     jump ebb2

--- a/filetests/regalloc/x86-regres.clif
+++ b/filetests/regalloc/x86-regres.clif
@@ -3,6 +3,7 @@ test regalloc
 target i686
 
 ; regex: V=v\d+
+; regex: EBB=ebb\d+
 
 ; The value v9 appears both as the branch control and one of the EBB arguments
 ; in the brnz instruction in ebb2. It also happens that v7 and v9 are assigned
@@ -24,7 +25,7 @@ ebb2(v4: i32, v5: i32, v7: i32):
     v8 = iconst.i32 -1
     ; v7 is killed here and v9 gets the same register.
     v9 = iadd v7, v8
-    ; check: v9 = iadd v7, v8
+    ; check:   v9 = iadd v7, v8
     ; Here v9 the brnz control appears to interfere with v9 the EBB argument,
     ; so divert_fixed_input_conflicts() calls add_var(v9), which is ok. The
     ; add_var sanity checks got confused when no fixed assignment could be
@@ -32,9 +33,11 @@ ebb2(v4: i32, v5: i32, v7: i32):
     ;
     ; We should be able to handle this situation without making copies of v9.
     brnz v9, ebb2(v5, v6, v9)
-    ; check: brnz v9, ebb2($V, $V, v9)
+    ; check:   brnz v9, $(splitEdge=$EBB)
     jump ebb3
 
+    ; check: $splitEdge:
+    ; check:   jump ebb2($V, $V, v9)
 ebb3:
     return v5
 }


### PR DESCRIPTION
This patch unregresses the extra jumps in the codegen introduced by basic-block branch splitting.

This is a simpler version of the fold-redundant-branches code that is much easier to get correct. The issue with the previous pass was that some ebbs were functioning as phi nodes in the CFG, and those blocks were not actually redundant. This patch only considers blocks that were added specifically by regalloc (in nbp's branch-splitting patch), therefore none of the blocks are effective phis, and they're formed predictably.

This is a WIP patch. If this looks good, I'll muddle through data structures to clean it up. In particular, deleting an ebb means that we need to update the Liveness struct -- currently, it just recomputes the entire data structure, but it's possible that I could update the bforest to support deletion. Although with trees, that's fairly error-prone.

At this point, just soliciting comments.