### PR TITLE
Simplify and rename `Stackmap::from_vec`

### DIFF
--- a/cranelift-codegen/src/binemit/stackmap.rs
+++ b/cranelift-codegen/src/binemit/stackmap.rs
@@ -56,7 +56,7 @@ impl Stackmap {
     }
 
     /// Create a vec of Bitsets from a vec of bools.
-    pub fn from_vec(vec: &Vec<bool>) -> Self {
+    pub fn from_vec(vec: &[bool]) -> Self {
         let len = vec.len();
         let num_word = len / 32 + (len % 32 != 0) as usize;
         let mut bitmap = Vec::with_capacity(num_word);

--- a/cranelift-codegen/src/binemit/stackmap.rs
+++ b/cranelift-codegen/src/binemit/stackmap.rs
@@ -52,11 +52,11 @@ impl Stackmap {
             }
         }
 
-        Stackmap::from_vec(&vec)
+        Stackmap::from_slice(&vec)
     }
 
     /// Create a vec of Bitsets from a vec of bools.
-    pub fn from_vec(vec: &[bool]) -> Self {
+    pub fn from_slice(vec: &[bool]) -> Self {
         let len = vec.len();
         let num_word = len / 32 + (len % 32 != 0) as usize;
         let mut bitmap = Vec::with_capacity(num_word);
@@ -89,7 +89,7 @@ mod tests {
     #[test]
     fn stackmaps() {
         let vec: Vec<bool> = Vec::new();
-        assert!(Stackmap::from_vec(&vec).bitmap.is_empty());
+        assert!(Stackmap::from_slice(&vec).bitmap.is_empty());
 
         let mut vec: [bool; 32] = Default::default();
         let set_true_idx = [5, 7, 24, 31];
@@ -101,12 +101,12 @@ mod tests {
         let mut vec = vec.to_vec();
         assert_eq!(
             vec![BitSet::<u32>(2164261024)],
-            Stackmap::from_vec(&vec).bitmap
+            Stackmap::from_slice(&vec).bitmap
         );
 
         vec.push(false);
         vec.push(true);
-        let res = Stackmap::from_vec(&vec);
+        let res = Stackmap::from_slice(&vec);
         assert_eq!(
             vec![BitSet::<u32>(2164261024), BitSet::<u32>(2)],
             res.bitmap

--- a/cranelift-codegen/src/binemit/stackmap.rs
+++ b/cranelift-codegen/src/binemit/stackmap.rs
@@ -63,7 +63,7 @@ impl Stackmap {
 
         for segment in vec.chunks(32) {
             let mut curr_word = 0;
-            for (set, i) in segment.iter().zip(0..) {
+            for (i, set) in segment.iter().enumerate() {
                 if *set {
                     curr_word |= 1 << i;
                 }

--- a/cranelift-codegen/src/binemit/stackmap.rs
+++ b/cranelift-codegen/src/binemit/stackmap.rs
@@ -57,20 +57,18 @@ impl Stackmap {
 
     /// Create a vec of Bitsets from a vec of bools.
     pub fn from_vec(vec: &Vec<bool>) -> Self {
-        let mut rem = vec.len();
-        let num_word = ((rem as f32) / 32.0).ceil() as usize;
+        let len = vec.len();
+        let num_word = len / 32 + (len % 32 != 0) as usize;
         let mut bitmap = Vec::with_capacity(num_word);
 
-        for i in 0..num_word {
+        for segment in vec.chunks(32) {
             let mut curr_word = 0;
-            let count = if rem > 32 { 32 } else { rem };
-            for j in 0..count {
-                if vec[i * 32 + j] {
-                    curr_word |= 1 << j;
+            for (set, i) in segment.iter().zip(0..) {
+                if *set {
+                    curr_word |= 1 << i;
                 }
             }
-            bitmap.push(BitSet::<u32>(curr_word));
-            rem -= count;
+            bitmap.push(BitSet(curr_word));
         }
         Self { bitmap }
     }


### PR DESCRIPTION
Functionality is preserved, all tests pass.

It is unclear if this method really should take `&Vec<bool>` rather than `&[bool]`. Should I make this change as well?