### PR TITLE
Fixed broken pipe race condition in ensure_installed

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -55,7 +55,7 @@ ensure_installed() {
     program="$1"
     toolchain="${2:-stable}"
     if has_toolchain $toolchain; then
-        if cargo +$toolchain install --list | grep -q $program; then
+        if grep -q $program <(cargo +$toolchain install --list); then
             echo "$program found"
         else
             echo "installing $program"


### PR DESCRIPTION
Cargo doesn't exit gracefully when it receives a broken pipe, when it does it outputs as non zero exit code triggering the else branch. This doesn't happen in every case, but I can get it consistently on macOS 10.14.6 for `ensure_installed cargo-deadlinks`.

https://github.com/CraneStation/cranelift/blob/92f5c55449b5aee42b09c4436289d815d429b72f/test-all.sh#L76

This changes the condition from piping cargo's output into collecting the output into a anonymous file and providing that as an argument to grep.