### PR TITLE
[codegen] add encodings for isub borrow variants

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -397,6 +397,9 @@ pub fn define(
     let istore8 = shared.by_name("istore8");
     let istore8_complex = shared.by_name("istore8_complex");
     let isub = shared.by_name("isub");
+    let isub_bout = shared.by_name("isub_bout");
+    let isub_bin = shared.by_name("isub_bin");
+    let isub_borrow = shared.by_name("isub_borrow");
     let jump = shared.by_name("jump");
     let jump_table_base = shared.by_name("jump_table_base");
     let jump_table_entry = shared.by_name("jump_table_entry");
@@ -560,8 +563,8 @@ pub fn define(
     let rec_rfurm = r.template("rfurm");
     let rec_rmov = r.template("rmov");
     let rec_rr = r.template("rr");
-    let rec_rcin = r.template("rcin");
-    let rec_rcarry = r.template("rcarry");
+    let rec_rin = r.template("rin");
+    let rec_rio = r.template("rio");
     let rec_rrx = r.template("rrx");
     let rec_safepoint = r.recipe("safepoint");
     let rec_setf_abcd = r.template("setf_abcd");
@@ -618,10 +621,14 @@ pub fn define(
 
     e.enc_i32_i64(iadd, rec_rr.opcodes(vec![0x01]));
     e.enc_i32_i64(iadd_cout, rec_rr.opcodes(vec![0x01]));
-    e.enc_i32_i64(iadd_cin, rec_rcin.opcodes(vec![0x11]));
-    e.enc_i32_i64(iadd_carry, rec_rcarry.opcodes(vec![0x11]));
+    e.enc_i32_i64(iadd_cin, rec_rin.opcodes(vec![0x11]));
+    e.enc_i32_i64(iadd_carry, rec_rio.opcodes(vec![0x11]));
 
     e.enc_i32_i64(isub, rec_rr.opcodes(vec![0x29]));
+    e.enc_i32_i64(isub_bout, rec_rr.opcodes(vec![0x29]));
+    e.enc_i32_i64(isub_bin, rec_rin.opcodes(vec![0x19]));
+    e.enc_i32_i64(isub_borrow, rec_rio.opcodes(vec![0x19]));
+
     e.enc_i32_i64(band, rec_rr.opcodes(vec![0x21]));
     e.enc_i32_i64(bor, rec_rr.opcodes(vec![0x09]));
     e.enc_i32_i64(bxor, rec_rr.opcodes(vec![0x31]));

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -2532,7 +2532,7 @@ pub fn define<'shared>(
 
     // XX /r, MR form. Add two GPR registers and get carry flag.
     recipes.add_template_recipe(
-        EncodingRecipeBuilder::new("rcin", f_ternary, 1)
+        EncodingRecipeBuilder::new("rin", f_ternary, 1)
             .operands_in(vec![
                 OperandConstraint::RegClass(gpr),
                 OperandConstraint::RegClass(gpr),
@@ -2550,7 +2550,7 @@ pub fn define<'shared>(
 
     // XX /r, MR form. Add two GPR registers with carry flag.
     recipes.add_template_recipe(
-        EncodingRecipeBuilder::new("rcarry", f_ternary, 1)
+        EncodingRecipeBuilder::new("rio", f_ternary, 1)
             .operands_in(vec![
                 OperandConstraint::RegClass(gpr),
                 OperandConstraint::RegClass(gpr),

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -1866,8 +1866,8 @@ pub fn define(
     let y = &operand("y", iB);
     let c_in = &operand_doc("c_in", iflags, "Input carry flag");
     let c_out = &operand_doc("c_out", iflags, "Output carry flag");
-    let b_in = &operand_doc("b_in", b1, "Input borrow flag");
-    let b_out = &operand_doc("b_out", b1, "Output borrow flag");
+    let b_in = &operand_doc("b_in", iflags, "Input borrow flag");
+    let b_out = &operand_doc("b_out", iflags, "Output borrow flag");
 
     ig.push(
         Inst::new(

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -86,7 +86,6 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
     let istore16 = insts.by_name("istore16");
     let isub = insts.by_name("isub");
     let isub_bin = insts.by_name("isub_bin");
-    let isub_borrow = insts.by_name("isub_borrow");
     let isub_bout = insts.by_name("isub_bout");
     let load = insts.by_name("load");
     let popcnt = insts.by_name("popcnt");
@@ -160,8 +159,6 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
     let b2 = var("b2");
     let b3 = var("b3");
     let b4 = var("b4");
-    let b_in = var("b_in");
-    let b_int = var("b_int");
     let c = var("c");
     let c1 = var("c1");
     let c2 = var("c2");
@@ -458,33 +455,6 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
             );
         }
     }
-
-    // Expand integer operations with carry for RISC architectures that don't have
-    // the flags.
-    let intcc_ugt = Literal::enumerator_for(intcc, "ugt");
-    expand.legalize(
-        def!((a, b) = isub_bout(x, y)),
-        vec![def!(a = isub(x, y)), def!(b = icmp(intcc_ugt, a, x))],
-    );
-
-    expand.legalize(
-        def!(a = isub_bin(x, y, b)),
-        vec![
-            def!(a1 = isub(x, y)),
-            def!(b_int = bint(b)),
-            def!(a = isub(a1, b_int)),
-        ],
-    );
-
-    expand.legalize(
-        def!((a, b) = isub_borrow(x, y, b_in)),
-        vec![
-            def!((a1, b1) = isub_bout(x, y)),
-            def!(b_int = bint(b_in)),
-            def!((a, b2) = isub_bout(a1, b_int)),
-            def!(b = bor(b1, b2)),
-        ],
-    );
 
     // Expansions for fcvt_from_{u,s}int for smaller integer types.
     // These use expand and not widen because the controlling type variable for

--- a/filetests/isa/x86/binary32.clif
+++ b/filetests/isa/x86/binary32.clif
@@ -477,6 +477,14 @@ ebb0:
     ; asm: adcl %esi, %ecx
     [-,%rcx,%rflags] v704, v705 = iadd_carry v1, v2, v702 ; bin: 11 f1
 
+    ; Borrow Subtraction
+    ; asm: subl %esi, %ecx
+    [-,%rcx,%rflags] v706, v707 = isub_bout v1, v2         ; bin: 29 f1
+    ; asm: sbbl %esi, %ecx
+    [-,%rcx] v708 = isub_bin v1, v2, v707                  ; bin: 19 f1
+    ; asm: sbbl %esi, %ecx
+    [-,%rcx,%rflags] v709, v710 = isub_borrow v1, v2, v707 ; bin: 19 f1
+
     ; asm: testl %ecx, %ecx
     ; asm: je ebb1
     brz v1, ebb1                                ; bin: 85 c9 74 0e

--- a/filetests/isa/x86/legalize-i64.clif
+++ b/filetests/isa/x86/legalize-i64.clif
@@ -8,9 +8,20 @@ function %iadd(i64, i64) -> i64 {
 ebb0(v1: i64, v2: i64):
     v10 = iadd v1, v2
     ; check: v1 = iconcat $(v1_lsb=$V), $(v1_msb=$V)
-    ; check: v2 = iconcat $(v2_lsb=$V), $(v2_msb=$V)
-    ; check: $(v10_lsb=$V), $(carry=$V) = iadd_cout $v1_lsb, $v2_lsb
-    ; check: $(v10_msb=$V) = iadd_cin $v1_msb, $v2_msb, $carry
-    ; check: v10 = iconcat $v10_lsb, $v10_msb
+    ; nextln: v2 = iconcat $(v2_lsb=$V), $(v2_msb=$V)
+    ; nextln: $(v10_lsb=$V), $(carry=$V) = iadd_cout $v1_lsb, $v2_lsb
+    ; nextln: $(v10_msb=$V) = iadd_cin $v1_msb, $v2_msb, $carry
+    ; nextln: v10 = iconcat $v10_lsb, $v10_msb
+    return v10
+}
+
+function %isub(i64, i64) -> i64 {
+ebb0(v1: i64, v2: i64):
+    v10 = isub v1, v2
+    ; check: v1 = iconcat $(v1_lsb=$V), $(v1_msb=$V)
+    ; nextln: v2 = iconcat $(v2_lsb=$V), $(v2_msb=$V)
+    ; nextln: $(v10_lsb=$V), $(borrow=$V) = isub_bout $v1_lsb, $v2_lsb
+    ; nextln: $(v10_msb=$V) = isub_bin $v1_msb, $v2_msb, $borrow
+    ; nextln: v10 = iconcat $v10_lsb, $v10_msb
     return v10
 }


### PR DESCRIPTION
Add encodings for isub borrow variants (isub_bout, isub_bin, isub_borrow) for x86_32, enabling the legalization for isub.i64 to work.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1576675
Bug: https://github.com/CraneStation/cranelift/issues/765

/cc @bnjbvr @wingo @caitp