### PR TITLE
Create a new optimisation level, "nearly_best", and use it to disable…

### DIFF
--- a/cranelift-codegen/meta/src/shared/settings.rs
+++ b/cranelift-codegen/meta/src/shared/settings.rs
@@ -8,11 +8,12 @@ pub fn define() -> SettingGroup {
         r#"
         Optimization level:
 
-        - default: Very profitable optimizations enabled, none slow.
-        - best: Enable all optimizations
-        - fastest: Optimize for compile time by disabling most optimizations.
+        - none: Minimise compile time by disabling most optimizations.
+        - speed: Generate the fastest possible code
+        - speed_and_size: like "speed", but also perform transformations
+          aimed at reducing code size.
         "#,
-        vec!["default", "best", "fastest"],
+        vec!["none", "speed", "speed_and_size"],
     );
 
     settings.add_bool(

--- a/cranelift-codegen/src/settings.rs
+++ b/cranelift-codegen/src/settings.rs
@@ -14,10 +14,10 @@
 //! use cranelift_codegen::settings::{self, Configurable};
 //!
 //! let mut b = settings::builder();
-//! b.set("opt_level", "fastest");
+//! b.set("opt_level", "speed_and_size");
 //!
 //! let f = settings::Flags::new(b);
-//! assert_eq!(f.opt_level(), settings::OptLevel::Fastest);
+//! assert_eq!(f.opt_level(), settings::OptLevel::SpeedAndSize);
 //! ```
 
 use crate::constant_hash::{probe, simple_hash};
@@ -378,7 +378,7 @@ mod tests {
         assert_eq!(
             f.to_string(),
             "[shared]\n\
-             opt_level = \"default\"\n\
+             opt_level = \"none\"\n\
              libcall_call_conv = \"isa_default\"\n\
              baldrdash_prologue_words = 0\n\
              probestack_size_log2 = 12\n\
@@ -398,7 +398,7 @@ mod tests {
              probestack_func_adjusts_sp = false\n\
              jump_tables_enabled = true\n"
         );
-        assert_eq!(f.opt_level(), super::OptLevel::Default);
+        assert_eq!(f.opt_level(), super::OptLevel::None);
         assert_eq!(f.enable_simd(), false);
         assert_eq!(f.baldrdash_prologue_words(), 0);
     }
@@ -428,13 +428,15 @@ mod tests {
         );
         assert_eq!(
             b.set("opt_level", "true"),
-            Err(BadValue("any among default, best, fastest".to_string()))
+            Err(BadValue(
+                "any among none, speed, speed_and_size".to_string()
+            ))
         );
-        assert_eq!(b.set("opt_level", "best"), Ok(()));
+        assert_eq!(b.set("opt_level", "speed"), Ok(()));
         assert_eq!(b.set("enable_simd", "0"), Ok(()));
 
         let f = Flags::new(b);
         assert_eq!(f.enable_simd(), false);
-        assert_eq!(f.opt_level(), super::OptLevel::Best);
+        assert_eq!(f.opt_level(), super::OptLevel::Speed);
     }
 }

--- a/cranelift-filetests/src/test_binemit.rs
+++ b/cranelift-filetests/src/test_binemit.rs
@@ -162,7 +162,7 @@ impl SubTest for TestBinEmit {
                                 recipe_constraints.satisfied(inst, &divert, &func)
                             });
 
-                        if opt_level == OptLevel::Best {
+                        if opt_level == OptLevel::SpeedAndSize {
                             // Get the smallest legal encoding
                             legal_encodings
                                 .min_by_key(|&e| encinfo.byte_size(e, inst, &divert, &func))

--- a/filetests/isa/x86/allones_funcaddrs32.clif
+++ b/filetests/isa/x86/allones_funcaddrs32.clif
@@ -1,6 +1,6 @@
 ; binary emission of 32-bit code.
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 set allones_funcaddrs
 target i686 haswell
 

--- a/filetests/isa/x86/allones_funcaddrs64.clif
+++ b/filetests/isa/x86/allones_funcaddrs64.clif
@@ -1,6 +1,6 @@
 ; binary emission of 64-bit code.
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 set allones_funcaddrs
 target x86_64 haswell
 

--- a/filetests/isa/x86/baseline_clz_ctz_popcount_encoding.clif
+++ b/filetests/isa/x86/baseline_clz_ctz_popcount_encoding.clif
@@ -1,5 +1,5 @@
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 target x86_64 baseline
 
 ; The binary encodings can be verified with the command:

--- a/filetests/isa/x86/binary32.clif
+++ b/filetests/isa/x86/binary32.clif
@@ -1,6 +1,6 @@
 ; binary emission of x86-32 code.
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 target i686 haswell
 
 ; The binary encodings can be verified with the command:

--- a/filetests/isa/x86/binary64-float.clif
+++ b/filetests/isa/x86/binary64-float.clif
@@ -1,6 +1,6 @@
 ; Binary emission of 64-bit floating point code.
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 target x86_64 haswell
 
 ; The binary encodings can be verified with the command:

--- a/filetests/isa/x86/binary64-pic.clif
+++ b/filetests/isa/x86/binary64-pic.clif
@@ -1,6 +1,6 @@
 ; binary emission of 64-bit code.
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 set is_pic
 target x86_64 haswell
 

--- a/filetests/isa/x86/binary64.clif
+++ b/filetests/isa/x86/binary64.clif
@@ -1,6 +1,6 @@
 ; binary emission of x86-64 code.
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 target x86_64 haswell
 
 ; The binary encodings can be verified with the command:

--- a/filetests/isa/x86/isub_imm-i8.clif
+++ b/filetests/isa/x86/isub_imm-i8.clif
@@ -1,4 +1,5 @@
 test compile
+set opt_level=speed_and_size
 target x86_64
 
 function u0:0(i8) -> i8 fast {

--- a/filetests/isa/x86/legalize-br-table.clif
+++ b/filetests/isa/x86/legalize-br-table.clif
@@ -1,4 +1,5 @@
 test compile
+set opt_level=speed_and_size
 target x86_64
 feature !"basic-blocks"
 ; regex: V=v\d+

--- a/filetests/isa/x86/legalize-call.clif
+++ b/filetests/isa/x86/legalize-call.clif
@@ -1,6 +1,6 @@
 ; Test legalization of a non-colocated call in 64-bit non-PIC mode.
 test legalizer
-set opt_level=best
+set opt_level=speed_and_size
 target x86_64 haswell
 
 function %call() {

--- a/filetests/isa/x86/optimized-zero-constants-32bit.clif
+++ b/filetests/isa/x86/optimized-zero-constants-32bit.clif
@@ -1,6 +1,6 @@
 ; Check that floating-point and integer constants equal to zero are optimized correctly.
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 target i686
 
 function %foo() -> f32 fast {

--- a/filetests/isa/x86/optimized-zero-constants.clif
+++ b/filetests/isa/x86/optimized-zero-constants.clif
@@ -1,6 +1,6 @@
 ; Check that floating-point constants equal to zero are optimized correctly.
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 target x86_64
 
 function %zero_const_32bit_no_rex() -> f32 fast {

--- a/filetests/isa/x86/pinned-reg.clif
+++ b/filetests/isa/x86/pinned-reg.clif
@@ -2,7 +2,7 @@ test compile
 
 set enable_pinned_reg=true
 set use_pinned_reg_as_heap_base=true
-set opt_level=best
+set opt_level=speed_and_size
 
 target x86_64
 

--- a/filetests/isa/x86/prologue-epilogue.clif
+++ b/filetests/isa/x86/prologue-epilogue.clif
@@ -1,5 +1,5 @@
 test compile
-set opt_level=best
+set opt_level=speed_and_size
 set is_pic
 target x86_64 haswell
 

--- a/filetests/isa/x86/relax_branch.clif
+++ b/filetests/isa/x86/relax_branch.clif
@@ -1,5 +1,5 @@
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 set avoid_div_traps
 set baldrdash_prologue_words=3
 set allones_funcaddrs

--- a/filetests/isa/x86/scalar_to_vector-binemit.clif
+++ b/filetests/isa/x86/scalar_to_vector-binemit.clif
@@ -1,5 +1,5 @@
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 set enable_simd
 target x86_64
 

--- a/filetests/isa/x86/scalar_to_vector-compile.clif
+++ b/filetests/isa/x86/scalar_to_vector-compile.clif
@@ -1,5 +1,5 @@
 test compile
-set opt_level=best
+set opt_level=speed_and_size
 set probestack_enabled=false
 set enable_simd
 target x86_64

--- a/filetests/isa/x86/shrink-multiple-uses.clif
+++ b/filetests/isa/x86/shrink-multiple-uses.clif
@@ -1,5 +1,5 @@
 test shrink
-set opt_level=best
+set opt_level=speed_and_size
 target x86_64
 
 function %test_multiple_uses(i32 [%rdi]) -> i32 {

--- a/filetests/isa/x86/shrink.clif
+++ b/filetests/isa/x86/shrink.clif
@@ -1,5 +1,5 @@
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 target x86_64
 
 ; Test that instruction shrinking eliminates REX prefixes when possible.

--- a/filetests/isa/x86/stack-addr64.clif
+++ b/filetests/isa/x86/stack-addr64.clif
@@ -1,6 +1,6 @@
 ; binary emission of stack address instructions on x86-64.
 test binemit
-set opt_level=fastest
+set opt_level=none
 target x86_64 haswell
 
 ; The binary encodings can be verified with the command:

--- a/filetests/isa/x86/stack-load-store64.clif
+++ b/filetests/isa/x86/stack-load-store64.clif
@@ -1,6 +1,6 @@
 ; legalization of stack load and store instructions on x86-64.
 test legalizer
-set opt_level=fastest
+set opt_level=none
 target x86_64 haswell
 
 function %stack_load_and_store() {

--- a/filetests/isa/x86/vconst-binemit.clif
+++ b/filetests/isa/x86/vconst-binemit.clif
@@ -1,5 +1,5 @@
 test binemit
-set opt_level=best
+set opt_level=speed_and_size
 set enable_simd
 target x86_64
 

--- a/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/filetests/isa/x86/windows_fastcall_x64.clif
@@ -1,5 +1,5 @@
 test compile
-set opt_level=best
+set opt_level=speed_and_size
 set is_pic
 target x86_64 haswell
 


### PR DESCRIPTION
… the insn shrink pass

The optimisation level called "best" runs at least one pass which, according
to measurements on a large wasm input, slows the compiler down whilst having
very little benefit for the final generated code.

This patch creates a new optimisation level, "nearly_best", which is intended
to be the same as "best", except with such low-win transformations removed.
The "instruction shrinking" pass is then omitted at the "nearly_best" level.
Behaviour of the compiler is unchanged for the three existing settings
"default", "fastest" and "best".  So all existing uses of Cranelift will not
see any change in behaviour from this patch.