### PR TITLE
Upgrade to target-lexicon 0.8 and faerie 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = "1.0.8"
 term = "0.6.1"
 capstone = { version = "0.6.0", optional = true }
 wabt = { version = "0.9.1", optional = true }
-target-lexicon = "0.4.0"
+target-lexicon = "0.8.0"
 pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.2"
 indicatif = "0.11.0"

--- a/cranelift-bforest/src/lib.rs
+++ b/cranelift-bforest/src/lib.rs
@@ -32,7 +32,6 @@
     )
 )]
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(test)]
 #[cfg(not(feature = "std"))]

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -18,7 +18,7 @@ cranelift-bforest = { path = "../cranelift-bforest", version = "0.41.0", default
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }
-target-lexicon = { version = "0.4.0", default-features = false }
+target-lexicon = "0.8.0"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
@@ -38,7 +38,6 @@ default = ["std"]
 std = [
     "cranelift-entity/std",
     "cranelift-bforest/std",
-    "target-lexicon/std",
     "cranelift-codegen-meta/std"
 ]
 

--- a/cranelift-codegen/src/isa/arm32/mod.rs
+++ b/cranelift-codegen/src/isa/arm32/mod.rs
@@ -42,14 +42,13 @@ fn isa_constructor(
     builder: shared_settings::Builder,
 ) -> Box<dyn TargetIsa> {
     let level1 = match triple.architecture {
-        Architecture::Thumbv6m | Architecture::Thumbv7em | Architecture::Thumbv7m => {
-            &enc_tables::LEVEL1_T32[..]
+        Architecture::Arm(arm) => {
+            if arm.is_thumb() {
+                &enc_tables::LEVEL1_T32[..]
+            } else {
+                &enc_tables::LEVEL1_A32[..]
+            }
         }
-        Architecture::Arm
-        | Architecture::Armv4t
-        | Architecture::Armv5te
-        | Architecture::Armv7
-        | Architecture::Armv7s => &enc_tables::LEVEL1_A32[..],
         _ => panic!(),
     };
     Box::new(Isa {

--- a/cranelift-codegen/src/isa/call_conv.rs
+++ b/cranelift-codegen/src/isa/call_conv.rs
@@ -31,6 +31,7 @@ impl CallConv {
             // uses System V.
             Ok(CallingConvention::SystemV) | Err(()) => CallConv::SystemV,
             Ok(CallingConvention::WindowsFastcall) => CallConv::WindowsFastcall,
+            Ok(unimp) => unimplemented!("calling convention: {:?}", unimp),
         }
     }
 

--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -111,15 +111,8 @@ pub fn lookup(triple: Triple) -> Result<Builder, LookupError> {
         Architecture::I386 | Architecture::I586 | Architecture::I686 | Architecture::X86_64 => {
             isa_builder!(x86, "x86")(triple)
         }
-        Architecture::Thumbv6m
-        | Architecture::Thumbv7em
-        | Architecture::Thumbv7m
-        | Architecture::Arm
-        | Architecture::Armv4t
-        | Architecture::Armv5te
-        | Architecture::Armv7
-        | Architecture::Armv7s => isa_builder!(arm32, "arm32")(triple),
-        Architecture::Aarch64 => isa_builder!(arm64, "arm64")(triple),
+        Architecture::Arm { .. } => isa_builder!(arm32, "arm32")(triple),
+        Architecture::Aarch64 { .. } => isa_builder!(arm64, "arm64")(triple),
         _ => Err(LookupError::Unsupported),
     }
 }

--- a/cranelift-codegen/src/lib.rs
+++ b/cranelift-codegen/src/lib.rs
@@ -41,7 +41,6 @@
     )
 )]
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]

--- a/cranelift-entity/src/lib.rs
+++ b/cranelift-entity/src/lib.rs
@@ -51,7 +51,6 @@
     )
 )]
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]

--- a/cranelift-faerie/Cargo.toml
+++ b/cranelift-faerie/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0" }
 cranelift-module = { path = "../cranelift-module", version = "0.41.0" }
-faerie = "0.10.0"
+faerie = "0.11.0"
 goblin = "0.0.24"
 failure = "0.1.2"
 target-lexicon = "0.8.0"

--- a/cranelift-faerie/Cargo.toml
+++ b/cranelift-faerie/Cargo.toml
@@ -15,7 +15,7 @@ cranelift-module = { path = "../cranelift-module", version = "0.41.0" }
 faerie = "0.10.0"
 goblin = "0.0.24"
 failure = "0.1.2"
-target-lexicon = "0.4.0"
+target-lexicon = "0.8.0"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-faerie/src/backend.rs
+++ b/cranelift-faerie/src/backend.rs
@@ -342,7 +342,7 @@ fn translate_function_linkage(linkage: Linkage) -> faerie::Decl {
 }
 
 fn translate_data_linkage(linkage: Linkage, writable: bool, align: Option<u8>) -> faerie::Decl {
-    let align = align.map(|align| usize::from(align));
+    let align = align.map(|align| u64::from(align));
     match linkage {
         Linkage::Import => faerie::Decl::data_import().into(),
         Linkage::Local => faerie::Decl::data()

--- a/cranelift-frontend/Cargo.toml
+++ b/cranelift-frontend/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0", default-features = false }
-target-lexicon = { version = "0.4.0", default-features = false }
+target-lexicon = "0.8.0"
 log = { version = "0.4.6", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }
 

--- a/cranelift-frontend/src/lib.rs
+++ b/cranelift-frontend/src/lib.rs
@@ -175,7 +175,6 @@
     )
 )]
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]

--- a/cranelift-module/src/lib.rs
+++ b/cranelift-module/src/lib.rs
@@ -19,7 +19,6 @@
     )
 )]
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]

--- a/cranelift-native/Cargo.toml
+++ b/cranelift-native/Cargo.toml
@@ -11,14 +11,14 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0", default-features = false }
-target-lexicon = { version = "0.4.0", default-features = false }
+target-lexicon = "0.8.0"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 raw-cpuid = "6.0.0"
 
 [features]
 default = ["std"]
-std = ["cranelift-codegen/std", "target-lexicon/std"]
+std = ["cranelift-codegen/std"]
 # when compiling with the "core" feature, nightly must be enabled
 # enabling the "nightly" feature for raw-cpuid allows avoiding
 # linking in a c-library.

--- a/cranelift-preopt/src/lib.rs
+++ b/cranelift-preopt/src/lib.rs
@@ -19,7 +19,6 @@
     )
 )]
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]

--- a/cranelift-reader/Cargo.toml
+++ b/cranelift-reader/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0" }
-target-lexicon = "0.4.0"
+target-lexicon = "0.8.0"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-simplejit/Cargo.toml
+++ b/cranelift-simplejit/Cargo.toml
@@ -16,7 +16,7 @@ cranelift-native = { path = "../cranelift-native", version = "0.41.0" }
 region = "2.0.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
-target-lexicon = { version = "0.4.0" }
+target-lexicon = "0.8.0"
 memmap = { version = "0.7.0", optional = true } 
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 
 [dev-dependencies]
 wabt = "0.9.1"
-target-lexicon = "0.4.0"
+target-lexicon = "0.8.0"
 
 [features]
 default = ["std"]

--- a/cranelift-wasm/src/lib.rs
+++ b/cranelift-wasm/src/lib.rs
@@ -28,7 +28,6 @@
     )
 )]
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 cranelift-codegen = { path = "../cranelift-codegen" }
 cranelift-wasm = { path = "../cranelift-wasm" }
 cranelift-reader = { path = "../cranelift-reader" }
-target-lexicon = "0.4.0"
+target-lexicon = "0.8.0"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -136,16 +136,20 @@ cfg_if! {
                     .x86()
                     .mode(arch::x86::ArchMode::Mode64)
                     .build(),
-                Architecture::Arm
-                | Architecture::Armv4t
-                | Architecture::Armv5te
-                | Architecture::Armv7
-                | Architecture::Armv7s => Capstone::new().arm().mode(arch::arm::ArchMode::Arm).build(),
-                Architecture::Thumbv6m | Architecture::Thumbv7em | Architecture::Thumbv7m => Capstone::new(
-                ).arm()
-                    .mode(arch::arm::ArchMode::Thumb)
-                    .build(),
-                Architecture::Aarch64 => Capstone::new()
+                Architecture::Arm(arm) => {
+                    if arm.is_thumb() {
+                        Capstone::new()
+                            .arm()
+                            .mode(arch::arm::ArchMode::Thumb)
+                            .build()
+                    } else {
+                        Capstone::new()
+                            .arm()
+                            .mode(arch::arm::ArchMode::Arm)
+                            .build()
+                    }
+                }
+                Architecture::Aarch64 {..} => Capstone::new()
                     .arm64()
                     .mode(arch::arm64::ArchMode::Arm)
                     .build(),


### PR DESCRIPTION
Faerie 0.11.0 has an [updated dependency](https://github.com/m4b/faerie/pull/94) on string-interner 0.7.1, which fixes a [security issue in prior versions](https://github.com/Robbepop/string-interner/issues/9).

Faerie 0.11.0 depends target-lexicon 0.8.0, so the rest of this repo has been updated to use the latest version. The representation of Arm architectures has changed a little bit, simplifying some case statements. The crate no longer requires special feature flags to work as a no-std crate, so many of these flags have been removed from cargo and lib.rs files.