### PR TITLE
Remove "kind" from Literal

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -8,7 +8,7 @@ use cranelift_entity::{entity_impl, PrimaryMap};
 
 use std::fmt;
 
-pub enum Expr {
+pub(crate) enum Expr {
     Var(VarIndex),
     Literal(Literal),
 }
@@ -43,7 +43,7 @@ impl Expr {
 }
 
 /// An AST definition associates a set of variables with the values produced by an expression.
-pub struct Def {
+pub(crate) struct Def {
     pub apply: Apply,
     pub defined_vars: Vec<VarIndex>,
 }
@@ -66,7 +66,7 @@ impl Def {
     }
 }
 
-pub struct DefPool {
+pub(crate) struct DefPool {
     pool: PrimaryMap<DefIndex, Def>,
 }
 
@@ -91,11 +91,11 @@ impl DefPool {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct DefIndex(u32);
+pub(crate) struct DefIndex(u32);
 entity_impl!(DefIndex);
 
 #[derive(Clone, Debug)]
-pub enum Literal {
+pub(crate) enum Literal {
     /// A value of an enumerated immediate operand.
     ///
     /// Some immediate operand kinds like `intcc` and `floatcc` have an enumerated range of values
@@ -157,7 +157,7 @@ impl Literal {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub enum PatternPosition {
+pub(crate) enum PatternPosition {
     Source,
     Destination,
 }
@@ -179,7 +179,7 @@ pub enum PatternPosition {
 /// deleted immediately.
 ///
 /// Temporary values are defined only in the destination pattern.
-pub struct Var {
+pub(crate) struct Var {
     pub name: &'static str,
 
     /// The `Def` defining this variable in a source pattern.
@@ -307,10 +307,10 @@ impl fmt::Debug for Var {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct VarIndex(u32);
+pub(crate) struct VarIndex(u32);
 entity_impl!(VarIndex);
 
-pub struct VarPool {
+pub(crate) struct VarPool {
     pool: PrimaryMap<VarIndex, Var>,
 }
 
@@ -335,7 +335,7 @@ impl VarPool {
 ///
 /// An `Apply` AST expression is created by using function call syntax on instructions. This
 /// applies to both bound and unbound polymorphic instructions.
-pub struct Apply {
+pub(crate) struct Apply {
     pub inst: Instruction,
     pub args: Vec<Expr>,
     pub value_types: Vec<ValueType>,
@@ -506,14 +506,14 @@ impl Apply {
 
 // Simple helpers for legalize actions construction.
 
-pub enum DummyExpr {
+pub(crate) enum DummyExpr {
     Var(DummyVar),
     Literal(Literal),
     Apply(InstSpec, Vec<DummyExpr>),
 }
 
 #[derive(Clone)]
-pub struct DummyVar {
+pub(crate) struct DummyVar {
     pub name: &'static str,
 }
 
@@ -528,16 +528,16 @@ impl Into<DummyExpr> for Literal {
     }
 }
 
-pub fn var(name: &'static str) -> DummyVar {
+pub(crate) fn var(name: &'static str) -> DummyVar {
     DummyVar { name }
 }
 
-pub struct DummyDef {
+pub(crate) struct DummyDef {
     pub expr: DummyExpr,
     pub defined_vars: Vec<DummyVar>,
 }
 
-pub struct ExprBuilder {
+pub(crate) struct ExprBuilder {
     expr: DummyExpr,
 }
 

--- a/cranelift-codegen/meta/src/cdsl/cpu_modes.rs
+++ b/cranelift-codegen/meta/src/cdsl/cpu_modes.rs
@@ -5,7 +5,7 @@ use crate::cdsl::encodings::Encoding;
 use crate::cdsl::types::{LaneType, ValueType};
 use crate::cdsl::xform::{TransformGroup, TransformGroupIndex};
 
-pub struct CpuMode {
+pub(crate) struct CpuMode {
     pub name: &'static str,
     default_legalize: Option<TransformGroupIndex>,
     monomorphic_legalize: Option<TransformGroupIndex>,

--- a/cranelift-codegen/meta/src/cdsl/encodings.rs
+++ b/cranelift-codegen/meta/src/cdsl/encodings.rs
@@ -20,7 +20,7 @@ use crate::cdsl::types::ValueType;
 /// 3. With operands providing constraints: `icmp.i32(intcc.eq, x, y)`.
 ///
 /// If the instruction is polymorphic, all type variables must be provided.
-pub struct EncodingContent {
+pub(crate) struct EncodingContent {
     /// The `Instruction` or `BoundInstruction` being encoded.
     inst: InstSpec,
 
@@ -49,9 +49,9 @@ impl EncodingContent {
     }
 }
 
-pub type Encoding = Rc<EncodingContent>;
+pub(crate) type Encoding = Rc<EncodingContent>;
 
-pub struct EncodingBuilder {
+pub(crate) struct EncodingBuilder {
     inst: InstSpec,
     recipe: EncodingRecipeNumber,
     encbits: u16,

--- a/cranelift-codegen/meta/src/cdsl/isa.rs
+++ b/cranelift-codegen/meta/src/cdsl/isa.rs
@@ -8,7 +8,7 @@ use crate::cdsl::regs::IsaRegs;
 use crate::cdsl::settings::SettingGroup;
 use crate::cdsl::xform::{TransformGroupIndex, TransformGroups};
 
-pub struct TargetIsa {
+pub(crate) struct TargetIsa {
     pub name: &'static str,
     pub instructions: InstructionGroup,
     pub settings: SettingGroup,

--- a/cranelift-codegen/meta/src/cdsl/type_inference.rs
+++ b/cranelift-codegen/meta/src/cdsl/type_inference.rs
@@ -122,7 +122,7 @@ enum TypeEnvRank {
 }
 
 /// Class encapsulating the necessary bookkeeping for type inference.
-pub struct TypeEnvironment {
+pub(crate) struct TypeEnvironment {
     vars: HashSet<VarIndex>,
     ranks: HashMap<TypeVar, TypeEnvRank>,
     equivalency_map: HashMap<TypeVar, TypeVar>,
@@ -602,7 +602,7 @@ fn infer_definition(
 }
 
 /// Perform type inference on an transformation. Return an updated type environment or error.
-pub fn infer_transform(
+pub(crate) fn infer_transform(
     src: DefIndex,
     dst: &Vec<DefIndex>,
     def_pool: &DefPool,

--- a/cranelift-codegen/meta/src/cdsl/xform.rs
+++ b/cranelift-codegen/meta/src/cdsl/xform.rs
@@ -17,7 +17,7 @@ use std::iter::FromIterator;
 /// cases when it applies.
 ///
 /// The source pattern can contain only a single instruction.
-pub struct Transform {
+pub(crate) struct Transform {
     pub src: DefIndex,
     pub dst: Vec<DefIndex>,
     pub var_pool: VarPool,
@@ -268,7 +268,7 @@ fn rewrite_def_list(
 }
 
 /// A group of related transformations.
-pub struct TransformGroup {
+pub(crate) struct TransformGroup {
     pub name: &'static str,
     pub doc: &'static str,
     pub chain_with: Option<TransformGroupIndex>,
@@ -294,10 +294,10 @@ impl TransformGroup {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct TransformGroupIndex(u32);
+pub(crate) struct TransformGroupIndex(u32);
 entity_impl!(TransformGroupIndex);
 
-pub struct TransformGroupBuilder {
+pub(crate) struct TransformGroupBuilder {
     name: &'static str,
     doc: &'static str,
     chain_with: Option<TransformGroupIndex>,
@@ -369,7 +369,7 @@ impl TransformGroupBuilder {
     }
 }
 
-pub struct TransformGroups {
+pub(crate) struct TransformGroups {
     groups: PrimaryMap<TransformGroupIndex, TransformGroup>,
 }
 

--- a/cranelift-codegen/meta/src/constant_hash.rs
+++ b/cranelift-codegen/meta/src/constant_hash.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-pub fn simple_hash(s: &str) -> usize {
+pub(crate) fn simple_hash(s: &str) -> usize {
     let mut h: u32 = 5381;
     for c in s.chars() {
         h = (h ^ c as u32).wrapping_add(h.rotate_right(6));
@@ -11,7 +11,7 @@ pub fn simple_hash(s: &str) -> usize {
 /// Compute an open addressed, quadratically probed hash table containing
 /// `items`. The returned table is a list containing the elements of the
 /// iterable `items` and `None` in unused slots.
-pub fn generate_table<'cont, T, I: iter::Iterator<Item = &'cont T>, H: Fn(&T) -> usize>(
+pub(crate) fn generate_table<'cont, T, I: iter::Iterator<Item = &'cont T>, H: Fn(&T) -> usize>(
     items: I,
     num_items: usize,
     hash_function: H,

--- a/cranelift-codegen/meta/src/default_map.rs
+++ b/cranelift-codegen/meta/src/default_map.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
-pub trait MapWithDefault<K, V: Default> {
+pub(crate) trait MapWithDefault<K, V: Default> {
     fn get_or_default(&mut self, k: K) -> &mut V;
 }
 

--- a/cranelift-codegen/meta/src/gen_binemit.rs
+++ b/cranelift-codegen/meta/src/gen_binemit.rs
@@ -211,7 +211,7 @@ fn gen_isa(formats: &FormatRegistry, isa_name: &str, recipes: &Recipes, fmt: &mu
     fmt.line("}");
 }
 
-pub fn generate(
+pub(crate) fn generate(
     formats: &FormatRegistry,
     isa_name: &str,
     recipes: &Recipes,

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -577,7 +577,7 @@ fn gen_isa(
 }
 
 /// Generate the legalizer files.
-pub fn generate(
+pub(crate) fn generate(
     isas: &Vec<TargetIsa>,
     format_registry: &FormatRegistry,
     transform_groups: &TransformGroups,

--- a/cranelift-codegen/meta/src/gen_registers.rs
+++ b/cranelift-codegen/meta/src/gen_registers.rs
@@ -133,7 +133,7 @@ fn gen_isa(isa: &TargetIsa, fmt: &mut Formatter) {
     fmtln!(fmt, "}");
 }
 
-pub fn generate(isa: &TargetIsa, filename: &str, out_dir: &str) -> Result<(), error::Error> {
+pub(crate) fn generate(isa: &TargetIsa, filename: &str, out_dir: &str) -> Result<(), error::Error> {
     let mut fmt = Formatter::new();
     gen_isa(&isa, &mut fmt);
     fmt.update_file(filename, out_dir)?;

--- a/cranelift-codegen/meta/src/gen_settings.rs
+++ b/cranelift-codegen/meta/src/gen_settings.rs
@@ -431,7 +431,7 @@ fn gen_group(group: &SettingGroup, parent: ParentGroup, fmt: &mut Formatter) {
     gen_display(group, fmt);
 }
 
-pub fn generate(
+pub(crate) fn generate(
     settings: &SettingGroup,
     parent_group: ParentGroup,
     filename: &str,

--- a/cranelift-codegen/meta/src/gen_types.rs
+++ b/cranelift-codegen/meta/src/gen_types.rs
@@ -68,7 +68,7 @@ fn emit_types(fmt: &mut srcgen::Formatter) -> Result<(), error::Error> {
 }
 
 /// Generate the types file.
-pub fn generate(filename: &str, out_dir: &str) -> Result<(), error::Error> {
+pub(crate) fn generate(filename: &str, out_dir: &str) -> Result<(), error::Error> {
     let mut fmt = srcgen::Formatter::new();
     emit_types(&mut fmt)?;
     fmt.update_file(filename, out_dir)?;

--- a/cranelift-codegen/meta/src/isa/riscv/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/encodings.rs
@@ -18,7 +18,7 @@ fn enc(inst: impl Into<InstSpec>, recipe: EncodingRecipeNumber, bits: u16) -> En
     EncodingBuilder::new(inst.into(), recipe, bits)
 }
 
-pub struct PerCpuModeEncodings<'defs> {
+pub(crate) struct PerCpuModeEncodings<'defs> {
     pub inst_pred_reg: InstructionPredicateRegistry,
     pub enc32: Vec<Encoding>,
     pub enc64: Vec<Encoding>,

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -18,7 +18,7 @@ use crate::shared::Definitions as SharedDefinitions;
 
 use super::recipes::{RecipeGroup, Template};
 
-pub struct PerCpuModeEncodings {
+pub(crate) struct PerCpuModeEncodings {
     pub enc32: Vec<Encoding>,
     pub enc64: Vec<Encoding>,
     pub recipes: Recipes,

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -13,7 +13,7 @@ use crate::shared::Definitions as SharedDefinitions;
 /// Helper data structure to create recipes and template recipes.
 /// It contains all the recipes and recipe templates that might be used in the encodings crate of
 /// this same directory.
-pub struct RecipeGroup<'builder> {
+pub(crate) struct RecipeGroup<'builder> {
     /// Memoized format pointer, to pass it to builders later.
     formats: &'builder FormatRegistry,
 


### PR DESCRIPTION
Removing kind from the literal field is simple enough; it just lowers the precision of the check when a literal is used in an Apply, but that seems fine.

Also an additional commit that replace a lot of pub by pub(crate), trying to help the compiler catch more unused methods/fields.