### PR TITLE
Legalize i64.const by breaking it into two i32.const

### DIFF
--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -188,6 +188,10 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
     narrow.custom_legalize(load, "narrow_load");
     narrow.custom_legalize(store, "narrow_store");
 
+    // iconst.i64 can't be legalized in the meta langage (because integer literals can't be
+    // embedded as part of arguments), so use a custom legalization for now.
+    narrow.custom_legalize(iconst, "narrow_iconst");
+
     narrow.legalize(
         def!(a = iadd(x, y)),
         vec![

--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -238,7 +238,7 @@ impl Context {
 
     /// Perform pre-legalization rewrites on the function.
     pub fn preopt(&mut self, isa: &dyn TargetIsa) -> CodegenResult<()> {
-        do_preopt(&mut self.func, &mut self.cfg);
+        do_preopt(&mut self.func, &mut self.cfg, isa);
         self.verify_if(isa)?;
         Ok(())
     }

--- a/filetests/isa/x86/legalize-custom.clif
+++ b/filetests/isa/x86/legalize-custom.clif
@@ -62,14 +62,6 @@ ebb0:
     return v1
 }
 
-function %f64const() -> f64 {
-ebb0:
-    v1 = f64const 0x1.0p1
-    ; check: $(tmp=$V) = iconst.i64
-    ; check: v1 = bitcast.f64 $tmp
-    return v1
-}
-
 function %select_f64(f64, f64, i32) -> f64 {
 ebb0(v0: f64, v1: f64, v2: i32):
     v3 = select v2, v0, v1

--- a/filetests/isa/x86/legalize-f64const-x64.clif
+++ b/filetests/isa/x86/legalize-f64const-x64.clif
@@ -1,0 +1,13 @@
+; Test the legalization of f64const.
+test legalizer
+target x86_64
+
+; regex: V=v\d+
+
+function %f64const() -> f64 {
+ebb0:
+    v1 = f64const 0x1.0p1
+    ; check: $(tmp=$V) = iconst.i64
+    ; check: v1 = bitcast.f64 $tmp
+    return v1
+}

--- a/filetests/legalizer/iconst-i64.clif
+++ b/filetests/legalizer/iconst-i64.clif
@@ -1,0 +1,12 @@
+test legalizer
+target i686
+
+function %foo() -> i64 {
+ebb0:
+    v1 = iconst.i64 0x6400000042
+    return v1
+}
+
+; check: v2 = iconst.i32 66
+; check: v3 = iconst.i32 100
+; check: v1 = iconcat v2, v3

--- a/filetests/simple_preopt/div_by_const_indirect.clif
+++ b/filetests/simple_preopt/div_by_const_indirect.clif
@@ -1,5 +1,5 @@
 test simple_preopt
-target i686 baseline
+target x86_64 baseline
 
 ; Cases where the denominator is created by an iconst
 

--- a/filetests/simple_preopt/simplify32.clif
+++ b/filetests/simple_preopt/simplify32.clif
@@ -1,0 +1,61 @@
+test simple_preopt
+target i686
+
+;; 32-bits platforms.
+
+function %iadd_imm(i32) -> i32 {
+ebb0(v0: i32):
+    v1 = iconst.i32 2
+    v2 = iadd v0, v1
+    return v2
+}
+; sameln: function %iadd_imm
+; nextln: ebb0(v0: i32):
+; nextln:     v1 = iconst.i32 2
+; nextln:     v2 = iadd_imm v0, 2
+; nextln:     return v2
+; nextln: }
+
+function %isub_imm(i32) -> i32 {
+ebb0(v0: i32):
+    v1 = iconst.i32 2
+    v2 = isub v0, v1
+    return v2
+}
+; sameln: function %isub_imm
+; nextln: ebb0(v0: i32):
+; nextln:     v1 = iconst.i32 2
+; nextln:     v2 = iadd_imm v0, -2
+; nextln:     return v2
+; nextln: }
+
+function %icmp_imm(i32) -> i32 {
+ebb0(v0: i32):
+    v1 = iconst.i32 2
+    v2 = icmp slt v0, v1
+    v3 = bint.i32 v2
+    return v3
+}
+; sameln: function %icmp_imm
+; nextln: ebb0(v0: i32):
+; nextln:     v1 = iconst.i32 2
+; nextln:     v2 = icmp_imm slt v0, 2
+; nextln:     v3 = bint.i32 v2
+; nextln:     return v3
+; nextln: }
+
+;; Don't simplify operations that would get illegal because of lack of native
+;; support.
+function %iadd_imm(i64) -> i64 {
+ebb0(v0: i64):
+    v1 = iconst.i64 2
+    v2 = iadd v0, v1
+    return v2
+}
+; sameln: function %iadd_imm
+; nextln: ebb0(v0: i64):
+; nextln:     v1 = iconst.i64 2
+; nextln:     v2 = iadd v0, v1
+; nextln:     return v2
+; nextln: }
+

--- a/filetests/simple_preopt/simplify64.clif
+++ b/filetests/simple_preopt/simplify64.clif
@@ -1,5 +1,7 @@
 test simple_preopt
-target i686
+target x86_64
+
+;; 64-bits platforms.
 
 function %iadd_imm(i32) -> i32 {
 ebb0(v0: i32):


### PR DESCRIPTION
So my current thinking about isplit/iconcat is that both should not appear post-legalization, and every isplit must have an iconcat input, so the iconcat results are used instead. This seems to make sense if isplit/iconcat are just type system artifacts.

So trying a very simple program on x86 32-bits, that is generating an i64 constant, I implemented this legalization. This could be done in the meta language if there was literal support in the legalize patterns (cc @abrown).

Now it's funny because it interacts with f64const generation on 32 bits (so the test will fail, hence the WIP status of this PR). f64const are generated by reproducing the bit pattern in an i64, then bitcasting this to a f64 register. This is wrong on 32 bits platforms, where instead we should probably legalize it into two GPRs and then bitcast this to a f64. Or implement real constant pools for f32/f64, which would be even better.