### PR TITLE
Add SIMD arithmetic instructions on x86

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -480,6 +480,7 @@ pub(crate) fn define(
     let sqrt = shared.by_name("sqrt");
     let sshr = shared.by_name("sshr");
     let sshr_imm = shared.by_name("sshr_imm");
+    let ssub_sat = shared.by_name("ssub_sat");
     let stack_addr = shared.by_name("stack_addr");
     let store = shared.by_name("store");
     let store_complex = shared.by_name("store_complex");
@@ -501,6 +502,7 @@ pub(crate) fn define(
     let uload8_complex = shared.by_name("uload8_complex");
     let ushr = shared.by_name("ushr");
     let ushr_imm = shared.by_name("ushr_imm");
+    let usub_sat = shared.by_name("usub_sat");
     let vconst = shared.by_name("vconst");
     let x86_bsf = x86.by_name("x86_bsf");
     let x86_bsr = x86.by_name("x86_bsr");
@@ -1964,6 +1966,24 @@ pub(crate) fn define(
         let isub = isub.bind_vector_from_lane(ty.clone(), sse_vector_size);
         e.enc_32_64(isub, rec_fa.opcodes(*opcodes));
     }
+
+    // SIMD integer saturating subtraction
+    e.enc_32_64(
+        ssub_sat.bind_vector_from_lane(I8, sse_vector_size),
+        rec_fa.opcodes(&PSUBSB),
+    );
+    e.enc_32_64(
+        ssub_sat.bind_vector_from_lane(I16, sse_vector_size),
+        rec_fa.opcodes(&PSUBSW),
+    );
+    e.enc_32_64(
+        usub_sat.bind_vector_from_lane(I8, sse_vector_size),
+        rec_fa.opcodes(&PSUBUSB),
+    );
+    e.enc_32_64(
+        usub_sat.bind_vector_from_lane(I16, sse_vector_size),
+        rec_fa.opcodes(&PSUBUSW),
+    );
 
     // SIMD integer multiplication: the x86 ISA does not have instructions for multiplying I8x16
     // and I64x2 and these are (at the time of writing) not necessary for WASM SIMD.

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1945,6 +1945,16 @@ pub(crate) fn define(
         e.enc_32_64(isub, rec_fa.opcodes(*opcodes));
     }
 
+    // SIMD integer multiplication: the x86 ISA does not have instructions for multiplying I8x16
+    // and I64x2 and these are (at the time of writing) not necessary for WASM SIMD.
+    for (ty, opcodes, isap) in &[
+        (I16, &PMULLW[..], None),
+        (I32, &PMULLD[..], Some(use_sse41_simd)),
+    ] {
+        let imul = imul.bind_vector_from_lane(ty.clone(), sse_vector_size);
+        e.enc_32_64_maybe_isap(imul, rec_fa.opcodes(opcodes), *isap);
+    }
+
     // SIMD icmp using PCMPEQ*
     let mut pcmpeq_mapping: HashMap<u64, (&[u8], Option<SettingPredicateNumber>)> = HashMap::new();
     pcmpeq_mapping.insert(8, (&PCMPEQB, None));

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -464,6 +464,7 @@ pub(crate) fn define(
     let rotl_imm = shared.by_name("rotl_imm");
     let rotr = shared.by_name("rotr");
     let rotr_imm = shared.by_name("rotr_imm");
+    let sadd_sat = shared.by_name("sadd_sat");
     let safepoint = shared.by_name("safepoint");
     let scalar_to_vector = shared.by_name("scalar_to_vector");
     let selectif = shared.by_name("selectif");
@@ -490,6 +491,7 @@ pub(crate) fn define(
     let trueff = shared.by_name("trueff");
     let trueif = shared.by_name("trueif");
     let trunc = shared.by_name("trunc");
+    let uadd_sat = shared.by_name("uadd_sat");
     let uextend = shared.by_name("uextend");
     let uload16 = shared.by_name("uload16");
     let uload16_complex = shared.by_name("uload16_complex");
@@ -1938,6 +1940,24 @@ pub(crate) fn define(
         let iadd = iadd.bind_vector_from_lane(ty.clone(), sse_vector_size);
         e.enc_32_64(iadd, rec_fa.opcodes(*opcodes));
     }
+
+    // SIMD integer saturating addition
+    e.enc_32_64(
+        sadd_sat.bind_vector_from_lane(I8, sse_vector_size),
+        rec_fa.opcodes(&PADDSB),
+    );
+    e.enc_32_64(
+        sadd_sat.bind_vector_from_lane(I16, sse_vector_size),
+        rec_fa.opcodes(&PADDSW),
+    );
+    e.enc_32_64(
+        uadd_sat.bind_vector_from_lane(I8, sse_vector_size),
+        rec_fa.opcodes(&PADDUSB),
+    );
+    e.enc_32_64(
+        uadd_sat.bind_vector_from_lane(I16, sse_vector_size),
+        rec_fa.opcodes(&PADDUSW),
+    );
 
     // SIMD integer subtraction
     for (ty, opcodes) in &[(I8, &PSUBB), (I16, &PSUBW), (I32, &PSUBD), (I64, &PSUBQ)] {

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1940,6 +1940,12 @@ pub(crate) fn define(
         e.enc_32_64(iadd, rec_fa.opcodes(*opcodes));
     }
 
+    // SIMD integer subtraction
+    for (ty, opcodes) in &[(I8, &PSUBB), (I16, &PSUBW), (I32, &PSUBD), (I64, &PSUBQ)] {
+        let isub = isub.bind_vector_from_lane(ty.clone(), sse_vector_size);
+        e.enc_32_64(isub, rec_fa.opcodes(*opcodes));
+    }
+
     // SIMD icmp using PCMPEQ*
     let mut pcmpeq_mapping: HashMap<u64, (&[u8], Option<SettingPredicateNumber>)> = HashMap::new();
     pcmpeq_mapping.insert(8, (&PCMPEQB, None));

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -36,6 +36,7 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
     let iadd = insts.by_name("iadd");
     let iconst = insts.by_name("iconst");
     let imul = insts.by_name("imul");
+    let ineg = insts.by_name("ineg");
     let insertlane = insts.by_name("insertlane");
     let isub = insts.by_name("isub");
     let popcnt = insts.by_name("popcnt");
@@ -385,6 +386,7 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
     narrow.custom_legalize(shuffle, "convert_shuffle");
     narrow.custom_legalize(extractlane, "convert_extractlane");
     narrow.custom_legalize(insertlane, "convert_insertlane");
+    narrow.custom_legalize(ineg, "convert_ineg");
 
     narrow.build_and_add_to(&mut shared.transform_groups);
 }

--- a/cranelift-codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/opcodes.rs
@@ -251,6 +251,18 @@ pub static PADDQ: [u8; 3] = [0x66, 0x0f, 0xd4];
 /// Add packed word integers from xmm2/m128 and xmm1 (SSE2).
 pub static PADDW: [u8; 3] = [0x66, 0x0f, 0xfd];
 
+/// Add packed signed byte integers from xmm2/m128 and xmm1 saturate the results (SSE).
+pub static PADDSB: [u8; 3] = [0x66, 0x0f, 0xec];
+
+/// Add packed signed word integers from xmm2/m128 and xmm1 saturate the results (SSE).
+pub static PADDSW: [u8; 3] = [0x66, 0x0f, 0xed];
+
+/// Add packed unsigned byte integers from xmm2/m128 and xmm1 saturate the results (SSE).
+pub static PADDUSB: [u8; 3] = [0x66, 0x0f, 0xdc];
+
+/// Add packed unsigned word integers from xmm2/m128 and xmm1 saturate the results (SSE).
+pub static PADDUSW: [u8; 3] = [0x66, 0x0f, 0xdd];
+
 /// Compare packed data for equal (SSE2).
 pub static PCMPEQB: [u8; 3] = [0x66, 0x0f, 0x74];
 

--- a/cranelift-codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/opcodes.rs
@@ -294,6 +294,18 @@ pub static PSHUFB: [u8; 4] = [0x66, 0x0f, 0x38, 0x00];
 /// store the result in xmm1 (SSE2).
 pub static PSHUFD: [u8; 3] = [0x66, 0x0f, 0x70];
 
+/// Subtract packed byte integers in xmm2/m128 from packed byte integers in xmm1 (SSE2).
+pub static PSUBB: [u8; 3] = [0x66, 0x0f, 0xf8];
+
+/// Subtract packed word integers in xmm2/m128 from packed word integers in xmm1 (SSE2).
+pub static PSUBW: [u8; 3] = [0x66, 0x0f, 0xf9];
+
+/// Subtract packed doubleword integers in xmm2/m128 from doubleword byte integers in xmm1 (SSE2).
+pub static PSUBD: [u8; 3] = [0x66, 0x0f, 0xfa];
+
+/// Subtract packed quadword integers in xmm2/m128 from xmm1 (SSE2).
+pub static PSUBQ: [u8; 3] = [0x66, 0x0f, 0xfb];
+
 /// Push r{16,32,64}.
 pub static PUSH_REG: [u8; 1] = [0x50];
 

--- a/cranelift-codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/opcodes.rs
@@ -326,6 +326,22 @@ pub static PSUBD: [u8; 3] = [0x66, 0x0f, 0xfa];
 /// Subtract packed quadword integers in xmm2/m128 from xmm1 (SSE2).
 pub static PSUBQ: [u8; 3] = [0x66, 0x0f, 0xfb];
 
+/// Subtract packed signed byte integers in xmm2/m128 from packed signed byte integers in xmm1
+/// and saturate results (SSE2).
+pub static PSUBSB: [u8; 3] = [0x66, 0x0f, 0xe8];
+
+/// Subtract packed signed word integers in xmm2/m128 from packed signed word integers in xmm1
+/// and saturate results (SSE2).
+pub static PSUBSW: [u8; 3] = [0x66, 0x0f, 0xe9];
+
+/// Subtract packed unsigned byte integers in xmm2/m128 from packed unsigned byte integers in xmm1
+/// and saturate results (SSE2).
+pub static PSUBUSB: [u8; 3] = [0x66, 0x0f, 0xd8];
+
+/// Subtract packed unsigned word integers in xmm2/m128 from packed unsigned word integers in xmm1
+/// and saturate results (SSE2).
+pub static PSUBUSW: [u8; 3] = [0x66, 0x0f, 0xd9];
+
 /// Push r{16,32,64}.
 pub static PUSH_REG: [u8; 1] = [0x50];
 

--- a/cranelift-codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/opcodes.rs
@@ -269,8 +269,8 @@ pub static PEXTR: [u8; 4] = [0x66, 0x0f, 0x3a, 0x16];
 /// Extract byte (SSE4.1).
 pub static PEXTRB: [u8; 4] = [0x66, 0x0f, 0x3a, 0x14];
 
-/// Extract word (SSE2). There is a 4-byte SSE4.1 variant that can also move to m/16.
-pub static PEXTRW_SSE2: [u8; 3] = [0x66, 0x0f, 0xc5];
+/// Extract word (SSE4.1). There is a 3-byte SSE2 variant that can also move to m/16.
+pub static PEXTRW: [u8; 4] = [0x66, 0x0f, 0x3a, 0x15];
 
 /// Insert doubleword or quadword, depending on REX.W (SSE4.1).
 pub static PINSR: [u8; 4] = [0x66, 0x0f, 0x3a, 0x22];

--- a/cranelift-codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/opcodes.rs
@@ -281,6 +281,14 @@ pub static PINSRB: [u8; 4] = [0x66, 0x0f, 0x3a, 0x20];
 /// Insert word (SSE2).
 pub static PINSRW: [u8; 3] = [0x66, 0x0f, 0xc4];
 
+/// Multiply the packed signed word integers in xmm1 and xmm2/m128, and store the low 16 bits of
+/// the results in xmm1 (SSE2).
+pub static PMULLW: [u8; 3] = [0x66, 0x0f, 0xd5];
+
+/// Multiply the packed doubleword signed integers in xmm1 and xmm2/m128 and store the low 32
+/// bits of each product in xmm1 (SSE4.1).
+pub static PMULLD: [u8; 4] = [0x66, 0x0f, 0x38, 0x40];
+
 /// Pop top of stack into r{16,32,64}; increment stack pointer.
 pub static POP_REG: [u8; 1] = [0x58];
 

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -1738,6 +1738,36 @@ pub(crate) fn define(
 
     ig.push(
         Inst::new(
+            "usub_sat",
+            r#"
+        Subtract with unsigned saturation.
+
+        This is similar to `isub` but the operands are interpreted as unsigned integers and their 
+        difference, instead of wrapping, will be saturated to the lowest unsigned integer for
+        the controlling type (e.g. `0x00` for i8).
+        "#,
+        )
+        .operands_in(vec![x, y])
+        .operands_out(vec![a]),
+    );
+
+    ig.push(
+        Inst::new(
+            "ssub_sat",
+            r#"
+        Subtract with signed saturation.
+
+        This is similar to `isub` but the operands are interpreted as signed integers and their 
+        difference, instead of wrapping, will be saturated to the lowest or highest 
+        signed integer for the controlling type (e.g. `0x80` or `0x7F` for i8).
+        "#,
+        )
+        .operands_in(vec![x, y])
+        .operands_out(vec![a]),
+    );
+
+    ig.push(
+        Inst::new(
             "ineg",
             r#"
         Integer negation: `a := -x \pmod{2^B}`.

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -1706,6 +1706,17 @@ pub(crate) fn define(
 
     ig.push(
         Inst::new(
+            "ineg",
+            r#"
+        Integer negation: `a := -x \pmod{2^B}`.
+        "#,
+        )
+        .operands_in(vec![x])
+        .operands_out(vec![a]),
+    );
+
+    ig.push(
+        Inst::new(
             "imul",
             r#"
         Wrapping integer multiplication: `a := x y \pmod{2^B}`.

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -1722,8 +1722,7 @@ pub(crate) fn define(
         Wrapping integer multiplication: `a := x y \pmod{2^B}`.
 
         This instruction does not depend on the signed/unsigned interpretation
-        of the
-        operands.
+        of the operands.
 
         Polymorphic over all integer types (vector and scalar).
         "#,

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -1692,6 +1692,38 @@ pub(crate) fn define(
 
     ig.push(
         Inst::new(
+            "uadd_sat",
+            r#"
+        Add with unsigned saturation.
+
+        This is similar to `iadd` but the operands are interpreted as unsigned integers and their 
+        summed result, instead of wrapping, will be saturated to the highest unsigned integer for
+        the controlling type (e.g. `0xFF` for i8).
+        "#,
+        )
+        .operands_in(vec![x, y])
+        .operands_out(vec![a]),
+    );
+
+    ig.push(
+        Inst::new(
+            "sadd_sat",
+            r#"
+        Add with signed saturation.
+
+        This is similar to `iadd` but the operands are interpreted as signed integers and their 
+        summed result, instead of wrapping, will be saturated to the lowest or highest 
+        signed integer for the controlling type (e.g. `0x80` or `0x7F` for i8). For example, 
+        since an `iadd_ssat.i8` of `0x70` and `0x70` is greater than `0x7F`, the result will be 
+        clamped to `0x7F`.
+        "#,
+        )
+        .operands_in(vec![x, y])
+        .operands_out(vec![a]),
+    );
+
+    ig.push(
+        Inst::new(
             "isub",
             r#"
         Wrapping integer subtraction: `a := x - y \pmod{2^B}`.

--- a/cranelift-codegen/src/ir/immediates.rs
+++ b/cranelift-codegen/src/ir/immediates.rs
@@ -22,6 +22,12 @@ impl IntoBytes for u8 {
     }
 }
 
+impl IntoBytes for i16 {
+    fn into_bytes(self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+}
+
 impl IntoBytes for i32 {
     fn into_bytes(self) -> Vec<u8> {
         self.to_le_bytes().to_vec()
@@ -429,6 +435,7 @@ impl FromIterator<bool> for V128Imm {
 }
 
 construct_uimm128_from_iterator_of!(u8, 16);
+construct_uimm128_from_iterator_of!(i16, 8);
 construct_uimm128_from_iterator_of!(i32, 4);
 construct_uimm128_from_iterator_of!(Ieee32, 4);
 construct_uimm128_from_iterator_of!(Imm64, 2);

--- a/cranelift-reader/src/parser.rs
+++ b/cranelift-reader/src/parser.rs
@@ -665,6 +665,19 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // Match and consume a signed 16-bit immediate.
+    fn match_imm16(&mut self, err_msg: &str) -> ParseResult<i16> {
+        if let Some(Token::Integer(text)) = self.token() {
+            self.consume();
+            // Lexer just gives us raw text that looks like an integer.
+            // Parse it as a i16 to check for overflow and other issues.
+            text.parse()
+                .map_err(|_| self.error("expected i16 decimal immediate"))
+        } else {
+            err!(self.loc, err_msg)
+        }
+    }
+
     // Match and consume an i32 immediate.
     // This is used for stack argument byte offsets.
     fn match_imm32(&mut self, err_msg: &str) -> ParseResult<i32> {
@@ -855,7 +868,7 @@ impl<'a> Parser<'a> {
         } else {
             let uimm128 = match ty.lane_type() {
                 I8 => consume!(ty, self.match_uimm8("Expected an 8-bit unsigned integer")),
-                I16 => unimplemented!(), // TODO no 16-bit match yet
+                I16 => consume!(ty, self.match_imm16("Expected a 16-bit integer")),
                 I32 => consume!(ty, self.match_imm32("Expected a 32-bit integer")),
                 I64 => consume!(ty, self.match_imm64("Expected a 64-bit integer")),
                 F32 => consume!(ty, self.match_ieee32("Expected a 32-bit float...")),

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -1008,6 +1008,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a = state.pop1();
             state.push1(builder.ins().ineg(a))
         }
+        Operator::I16x8Mul | Operator::I32x4Mul => {
+            let (a, b) = state.pop2();
+            state.push1(builder.ins().imul(a, b))
+        }
         Operator::I8x16Eq
         | Operator::I8x16Ne
         | Operator::I8x16LtS
@@ -1074,13 +1078,11 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I16x8AddSaturateU
         | Operator::I16x8SubSaturateS
         | Operator::I16x8SubSaturateU
-        | Operator::I16x8Mul
         | Operator::I32x4AnyTrue
         | Operator::I32x4AllTrue
         | Operator::I32x4Shl
         | Operator::I32x4ShrS
         | Operator::I32x4ShrU
-        | Operator::I32x4Mul
         | Operator::I64x2AnyTrue
         | Operator::I64x2AllTrue
         | Operator::I64x2Shl

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -1004,6 +1004,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (a, b) = state.pop2();
             state.push1(builder.ins().isub(a, b))
         }
+        Operator::I8x16Neg | Operator::I16x8Neg | Operator::I32x4Neg | Operator::I64x2Neg => {
+            let a = state.pop1();
+            state.push1(builder.ins().ineg(a))
+        }
         Operator::I8x16Eq
         | Operator::I8x16Ne
         | Operator::I8x16LtS
@@ -1051,7 +1055,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::V128Or
         | Operator::V128Xor
         | Operator::V128Bitselect
-        | Operator::I8x16Neg
         | Operator::I8x16AnyTrue
         | Operator::I8x16AllTrue
         | Operator::I8x16Shl
@@ -1062,7 +1065,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I8x16SubSaturateS
         | Operator::I8x16SubSaturateU
         | Operator::I8x16Mul
-        | Operator::I16x8Neg
         | Operator::I16x8AnyTrue
         | Operator::I16x8AllTrue
         | Operator::I16x8Shl
@@ -1073,14 +1075,12 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I16x8SubSaturateS
         | Operator::I16x8SubSaturateU
         | Operator::I16x8Mul
-        | Operator::I32x4Neg
         | Operator::I32x4AnyTrue
         | Operator::I32x4AllTrue
         | Operator::I32x4Shl
         | Operator::I32x4ShrS
         | Operator::I32x4ShrU
         | Operator::I32x4Mul
-        | Operator::I64x2Neg
         | Operator::I64x2AnyTrue
         | Operator::I64x2AllTrue
         | Operator::I64x2Shl

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -1000,6 +1000,14 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (a, b) = state.pop2();
             state.push1(builder.ins().iadd(a, b))
         }
+        Operator::I8x16AddSaturateS | Operator::I16x8AddSaturateS => {
+            let (a, b) = state.pop2();
+            state.push1(builder.ins().sadd_sat(a, b))
+        }
+        Operator::I8x16AddSaturateU | Operator::I16x8AddSaturateU => {
+            let (a, b) = state.pop2();
+            state.push1(builder.ins().uadd_sat(a, b))
+        }
         Operator::I8x16Sub | Operator::I16x8Sub | Operator::I32x4Sub | Operator::I64x2Sub => {
             let (a, b) = state.pop2();
             state.push1(builder.ins().isub(a, b))
@@ -1064,8 +1072,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I8x16Shl
         | Operator::I8x16ShrS
         | Operator::I8x16ShrU
-        | Operator::I8x16AddSaturateS
-        | Operator::I8x16AddSaturateU
         | Operator::I8x16SubSaturateS
         | Operator::I8x16SubSaturateU
         | Operator::I8x16Mul
@@ -1074,8 +1080,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I16x8Shl
         | Operator::I16x8ShrS
         | Operator::I16x8ShrU
-        | Operator::I16x8AddSaturateS
-        | Operator::I16x8AddSaturateU
         | Operator::I16x8SubSaturateS
         | Operator::I16x8SubSaturateU
         | Operator::I32x4AnyTrue

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -1000,6 +1000,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (a, b) = state.pop2();
             state.push1(builder.ins().iadd(a, b))
         }
+        Operator::I8x16Sub | Operator::I16x8Sub | Operator::I32x4Sub | Operator::I64x2Sub => {
+            let (a, b) = state.pop2();
+            state.push1(builder.ins().isub(a, b))
+        }
         Operator::I8x16Eq
         | Operator::I8x16Ne
         | Operator::I8x16LtS
@@ -1055,7 +1059,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I8x16ShrU
         | Operator::I8x16AddSaturateS
         | Operator::I8x16AddSaturateU
-        | Operator::I8x16Sub
         | Operator::I8x16SubSaturateS
         | Operator::I8x16SubSaturateU
         | Operator::I8x16Mul
@@ -1067,7 +1070,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I16x8ShrU
         | Operator::I16x8AddSaturateS
         | Operator::I16x8AddSaturateU
-        | Operator::I16x8Sub
         | Operator::I16x8SubSaturateS
         | Operator::I16x8SubSaturateU
         | Operator::I16x8Mul
@@ -1077,7 +1079,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I32x4Shl
         | Operator::I32x4ShrS
         | Operator::I32x4ShrU
-        | Operator::I32x4Sub
         | Operator::I32x4Mul
         | Operator::I64x2Neg
         | Operator::I64x2AnyTrue
@@ -1085,7 +1086,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I64x2Shl
         | Operator::I64x2ShrS
         | Operator::I64x2ShrU
-        | Operator::I64x2Sub
         | Operator::F32x4Abs
         | Operator::F32x4Neg
         | Operator::F32x4Sqrt

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -1012,6 +1012,14 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (a, b) = state.pop2();
             state.push1(builder.ins().isub(a, b))
         }
+        Operator::I8x16SubSaturateS | Operator::I16x8SubSaturateS => {
+            let (a, b) = state.pop2();
+            state.push1(builder.ins().ssub_sat(a, b))
+        }
+        Operator::I8x16SubSaturateU | Operator::I16x8SubSaturateU => {
+            let (a, b) = state.pop2();
+            state.push1(builder.ins().usub_sat(a, b))
+        }
         Operator::I8x16Neg | Operator::I16x8Neg | Operator::I32x4Neg | Operator::I64x2Neg => {
             let a = state.pop1();
             state.push1(builder.ins().ineg(a))
@@ -1072,16 +1080,12 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I8x16Shl
         | Operator::I8x16ShrS
         | Operator::I8x16ShrU
-        | Operator::I8x16SubSaturateS
-        | Operator::I8x16SubSaturateU
         | Operator::I8x16Mul
         | Operator::I16x8AnyTrue
         | Operator::I16x8AllTrue
         | Operator::I16x8Shl
         | Operator::I16x8ShrS
         | Operator::I16x8ShrU
-        | Operator::I16x8SubSaturateS
-        | Operator::I16x8SubSaturateU
         | Operator::I32x4AnyTrue
         | Operator::I32x4AllTrue
         | Operator::I32x4Shl

--- a/filetests/isa/x86/extractlane-binemit.clif
+++ b/filetests/isa/x86/extractlane-binemit.clif
@@ -17,7 +17,7 @@ function %test_extractlane_i16() {
 ebb0:
 [-, %rax]   v0 = iconst.i16 4
 [-, %xmm1]  v1 = splat.i16x8 v0
-[-, %rax]   v2 = x86_pextr v1, 4    ; bin: 66 0f c5 c8 04
+[-, %rax]   v2 = x86_pextr v1, 4    ; bin: 66 0f 3a 15 c8 04
             return
 }
 

--- a/filetests/isa/x86/simd-arithmetic-binemit.clif
+++ b/filetests/isa/x86/simd-arithmetic-binemit.clif
@@ -1,6 +1,4 @@
-test run
 test binemit
-test legalizer
 set enable_simd
 target x86_64 skylake
 
@@ -15,13 +13,10 @@ ebb0:
 
     v5 = extractlane v2, 3
     v6 = icmp_imm eq v5, 5
-    ; TODO replace extractlanes with vector comparison
 
     v7 = band v4, v6
     return v7
 }
-
-; run
 
 function %iadd_i8x16_with_overflow() -> b1 {
 ebb0:
@@ -31,12 +26,9 @@ ebb0:
 
     v3 = extractlane v2, 0
     v4 = icmp_imm eq v3, 1
-    ; TODO replace extractlane with vector comparison
 
     return v4
 }
-
-; run
 
 function %iadd_i16x8(i16x8, i16x8) -> i16x8 {
 ebb0(v0: i16x8 [%xmm1], v1: i16x8 [%xmm2]):
@@ -61,13 +53,10 @@ ebb0:
 
     v5 = extractlane v2, 1
     v6 = icmp_imm eq v5, 0xffffffff
-    ; TODO replace extractlanes with vector comparison
 
     v7 = band v4, v6
     return v7
 }
-
-; run
 
 function %isub_i64x2(i64x2, i64x2) -> i64x2 {
 ebb0(v0: i64x2 [%xmm0], v1: i64x2 [%xmm1]):
@@ -85,40 +74,6 @@ function %isub_i8x16(i8x16, i8x16) -> i8x16 {
 ebb0(v0: i8x16 [%xmm3], v1: i8x16 [%xmm4]):
 [-, %xmm3]  v2 = isub v0, v1      ; bin: 66 0f f8 dc
     return v2
-}
-
-function %ineg_i32x4() -> b1 {
-ebb0:
-    v0 = vconst.i32x4 [1 1 1 1]
-    v2 = ineg v0
-    ; check: v5 = vconst.i32x4 0x00
-    ; nextln: v2 = isub v5, v0
-
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, -1
-
-    return v4 ; bin: c3
-}
-; run
-
-function %ineg_legalized() {
-ebb0:
-    v0 = vconst.i8x16 0x00
-    v1 = ineg v0
-    ; check: v6 = vconst.i8x16 0x00
-    ; nextln: v1 = isub v6, v0
-
-    v2 = raw_bitcast.i16x8 v0
-    v3 = ineg v2
-    ; check: v7 = vconst.i16x8 0x00
-    ; nextln: v3 = isub v7, v2
-
-    v4 = raw_bitcast.i64x2 v0
-    v5 = ineg v4
-    ; check: v8 = vconst.i64x2 0x00
-    ; nextln: v5 = isub v8, v4
-
-    return ; bin: c3
 }
 
 function %imul_i32x4() -> b1 {
@@ -140,7 +95,7 @@ ebb0:
     v10 = band v8, v9
     return v10
 }
-; run
+
 
 function %imul_i16x8() -> b1 {
 ebb0:
@@ -149,8 +104,8 @@ ebb0:
 [-, %xmm1]    v2 = imul v0, v1 ; bin: 66 0f d5 ca
 
     v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 0xfffe ; TODO -2 will not work here and below because v3 is being
-    ; uextend-ed, not sextend-ed
+    v4 = icmp_imm eq v3, 0xfffe ; 0xfffe == -2; -2 will not work here and below because v3 is
+    ; being uextend-ed, not sextend-ed
 
     v5 = extractlane v2, 1
     v6 = icmp_imm eq v5, 0
@@ -163,7 +118,7 @@ ebb0:
 
     return v4
 }
-; run
+
 
 function %sadd_sat_i8x16() -> b1 {
 ebb0:
@@ -176,7 +131,7 @@ ebb0:
 
     return v4
 }
-; run
+
 
 function %uadd_sat_i16x8() -> b1 {
 ebb0:
@@ -189,16 +144,16 @@ ebb0:
 
     return v4
 }
-; run
+
 
 function %sub_sat_i8x16() -> b1 {
 ebb0:
-[-, %xmm2]    v0 = vconst.i8x16 [128 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] ; 120 == 0x80 == -128
+[-, %xmm2]    v0 = vconst.i8x16 [128 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] ; 128 == 0x80 == -128
 [-, %xmm3]    v1 = vconst.i8x16 [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
 
 [-, %xmm2]    v2 = ssub_sat v0, v1 ; bin: 66 0f e8 d3
     v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 0x80 ; still -128, TODO it's unclear why I can't use -128 here
+    v4 = icmp_imm eq v3, 0x80 ; 0x80 == -128
 
     ; now re-use 0x80 as an unsigned 128
 [-, %xmm2]    v5 = usub_sat v0, v2 ; bin: 66 0f d8 d2
@@ -208,7 +163,7 @@ ebb0:
     v8 = band v4, v7
     return v8
 }
-; run
+
 
 function %sub_sat_i16x8() {
 ebb0:

--- a/filetests/isa/x86/simd-arithmetic-legalize.clif
+++ b/filetests/isa/x86/simd-arithmetic-legalize.clif
@@ -1,0 +1,36 @@
+test legalizer
+set enable_simd
+target x86_64 skylake
+
+function %ineg_i32x4() -> b1 {
+ebb0:
+    v0 = vconst.i32x4 [1 1 1 1]
+    v2 = ineg v0
+    ; check: v5 = vconst.i32x4 0x00
+    ; nextln: v2 = isub v5, v0
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, -1
+
+    return v4
+}
+
+function %ineg_legalized() {
+ebb0:
+    v0 = vconst.i8x16 0x00
+    v1 = ineg v0
+    ; check: v6 = vconst.i8x16 0x00
+    ; nextln: v1 = isub v6, v0
+
+    v2 = raw_bitcast.i16x8 v0
+    v3 = ineg v2
+    ; check: v7 = vconst.i16x8 0x00
+    ; nextln: v3 = isub v7, v2
+
+    v4 = raw_bitcast.i64x2 v0
+    v5 = ineg v4
+    ; check: v8 = vconst.i64x2 0x00
+    ; nextln: v5 = isub v8, v4
+
+    return
+}

--- a/filetests/isa/x86/simd-arithmetic-run.clif
+++ b/filetests/isa/x86/simd-arithmetic-run.clif
@@ -1,0 +1,155 @@
+test run
+set enable_simd
+target x86_64 skylake
+
+function %iadd_i32x4() -> b1 {
+ebb0:
+    v0 = vconst.i32x4 [1 1 1 1]
+    v1 = vconst.i32x4 [1 2 3 4]
+    v2 = iadd v0, v1
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 2
+
+    v5 = extractlane v2, 3
+    v6 = icmp_imm eq v5, 5
+    ; TODO replace extractlanes with vector comparison
+
+    v7 = band v4, v6
+    return v7
+}
+; run
+
+function %iadd_i8x16_with_overflow() -> b1 {
+ebb0:
+    v0 = vconst.i8x16 [255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255]
+    v1 = vconst.i8x16 [2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2]
+    v2 = iadd v0, v1
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 1
+    ; TODO replace extractlane with vector comparison
+
+    return v4
+}
+; run
+
+function %isub_i32x4() -> b1 {
+ebb0:
+    v0 = vconst.i32x4 [1 1 1 1]
+    v1 = vconst.i32x4 [1 2 3 4]
+    v2 = isub v0, v1
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 0
+
+    v5 = extractlane v2, 1
+    v6 = icmp_imm eq v5, 0xffffffff
+    ; TODO replace extractlanes with vector comparison
+
+    v7 = band v4, v6
+    return v7
+}
+; run
+
+
+function %ineg_i32x4() -> b1 {
+ebb0:
+    v0 = vconst.i32x4 [1 1 1 1]
+    v2 = ineg v0
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, -1
+
+    return v4
+}
+; run
+
+function %imul_i32x4() -> b1 {
+ebb0:
+    v0 = vconst.i32x4 [-1 0 1 -2147483647] ; e.g. -2147483647 == 0x80_00_00_01
+    v1 = vconst.i32x4 [2 2 2 2]
+    v2 = imul v0, v1
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, -2
+
+    v5 = extractlane v2, 1
+    v6 = icmp_imm eq v5, 0
+
+    v7 = extractlane v2, 3
+    v8 = icmp_imm eq v7, 2 ; 0x80_00_00_01 * 2 == 0x1_00_00_00_02 (and the 1 is dropped)
+
+    v9 = band v4, v6
+    v10 = band v8, v9
+    return v10
+}
+; run
+
+function %imul_i16x8() -> b1 {
+ebb0:
+    v0 = vconst.i16x8 [-1 0 1 32767 0 0 0 0] ; e.g. 32767 == 0x7f_ff
+    v1 = vconst.i16x8 [2 2 2 2 0 0 0 0]
+    v2 = imul v0, v1
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 0xfffe ; 0xfffe == -2; -2 will not work here and below because v3 is
+    ; being uextend-ed, not sextend-ed
+
+    v5 = extractlane v2, 1
+    v6 = icmp_imm eq v5, 0
+
+    v7 = extractlane v2, 3
+    v8 = icmp_imm eq v7, 0xfffe ; 0x7f_ff * 2 == 0xff_fe
+
+    v9 = band v4, v6
+    v10 = band v8, v9
+
+    return v4
+}
+; run
+
+function %sadd_sat_i8x16() -> b1 {
+ebb0:
+    v0 = vconst.i8x16 [127 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
+    v1 = vconst.i8x16 [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
+
+    v2 = sadd_sat v0, v1
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 127
+
+    return v4
+}
+; run
+
+function %uadd_sat_i16x8() -> b1 {
+ebb0:
+    v0 = vconst.i16x8 [-1 0 0 0 0 0 0 0]
+    v1 = vconst.i16x8 [-1 1 1 1 1 1 1 1]
+
+    v2 = uadd_sat v0, v1
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 65535
+
+    return v4
+}
+; run
+
+function %sub_sat_i8x16() -> b1 {
+ebb0:
+    v0 = vconst.i8x16 [128 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] ; 128 == 0x80 == -128
+    v1 = vconst.i8x16 [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
+
+    v2 = ssub_sat v0, v1
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 0x80 ; 0x80 == -128
+
+    ; now re-use 0x80 as an unsigned 128
+    v5 = usub_sat v0, v2
+    v6 = extractlane v5, 0
+    v7 = icmp_imm eq v6, 0
+
+    v8 = band v4, v7
+    return v8
+}
+; run

--- a/filetests/isa/x86/simd-arithmetic.clif
+++ b/filetests/isa/x86/simd-arithmetic.clif
@@ -164,3 +164,29 @@ ebb0:
     return v4
 }
 ; run
+
+function %sadd_sat_i8x16() -> b1 {
+ebb0:
+[-, %xmm2]    v0 = vconst.i8x16 [127 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
+[-, %xmm3]    v1 = vconst.i8x16 [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
+
+[-, %xmm2]    v2 = sadd_sat v0, v1 ; bin: 66 0f ec d3
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 127
+
+    return v4
+}
+; run
+
+function %uadd_sat_i16x8() -> b1 {
+ebb0:
+[-, %xmm2]    v0 = vconst.i16x8 [-1 0 0 0 0 0 0 0]
+[-, %xmm3]    v1 = vconst.i16x8 [-1 1 1 1 1 1 1 1]
+
+[-, %xmm2]    v2 = uadd_sat v0, v1 ; bin: 66 0f dd d3
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 65535
+
+    return v4
+}
+; run

--- a/filetests/isa/x86/simd-arithmetic.clif
+++ b/filetests/isa/x86/simd-arithmetic.clif
@@ -190,3 +190,31 @@ ebb0:
     return v4
 }
 ; run
+
+function %sub_sat_i8x16() -> b1 {
+ebb0:
+[-, %xmm2]    v0 = vconst.i8x16 [128 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] ; 120 == 0x80 == -128
+[-, %xmm3]    v1 = vconst.i8x16 [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
+
+[-, %xmm2]    v2 = ssub_sat v0, v1 ; bin: 66 0f e8 d3
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 0x80 ; still -128, TODO it's unclear why I can't use -128 here
+
+    ; now re-use 0x80 as an unsigned 128
+[-, %xmm2]    v5 = usub_sat v0, v2 ; bin: 66 0f d8 d2
+    v6 = extractlane v5, 0
+    v7 = icmp_imm eq v6, 0
+
+    v8 = band v4, v7
+    return v8
+}
+; run
+
+function %sub_sat_i16x8() {
+ebb0:
+[-, %xmm3]    v0 = vconst.i16x8 [0 0 0 0 0 0 0 0]
+[-, %xmm5]    v1 = vconst.i16x8 [1 1 1 1 1 1 1 1]
+[-, %xmm3]    v2 = ssub_sat v0, v1 ; bin: 66 0f e9 dd
+[-, %xmm3]    v3 = usub_sat v0, v1 ; bin: 66 0f d9 dd
+    return
+}

--- a/filetests/isa/x86/simd-arithmetic.clif
+++ b/filetests/isa/x86/simd-arithmetic.clif
@@ -1,5 +1,6 @@
 test run
 test binemit
+test legalizer
 set enable_simd
 target x86_64 skylake
 
@@ -84,4 +85,38 @@ function %isub_i8x16(i8x16, i8x16) -> i8x16 {
 ebb0(v0: i8x16 [%xmm3], v1: i8x16 [%xmm4]):
 [-, %xmm3]  v2 = isub v0, v1      ; bin: 66 0f f8 dc
     return v2
+}
+
+function %ineg_i32x4() -> b1 {
+ebb0:
+    v0 = vconst.i32x4 [1 1 1 1]
+    v2 = ineg v0
+    ; check: v5 = vconst.i32x4 0x00
+    ; nextln: v2 = isub v5, v0
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, -1
+
+    return v4 ; bin: c3
+}
+; run
+
+function %ineg_legalized() {
+ebb0:
+    v0 = vconst.i8x16 0x00
+    v1 = ineg v0
+    ; check: v6 = vconst.i8x16 0x00
+    ; nextln: v1 = isub v6, v0
+
+    v2 = raw_bitcast.i16x8 v0
+    v3 = ineg v2
+    ; check: v7 = vconst.i16x8 0x00
+    ; nextln: v3 = isub v7, v2
+
+    v4 = raw_bitcast.i64x2 v0
+    v5 = ineg v4
+    ; check: v8 = vconst.i64x2 0x00
+    ; nextln: v5 = isub v8, v4
+
+    return ; bin: c3
 }

--- a/filetests/isa/x86/simd-arithmetic.clif
+++ b/filetests/isa/x86/simd-arithmetic.clif
@@ -120,3 +120,47 @@ ebb0:
 
     return ; bin: c3
 }
+
+function %imul_i32x4() -> b1 {
+ebb0:
+[-, %xmm0]    v0 = vconst.i32x4 [-1 0 1 -2147483647] ; e.g. -2147483647 == 0x80_00_00_01
+[-, %xmm1]    v1 = vconst.i32x4 [2 2 2 2]
+[-, %xmm0]    v2 = imul v0, v1 ; bin: 66 0f 38 40 c1
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, -2
+
+    v5 = extractlane v2, 1
+    v6 = icmp_imm eq v5, 0
+
+    v7 = extractlane v2, 3
+    v8 = icmp_imm eq v7, 2 ; 0x80_00_00_01 * 2 == 0x1_00_00_00_02 (and the 1 is dropped)
+
+    v9 = band v4, v6
+    v10 = band v8, v9
+    return v10
+}
+; run
+
+function %imul_i16x8() -> b1 {
+ebb0:
+[-, %xmm1]    v0 = vconst.i16x8 [-1 0 1 32767 0 0 0 0] ; e.g. 32767 == 0x7f_ff
+[-, %xmm2]    v1 = vconst.i16x8 [2 2 2 2 0 0 0 0]
+[-, %xmm1]    v2 = imul v0, v1 ; bin: 66 0f d5 ca
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 0xfffe ; TODO -2 will not work here and below because v3 is being
+    ; uextend-ed, not sextend-ed
+
+    v5 = extractlane v2, 1
+    v6 = icmp_imm eq v5, 0
+
+    v7 = extractlane v2, 3
+    v8 = icmp_imm eq v7, 0xfffe ; 0x7f_ff * 2 == 0xff_fe
+
+    v9 = band v4, v6
+    v10 = band v8, v9
+
+    return v4
+}
+; run

--- a/filetests/isa/x86/simd-arithmetic.clif
+++ b/filetests/isa/x86/simd-arithmetic.clif
@@ -48,3 +48,40 @@ ebb0(v0: i64x2 [%xmm3], v1: i64x2 [%xmm4]):
 [-, %xmm3]  v2 = iadd v0, v1      ; bin: 66 0f d4 dc
             return v2
 }
+
+function %isub_i32x4() -> b1 {
+ebb0:
+[-, %xmm3]    v0 = vconst.i32x4 [1 1 1 1]
+[-, %xmm5]    v1 = vconst.i32x4 [1 2 3 4]
+[-, %xmm3]    v2 = isub v0, v1  ; bin: 66 0f fa dd
+
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 0
+
+    v5 = extractlane v2, 1
+    v6 = icmp_imm eq v5, 0xffffffff
+    ; TODO replace extractlanes with vector comparison
+
+    v7 = band v4, v6
+    return v7
+}
+
+; run
+
+function %isub_i64x2(i64x2, i64x2) -> i64x2 {
+ebb0(v0: i64x2 [%xmm0], v1: i64x2 [%xmm1]):
+[-, %xmm0]  v2 = isub v0, v1      ; bin: 66 0f fb c1
+    return v2
+}
+
+function %isub_i16x8(i16x8, i16x8) -> i16x8 {
+ebb0(v0: i16x8 [%xmm3], v1: i16x8 [%xmm4]):
+[-, %xmm3]  v2 = isub v0, v1      ; bin: 66 0f f9 dc
+    return v2
+}
+
+function %isub_i8x16(i8x16, i8x16) -> i8x16 {
+ebb0(v0: i8x16 [%xmm3], v1: i8x16 [%xmm4]):
+[-, %xmm3]  v2 = isub v0, v1      ; bin: 66 0f f8 dc
+    return v2
+}


### PR DESCRIPTION
Includes:
 - new `ineg` instruction
 - `isub` encodings
 - `imul` encodings, but only for 16-bit and 32-bit
 - saturating addition and subtraction with new instructions `sadd_sat`, `uadd_sat`, `ssub_sat`, `usub_sat`
 - a fix for an incorrect recipe in `extractlane.t16x8`