### PR TITLE
[codegen] add new recipe "rout"

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -566,6 +566,7 @@ pub(crate) fn define(
     let rec_rfurm = r.template("rfurm");
     let rec_rmov = r.template("rmov");
     let rec_rr = r.template("rr");
+    let rec_rout = r.template("rout");
     let rec_rin = r.template("rin");
     let rec_rio = r.template("rio");
     let rec_rrx = r.template("rrx");
@@ -631,12 +632,12 @@ pub(crate) fn define(
     );
 
     e.enc_i32_i64(iadd, rec_rr.opcodes(vec![0x01]));
-    e.enc_i32_i64(iadd_cout, rec_rr.opcodes(vec![0x01]));
+    e.enc_i32_i64(iadd_cout, rec_rout.opcodes(vec![0x01]));
     e.enc_i32_i64(iadd_cin, rec_rin.opcodes(vec![0x11]));
     e.enc_i32_i64(iadd_carry, rec_rio.opcodes(vec![0x11]));
 
     e.enc_i32_i64(isub, rec_rr.opcodes(vec![0x29]));
-    e.enc_i32_i64(isub_bout, rec_rr.opcodes(vec![0x29]));
+    e.enc_i32_i64(isub_bout, rec_rout.opcodes(vec![0x29]));
     e.enc_i32_i64(isub_bin, rec_rin.opcodes(vec![0x19]));
     e.enc_i32_i64(isub_borrow, rec_rio.opcodes(vec![0x19]));
 

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -2548,7 +2548,24 @@ pub(crate) fn define<'shared>(
             ),
     );
 
-    // Adding with carry
+    // Arithematic with flag I/O.
+
+    // XX /r, MR form. Add two GPR registers and set carry flag.
+    recipes.add_template_recipe(
+        EncodingRecipeBuilder::new("rout", f_binary, 1)
+            .operands_in(vec![gpr, gpr])
+            .operands_out(vec![
+                OperandConstraint::TiedInput(0),
+                OperandConstraint::FixedReg(reg_rflags),
+            ])
+            .clobbers_flags(true)
+            .emit(
+                r#"
+                    {{PUT_OP}}(bits, rex2(in_reg0, in_reg1), sink);
+                    modrm_rr(in_reg0, in_reg1, sink);
+                "#,
+            ),
+    );
 
     // XX /r, MR form. Add two GPR registers and get carry flag.
     recipes.add_template_recipe(

--- a/filetests/isa/x86/run-i64.clif
+++ b/filetests/isa/x86/run-i64.clif
@@ -1,0 +1,17 @@
+; Test i64 instructions on x86_32.
+test compile
+target i686 haswell
+
+function %iadd(i64, i64) -> i64 {
+ebb0(v1: i64, v2: i64):
+    v10 = iadd v1, v2
+    ; check: iadd
+    return v10
+}
+
+function %isub(i64, i64) -> i64 {
+ebb0(v1: i64, v2: i64):
+    v10 = isub v1, v2
+    ; check: isub
+    return v10
+}

--- a/filetests/isa/x86/run-i64.clif
+++ b/filetests/isa/x86/run-i64.clif
@@ -5,13 +5,13 @@ target i686 haswell
 function %iadd(i64, i64) -> i64 {
 ebb0(v1: i64, v2: i64):
     v10 = iadd v1, v2
-    ; check: iadd
+    ; check: iadd_cout
     return v10
 }
 
 function %isub(i64, i64) -> i64 {
 ebb0(v1: i64, v2: i64):
     v10 = isub v1, v2
-    ; check: isub
+    ; check: isub_bout
     return v10
 }


### PR DESCRIPTION
Add a new recipe "rout" intended to be used by arithematic operations
that output flags, currently being used for `iadd_cout` and `isub_bout`.

Fixes: https://github.com/CraneStation/cranelift/issues/1009

/cc @wingo @caitp @sunfishcode @bnjbvr 