### PR TITLE
Fix x86/br-i128 test case to use basic blocks.

### DIFF
--- a/filetests/isa/x86/br-i128.clif
+++ b/filetests/isa/x86/br-i128.clif
@@ -3,22 +3,28 @@ target x86_64
 
 function u0:0(i128) -> i8 fast {
 ebb0(v0: i128):
-    brz v0, ebb1
+    brz v0, ebb2
+    jump ebb1
+
+ebb1:
     v1 = iconst.i8 0
     return v1
 
-ebb1:
+ebb2:
     v2 = iconst.i8 1
     return v2
 }
 
 function u0:1(i128) -> i8 fast {
 ebb0(v0: i128):
-    brnz v0, ebb1
+    brnz v0, ebb2
+    jump ebb1
+
+ebb1:
     v1 = iconst.i8 0
     return v1
 
-ebb1:
+ebb2:
     v2 = iconst.i8 1
     return v2
 }


### PR DESCRIPTION
(cc @bjorn3)