### PR TITLE
tidy: Remove extra semicolons

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift-codegen/meta/src/cdsl/typevar.rs
@@ -851,7 +851,7 @@ impl TypeSetBuilder {
 
     pub fn build(self) -> TypeSet {
         let min_lanes = if self.includes_scalars { 1 } else { 2 };
-;
+
         let bools = range_to_set(self.bools.to_range(1..MAX_BITS, None))
             .into_iter()
             .filter(legal_bool)

--- a/cranelift-codegen/meta/src/shared/formats.rs
+++ b/cranelift-codegen/meta/src/shared/formats.rs
@@ -59,7 +59,7 @@ pub(crate) fn define(imm: &Immediates, entities: &EntityRefs) -> FormatRegistry 
             .value()
             .value(),
     );
-    registry.insert(Builder::new("FloatCond").imm(&imm.floatcc).value());;
+    registry.insert(Builder::new("FloatCond").imm(&imm.floatcc).value());
 
     registry.insert(
         Builder::new("IntSelect")

--- a/cranelift-codegen/meta/src/shared/mod.rs
+++ b/cranelift-codegen/meta/src/shared/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn define() -> Definitions {
     let mut all_instructions = AllInstructions::new();
 
     let immediates = Immediates::new();
-    let entities = EntityRefs::new();;
+    let entities = EntityRefs::new();
     let format_registry = formats::define(&immediates, &entities);
     let instructions = instructions::define(
         &mut all_instructions,


### PR DESCRIPTION
These were causing compilation warnings.