### PR TITLE
[frontend] Add message for pristine assertion violation

### DIFF
--- a/cranelift-frontend/src/frontend.rs
+++ b/cranelift-frontend/src/frontend.rs
@@ -523,7 +523,10 @@ impl FunctionBuilder {
     /// **Note:** this function has to be called at the creation of the `Ebb` before adding
     /// instructions to it, otherwise this could interfere with SSA construction.
     pub fn append_ebb_param(&mut self, ebb: Ebb, ty: Type) -> Value {
-        debug_assert!(self.func_ctx.ebbs[ebb].pristine);
+        debug_assert!(
+            self.func_ctx.ebbs[ebb].pristine,
+            "You can't add EBB parameters after adding any instruction"
+        );
         debug_assert_eq!(
             self.func_ctx.ebbs[ebb].user_param_count,
             self.func.dfg.num_ebb_params(ebb)


### PR DESCRIPTION
After we add any instruction to an EBB, we can't add EBB parameters
anymore. There is an assertion in `append_ebb_param` to detect this
error, but the backtrace generated doesn't give any hint what happened.

We add an error message to the assertion so the user can understand what
is wrong.

fixes #1003