### PR TITLE
[meta] Use giant structures for Immediates/EntityRefs

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -11,7 +11,6 @@ use std::fmt;
 pub enum Expr {
     Var(VarIndex),
     Literal(Literal),
-    Apply(Apply),
 }
 
 impl Expr {
@@ -39,7 +38,6 @@ impl Expr {
         match self {
             Expr::Var(var_index) => var_pool.get(*var_index).to_rust_code(),
             Expr::Literal(literal) => literal.to_rust_code(),
-            Expr::Apply(a) => a.to_rust_code(var_pool),
         }
     }
 }
@@ -80,9 +78,6 @@ impl DefPool {
     }
     pub fn get(&self, index: DefIndex) -> &Def {
         self.pool.get(index).unwrap()
-    }
-    pub fn get_mut(&mut self, index: DefIndex) -> &mut Def {
-        self.pool.get_mut(index).unwrap()
     }
     pub fn next_index(&self) -> DefIndex {
         self.pool.next_key()
@@ -428,16 +423,6 @@ impl Apply {
         let inst_name = inst_and_bound_types.join(".");
 
         format!("{}({})", inst_name, args)
-    }
-
-    fn to_rust_code(&self, var_pool: &VarPool) -> String {
-        let args = self
-            .args
-            .iter()
-            .map(|arg| arg.to_rust_code(var_pool))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("{}({})", self.inst.name, args)
     }
 
     pub fn inst_predicate(

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::ops;
 use std::rc::Rc;
-use std::slice;
 
 use crate::cdsl::camel_case;
 use crate::cdsl::formats::{
@@ -72,10 +71,6 @@ pub struct InstructionGroup {
 }
 
 impl InstructionGroup {
-    pub fn iter(&self) -> slice::Iter<Instruction> {
-        self.instructions.iter()
-    }
-
     pub fn by_name(&self, name: &'static str) -> &Instruction {
         self.instructions
             .iter()

--- a/cranelift-codegen/meta/src/cdsl/xform.rs
+++ b/cranelift-codegen/meta/src/cdsl/xform.rs
@@ -384,9 +384,6 @@ impl TransformGroups {
     pub fn get(&self, id: TransformGroupIndex) -> &TransformGroup {
         &self.groups[id]
     }
-    pub fn get_mut(&mut self, id: TransformGroupIndex) -> &mut TransformGroup {
-        self.groups.get_mut(id).unwrap()
-    }
     fn next_key(&self) -> TransformGroupIndex {
         self.groups.next_key()
     }

--- a/cranelift-codegen/meta/src/gen_encodings.rs
+++ b/cranelift-codegen/meta/src/gen_encodings.rs
@@ -1126,7 +1126,7 @@ fn gen_isa(defs: &SharedDefinitions, isa: &TargetIsa, fmt: &mut Formatter) {
     fmt.line("};");
 }
 
-pub fn generate(
+pub(crate) fn generate(
     defs: &SharedDefinitions,
     isa: &TargetIsa,
     filename: &str,

--- a/cranelift-codegen/meta/src/gen_inst.rs
+++ b/cranelift-codegen/meta/src/gen_inst.rs
@@ -1059,7 +1059,7 @@ fn gen_builder(instructions: &AllInstructions, formats: &FormatRegistry, fmt: &m
     fmt.line("}");
 }
 
-pub fn generate(
+pub(crate) fn generate(
     shared_defs: &SharedDefinitions,
     opcode_filename: &str,
     inst_builder_filename: &str,

--- a/cranelift-codegen/meta/src/isa/arm32/mod.rs
+++ b/cranelift-codegen/meta/src/isa/arm32/mod.rs
@@ -49,7 +49,7 @@ fn define_regs() -> IsaRegs {
     regs.build()
 }
 
-pub fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
+pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = define_settings(&shared_defs.settings);
     let regs = define_regs();
 

--- a/cranelift-codegen/meta/src/isa/arm64/mod.rs
+++ b/cranelift-codegen/meta/src/isa/arm64/mod.rs
@@ -45,7 +45,7 @@ fn define_registers() -> IsaRegs {
     regs.build()
 }
 
-pub fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
+pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = define_settings(&shared_defs.settings);
     let regs = define_registers();
 

--- a/cranelift-codegen/meta/src/isa/mod.rs
+++ b/cranelift-codegen/meta/src/isa/mod.rs
@@ -55,7 +55,7 @@ impl fmt::Display for Isa {
     }
 }
 
-pub fn define(isas: &Vec<Isa>, shared_defs: &mut SharedDefinitions) -> Vec<TargetIsa> {
+pub(crate) fn define(isas: &Vec<Isa>, shared_defs: &mut SharedDefinitions) -> Vec<TargetIsa> {
     isas.iter()
         .map(|isa| match isa {
             Isa::Riscv => riscv::define(shared_defs),

--- a/cranelift-codegen/meta/src/isa/riscv/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/encodings.rs
@@ -230,8 +230,7 @@ pub fn define<'defs>(
          -> InstructionPredicateNode {
             let x = var_pool.create("x");
             let y = var_pool.create("y");
-            let cc =
-                Literal::enumerator_for(shared_defs.operand_kinds.by_name("intcc"), intcc_field);
+            let cc = Literal::enumerator_for(&shared_defs.imm.intcc, intcc_field);
             Apply::new(
                 bound_inst.clone().into(),
                 vec![Expr::Literal(cc), Expr::Var(x), Expr::Var(y)],
@@ -313,8 +312,7 @@ pub fn define<'defs>(
             let y = var_pool.create("y");
             let dest = var_pool.create("dest");
             let args = var_pool.create("args");
-            let cc =
-                Literal::enumerator_for(shared_defs.operand_kinds.by_name("intcc"), intcc_field);
+            let cc = Literal::enumerator_for(&shared_defs.imm.intcc, intcc_field);
             Apply::new(
                 bound_inst.clone().into(),
                 vec![

--- a/cranelift-codegen/meta/src/isa/riscv/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/encodings.rs
@@ -101,7 +101,7 @@ fn lui_bits() -> u16 {
     0b01101
 }
 
-pub fn define<'defs>(
+pub(crate) fn define<'defs>(
     shared_defs: &'defs SharedDefinitions,
     isa_settings: &SettingGroup,
     recipes: &'defs RecipeGroup,

--- a/cranelift-codegen/meta/src/isa/riscv/mod.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/mod.rs
@@ -85,7 +85,7 @@ fn define_registers() -> IsaRegs {
     regs.build()
 }
 
-pub fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
+pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = define_settings(&shared_defs.settings);
     let regs = define_registers();
 

--- a/cranelift-codegen/meta/src/isa/riscv/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/recipes.rs
@@ -50,7 +50,7 @@ impl<'formats> RecipeGroup<'formats> {
     }
 }
 
-pub fn define<'formats>(
+pub(crate) fn define<'formats>(
     shared_defs: &'formats SharedDefinitions,
     regs: &IsaRegs,
 ) -> RecipeGroup<'formats> {

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -318,7 +318,7 @@ impl PerCpuModeEncodings {
 
 // Definitions.
 
-pub fn define(
+pub(crate) fn define(
     shared_defs: &SharedDefinitions,
     settings: &SettingGroup,
     x86: &InstructionGroup,

--- a/cranelift-codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift-codegen/meta/src/isa/x86/instructions.rs
@@ -10,7 +10,7 @@ use crate::cdsl::typevar::{Interval, TypeSetBuilder, TypeVar};
 use crate::shared::immediates::Immediates;
 use crate::shared::types;
 
-pub fn define(
+pub(crate) fn define(
     mut all_instructions: &mut AllInstructions,
     format_registry: &FormatRegistry,
     immediates: &Immediates,

--- a/cranelift-codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift-codegen/meta/src/isa/x86/instructions.rs
@@ -7,11 +7,13 @@ use crate::cdsl::instructions::{
 use crate::cdsl::operands::{create_operand as operand, create_operand_doc as operand_doc};
 use crate::cdsl::types::ValueType;
 use crate::cdsl::typevar::{Interval, TypeSetBuilder, TypeVar};
-use crate::shared::{immediates, types, OperandKinds};
+use crate::shared::immediates::Immediates;
+use crate::shared::types;
 
 pub fn define(
     mut all_instructions: &mut AllInstructions,
     format_registry: &FormatRegistry,
+    immediates: &Immediates,
 ) -> InstructionGroup {
     let mut ig = InstructionGroupBuilder::new(
         "x86",
@@ -249,8 +251,7 @@ pub fn define(
         .operands_out(vec![y, rflags]),
     );
 
-    let immediates = OperandKinds::from(immediates::define());
-    let uimm8 = immediates.by_name("uimm8");
+    let uimm8 = &immediates.uimm8;
     let TxN = &TypeVar::new(
         "TxN",
         "A SIMD vector type",

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -58,12 +58,7 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
     let x86_umulx = x86_instructions.by_name("x86_umulx");
     let x86_smulx = x86_instructions.by_name("x86_smulx");
 
-    // List of immediates.
-    let floatcc = shared.operand_kinds.by_name("floatcc");
-    let imm64 = shared.operand_kinds.by_name("imm64");
-    let intcc = shared.operand_kinds.by_name("intcc");
-    let uimm8 = shared.operand_kinds.by_name("uimm8");
-    let ieee64 = shared.operand_kinds.by_name("ieee64");
+    let imm = &shared.imm;
 
     // Division and remainder.
     //
@@ -99,12 +94,12 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
     // `ucomiss` or `ucomisd` instruction. The remaining codes need legalization
     // patterns.
 
-    let floatcc_eq = Literal::enumerator_for(floatcc, "eq");
-    let floatcc_ord = Literal::enumerator_for(floatcc, "ord");
-    let floatcc_ueq = Literal::enumerator_for(floatcc, "ueq");
-    let floatcc_ne = Literal::enumerator_for(floatcc, "ne");
-    let floatcc_uno = Literal::enumerator_for(floatcc, "uno");
-    let floatcc_one = Literal::enumerator_for(floatcc, "one");
+    let floatcc_eq = Literal::enumerator_for(&imm.floatcc, "eq");
+    let floatcc_ord = Literal::enumerator_for(&imm.floatcc, "ord");
+    let floatcc_ueq = Literal::enumerator_for(&imm.floatcc, "ueq");
+    let floatcc_ne = Literal::enumerator_for(&imm.floatcc, "ne");
+    let floatcc_uno = Literal::enumerator_for(&imm.floatcc, "uno");
+    let floatcc_one = Literal::enumerator_for(&imm.floatcc, "one");
 
     // Equality needs an explicit `ord` test which checks the parity bit.
     group.legalize(
@@ -124,14 +119,14 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
         ],
     );
 
-    let floatcc_lt = &Literal::enumerator_for(floatcc, "lt");
-    let floatcc_gt = &Literal::enumerator_for(floatcc, "gt");
-    let floatcc_le = &Literal::enumerator_for(floatcc, "le");
-    let floatcc_ge = &Literal::enumerator_for(floatcc, "ge");
-    let floatcc_ugt = &Literal::enumerator_for(floatcc, "ugt");
-    let floatcc_ult = &Literal::enumerator_for(floatcc, "ult");
-    let floatcc_uge = &Literal::enumerator_for(floatcc, "uge");
-    let floatcc_ule = &Literal::enumerator_for(floatcc, "ule");
+    let floatcc_lt = &Literal::enumerator_for(&imm.floatcc, "lt");
+    let floatcc_gt = &Literal::enumerator_for(&imm.floatcc, "gt");
+    let floatcc_le = &Literal::enumerator_for(&imm.floatcc, "le");
+    let floatcc_ge = &Literal::enumerator_for(&imm.floatcc, "ge");
+    let floatcc_ugt = &Literal::enumerator_for(&imm.floatcc, "ugt");
+    let floatcc_ult = &Literal::enumerator_for(&imm.floatcc, "ult");
+    let floatcc_uge = &Literal::enumerator_for(&imm.floatcc, "uge");
+    let floatcc_ule = &Literal::enumerator_for(&imm.floatcc, "ule");
 
     // Inequalities that need to be reversed.
     for &(cc, rev_cc) in &[
@@ -165,9 +160,9 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
     let r2flags = var("r2flags");
     let index2 = var("index2");
 
-    let intcc_eq = Literal::enumerator_for(intcc, "eq");
-    let imm64_minus_one = Literal::constant(imm64, -1);
-    let imm64_63 = Literal::constant(imm64, 63);
+    let intcc_eq = Literal::enumerator_for(&imm.intcc, "eq");
+    let imm64_minus_one = Literal::constant(&imm.imm64, -1);
+    let imm64_63 = Literal::constant(&imm.imm64, 63);
     group.legalize(
         def!(a = clz.I64(x)),
         vec![
@@ -179,7 +174,7 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
         ],
     );
 
-    let imm64_31 = Literal::constant(imm64, 31);
+    let imm64_31 = Literal::constant(&imm.imm64, 31);
     group.legalize(
         def!(a = clz.I32(x)),
         vec![
@@ -191,7 +186,7 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
         ],
     );
 
-    let imm64_64 = Literal::constant(imm64, 64);
+    let imm64_64 = Literal::constant(&imm.imm64, 64);
     group.legalize(
         def!(a = ctz.I64(x)),
         vec![
@@ -201,7 +196,7 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
         ],
     );
 
-    let imm64_32 = Literal::constant(imm64, 32);
+    let imm64_32 = Literal::constant(&imm.imm64, 32);
     group.legalize(
         def!(a = ctz.I32(x)),
         vec![
@@ -232,13 +227,13 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
     let qc0F = var("qc0F");
     let qc01 = var("qc01");
 
-    let imm64_1 = Literal::constant(imm64, 1);
-    let imm64_4 = Literal::constant(imm64, 4);
+    let imm64_1 = Literal::constant(&imm.imm64, 1);
+    let imm64_4 = Literal::constant(&imm.imm64, 4);
     group.legalize(
         def!(qv16 = popcnt.I64(qv1)),
         vec![
             def!(qv3 = ushr_imm(qv1, imm64_1)),
-            def!(qc77 = iconst(Literal::constant(imm64, 0x7777777777777777))),
+            def!(qc77 = iconst(Literal::constant(&imm.imm64, 0x7777777777777777))),
             def!(qv4 = band(qv3, qc77)),
             def!(qv5 = isub(qv1, qv4)),
             def!(qv6 = ushr_imm(qv4, imm64_1)),
@@ -249,11 +244,11 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
             def!(qv11 = isub(qv8, qv10)),
             def!(qv12 = ushr_imm(qv11, imm64_4)),
             def!(qv13 = iadd(qv11, qv12)),
-            def!(qc0F = iconst(Literal::constant(imm64, 0x0F0F0F0F0F0F0F0F))),
+            def!(qc0F = iconst(Literal::constant(&imm.imm64, 0x0F0F0F0F0F0F0F0F))),
             def!(qv14 = band(qv13, qc0F)),
-            def!(qc01 = iconst(Literal::constant(imm64, 0x0101010101010101))),
+            def!(qc01 = iconst(Literal::constant(&imm.imm64, 0x0101010101010101))),
             def!(qv15 = imul(qv14, qc01)),
-            def!(qv16 = ushr_imm(qv15, Literal::constant(imm64, 56))),
+            def!(qv16 = ushr_imm(qv15, Literal::constant(&imm.imm64, 56))),
         ],
     );
 
@@ -281,7 +276,7 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
         def!(lv16 = popcnt.I32(lv1)),
         vec![
             def!(lv3 = ushr_imm(lv1, imm64_1)),
-            def!(lc77 = iconst(Literal::constant(imm64, 0x77777777))),
+            def!(lc77 = iconst(Literal::constant(&imm.imm64, 0x77777777))),
             def!(lv4 = band(lv3, lc77)),
             def!(lv5 = isub(lv1, lv4)),
             def!(lv6 = ushr_imm(lv4, imm64_1)),
@@ -292,11 +287,11 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
             def!(lv11 = isub(lv8, lv10)),
             def!(lv12 = ushr_imm(lv11, imm64_4)),
             def!(lv13 = iadd(lv11, lv12)),
-            def!(lc0F = iconst(Literal::constant(imm64, 0x0F0F0F0F))),
+            def!(lc0F = iconst(Literal::constant(&imm.imm64, 0x0F0F0F0F))),
             def!(lv14 = band(lv13, lc0F)),
-            def!(lc01 = iconst(Literal::constant(imm64, 0x01010101))),
+            def!(lc01 = iconst(Literal::constant(&imm.imm64, 0x01010101))),
             def!(lv15 = imul(lv14, lc01)),
-            def!(lv16 = ushr_imm(lv15, Literal::constant(imm64, 24))),
+            def!(lv16 = ushr_imm(lv15, Literal::constant(&imm.imm64, 24))),
         ],
     );
 
@@ -313,9 +308,9 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
     .chain_with(shared.transform_groups.by_name("narrow").id);
 
     // SIMD
-    let uimm8_zero = Literal::constant(uimm8, 0x00);
-    let uimm8_one = Literal::constant(uimm8, 0x01);
-    let ieee64_zero = Literal::constant(ieee64, 0x00);
+    let uimm8_zero = Literal::constant(&imm.uimm8, 0x00);
+    let uimm8_one = Literal::constant(&imm.uimm8, 0x01);
+    let ieee64_zero = Literal::constant(&imm.ieee64, 0x00);
     let b = var("b");
     let c = var("c");
     let d = var("d");

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -6,7 +6,7 @@ use crate::shared::types::Float::F64;
 use crate::shared::types::Int::{I32, I64};
 use crate::shared::Definitions as SharedDefinitions;
 
-pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGroup) {
+pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGroup) {
     let mut group = TransformGroupBuilder::new(
         "x86_expand",
         r#"

--- a/cranelift-codegen/meta/src/isa/x86/mod.rs
+++ b/cranelift-codegen/meta/src/isa/x86/mod.rs
@@ -13,7 +13,7 @@ mod recipes;
 mod registers;
 mod settings;
 
-pub fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
+pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = settings::define(&shared_defs.settings);
     let regs = registers::define();
 

--- a/cranelift-codegen/meta/src/isa/x86/mod.rs
+++ b/cranelift-codegen/meta/src/isa/x86/mod.rs
@@ -20,6 +20,7 @@ pub fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let inst_group = instructions::define(
         &mut shared_defs.all_instructions,
         &shared_defs.format_registry,
+        &shared_defs.imm,
     );
     legalize::define(shared_defs, &inst_group);
 

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -332,7 +332,7 @@ pub fn define<'shared>(
 ) -> RecipeGroup<'shared> {
     // The set of floating point condition codes that are directly supported.
     // Other condition codes need to be reversed or expressed as two tests.
-    let floatcc = shared_defs.operand_kinds.by_name("floatcc");
+    let floatcc = &shared_defs.imm.floatcc;
     let supported_floatccs: Vec<Literal> = ["ord", "uno", "one", "ueq", "gt", "ge", "ult", "ule"]
         .iter()
         .map(|name| Literal::enumerator_for(floatcc, name))

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -325,7 +325,7 @@ fn valid_scale(format: &InstructionFormat) -> InstructionPredicate {
         })
 }
 
-pub fn define<'shared>(
+pub(crate) fn define<'shared>(
     shared_defs: &'shared SharedDefinitions,
     settings: &'shared SettingGroup,
     regs: &'shared IsaRegs,

--- a/cranelift-codegen/meta/src/shared/entities.rs
+++ b/cranelift-codegen/meta/src/shared/entities.rs
@@ -1,65 +1,76 @@
 use crate::cdsl::operands::{OperandKind, OperandKindBuilder as Builder, OperandKindFields};
 
+pub struct EntityRefs {
+    /// A reference to an extended basic block in the same function.
+    /// This is primarliy used in control flow instructions.
+    pub ebb: OperandKind,
+
+    /// A reference to a stack slot declared in the function preamble.
+    pub stack_slot: OperandKind,
+
+    /// A reference to a global value.
+    pub global_value: OperandKind,
+
+    /// A reference to a function signature declared in the function preamble.
+    /// This is used to provide the call signature in a call_indirect instruction.
+    pub sig_ref: OperandKind,
+
+    /// A reference to an external function declared in the function preamble.
+    /// This is used to provide the callee and signature in a call instruction.
+    pub func_ref: OperandKind,
+
+    /// A reference to a jump table declared in the function preamble.
+    pub jump_table: OperandKind,
+
+    /// A reference to a heap declared in the function preamble.
+    pub heap: OperandKind,
+
+    /// A reference to a table declared in the function preamble.
+    pub table: OperandKind,
+
+    /// A variable-sized list of value operands. Use for Ebb and function call arguments.
+    pub varargs: OperandKind,
+}
+
+impl EntityRefs {
+    pub fn new() -> Self {
+        Self {
+            ebb: create("ebb", "An extended basic block in the same function.")
+                .default_member("destination")
+                .build(),
+
+            stack_slot: create("stack_slot", "A stack slot").build(),
+
+            global_value: create("global_value", "A global value.").build(),
+
+            sig_ref: create("sig_ref", "A function signature.").build(),
+
+            func_ref: create("func_ref", "An external function.").build(),
+
+            jump_table: create("jump_table", "A jump table.")
+                .default_member("table")
+                .build(),
+
+            heap: create("heap", "A heap.").build(),
+
+            table: create("table", "A table.").build(),
+
+            varargs: Builder::new("variable_args", OperandKindFields::VariableArgs)
+                .doc(
+                    r#"
+                        A variable size list of `value` operands.
+
+                        Use this to represent arguments passed to a function call, arguments
+                        passed to an extended basic block, or a variable number of results
+                        returned from an instruction.
+                    "#,
+                )
+                .build(),
+        }
+    }
+}
+
 /// Small helper to initialize an OperandBuilder with the right kind, for a given name and doc.
 fn create(name: &'static str, doc: &'static str) -> Builder {
     Builder::new(name, OperandKindFields::EntityRef).doc(doc)
-}
-
-pub fn define() -> Vec<OperandKind> {
-    let mut kinds = Vec::new();
-
-    // A reference to an extended basic block in the same function.
-    // This is primarliy used in control flow instructions.
-    let ebb = create("ebb", "An extended basic block in the same function.")
-        .default_member("destination")
-        .build();
-    kinds.push(ebb);
-
-    // A reference to a stack slot declared in the function preamble.
-    let stack_slot = create("stack_slot", "A stack slot").build();
-    kinds.push(stack_slot);
-
-    // A reference to a global value.
-    let global_value = create("global_value", "A global value.").build();
-    kinds.push(global_value);
-
-    // A reference to a function signature declared in the function preamble.
-    // This is used to provide the call signature in a call_indirect instruction.
-    let sig_ref = create("sig_ref", "A function signature.").build();
-    kinds.push(sig_ref);
-
-    // A reference to an external function declared in the function preamble.
-    // This is used to provide the callee and signature in a call instruction.
-    let func_ref = create("func_ref", "An external function.").build();
-    kinds.push(func_ref);
-
-    // A reference to a jump table declared in the function preamble.
-    let jump_table = create("jump_table", "A jump table.")
-        .default_member("table")
-        .build();
-    kinds.push(jump_table);
-
-    // A reference to a heap declared in the function preamble.
-    let heap = create("heap", "A heap.").build();
-    kinds.push(heap);
-
-    // A reference to a table declared in the function preamble.
-    let table = create("table", "A table.").build();
-    kinds.push(table);
-
-    // A variable-sized list of value operands. Use for Ebb and function call arguments.
-    let varargs = Builder::new("variable_args", OperandKindFields::VariableArgs)
-        .doc(
-            r#"
-            A variable size list of `value` operands.
-
-            Use this to represent arguments passed to a function call, arguments
-            passed to an extended basic block, or a variable number of results
-            returned from an instruction.
-        "#,
-        )
-        .build();
-    kinds.push(varargs);
-
-    return kinds;
 }

--- a/cranelift-codegen/meta/src/shared/formats.rs
+++ b/cranelift-codegen/meta/src/shared/formats.rs
@@ -1,7 +1,7 @@
 use crate::cdsl::formats::{FormatRegistry, InstructionFormatBuilder as Builder};
 use crate::shared::{entities::EntityRefs, immediates::Immediates};
 
-pub fn define(imm: &Immediates, entities: &EntityRefs) -> FormatRegistry {
+pub(crate) fn define(imm: &Immediates, entities: &EntityRefs) -> FormatRegistry {
     let mut registry = FormatRegistry::new();
 
     registry.insert(Builder::new("Unary").value());

--- a/cranelift-codegen/meta/src/shared/formats.rs
+++ b/cranelift-codegen/meta/src/shared/formats.rs
@@ -1,22 +1,8 @@
 use crate::cdsl::formats::{FormatRegistry, InstructionFormatBuilder as Builder};
+use crate::shared::immediates::Immediates;
 use crate::shared::OperandKinds;
 
-pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegistry {
-    // Shorthands for immediates.
-    let uimm8 = immediates.by_name("uimm8");
-    let uimm32 = immediates.by_name("uimm32");
-    let uimm128 = immediates.by_name("uimm128");
-    let imm64 = immediates.by_name("imm64");
-    let ieee32 = immediates.by_name("ieee32");
-    let ieee64 = immediates.by_name("ieee64");
-    let boolean = immediates.by_name("boolean");
-    let intcc = immediates.by_name("intcc");
-    let floatcc = immediates.by_name("floatcc");
-    let memflags = immediates.by_name("memflags");
-    let offset32 = immediates.by_name("offset32");
-    let trapcode = immediates.by_name("trapcode");
-    let regunit = immediates.by_name("regunit");
-
+pub fn define(imm: &Immediates, entities: &OperandKinds) -> FormatRegistry {
     // Shorthands for entities.
     let global_value = entities.by_name("global_value");
     let ebb = entities.by_name("ebb");
@@ -30,15 +16,15 @@ pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegis
     let mut registry = FormatRegistry::new();
 
     registry.insert(Builder::new("Unary").value());
-    registry.insert(Builder::new("UnaryImm").imm(imm64));
-    registry.insert(Builder::new("UnaryImm128").imm(uimm128));
-    registry.insert(Builder::new("UnaryIeee32").imm(ieee32));
-    registry.insert(Builder::new("UnaryIeee64").imm(ieee64));
-    registry.insert(Builder::new("UnaryBool").imm(boolean));
+    registry.insert(Builder::new("UnaryImm").imm(&imm.imm64));
+    registry.insert(Builder::new("UnaryImm128").imm(&imm.uimm128));
+    registry.insert(Builder::new("UnaryIeee32").imm(&imm.ieee32));
+    registry.insert(Builder::new("UnaryIeee64").imm(&imm.ieee64));
+    registry.insert(Builder::new("UnaryBool").imm(&imm.boolean));
     registry.insert(Builder::new("UnaryGlobalValue").imm(global_value));
 
     registry.insert(Builder::new("Binary").value().value());
-    registry.insert(Builder::new("BinaryImm").value().imm(imm64));
+    registry.insert(Builder::new("BinaryImm").value().imm(&imm.imm64));
 
     // The select instructions are controlled by the second VALUE operand.
     // The first VALUE operand is the controlling flag which has a derived type.
@@ -60,43 +46,59 @@ pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegis
     registry.insert(
         Builder::new("InsertLane")
             .value()
-            .imm_with_name("lane", uimm8)
+            .imm_with_name("lane", &imm.uimm8)
             .value(),
     );
     registry.insert(
         Builder::new("ExtractLane")
             .value()
-            .imm_with_name("lane", uimm8),
+            .imm_with_name("lane", &imm.uimm8),
     );
 
-    registry.insert(Builder::new("IntCompare").imm(intcc).value().value());
-    registry.insert(Builder::new("IntCompareImm").imm(intcc).value().imm(imm64));
-    registry.insert(Builder::new("IntCond").imm(intcc).value());
+    registry.insert(Builder::new("IntCompare").imm(&imm.intcc).value().value());
+    registry.insert(
+        Builder::new("IntCompareImm")
+            .imm(&imm.intcc)
+            .value()
+            .imm(&imm.imm64),
+    );
+    registry.insert(Builder::new("IntCond").imm(&imm.intcc).value());
 
-    registry.insert(Builder::new("FloatCompare").imm(floatcc).value().value());
-    registry.insert(Builder::new("FloatCond").imm(floatcc).value());;
+    registry.insert(
+        Builder::new("FloatCompare")
+            .imm(&imm.floatcc)
+            .value()
+            .value(),
+    );
+    registry.insert(Builder::new("FloatCond").imm(&imm.floatcc).value());;
 
-    registry.insert(Builder::new("IntSelect").imm(intcc).value().value().value());
+    registry.insert(
+        Builder::new("IntSelect")
+            .imm(&imm.intcc)
+            .value()
+            .value()
+            .value(),
+    );
 
     registry.insert(Builder::new("Jump").imm(ebb).varargs());
     registry.insert(Builder::new("Branch").value().imm(ebb).varargs());
     registry.insert(
         Builder::new("BranchInt")
-            .imm(intcc)
+            .imm(&imm.intcc)
             .value()
             .imm(ebb)
             .varargs(),
     );
     registry.insert(
         Builder::new("BranchFloat")
-            .imm(floatcc)
+            .imm(&imm.floatcc)
             .value()
             .imm(ebb)
             .varargs(),
     );
     registry.insert(
         Builder::new("BranchIcmp")
-            .imm(intcc)
+            .imm(&imm.intcc)
             .value()
             .value()
             .imm(ebb)
@@ -107,7 +109,7 @@ pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegis
         Builder::new("BranchTableEntry")
             .value()
             .value()
-            .imm(uimm8)
+            .imm(&imm.uimm8)
             .imm(jump_table),
     );
     registry.insert(Builder::new("BranchTableBase").imm(jump_table));
@@ -117,74 +119,89 @@ pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegis
     registry.insert(Builder::new("CallIndirect").imm(sig_ref).value().varargs());
     registry.insert(Builder::new("FuncAddr").imm(func_ref));
 
-    registry.insert(Builder::new("Load").imm(memflags).value().imm(offset32));
+    registry.insert(
+        Builder::new("Load")
+            .imm(&imm.memflags)
+            .value()
+            .imm(&imm.offset32),
+    );
     registry.insert(
         Builder::new("LoadComplex")
-            .imm(memflags)
+            .imm(&imm.memflags)
             .varargs()
-            .imm(offset32),
+            .imm(&imm.offset32),
     );
     registry.insert(
         Builder::new("Store")
-            .imm(memflags)
+            .imm(&imm.memflags)
             .value()
             .value()
-            .imm(offset32),
+            .imm(&imm.offset32),
     );
     registry.insert(
         Builder::new("StoreComplex")
-            .imm(memflags)
+            .imm(&imm.memflags)
             .value()
             .varargs()
-            .imm(offset32),
+            .imm(&imm.offset32),
     );
-    registry.insert(Builder::new("StackLoad").imm(stack_slot).imm(offset32));
+    registry.insert(Builder::new("StackLoad").imm(stack_slot).imm(&imm.offset32));
     registry.insert(
         Builder::new("StackStore")
             .value()
             .imm(stack_slot)
-            .imm(offset32),
+            .imm(&imm.offset32),
     );
 
     // Accessing a WebAssembly heap.
-    registry.insert(Builder::new("HeapAddr").imm(heap).value().imm(uimm32));
+    registry.insert(Builder::new("HeapAddr").imm(heap).value().imm(&imm.uimm32));
 
     // Accessing a WebAssembly table.
-    registry.insert(Builder::new("TableAddr").imm(table).value().imm(offset32));
+    registry.insert(
+        Builder::new("TableAddr")
+            .imm(table)
+            .value()
+            .imm(&imm.offset32),
+    );
 
     registry.insert(
         Builder::new("RegMove")
             .value()
-            .imm_with_name("src", regunit)
-            .imm_with_name("dst", regunit),
+            .imm_with_name("src", &imm.regunit)
+            .imm_with_name("dst", &imm.regunit),
     );
     registry.insert(
         Builder::new("CopySpecial")
-            .imm_with_name("src", regunit)
-            .imm_with_name("dst", regunit),
+            .imm_with_name("src", &imm.regunit)
+            .imm_with_name("dst", &imm.regunit),
     );
-    registry.insert(Builder::new("CopyToSsa").imm_with_name("src", regunit));
+    registry.insert(Builder::new("CopyToSsa").imm_with_name("src", &imm.regunit));
     registry.insert(
         Builder::new("RegSpill")
             .value()
-            .imm_with_name("src", regunit)
+            .imm_with_name("src", &imm.regunit)
             .imm_with_name("dst", stack_slot),
     );
     registry.insert(
         Builder::new("RegFill")
             .value()
             .imm_with_name("src", stack_slot)
-            .imm_with_name("dst", regunit),
+            .imm_with_name("dst", &imm.regunit),
     );
 
-    registry.insert(Builder::new("Trap").imm(trapcode));
-    registry.insert(Builder::new("CondTrap").value().imm(trapcode));
-    registry.insert(Builder::new("IntCondTrap").imm(intcc).value().imm(trapcode));
+    registry.insert(Builder::new("Trap").imm(&imm.trapcode));
+    registry.insert(Builder::new("CondTrap").value().imm(&imm.trapcode));
+    registry.insert(
+        Builder::new("IntCondTrap")
+            .imm(&imm.intcc)
+            .value()
+            .imm(&imm.trapcode),
+    );
     registry.insert(
         Builder::new("FloatCondTrap")
-            .imm(floatcc)
+            .imm(&imm.floatcc)
             .value()
-            .imm(trapcode),
+            .imm(&imm.trapcode),
     );
 
     registry

--- a/cranelift-codegen/meta/src/shared/immediates.rs
+++ b/cranelift-codegen/meta/src/shared/immediates.rs
@@ -2,7 +2,7 @@ use crate::cdsl::operands::{OperandKind, OperandKindBuilder as Builder};
 
 use std::collections::HashMap;
 
-pub struct Immediates {
+pub(crate) struct Immediates {
     /// A 64-bit immediate integer operand.
     ///
     /// This type of immediate integer can interact with SSA values with any IntType type.

--- a/cranelift-codegen/meta/src/shared/immediates.rs
+++ b/cranelift-codegen/meta/src/shared/immediates.rs
@@ -2,154 +2,174 @@ use crate::cdsl::operands::{OperandKind, OperandKindBuilder as Builder};
 
 use std::collections::HashMap;
 
-pub fn define() -> Vec<OperandKind> {
-    let mut kinds = Vec::new();
+pub struct Immediates {
+    /// A 64-bit immediate integer operand.
+    ///
+    /// This type of immediate integer can interact with SSA values with any IntType type.
+    pub imm64: OperandKind,
 
-    // A 64-bit immediate integer operand.
-    //
-    // This type of immediate integer can interact with SSA values with any
-    // IntType type.
-    let imm64 = Builder::new_imm("imm64")
-        .doc("A 64-bit immediate integer.")
-        .build();
-    kinds.push(imm64);
+    /// An unsigned 8-bit immediate integer operand.
+    ///
+    /// This small operand is used to indicate lane indexes in SIMD vectors and immediate bit
+    /// counts on shift instructions.
+    pub uimm8: OperandKind,
 
-    // An unsigned 8-bit immediate integer operand.
-    //
-    // This small operand is used to indicate lane indexes in SIMD vectors and
-    // immediate bit counts on shift instructions.
-    let uimm8 = Builder::new_imm("uimm8")
-        .doc("An 8-bit immediate unsigned integer.")
-        .build();
-    kinds.push(uimm8);
+    /// An unsigned 32-bit immediate integer operand.
+    pub uimm32: OperandKind,
 
-    // An unsigned 32-bit immediate integer operand.
-    let uimm32 = Builder::new_imm("uimm32")
-        .doc("A 32-bit immediate unsigned integer.")
-        .build();
-    kinds.push(uimm32);
+    /// An unsigned 128-bit immediate integer operand.
+    ///
+    /// This operand is used to pass entire 128-bit vectors as immediates to instructions like
+    /// const.
+    pub uimm128: OperandKind,
 
-    // An unsigned 128-bit immediate integer operand.
-    //
-    // This operand is used to pass entire 128-bit vectors as immediates to
-    // instructions like const.
-    let uimm128 = Builder::new_imm("uimm128")
-        .doc("A 128-bit immediate unsigned integer.")
-        .rust_type("ir::Constant")
-        .build();
-    kinds.push(uimm128);
+    /// A 32-bit immediate signed offset.
+    ///
+    /// This is used to represent an immediate address offset in load/store instructions.
+    pub offset32: OperandKind,
 
-    // A 32-bit immediate signed offset.
-    //
-    // This is used to represent an immediate address offset in load/store
-    // instructions.
-    let offset32 = Builder::new_imm("offset32")
-        .doc("A 32-bit immediate signed offset.")
-        .default_member("offset")
-        .build();
-    kinds.push(offset32);
+    /// A 32-bit immediate floating point operand.
+    ///
+    /// IEEE 754-2008 binary32 interchange format.
+    pub ieee32: OperandKind,
 
-    // A 32-bit immediate floating point operand.
-    //
-    // IEEE 754-2008 binary32 interchange format.
-    let ieee32 = Builder::new_imm("ieee32")
-        .doc("A 32-bit immediate floating point number.")
-        .build();
-    kinds.push(ieee32);
+    /// A 64-bit immediate floating point operand.
+    ///
+    /// IEEE 754-2008 binary64 interchange format.
+    pub ieee64: OperandKind,
 
-    // A 64-bit immediate floating point operand.
-    //
-    // IEEE 754-2008 binary64 interchange format.
-    let ieee64 = Builder::new_imm("ieee64")
-        .doc("A 64-bit immediate floating point number.")
-        .build();
-    kinds.push(ieee64);
+    /// An immediate boolean operand.
+    ///
+    /// This type of immediate boolean can interact with SSA values with any BoolType type.
+    pub boolean: OperandKind,
 
-    // An immediate boolean operand.
-    //
-    // This type of immediate boolean can interact with SSA values with any
-    // BoolType type.
-    let boolean = Builder::new_imm("boolean")
-        .doc("An immediate boolean.")
-        .rust_type("bool")
-        .build();
-    kinds.push(boolean);
+    /// A condition code for comparing integer values.
+    ///
+    /// This enumerated operand kind is used for the `icmp` instruction and corresponds to the
+    /// condcodes::IntCC` Rust type.
+    pub intcc: OperandKind,
 
-    // A condition code for comparing integer values.
-    // This enumerated operand kind is used for the `icmp` instruction and corresponds to the
-    // condcodes::IntCC` Rust type.
-    let mut intcc_values = HashMap::new();
-    intcc_values.insert("eq", "Equal");
-    intcc_values.insert("ne", "NotEqual");
-    intcc_values.insert("sge", "SignedGreaterThanOrEqual");
-    intcc_values.insert("sgt", "SignedGreaterThan");
-    intcc_values.insert("sle", "SignedLessThanOrEqual");
-    intcc_values.insert("slt", "SignedLessThan");
-    intcc_values.insert("uge", "UnsignedGreaterThanOrEqual");
-    intcc_values.insert("ugt", "UnsignedGreaterThan");
-    intcc_values.insert("ule", "UnsignedLessThanOrEqual");
-    intcc_values.insert("ult", "UnsignedLessThan");
-    let intcc = Builder::new_enum("intcc", intcc_values)
-        .doc("An integer comparison condition code.")
-        .default_member("cond")
-        .rust_type("ir::condcodes::IntCC")
-        .build();
-    kinds.push(intcc);
+    /// A condition code for comparing floating point values.
+    ///
+    /// This enumerated operand kind is used for the `fcmp` instruction and corresponds to the
+    /// `condcodes::FloatCC` Rust type.
+    pub floatcc: OperandKind,
 
-    // A condition code for comparing floating point values.  This enumerated operand kind is used
-    // for the `fcmp` instruction and corresponds to the `condcodes::FloatCC` Rust type.
-    let mut floatcc_values = HashMap::new();
-    floatcc_values.insert("ord", "Ordered");
-    floatcc_values.insert("uno", "Unordered");
-    floatcc_values.insert("eq", "Equal");
-    floatcc_values.insert("ne", "NotEqual");
-    floatcc_values.insert("one", "OrderedNotEqual");
-    floatcc_values.insert("ueq", "UnorderedOrEqual");
-    floatcc_values.insert("lt", "LessThan");
-    floatcc_values.insert("le", "LessThanOrEqual");
-    floatcc_values.insert("gt", "GreaterThan");
-    floatcc_values.insert("ge", "GreaterThanOrEqual");
-    floatcc_values.insert("ult", "UnorderedOrLessThan");
-    floatcc_values.insert("ule", "UnorderedOrLessThanOrEqual");
-    floatcc_values.insert("ugt", "UnorderedOrGreaterThan");
-    floatcc_values.insert("uge", "UnorderedOrGreaterThanOrEqual");
-    let floatcc = Builder::new_enum("floatcc", floatcc_values)
-        .doc("A floating point comparison condition code")
-        .default_member("cond")
-        .rust_type("ir::condcodes::FloatCC")
-        .build();
-    kinds.push(floatcc);
+    /// Flags for memory operations like `load` and `store`.
+    pub memflags: OperandKind,
 
-    // Flags for memory operations like :clif:inst:`load` and :clif:inst:`store`.
-    let memflags = Builder::new_imm("memflags")
-        .doc("Memory operation flags")
-        .default_member("flags")
-        .rust_type("ir::MemFlags")
-        .build();
-    kinds.push(memflags);
+    /// A register unit in the current target ISA.
+    pub regunit: OperandKind,
 
-    // A register unit in the current target ISA.
-    let regunit = Builder::new_imm("regunit")
-        .doc("A register unit in the target ISA")
-        .rust_type("isa::RegUnit")
-        .build();
-    kinds.push(regunit);
+    /// A trap code indicating the reason for trapping.
+    ///
+    /// The Rust enum type also has a `User(u16)` variant for user-provided trap codes.
+    pub trapcode: OperandKind,
+}
 
-    // A trap code indicating the reason for trapping.
-    //
-    // The Rust enum type also has a `User(u16)` variant for user-provided trap
-    // codes.
-    let mut trapcode_values = HashMap::new();
-    trapcode_values.insert("stk_ovf", "StackOverflow");
-    trapcode_values.insert("heap_oob", "HeapOutOfBounds");
-    trapcode_values.insert("int_ovf", "IntegerOverflow");
-    trapcode_values.insert("int_divz", "IntegerDivisionByZero");
-    let trapcode = Builder::new_enum("trapcode", trapcode_values)
-        .doc("A trap reason code.")
-        .default_member("code")
-        .rust_type("ir::TrapCode")
-        .build();
-    kinds.push(trapcode);
+impl Immediates {
+    pub fn new() -> Self {
+        Self {
+            imm64: Builder::new_imm("imm64")
+                .doc("A 64-bit immediate integer.")
+                .build(),
 
-    return kinds;
+            uimm8: Builder::new_imm("uimm8")
+                .doc("An 8-bit immediate unsigned integer.")
+                .build(),
+
+            uimm32: Builder::new_imm("uimm32")
+                .doc("A 32-bit immediate unsigned integer.")
+                .build(),
+
+            uimm128: Builder::new_imm("uimm128")
+                .doc("A 128-bit immediate unsigned integer.")
+                .rust_type("ir::Constant")
+                .build(),
+
+            offset32: Builder::new_imm("offset32")
+                .doc("A 32-bit immediate signed offset.")
+                .default_member("offset")
+                .build(),
+
+            ieee32: Builder::new_imm("ieee32")
+                .doc("A 32-bit immediate floating point number.")
+                .build(),
+
+            ieee64: Builder::new_imm("ieee64")
+                .doc("A 64-bit immediate floating point number.")
+                .build(),
+
+            boolean: Builder::new_imm("boolean")
+                .doc("An immediate boolean.")
+                .rust_type("bool")
+                .build(),
+
+            intcc: {
+                let mut intcc_values = HashMap::new();
+                intcc_values.insert("eq", "Equal");
+                intcc_values.insert("ne", "NotEqual");
+                intcc_values.insert("sge", "SignedGreaterThanOrEqual");
+                intcc_values.insert("sgt", "SignedGreaterThan");
+                intcc_values.insert("sle", "SignedLessThanOrEqual");
+                intcc_values.insert("slt", "SignedLessThan");
+                intcc_values.insert("uge", "UnsignedGreaterThanOrEqual");
+                intcc_values.insert("ugt", "UnsignedGreaterThan");
+                intcc_values.insert("ule", "UnsignedLessThanOrEqual");
+                intcc_values.insert("ult", "UnsignedLessThan");
+                Builder::new_enum("intcc", intcc_values)
+                    .doc("An integer comparison condition code.")
+                    .default_member("cond")
+                    .rust_type("ir::condcodes::IntCC")
+                    .build()
+            },
+
+            floatcc: {
+                let mut floatcc_values = HashMap::new();
+                floatcc_values.insert("ord", "Ordered");
+                floatcc_values.insert("uno", "Unordered");
+                floatcc_values.insert("eq", "Equal");
+                floatcc_values.insert("ne", "NotEqual");
+                floatcc_values.insert("one", "OrderedNotEqual");
+                floatcc_values.insert("ueq", "UnorderedOrEqual");
+                floatcc_values.insert("lt", "LessThan");
+                floatcc_values.insert("le", "LessThanOrEqual");
+                floatcc_values.insert("gt", "GreaterThan");
+                floatcc_values.insert("ge", "GreaterThanOrEqual");
+                floatcc_values.insert("ult", "UnorderedOrLessThan");
+                floatcc_values.insert("ule", "UnorderedOrLessThanOrEqual");
+                floatcc_values.insert("ugt", "UnorderedOrGreaterThan");
+                floatcc_values.insert("uge", "UnorderedOrGreaterThanOrEqual");
+                Builder::new_enum("floatcc", floatcc_values)
+                    .doc("A floating point comparison condition code")
+                    .default_member("cond")
+                    .rust_type("ir::condcodes::FloatCC")
+                    .build()
+            },
+
+            memflags: Builder::new_imm("memflags")
+                .doc("Memory operation flags")
+                .default_member("flags")
+                .rust_type("ir::MemFlags")
+                .build(),
+
+            regunit: Builder::new_imm("regunit")
+                .doc("A register unit in the target ISA")
+                .rust_type("isa::RegUnit")
+                .build(),
+
+            trapcode: {
+                let mut trapcode_values = HashMap::new();
+                trapcode_values.insert("stk_ovf", "StackOverflow");
+                trapcode_values.insert("heap_oob", "HeapOutOfBounds");
+                trapcode_values.insert("int_ovf", "IntegerOverflow");
+                trapcode_values.insert("int_divz", "IntegerDivisionByZero");
+                Builder::new_enum("trapcode", trapcode_values)
+                    .doc("A trap reason code.")
+                    .default_member("code")
+                    .rust_type("ir::TrapCode")
+                    .build()
+            },
+        }
+    }
 }

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -11,7 +11,7 @@ use crate::cdsl::typevar::{Interval, TypeSetBuilder, TypeVar};
 use crate::shared::types;
 use crate::shared::{entities::EntityRefs, immediates::Immediates};
 
-pub fn define(
+pub(crate) fn define(
     all_instructions: &mut AllInstructions,
     format_registry: &FormatRegistry,
     imm: &Immediates,

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -6,7 +6,7 @@ use crate::shared::immediates::Immediates;
 use crate::shared::types::Float::{F32, F64};
 use crate::shared::types::Int::{I16, I32, I64, I8};
 
-pub fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGroups {
+pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGroups {
     let mut narrow = TransformGroupBuilder::new(
         "narrow",
         r#"

--- a/cranelift-codegen/meta/src/shared/mod.rs
+++ b/cranelift-codegen/meta/src/shared/mod.rs
@@ -1,6 +1,6 @@
 //! Shared definitions for the Cranelift intermediate language.
 
-pub mod entities;
+mod entities;
 pub mod formats;
 pub mod immediates;
 pub mod instructions;
@@ -10,10 +10,10 @@ pub mod types;
 
 use crate::cdsl::formats::FormatRegistry;
 use crate::cdsl::instructions::{AllInstructions, InstructionGroup};
-use crate::cdsl::operands::OperandKind;
 use crate::cdsl::settings::SettingGroup;
 use crate::cdsl::xform::TransformGroups;
 
+use crate::shared::entities::EntityRefs;
 use crate::shared::immediates::Immediates;
 
 pub struct Definitions {
@@ -25,28 +25,11 @@ pub struct Definitions {
     pub transform_groups: TransformGroups,
 }
 
-pub struct OperandKinds(Vec<OperandKind>);
-
-impl OperandKinds {
-    pub fn by_name(&self, name: &'static str) -> &OperandKind {
-        self.0
-            .iter()
-            .find(|op| op.name == name)
-            .expect(&format!("unknown Operand name: {}", name))
-    }
-}
-
-impl From<Vec<OperandKind>> for OperandKinds {
-    fn from(kinds: Vec<OperandKind>) -> Self {
-        OperandKinds(kinds)
-    }
-}
-
 pub fn define() -> Definitions {
     let mut all_instructions = AllInstructions::new();
 
     let immediates = Immediates::new();
-    let entities = OperandKinds(entities::define());
+    let entities = EntityRefs::new();;
     let format_registry = formats::define(&immediates, &entities);
     let instructions = instructions::define(
         &mut all_instructions,

--- a/cranelift-codegen/meta/src/shared/mod.rs
+++ b/cranelift-codegen/meta/src/shared/mod.rs
@@ -16,7 +16,7 @@ use crate::cdsl::xform::TransformGroups;
 use crate::shared::entities::EntityRefs;
 use crate::shared::immediates::Immediates;
 
-pub struct Definitions {
+pub(crate) struct Definitions {
     pub settings: SettingGroup,
     pub all_instructions: AllInstructions,
     pub instructions: InstructionGroup,
@@ -25,7 +25,7 @@ pub struct Definitions {
     pub transform_groups: TransformGroups,
 }
 
-pub fn define() -> Definitions {
+pub(crate) fn define() -> Definitions {
     let mut all_instructions = AllInstructions::new();
 
     let immediates = Immediates::new();

--- a/cranelift-codegen/meta/src/shared/mod.rs
+++ b/cranelift-codegen/meta/src/shared/mod.rs
@@ -14,11 +14,13 @@ use crate::cdsl::operands::OperandKind;
 use crate::cdsl::settings::SettingGroup;
 use crate::cdsl::xform::TransformGroups;
 
+use crate::shared::immediates::Immediates;
+
 pub struct Definitions {
     pub settings: SettingGroup,
     pub all_instructions: AllInstructions,
     pub instructions: InstructionGroup,
-    pub operand_kinds: OperandKinds,
+    pub imm: Immediates,
     pub format_registry: FormatRegistry,
     pub transform_groups: TransformGroups,
 }
@@ -26,27 +28,11 @@ pub struct Definitions {
 pub struct OperandKinds(Vec<OperandKind>);
 
 impl OperandKinds {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
     pub fn by_name(&self, name: &'static str) -> &OperandKind {
         self.0
             .iter()
             .find(|op| op.name == name)
             .expect(&format!("unknown Operand name: {}", name))
-    }
-
-    pub fn push(&mut self, operand_kind: OperandKind) {
-        assert!(
-            self.0
-                .iter()
-                .find(|existing| existing.name == operand_kind.name)
-                .is_none(),
-            "trying to insert operand kind '{}' for the second time",
-            operand_kind.name
-        );
-        self.0.push(operand_kind);
     }
 }
 
@@ -59,7 +45,7 @@ impl From<Vec<OperandKind>> for OperandKinds {
 pub fn define() -> Definitions {
     let mut all_instructions = AllInstructions::new();
 
-    let immediates = OperandKinds(immediates::define());
+    let immediates = Immediates::new();
     let entities = OperandKinds(entities::define());
     let format_registry = formats::define(&immediates, &entities);
     let instructions = instructions::define(
@@ -74,7 +60,7 @@ pub fn define() -> Definitions {
         settings: settings::define(),
         all_instructions,
         instructions,
-        operand_kinds: immediates,
+        imm: immediates,
         format_registry,
         transform_groups,
     }


### PR DESCRIPTION
... instead of static instances.

This is nice too: it gets the explicit passing to functions that need it (instead of global variables with hacks to make them static), erroneous lookup is impossible, jump-to-definition is better (not as good as static variables: you jump to the definition, and have to look at the constructor to see how it was formed), it doesn't require a new dependency just for the build step.

Would people like this, it'd be much easier to keep on doing this for formats and other things.

cc @abrown @sunfishcode