### PR TITLE
Don't incorrectly omit a REX prefix for some encodings of `copy_to_ss…

### DIFF
--- a/filetests/isa/x86/binary64-float.clif
+++ b/filetests/isa/x86/binary64-float.clif
@@ -96,6 +96,26 @@ ebb0:
     ; asm: movaps %xmm5, %xmm10
     [-,%xmm10]          v39 = copy v10                          ; bin: 44 0f 28 d5
 
+    ; Copy to SSA
+
+    ; asm: movsd %xmm0, %xmm15
+    [-,%xmm15]          v400 = copy_to_ssa.f64 %xmm0            ; bin: f2 44 0f 10 f8
+    ; asm: movsd %xmm15, %xmm0
+    [-,%xmm0]           v401 = copy_to_ssa.f64 %xmm15           ; bin: f2 41 0f 10 c7
+    ; asm: movsd %xmm7, %xmm6.  Unfortunately we get a redundant REX prefix.
+    [-,%xmm6]           v402 = copy_to_ssa.f64 %xmm7            ; bin: f2 40 0f 10 f7
+    ; asm: movsd %xmm11, %xmm14
+    [-,%xmm14]          v403 = copy_to_ssa.f64 %xmm11           ; bin: f2 45 0f 10 f3
+
+    ; asm: movss %xmm0, %xmm15
+    [-,%xmm15]          v404 = copy_to_ssa.f32 %xmm0            ; bin: f3 44 0f 10 f8
+    ; asm: movss %xmm15, %xmm0
+    [-,%xmm0]           v405 = copy_to_ssa.f32 %xmm15           ; bin: f3 41 0f 10 c7
+    ; asm: movss %xmm7, %xmm6.  Unfortunately we get a redundant REX prefix.
+    [-,%xmm6]           v406 = copy_to_ssa.f32 %xmm7            ; bin: f3 40 0f 10 f7
+    ; asm: movss %xmm11, %xmm14
+    [-,%xmm14]          v407 = copy_to_ssa.f32 %xmm11           ; bin: f3 45 0f 10 f3
+
     ; Convert float to int.
 
     ; asm: cvttss2si %xmm5, %ecx

--- a/filetests/isa/x86/binary64.clif
+++ b/filetests/isa/x86/binary64.clif
@@ -179,6 +179,26 @@ ebb0:
     ; asm: movq %r10, %rsp
     copy_special %r10 -> %rsp                   ; bin: 4c 89 d4
 
+    ; Copy to SSA
+
+    ; asm: movq %rax, %r15
+    [-,%r15]      v700 = copy_to_ssa.i64 %rax    ; bin: 49 89 c7
+    ; asm: movq %r15, %rax
+    [-,%rax]      v701 = copy_to_ssa.i64 %r15    ; bin: 4c 89 f8
+    ; asm: movq %rdi, %rsi
+    [-,%rsi]      v702 = copy_to_ssa.i64 %rdi    ; bin: 48 89 fe
+    ; asm: movq %r11, %r14
+    [-,%r14]      v703 = copy_to_ssa.i64 %r11    ; bin: 4d 89 de
+
+    ; asm: movl %eax, %r15d
+    [-,%r15]      v704 = copy_to_ssa.i32 %rax    ; bin: 41 89 c7
+    ; asm: movl %r15d, %eax
+    [-,%rax]      v705 = copy_to_ssa.i32 %r15    ; bin: 44 89 f8
+    ; asm: movl %edi, %esi.  Unfortunately we get a redundant REX prefix.
+    [-,%rsi]      v706 = copy_to_ssa.i32 %rdi    ; bin: 40 89 fe
+    ; asm: movl %r11, %r14
+    [-,%r14]      v707 = copy_to_ssa.i32 %r11    ; bin: 45 89 de
+
     ; Load/Store instructions.
 
     ; Register indirect addressing with no displacement.


### PR DESCRIPTION
…a`.  Mozilla bug #1576969.

Also, as a ridealong fix, removes R32 encodings for x86_64 in `enc_r32_r64`,
since the type `rXX` by definition only exists for targets with word size `XX`
bits.