### PR TITLE
Random refactorings

### DIFF
--- a/cranelift-codegen/src/binemit/mod.rs
+++ b/cranelift-codegen/src/binemit/mod.rs
@@ -133,7 +133,7 @@ pub trait CodeSink {
     /// Add a relocation referencing an external symbol plus the addend at the current offset.
     fn reloc_external(&mut self, _: Reloc, _: &ExternalName, _: Addend);
 
-    /// Add a relocation referencing a jump table.
+    /// Add a relocation referencing a constant.
     fn reloc_constant(&mut self, _: Reloc, _: ConstantOffset);
 
     /// Add a relocation referencing a jump table.

--- a/cranelift-codegen/src/isa/x86/binemit.rs
+++ b/cranelift-codegen/src/isa/x86/binemit.rs
@@ -342,7 +342,7 @@ fn jt_disp4<CS: CodeSink + ?Sized>(jt: JumpTable, func: &Function, sink: &mut CS
     sink.reloc_jt(Reloc::X86PCRelRodata4, jt);
 }
 
-/// Emit a four-byte displacement to `constant`
+/// Emit a four-byte displacement to `constant`.
 fn const_disp4<CS: CodeSink + ?Sized>(constant: Constant, func: &Function, sink: &mut CS) {
     let offset = func.dfg.constants.get_offset(constant);
     let delta = offset.wrapping_sub(sink.offset() + 4);

--- a/cranelift-codegen/src/regalloc/coloring.rs
+++ b/cranelift-codegen/src/regalloc/coloring.rs
@@ -44,7 +44,7 @@
 
 use crate::cursor::{Cursor, EncCursor};
 use crate::dominator_tree::DominatorTree;
-use crate::ir::{AbiParam, ArgumentLoc, InstBuilder, ValueDef};
+use crate::ir::{ArgumentLoc, InstBuilder, ValueDef};
 use crate::ir::{Ebb, Function, Inst, InstructionData, Layout, Opcode, SigRef, Value, ValueLoc};
 use crate::isa::{regs_overlap, RegClass, RegInfo, RegUnit};
 use crate::isa::{ConstraintKind, EncInfo, OperandConstraint, RecipeConstraints, TargetIsa};
@@ -66,6 +66,12 @@ use log::debug;
 pub struct Coloring {
     divert: RegDiversions,
     solver: Solver,
+}
+
+/// Kinds of ABI parameters.
+enum AbiParams {
+    Parameters(SigRef),
+    Returns,
 }
 
 /// Bundle of references that the coloring algorithm needs.
@@ -284,6 +290,36 @@ impl<'a> Context<'a> {
         regs
     }
 
+    /// Program the input-side ABI constraints for `inst` into the constraint solver.
+    ///
+    /// ABI constraints are the fixed register assignments useds for calls and returns.
+    fn program_input_abi(&mut self, inst: Inst, abi_params: AbiParams) {
+        let abi_types = match abi_params {
+            AbiParams::Parameters(sig) => &self.cur.func.dfg.signatures[sig].params,
+            AbiParams::Returns => &self.cur.func.signature.returns,
+        };
+
+        for (abi, &value) in abi_types
+            .iter()
+            .zip(self.cur.func.dfg.inst_variable_args(inst))
+        {
+            if let ArgumentLoc::Reg(reg) = abi.location {
+                if let Affinity::Reg(rci) = self
+                    .liveness
+                    .get(value)
+                    .expect("ABI register must have live range")
+                    .affinity
+                {
+                    let rc = self.reginfo.rc(rci);
+                    let cur_reg = self.divert.reg(value, &self.cur.func.locations);
+                    self.solver.reassign_in(value, rc, cur_reg, reg);
+                } else {
+                    panic!("ABI argument {} should be in a register", value);
+                }
+            }
+        }
+    }
+
     /// Color the values defined by `inst` and insert any necessary shuffle code to satisfy
     /// instruction constraints.
     ///
@@ -315,25 +351,9 @@ impl<'a> Context<'a> {
         }
         let call_sig = self.cur.func.dfg.call_signature(inst);
         if let Some(sig) = call_sig {
-            program_input_abi(
-                &mut self.solver,
-                inst,
-                &self.cur.func.dfg.signatures[sig].params,
-                &self.cur.func,
-                &self.liveness,
-                &self.reginfo,
-                &self.divert,
-            );
+            self.program_input_abi(inst, AbiParams::Parameters(sig));
         } else if self.cur.func.dfg[inst].opcode().is_return() {
-            program_input_abi(
-                &mut self.solver,
-                inst,
-                &self.cur.func.signature.returns,
-                &self.cur.func,
-                &self.liveness,
-                &self.reginfo,
-                &self.divert,
-            );
+            self.program_input_abi(inst, AbiParams::Returns);
         } else if self.cur.func.dfg[inst].opcode().is_branch() {
             // This is a branch, so we need to make sure that globally live values are in their
             // global registers. For EBBs that take arguments, we also need to place the argument
@@ -1098,35 +1118,6 @@ impl<'a> Context<'a> {
                     regs.global
                         .free(rc, self.cur.func.locations[lv.value].unwrap_reg());
                 }
-            }
-        }
-    }
-}
-
-/// Program the input-side ABI constraints for `inst` into the constraint solver.
-///
-/// ABI constraints are the fixed register assignments used for calls and returns.
-fn program_input_abi(
-    solver: &mut Solver,
-    inst: Inst,
-    abi_types: &[AbiParam],
-    func: &Function,
-    liveness: &Liveness,
-    reginfo: &RegInfo,
-    divert: &RegDiversions,
-) {
-    for (abi, &value) in abi_types.iter().zip(func.dfg.inst_variable_args(inst)) {
-        if let ArgumentLoc::Reg(reg) = abi.location {
-            if let Affinity::Reg(rci) = liveness
-                .get(value)
-                .expect("ABI register must have live range")
-                .affinity
-            {
-                let rc = reginfo.rc(rci);
-                let cur_reg = divert.reg(value, &func.locations);
-                solver.reassign_in(value, rc, cur_reg, reg);
-            } else {
-                panic!("ABI argument {} should be in a register", value);
             }
         }
     }


### PR DESCRIPTION
(premises for next PR)

- first commit allows to retrieve a register like r15, which will be needed in the next PR
- second commit moves the only static function in regalloc::coloring back into the impl block, using a trick to quiet the borrow-checking gods.
- third commit just tweaks comments.