### PR TITLE
 Fix #1023: Update brnz.i128 legalization to use non-extended basic blocks.

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -111,6 +111,9 @@ pub(crate) enum Literal {
 
     /// A value of an integer immediate operand.
     Int(i64),
+
+    /// A empty list of variable set of arguments.
+    EmptyVarArgs,
 }
 
 impl Literal {
@@ -147,11 +150,16 @@ impl Literal {
         Literal::Int(value)
     }
 
+    pub fn empty_vararg() -> Self {
+        Literal::EmptyVarArgs
+    }
+
     pub fn to_rust_code(&self) -> String {
         match self {
             Literal::Enumerator { rust_type, value } => format!("{}::{}", rust_type, value),
             Literal::Bits { rust_type, value } => format!("{}::with_bits({:#x})", rust_type, value),
             Literal::Int(val) => val.to_string(),
+            Literal::EmptyVarArgs => "&[]".into(),
         }
     }
 }
@@ -388,7 +396,7 @@ impl Apply {
                              obtained enum value '{}'",
                             op.kind.name, value
                         ),
-                        Literal::Bits { .. } | Literal::Int(_) => {}
+                        Literal::Bits { .. } | Literal::Int(_) | Literal::EmptyVarArgs => {}
                     },
                     _ => {
                         panic!(

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -93,6 +93,7 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
     let isub_borrow = insts.by_name("isub_borrow");
     let isub_ifbin = insts.by_name("isub_ifbin");
     let isub_ifbout = insts.by_name("isub_ifbout");
+    let jump = insts.by_name("jump");
     let load = insts.by_name("load");
     let popcnt = insts.by_name("popcnt");
     let rotl = insts.by_name("rotl");
@@ -189,6 +190,8 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
     let ah = var("ah");
     let cc = var("cc");
     let ebb = var("ebb");
+    let ebb1 = var("ebb1");
+    let ebb2 = var("ebb2");
     let ptr = var("ptr");
     let flags = var("flags");
     let offset = var("off");
@@ -259,11 +262,13 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
     );
 
     narrow.legalize(
-        def!(brnz.I128(x, ebb, vararg)),
+        def!(brnz.I128(x, ebb1, vararg)),
         vec![
             def!((xl, xh) = isplit(x)),
-            def!(brnz(xl, ebb, vararg)),
-            def!(brnz(xh, ebb, vararg)),
+            def!(brnz(xl, ebb1, vararg)),
+            def!(jump(ebb2, Literal::empty_vararg())),
+            ebb!(ebb2),
+            def!(brnz(xh, ebb1, vararg)),
         ],
     );
 


### PR DESCRIPTION
In order to enable basic block by default (#796) , we have to reduce the legalization of `brnz.i128` to produce a temporary basic block in which the conditional jump on the second part can be produced.

This pull request changes the previous meta code to:
```rust
    narrow.legalize(
        def!(brnz.I128(x, ebb1, vararg)),
        vec![
            def!((xl, xh) = isplit(x)),
            def!(brnz(xl, ebb1, vararg)),
            def!(jump(ebb2, Literal::empty_vararg(&imm.vararg))),
            ebb!(ebb2),
            def!(brnz(xh, ebb1, vararg)),
        ],
    );
```

Which produces the following code:
```rust
            ir::Opcode::Brnz => {
                // Unwrap () << brnz.i128(x, ebb1, vararg)
                let (x, ebb1, vararg, predicate) = if let crate::ir::InstructionData::Branch {
                    destination,
                    ref args,
                    ..
                } = pos.func.dfg[inst] {
                    let func = &pos.func;
                    let args = args.as_slice(&func.dfg.value_lists);
                    (
                        func.dfg.resolve_aliases(args[0]),
                        destination,
                        args.iter().skip(2).map(|&arg| func.dfg.resolve_aliases(arg)).collect::<Vec<_>>(),
                        func.dfg.value_type(args[0]) == ir::types::I128
                    )
                } else {
                    unreachable!("bad instruction format")
                };
                let vararg = &vararg;
                if predicate {
                    let orig_ebb = pos.current_ebb().unwrap();
                    pos.func.dfg.clear_results(inst);
                    let ebb2 = pos.func.dfg.make_ebb();
                    let curpos = pos.position();
                    let srcloc = pos.srcloc();
                    let (xl, xh) = split::isplit(pos.func, cfg, curpos, srcloc, x);
                    pos.ins().brnz(xl, ebb1, vararg);
                    pos.ins().jump(ebb2, &[]);
                    pos.insert_ebb(ebb2);
                    pos.ins().brnz(xh, ebb1, vararg);
                    let removed = pos.remove_inst();
                    debug_assert_eq!(removed, inst);
                    cfg.recompute_ebb(pos.func, orig_ebb);
                    cfg.recompute_ebb(pos.func, ebb2);
                    return true;
                }
            }
```
