### PR TITLE
[WIP] Add more documentation for entities

### DIFF
--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -29,7 +29,8 @@ use serde::{Deserialize, Serialize};
 /// block](https://en.wikipedia.org/wiki/Extended_basic_block) in a
 /// [`Function`](super::function::Function).
 ///
-/// You can get an `Ebb` using `cranelift_frontend::FunctionBuilder::create_ebb`.
+/// You can get an `Ebb` using
+/// [`FunctionBuilder::create_ebb`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.create_ebb)
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Ebb(u32);
 entity_impl!(Ebb, "ebb");
@@ -100,7 +101,7 @@ entity_impl!(Inst, "inst");
 /// [call stack](https://en.wikipedia.org/wiki/Call_stack).
 ///
 /// `StackSlot`s can be created with
-/// `cranelift_frontend::FunctionBuilder::create_stackslot`.
+/// [`FunctionBuilder::create_stackslot`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.create_stack_slot).
 ///
 /// `StackSlot`s are most often used with
 /// [`stack_addr`](super::InstBuilder::stack_addr),
@@ -133,11 +134,11 @@ impl StackSlot {
 ///
 /// - When compiling to WASM, you can use it to load values from a
 /// [`VmContext`](super::GlobalValueData::VMContext) using
-/// [`make_global`](cranelift_wasm::FuncEnvironment::make_global).
+/// [`FuncEnvironment::make_global`](https://docs.rs/cranelift-wasm/*/cranelift_wasm/trait.FuncEnvironment.html#tymethod.make_global).
 /// - When compiling to native code, you can use it for objects in static memory with
-/// [`declare_data_in_func`](cranelift_module::Module::declare_data_in_func).
+/// [`Module::declare_data_in_func`](https://docs.rs/cranelift-module/*/cranelift_module/struct.Module.html#method.declare_data_in_func).
 /// - For any compilation target, it can be registered with
-/// `create_global_value`](cranelift_frontend::FunctionBuilder::create_global_value).
+/// [`FunctionBuilder::create_global_value`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.create_global_value).
 ///
 /// `GlobalValue`s can be retrieved with
 /// [`InstBuilder:global_value`](super::InstBuilder::global_value).
@@ -184,12 +185,12 @@ impl Constant {
 ///
 /// `JumpTable`s are used for indirect branching and are specialized for dense,
 /// 0-based jump offsets. If you want a jump table which doesn't start at 0,
-/// or is not contiguous, consider using a [`Switch`](cranelift_frontend::Switch) instead.
+/// or is not contiguous, consider using a [`Switch`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.Switch.html) instead.
 ///
 /// `JumpTable` are used with [`br_table`](super::InstBuilder::br_table).
 ///
 /// `JumpTable`s can be created with
-/// [`create_jump_table`](cranelift_frontend::FunctionBuilder::create_jump_table).
+/// [`create_jump_table`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.create_jump_table).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct JumpTable(u32);
@@ -216,14 +217,14 @@ impl JumpTable {
 ///
 /// `FuncRef`s can be created with
 ///
-/// - [`import_function`](cranelift_frontend::FunctionBuilder::import_function)
+/// - [`FunctionBuilder::import_function`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.import_function)
 /// for external functions
-/// - [`declare_func_in_func`](cranelift_module::Module::declare_func_in_func)
+/// - [`Module::declare_func_in_func`](https://docs.rs/cranelift-module/*/cranelift_module/struct.Module.html#method.declare_func_in_func)
 /// for functions declared elsewhere in the same native
-/// [`Module`](cranelift_module::Module)
-/// - [`make_direct_func`](cranelift_wasm::FuncEnvironment::make_direct_func)
+/// [`Module`](https://docs.rs/cranelift-module/*/cranelift_module/struct.Module.html)
+/// - [`FuncEnvironment::make_direct_func`](https://docs.rs/cranelift-wasm/*/cranelift_wasm/trait.FuncEnvironment.html#tymethod.make_direct_func)
 /// for functions declared in the same WebAssembly
-/// [`FuncEnvironment`](cranelift_wasm::FuncEnvironment)
+/// [`FuncEnvironment`](https://docs.rs/cranelift-wasm/*/cranelift_wasm/trait.FuncEnvironment.html#tymethod.make_direct_func)
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FuncRef(u32);
 entity_impl!(FuncRef, "fn");
@@ -244,14 +245,14 @@ impl FuncRef {
 /// An opaque reference to a function [`Signature`](super::Signature).
 ///
 /// `SigRef`s are used to declare a function with
-/// [`import_function`](cranelift_frontend::FunctionBuilder::import_function)
+/// [`FunctionBuiler::import_function`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.import_function)
 /// as well as to make an [indirect function call](super::InstBuilder::call_indirect).
 ///
 /// `SigRef`s can be created with
-/// [`import_signature`](cranelift_frontend::FunctionBuilder::import_signature).
+/// [`FunctionBuilder::import_signature`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.import_signature).
 ///
 /// You can retrieve the [`Signature`](super::Signature) that was used to create a `SigRef` with
-/// [`signature`](cranelift_frontend::FunctionBuilder::signature) or
+/// [`FunctionBuilder::signature`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.signature) or
 /// [`func.dfg.signatures`](super::dfg::DataFlowGraph::signatures).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct SigRef(u32);
@@ -275,7 +276,7 @@ impl SigRef {
 /// Heaps are used to access dynamically allocated memory through
 /// [`heap_addr`](super::InstBuilder::heap_addr).
 ///
-/// To create a heap, use [`create_heap`](cranelift_frontend::FunctionBuilder::create_heap).
+/// To create a heap, use [`FunctionBuilder::create_heap`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.create_heap).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Heap(u32);
 entity_impl!(Heap, "heap");
@@ -297,9 +298,9 @@ impl Heap {
 /// table](https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format#WebAssembly_tables).
 ///
 /// `Table`s are used to store a list of function references.
-/// They can be created with [`make_table`](cranelift_wasm::FuncEnvironment::make_table).
+/// They can be created with [`FuncEnvironment::make_table`](https://docs.rs/cranelift-wasm/*/cranelift_wasm/trait.FuncEnvironment.html#tymethod.make_table).
 /// They can be used with
-/// [`translate_call_indirect`](cranelift_wasm::FuncEnvironment::translate_call_indirect).
+/// [`FuncEnvironment::translate_call_indirect`](https://docs.rs/cranelift-wasm/*/cranelift_wasm/trait.FuncEnvironment.html#tymethod.translate_call_indirect).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Table(u32);
 entity_impl!(Table, "table");

--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -92,8 +92,8 @@ entity_impl!(Inst, "inst");
 /// `cranelift_frontend::FunctionBuilder::create_stackslot`.
 ///
 /// `StackSlot`s are most often used with
-/// [`stack_addr`](super::InstBuilder::stack_addr) and
-/// [`stack_load`](super::InstBuilder::stack_load).
+/// [`stack_addr`](super::InstBuilder::stack_addr),
+/// [`stack_load`](super::InstBuilder::stack_load), and
 /// [`stack_store`](super::InstBuilder::stack_store).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]

--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -57,7 +57,7 @@ impl Ebb {
 /// - [`f64const`](super::InstBuilder::f64const) for 64-bit float constants
 /// - [`bconst`](super::InstBuilder::bconst) for boolean constants
 /// - [`vconst`](super::InstBuilder::vconst) for vector constants
-/// - [`null`](super::InstBuilder::null) for null pointer constants
+/// - [`null`](super::InstBuilder::null) for null reference constants
 ///
 /// Any `InstBuilder` instruction that has an output will also return a `Value`.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -94,6 +94,7 @@ entity_impl!(Inst, "inst");
 /// `StackSlot`s are most often used with
 /// [`stack_addr`](super::InstBuilder::stack_addr) and
 /// [`stack_load`](super::InstBuilder::stack_load).
+/// [`stack_store`](super::InstBuilder::stack_store).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct StackSlot(u32);
@@ -150,8 +151,11 @@ impl Constant {
 
 /// An opaque reference to a [jump table](https://en.wikipedia.org/wiki/Branch_table).
 ///
-/// `JumpTable`s are used for indirect branching.
-/// See [`br_table`](super::InstBuilder::br_table) for details.
+/// `JumpTable`s are used for indirect branching and are specialized for dense,
+/// 0-based jump offsets. If you want a jump table which doesn't start at 0,
+/// or is not contiguous, consider using a [`Switch`](cranelift_frontend::Switch) instead.
+///
+/// `JumpTable` are used with [`br_table`](super::InstBuilder::br_table).
 ///
 /// `JumpTable`s can be created with
 /// [`create_jump_table`](cranelift_frontend::FunctionBuilder::create_jump_table).
@@ -216,7 +220,8 @@ impl FuncRef {
 /// [`import_signature`](cranelift_frontend::FunctionBuilder::import_signature).
 ///
 /// You can retrieve the [`Signature`](super::Signature) that was used to create a `SigRef` with
-/// [`signature`](cranelift_frontend::FunctionBuilder::signature).
+/// [`signature`](cranelift_frontend::FunctionBuilder::signature) or
+/// [`func.dfg.signatures`](super::dfg::DataFlowGraph::signatures).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct SigRef(u32);
 entity_impl!(SigRef, "sig");

--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -89,7 +89,7 @@ impl Value {
 /// or [performing reflection at compile time](super::DataFlowGraph::analyze_branch)
 /// on the type of instruction.
 ///
-/// [inst_comment]: https://github.com/CraneStation/cranelift/pull/1041#issuecomment-532575989
+/// [inst_comment]: https://github.com/bjorn3/rustc_codegen_cranelift/blob/0f8814fd6da3d436a90549d4bb19b94034f2b19c/src/pretty_clif.rs
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Inst(u32);
 entity_impl!(Inst, "inst");

--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -282,7 +282,13 @@ impl Heap {
     }
 }
 
-/// An opaque reference to a table.
+/// An opaque reference to a [WebAssembly
+/// table](https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format#WebAssembly_tables).
+///
+/// `Table`s are used to store a list of function references.
+/// They can be created with [`make_table`](cranelift_wasm::FuncEnvironment::make_table).
+/// They can be used with
+/// [`translate_call_indirect`](cranelift_wasm::FuncEnvironment::translate_call_indirect).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Table(u32);
 entity_impl!(Table, "table");

--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -114,6 +114,22 @@ impl StackSlot {
 }
 
 /// An opaque reference to a global value.
+///
+/// A `GlobalValue` is a [`Value`](Value) that will be live across the entire
+/// function lifetime. It can be preloaded from other global values.
+///
+/// You can create a `GlobalValue` in the following ways:
+///
+/// - When compiling to WASM, you can use it to load values from a
+/// [`VmContext`](super::GlobalValueData::VMContext) using
+/// [`make_global`](cranelift_wasm::FuncEnvironment::make_global).
+/// - When compiling to native code, you can use it for objects in static memory with
+/// [`declare_data_in_func`](cranelift_module::Module::declare_data_in_func).
+/// - For any compilation target, it can be registered with
+/// `create_global_value`](cranelift_frontend::FunctionBuilder::create_global_value).
+///
+/// `GlobalValue`s can be retrieved with
+/// [`InstBuilder:global_value`](super::InstBuilder::global_value).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct GlobalValue(u32);
 entity_impl!(GlobalValue, "gv");

--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -78,7 +78,18 @@ impl Value {
     }
 }
 
-/// An opaque reference to an instruction in a function.
+/// An opaque reference to an instruction in a [`Function`](super::Function).
+///
+/// Most usage of `Inst` is internal. `Inst`ructions are returned by
+/// [`InstBuilder`](super::InstBuilder) instructions that do not return a
+/// [`Value`], such as control flow and trap instructions.
+///
+/// If you look around the API, you can find many inventive uses for `Inst`,
+/// such as [annotating specific instructions with a comment][inst_comment]
+/// or [performing reflection at compile time](super::DataFlowGraph::analyze_branch)
+/// on the type of instruction.
+///
+/// [inst_comment]: https://github.com/CraneStation/cranelift/pull/1041#issuecomment-532575989
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Inst(u32);
 entity_impl!(Inst, "inst");

--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -25,7 +25,11 @@ use core::u32;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 
-/// An opaque reference to an extended basic block in a function.
+/// An opaque reference to an [extended basic
+/// block](https://en.wikipedia.org/wiki/Extended_basic_block) in a
+/// [`Function`](super::function::Function).
+///
+/// You can get an `Ebb` using `cranelift_frontend::FunctionBuilder::create_ebb`.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Ebb(u32);
 entity_impl!(Ebb, "ebb");
@@ -44,6 +48,18 @@ impl Ebb {
 }
 
 /// An opaque reference to an SSA value.
+///
+/// You can get a constant `Value` from the following
+/// [`InstBuilder`](super::InstBuilder) instructions:
+///
+/// - [`iconst`](super::InstBuilder::iconst) for integer constants
+/// - [`f32const`](super::InstBuilder::f32const) for 32-bit float constants
+/// - [`f64const`](super::InstBuilder::f64const) for 64-bit float constants
+/// - [`bconst`](super::InstBuilder::bconst) for boolean constants
+/// - [`vconst`](super::InstBuilder::vconst) for vector constants
+/// - [`null`](super::InstBuilder::null) for null pointer constants
+///
+/// Any `InstBuilder` instruction that has an output will also return a `Value`.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Value(u32);
 entity_impl!(Value, "v");
@@ -68,6 +84,16 @@ pub struct Inst(u32);
 entity_impl!(Inst, "inst");
 
 /// An opaque reference to a stack slot.
+///
+/// Stack slots represent an address on the
+/// [call stack](https://en.wikipedia.org/wiki/Call_stack).
+///
+/// `StackSlot`s can be created with
+/// `cranelift_frontend::FunctionBuilder::create_stackslot`.
+///
+/// `StackSlot`s are most often used with
+/// [`stack_addr`](super::InstBuilder::stack_addr) and
+/// [`stack_load`](super::InstBuilder::stack_load).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct StackSlot(u32);
@@ -104,7 +130,7 @@ impl GlobalValue {
     }
 }
 
-/// An opaque reference to a constant
+/// An opaque reference to a constant.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Constant(u32);
 entity_impl!(Constant, "const");
@@ -122,7 +148,13 @@ impl Constant {
     }
 }
 
-/// An opaque reference to a jump table.
+/// An opaque reference to a [jump table](https://en.wikipedia.org/wiki/Branch_table).
+///
+/// `JumpTable`s are used for indirect branching.
+/// See [`br_table`](super::InstBuilder::br_table) for details.
+///
+/// `JumpTable`s can be created with
+/// [`create_jump_table`](cranelift_frontend::FunctionBuilder::create_jump_table).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct JumpTable(u32);
@@ -141,7 +173,22 @@ impl JumpTable {
     }
 }
 
-/// A reference to an external function.
+/// An opaque reference to another [`Function`](super::Function).
+///
+/// `FuncRef`s are used for [direct](super::InstBuilder::call) function calls
+/// and by [`func_addr`](super::InstBuilder::func_addr) for use in
+/// [indirect](super::InstBuilder::call_indirect) function calls.
+///
+/// `FuncRef`s can be created with
+///
+/// - [`import_function`](cranelift_frontend::FunctionBuilder::import_function)
+/// for external functions
+/// - [`declare_func_in_func`](cranelift_module::Module::declare_func_in_func)
+/// for functions declared elsewhere in the same native
+/// [`Module`](cranelift_module::Module)
+/// - [`make_direct_func`](cranelift_wasm::FuncEnvironment::make_direct_func)
+/// for functions declared in the same WebAssembly
+/// [`FuncEnvironment`](cranelift_wasm::FuncEnvironment)
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FuncRef(u32);
 entity_impl!(FuncRef, "fn");
@@ -159,7 +206,17 @@ impl FuncRef {
     }
 }
 
-/// A reference to a function signature.
+/// An opaque reference to a function [`Signature`](super::Signature).
+///
+/// `SigRef`s are used to declare a function with
+/// [`import_function`](cranelift_frontend::FunctionBuilder::import_function)
+/// as well as to make an [indirect function call](super::InstBuilder::call_indirect).
+///
+/// `SigRef`s can be created with
+/// [`import_signature`](cranelift_frontend::FunctionBuilder::import_signature).
+///
+/// You can retrieve the [`Signature`](super::Signature) that was used to create a `SigRef` with
+/// [`signature`](cranelift_frontend::FunctionBuilder::signature).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct SigRef(u32);
 entity_impl!(SigRef, "sig");
@@ -177,7 +234,12 @@ impl SigRef {
     }
 }
 
-/// A reference to a heap.
+/// An opaque reference to a [heap](https://en.wikipedia.org/wiki/Memory_management#DYNAMIC).
+///
+/// Heaps are used to access dynamically allocated memory through
+/// [`heap_addr`](super::InstBuilder::heap_addr).
+///
+/// To create a heap, use [`create_heap`](cranelift_frontend::FunctionBuilder::create_heap).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Heap(u32);
 entity_impl!(Heap, "heap");
@@ -195,7 +257,7 @@ impl Heap {
     }
 }
 
-/// A reference to a table.
+/// An opaque reference to a table.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Table(u32);
 entity_impl!(Table, "table");
@@ -213,7 +275,7 @@ impl Table {
     }
 }
 
-/// A reference to any of the entities defined in this module that can appear in CLIF IR.
+/// An opaque reference to any of the entities defined in this module that can appear in CLIF IR.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum AnyEntity {
     /// The whole function.

--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -132,6 +132,10 @@ impl GlobalValue {
 }
 
 /// An opaque reference to a constant.
+///
+/// You can store [`ConstantData`](super::ConstantData) in a
+/// [`ConstantPool`](super::ConstantPool) for efficient storage and retrieval.
+/// See [`ConstantPool::insert`](super::ConstantPool::insert).
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Constant(u32);
 entity_impl!(Constant, "const");


### PR DESCRIPTION
Addresses https://github.com/CraneStation/cranelift/issues/1038

Document stackslots, funcrefs, heaps, sigrefs, and jumptables.
Also adds more inter-crate links.

## Undocumented

- [x] `Constant` - https://github.com/CraneStation/cranelift/pull/1041#issuecomment-532348093
- [x] `GlobalValue` - https://github.com/CraneStation/cranelift/pull/1041#issuecomment-532575257
- [x] `Table` - https://github.com/CraneStation/cranelift/pull/1041#issuecomment-532575257
- [x] `Inst` - https://github.com/CraneStation/cranelift/pull/1041#issuecomment-532575257

## Issues

I can't find a way to link to a type/function in a different crate if that crate isn't currently in scope for the code. For example, [the documentation for JumpTable](https://github.com/CraneStation/cranelift/compare/master...jyn514:doc-entity?expand=1#diff-dd78b3709a42d640a60ea2733dcdbe53R187) links to `FunctionBuilder::create_jump_table`, but the link is broken (it points to `cranelift_codegen/ir/entities/cranelift_frontend::FunctionBuilder::create_jump_table`, which is clearly wrong).

There are two ways I can think to resolve this:

1. Link directly to docs.rs like this: `https://docs.rs/cranelift-module/*/cranelift_module/struct.Module.html`. This has the downside that it will always point to the latest version (and won't work locally or offline).
2. Put the name of the type in prose and have users search for it. This is not ideal but will work the same everywhere.