### PR TITLE
Fix #796: Enable basic-blocks by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ indicatif = "0.11.0"
 walkdir = "2.2"
 
 [features]
-default = ["disas", "wasm", "cranelift-codegen/all-arch"]
+default = ["disas", "wasm", "cranelift-codegen/all-arch", "basic-blocks"]
 disas = ["capstone"]
 wasm = ["wabt", "cranelift-wasm"]
 basic-blocks = ["cranelift-codegen/basic-blocks", "cranelift-frontend/basic-blocks",

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -32,7 +32,7 @@ smallvec = { version = "0.6.10" }
 cranelift-codegen-meta = { path = "meta", version = "0.44.0", default-features = false }
 
 [features]
-default = ["std"]
+default = ["std", "basic-blocks"]
 
 # The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two

--- a/cranelift-frontend/Cargo.toml
+++ b/cranelift-frontend/Cargo.toml
@@ -18,7 +18,7 @@ hashmap_core = { version = "0.1.9", optional = true }
 smallvec = { version = "0.6.10" }
 
 [features]
-default = ["std"]
+default = ["std", "basic-blocks"]
 std = ["cranelift-codegen/std"]
 core = ["hashmap_core", "cranelift-codegen/core"]
 

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -26,7 +26,7 @@ wabt = "0.9.1"
 target-lexicon = "0.8.1"
 
 [features]
-default = ["std"]
+default = ["std", "basic-blocks"]
 std = ["cranelift-codegen/std", "cranelift-frontend/std", "wasmparser/std"]
 core = ["hashmap_core", "cranelift-codegen/core", "cranelift-frontend/core", "wasmparser/core"]
 enable-serde = ["serde"]


### PR DESCRIPTION
This patch enables by default the basic-blocks feature set.

It is enabled in the top-level directory, in order to test locally, as well as in sub-projects, such that any project which depends on Cranelift components will also benefit from it.

This PR depends on #991 and #1007 to be merged to get a green CI.
(cc @sstangl)
