### PR TITLE
Allow pinning a certain register in Cranelift, and use it as the heap base

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/regs.rs
+++ b/cranelift-codegen/meta/src/cdsl/regs.rs
@@ -11,6 +11,7 @@ pub struct RegBank {
     pub names: Vec<&'static str>,
     pub prefix: &'static str,
     pub pressure_tracking: bool,
+    pub pinned_reg: Option<u16>,
     pub toprcs: Vec<RegClassIndex>,
     pub classes: Vec<RegClassIndex>,
 }
@@ -23,6 +24,7 @@ impl RegBank {
         names: Vec<&'static str>,
         prefix: &'static str,
         pressure_tracking: bool,
+        pinned_reg: Option<u16>,
     ) -> Self {
         RegBank {
             name,
@@ -31,6 +33,7 @@ impl RegBank {
             names,
             prefix,
             pressure_tracking,
+            pinned_reg,
             toprcs: Vec::new(),
             classes: Vec::new(),
         }
@@ -183,6 +186,7 @@ pub struct RegBankBuilder {
     pub names: Vec<&'static str>,
     pub prefix: &'static str,
     pub pressure_tracking: Option<bool>,
+    pub pinned_reg: Option<u16>,
 }
 
 impl RegBankBuilder {
@@ -193,6 +197,7 @@ impl RegBankBuilder {
             names: vec![],
             prefix,
             pressure_tracking: None,
+            pinned_reg: None,
         }
     }
     pub fn units(mut self, units: u8) -> Self {
@@ -205,6 +210,11 @@ impl RegBankBuilder {
     }
     pub fn track_pressure(mut self, track: bool) -> Self {
         self.pressure_tracking = Some(track);
+        self
+    }
+    pub fn pinned_reg(mut self, unit: u16) -> Self {
+        assert!(unit < (self.units as u16));
+        self.pinned_reg = Some(unit);
         self
     }
 }
@@ -246,6 +256,7 @@ impl IsaRegsBuilder {
             builder
                 .pressure_tracking
                 .expect("Pressure tracking must be explicitly set"),
+            builder.pinned_reg,
         ))
     }
 

--- a/cranelift-codegen/meta/src/gen_registers.rs
+++ b/cranelift-codegen/meta/src/gen_registers.rs
@@ -56,6 +56,7 @@ fn gen_regclass(isa: &TargetIsa, reg_class: &RegClass, fmt: &mut Formatter) {
         fmtln!(fmt, "first: {},", reg_bank.first_unit + reg_class.start);
         fmtln!(fmt, "subclasses: {:#x},", reg_class.subclass_mask());
         fmtln!(fmt, "mask: [{}],", mask);
+        fmtln!(fmt, "pinned_reg: {:?},", reg_bank.pinned_reg);
         fmtln!(fmt, "info: &INFO,");
     });
     fmtln!(fmt, "};");

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -372,6 +372,7 @@ pub(crate) fn define(
     let fpromote = shared.by_name("fpromote");
     let fsub = shared.by_name("fsub");
     let func_addr = shared.by_name("func_addr");
+    let get_pinned_reg = shared.by_name("get_pinned_reg");
     let iadd = shared.by_name("iadd");
     let iadd_cout = shared.by_name("iadd_cout");
     let iadd_cin = shared.by_name("iadd_cin");
@@ -421,6 +422,7 @@ pub(crate) fn define(
     let scalar_to_vector = shared.by_name("scalar_to_vector");
     let selectif = shared.by_name("selectif");
     let sextend = shared.by_name("sextend");
+    let set_pinned_reg = shared.by_name("set_pinned_reg");
     let sload16 = shared.by_name("sload16");
     let sload16_complex = shared.by_name("sload16_complex");
     let sload32 = shared.by_name("sload32");
@@ -516,6 +518,7 @@ pub(crate) fn define(
     let rec_furm = r.template("furm");
     let rec_furm_reg_to_ssa = r.template("furm_reg_to_ssa");
     let rec_furmi_rnd = r.template("furmi_rnd");
+    let rec_get_pinned_reg = r.recipe("get_pinned_reg");
     let rec_got_fnaddr8 = r.template("got_fnaddr8");
     let rec_got_gvaddr8 = r.template("got_gvaddr8");
     let rec_gvaddr4 = r.template("gvaddr4");
@@ -569,6 +572,7 @@ pub(crate) fn define(
     let rec_safepoint = r.recipe("safepoint");
     let rec_setf_abcd = r.template("setf_abcd");
     let rec_seti_abcd = r.template("seti_abcd");
+    let rec_set_pinned_reg = r.template("set_pinned_reg");
     let rec_spaddr4_id = r.template("spaddr4_id");
     let rec_spaddr8_id = r.template("spaddr8_id");
     let rec_spillSib32 = r.template("spillSib32");
@@ -618,6 +622,13 @@ pub(crate) fn define(
 
     // Definitions.
     let mut e = PerCpuModeEncodings::new();
+
+    // The pinned reg is fixed to a certain value entirely user-controlled, so it generates nothing!
+    e.enc64_rec(get_pinned_reg.bind(I64), rec_get_pinned_reg, 0);
+    e.enc_x86_64(
+        set_pinned_reg.bind(I64),
+        rec_set_pinned_reg.opcodes(vec![0x89]).rex().w(),
+    );
 
     e.enc_i32_i64(iadd, rec_rr.opcodes(vec![0x01]));
     e.enc_i32_i64(iadd_cout, rec_rr.opcodes(vec![0x01]));

--- a/cranelift-codegen/meta/src/isa/x86/registers.rs
+++ b/cranelift-codegen/meta/src/isa/x86/registers.rs
@@ -6,7 +6,8 @@ pub fn define() -> IsaRegs {
     let builder = RegBankBuilder::new("IntRegs", "r")
         .units(16)
         .names(vec!["rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi"])
-        .track_pressure(true);
+        .track_pressure(true)
+        .pinned_reg(15);
     let int_regs = regs.add_bank(builder);
 
     let builder = RegBankBuilder::new("FloatRegs", "xmm")

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -964,6 +964,34 @@ pub(crate) fn define(
         .operands_out(vec![addr]),
     );
 
+    // Note this instruction is marked as having other side-effects, so GVN won't try to hoist it,
+    // which would result in it being subject to spilling. While not hoisting would generally hurt
+    // performance, since a computed value used many times may need to be regenerated before each
+    // use, it is not the case here: this instruction doesn't generate any code.  That's because,
+    // by definition the pinned register is never used by the register allocator, but is written to
+    // and read explicitly and exclusively by set_pinned_reg and get_pinned_reg.
+    ig.push(
+        Inst::new(
+            "get_pinned_reg",
+            r#"
+            Gets the content of the pinned register, when it's enabled.
+        "#,
+        )
+        .operands_out(vec![addr])
+        .other_side_effects(true),
+    );
+
+    ig.push(
+        Inst::new(
+            "set_pinned_reg",
+            r#"
+        Sets the content of the pinned register, when it's enabled.
+        "#,
+        )
+        .operands_in(vec![addr])
+        .other_side_effects(true),
+    );
+
     let TableOffset = &TypeVar::new(
         "TableOffset",
         "An unsigned table offset",

--- a/cranelift-codegen/meta/src/shared/settings.rs
+++ b/cranelift-codegen/meta/src/shared/settings.rs
@@ -84,6 +84,17 @@ pub fn define() -> SettingGroup {
         false,
     );
 
+    settings.add_bool(
+        "enable_pinned_reg",
+        r#"Enable the use of the pinned register.
+
+        This register is excluded from register allocation, and is completely under the control of
+        the end-user. It is possible to read it via the get_pinned_reg instruction, and to set it
+        with the set_pinned_reg instruction.
+        "#,
+        false,
+    );
+
     settings.add_bool("enable_simd", "Enable the use of SIMD instructions.", false);
 
     settings.add_bool(

--- a/cranelift-codegen/meta/src/shared/settings.rs
+++ b/cranelift-codegen/meta/src/shared/settings.rs
@@ -95,6 +95,21 @@ pub fn define() -> SettingGroup {
         false,
     );
 
+    settings.add_bool(
+        "use_pinned_reg_as_heap_base",
+        r#"Use the pinned register as the heap base.
+
+        Enabling this requires the enable_pinned_reg setting to be set to true. It enables a custom
+        legalization of the `heap_addr` instruction so it will use the pinned register as the heap
+        base, instead of fetching it from a global value.
+
+        Warning! Enabling this means that the pinned register *must* be maintained to contain the
+        heap base address at all times, during the lifetime of a function. Using the pinned
+        register for other purposes when this is set is very likely to cause crashes.
+        "#,
+        false,
+    );
+
     settings.add_bool("enable_simd", "Enable the use of SIMD instructions.", false);
 
     settings.add_bool(

--- a/cranelift-codegen/src/isa/registers.rs
+++ b/cranelift-codegen/src/isa/registers.rs
@@ -154,6 +154,12 @@ pub struct RegClassData {
 
     /// The global `RegInfo` instance containing this register class.
     pub info: &'static RegInfo,
+
+    /// The "pinned" register of the associated register bank.
+    ///
+    /// This register must be non-volatile (callee-preserved) and must not be the fixed
+    /// output register of any instruction.
+    pub pinned_reg: Option<RegUnit>,
 }
 
 impl RegClassData {
@@ -200,6 +206,15 @@ impl RegClassData {
     /// Does this register class contain `regunit`?
     pub fn contains(&self, regunit: RegUnit) -> bool {
         self.mask[(regunit / 32) as usize] & (1u32 << (regunit % 32)) != 0
+    }
+
+    /// If the pinned register is used, is the given regunit the pinned register of this class?
+    #[inline]
+    pub fn is_pinned_reg(&self, enabled: bool, regunit: RegUnit) -> bool {
+        enabled
+            && self
+                .pinned_reg
+                .map_or(false, |pinned_reg| pinned_reg == regunit)
     }
 }
 

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -89,9 +89,8 @@ impl ArgAssigner for Args {
                 let reg = FPR.unit(self.fpr_used);
                 self.fpr_used += 1;
                 return ArgumentLoc::Reg(reg).into();
-            } else {
-                return ValueConversion::VectorSplit.into();
             }
+            return ValueConversion::VectorSplit.into();
         }
 
         // Large integers and booleans are broken down to fit in a register.
@@ -229,7 +228,7 @@ pub fn regclass_for_abi_type(ty: ir::Type) -> RegClass {
 }
 
 /// Get the set of allocatable registers for `func`.
-pub fn allocatable_registers(_func: &ir::Function, triple: &Triple) -> RegisterSet {
+pub fn allocatable_registers(triple: &Triple, flags: &shared_settings::Flags) -> RegisterSet {
     let mut regs = RegisterSet::new();
     regs.take(GPR, RU::rsp as RegUnit);
     regs.take(GPR, RU::rbp as RegUnit);
@@ -239,6 +238,15 @@ pub fn allocatable_registers(_func: &ir::Function, triple: &Triple) -> RegisterS
         for i in 8..16 {
             regs.take(GPR, GPR.unit(i));
             regs.take(FPR, FPR.unit(i));
+        }
+        if flags.enable_pinned_reg() {
+            unimplemented!("Pinned register not implemented on x86-32.");
+        }
+    } else {
+        // Choose r15 as the pinned register on 64-bits: it is non-volatile on native ABIs and
+        // isn't the fixed output register of any instruction.
+        if flags.enable_pinned_reg() {
+            regs.take(GPR, RU::r15 as RegUnit);
         }
     }
 

--- a/cranelift-codegen/src/isa/x86/mod.rs
+++ b/cranelift-codegen/src/isa/x86/mod.rs
@@ -119,8 +119,8 @@ impl TargetIsa for Isa {
         abi::regclass_for_abi_type(ty)
     }
 
-    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::RegisterSet {
-        abi::allocatable_registers(func, &self.triple)
+    fn allocatable_registers(&self, _func: &ir::Function) -> regalloc::RegisterSet {
+        abi::allocatable_registers(&self.triple, &self.shared_flags)
     }
 
     #[cfg(feature = "testing_hooks")]

--- a/cranelift-codegen/src/regalloc/register_set.rs
+++ b/cranelift-codegen/src/regalloc/register_set.rs
@@ -268,6 +268,7 @@ mod tests {
         subclasses: 0,
         mask: [0xf0000000, 0x0000000f, 0],
         info: &INFO,
+        pinned_reg: None,
     };
 
     const DPR: RegClass = &RegClassData {
@@ -280,6 +281,7 @@ mod tests {
         subclasses: 0,
         mask: [0x50000000, 0x0000000a, 0],
         info: &INFO,
+        pinned_reg: None,
     };
 
     const INFO: RegInfo = RegInfo {

--- a/cranelift-codegen/src/regalloc/solver.rs
+++ b/cranelift-codegen/src/regalloc/solver.rs
@@ -877,6 +877,7 @@ impl Solver {
             let d = v.iter(&self.regs_in, &self.regs_out, global_regs).len();
             v.domain = cmp::min(d, u16::MAX as usize) as u16;
         }
+
         // Solve for vars with small domains first to increase the chance of finding a solution.
         //
         // Also consider this case:
@@ -949,9 +950,8 @@ impl Solver {
                     // live registers be diverted. We need to make it a non-global value.
                     if v.is_global && gregs.iter(rc).next().is_none() {
                         return Err(SolverError::Global(v.value));
-                    } else {
-                        return Err(SolverError::Divert(rc));
                     }
+                    return Err(SolverError::Divert(rc));
                 }
             };
 
@@ -976,7 +976,7 @@ impl Solver {
     }
 
     /// Check if `value` can be added as a variable to help find a solution.
-    pub fn can_add_var(&mut self, _value: Value, constraint: RegClass, from: RegUnit) -> bool {
+    pub fn can_add_var(&mut self, constraint: RegClass, from: RegUnit) -> bool {
         !self.regs_in.is_avail(constraint, from)
     }
 }
@@ -1030,7 +1030,7 @@ impl Solver {
         let mut avail = regs.clone();
         let mut i = 0;
         while i < self.moves.len() + self.fills.len() {
-            // Don't even look at the fills until we've spent all the moves. Deferring these let's
+            // Don't even look at the fills until we've spent all the moves. Deferring these lets
             // us potentially reuse the claimed registers to resolve multiple cycles.
             if i >= self.moves.len() {
                 self.moves.append(&mut self.fills);

--- a/cranelift-codegen/src/settings.rs
+++ b/cranelift-codegen/src/settings.rs
@@ -389,6 +389,7 @@ mod tests {
              enable_float = true\n\
              enable_nan_canonicalization = false\n\
              enable_pinned_reg = false\n\
+             use_pinned_reg_as_heap_base = false\n\
              enable_simd = false\n\
              enable_atomics = true\n\
              enable_safepoints = false\n\

--- a/cranelift-codegen/src/settings.rs
+++ b/cranelift-codegen/src/settings.rs
@@ -388,6 +388,7 @@ mod tests {
              avoid_div_traps = false\n\
              enable_float = true\n\
              enable_nan_canonicalization = false\n\
+             enable_pinned_reg = false\n\
              enable_simd = false\n\
              enable_atomics = true\n\
              enable_safepoints = false\n\

--- a/cranelift-codegen/src/verifier/mod.rs
+++ b/cranelift-codegen/src/verifier/mod.rs
@@ -676,6 +676,26 @@ impl<'a> Verifier<'a> {
                 self.verify_value_list(inst, args, errors)?;
             }
 
+            NullAry {
+                opcode: Opcode::GetPinnedReg,
+            }
+            | Unary {
+                opcode: Opcode::SetPinnedReg,
+                ..
+            } => {
+                if let Some(isa) = &self.isa {
+                    if !isa.flags().enable_pinned_reg() {
+                        return fatal!(
+                            errors,
+                            inst,
+                            "GetPinnedReg/SetPinnedReg cannot be used without enable_pinned_reg"
+                        );
+                    }
+                } else {
+                    return fatal!(errors, inst, "GetPinnedReg/SetPinnedReg need an ISA!");
+                }
+            }
+
             // Exhaustive list so we can't forget to add new formats
             Unary { .. }
             | UnaryImm { .. }

--- a/filetests/isa/x86/pinned-reg.clif
+++ b/filetests/isa/x86/pinned-reg.clif
@@ -1,0 +1,74 @@
+test compile
+
+set enable_pinned_reg=true
+set use_pinned_reg_as_heap_base=true
+set opt_level=best
+
+target x86_64
+
+; regex: V=v\d+
+
+; r15 is the pinned heap register. It must not be rewritten, so it must not be
+; used as a tied output register.
+function %tied_input() -> i64 system_v {
+ebb0:
+    v1 = get_pinned_reg.i64
+    v2 = iadd_imm v1, 42
+    return v2
+}
+
+; check: ,%r15]
+; sameln: v1 = get_pinned_reg.i64
+; nextln: regmove v1, %r15 -> %rax
+; nextln: ,%rax]
+; sameln: iadd_imm v1, 42
+
+;; It musn't be used even if this is a tied input used twice.
+function %tied_twice() -> i64 system_v {
+ebb0:
+    v1 = get_pinned_reg.i64
+    v2 = iadd v1, v1
+    return v2
+}
+
+; check: ,%r15]
+; sameln: v1 = get_pinned_reg.i64
+; nextln: regmove v1, %r15 -> %rax
+; nextln: ,%rax]
+; sameln: iadd v1, v1
+
+function %uses() -> i64 system_v {
+ebb0:
+    v1 = get_pinned_reg.i64
+    v2 = iadd_imm v1, 42
+    v3 = get_pinned_reg.i64
+    v4 = iadd v2, v3
+    return v4
+}
+
+; check: ,%r15]
+; sameln: v1 = get_pinned_reg.i64
+; nextln: regmove v1, %r15 -> %rax
+; nextln: ,%rax]
+; sameln: iadd_imm v1, 42
+; nextln: ,%r15
+; sameln: v3 = get_pinned_reg.i64
+; nextln: ,%rax]
+; sameln: iadd v2, v3
+
+; When the pinned register is used as the heap base, the final load instruction
+; must use the %r15 register, since x86 implements the complex addressing mode.
+function u0:1(i64 vmctx) -> i64 system_v {
+    gv0 = vmctx
+    heap0 = static gv0, min 0x000a_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000, index_type i32
+
+ebb0(v42: i64):
+    v5 = iconst.i32 42
+    v6 = heap_addr.i64 heap0, v5, 0
+    v7 = load.i64 v6
+    return v7
+}
+
+; check: ,%r15]
+; sameln: $(heap_base=$V) = get_pinned_reg.i64
+; nextln: load_complex.i64 $heap_base+


### PR DESCRIPTION
Based on #959. So this is very experimental, probably a bit sketchy. This allows pinning one register (r15 on x86 64 bits) so it's entirely in the control of the embedder. In particular, it tries to exclude it from register allocation. Assertions in this code plus all my tests passing make me confident it isn't horribly wrong, but it doesn't prove this is incredibly good either. (I'm a bit worried about local diversions in particular.) Also, this is not enough tested at the moment, I'll try to add more test cases and fuzz this a bit (?).

Second commit adds a second setting that enables use of the pinned register as the heap base when legalizing heap_addr instructions. If the embedder does the Right Thing, and correctly sets the heap base with set_pinned_reg, this is enough to avoid reloading the heap base before every single memory access, and is a nice win in Spidermonkey (up to 10% in some of our benchmarks).