### PR TITLE
Re-export ReplaceBuilder

### DIFF
--- a/cranelift-codegen/src/ir/mod.rs
+++ b/cranelift-codegen/src/ir/mod.rs
@@ -27,7 +27,9 @@ mod valueloc;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 
-pub use crate::ir::builder::{InsertBuilder, InstBuilder, InstBuilderBase, InstInserterBase};
+pub use crate::ir::builder::{
+    InsertBuilder, InstBuilder, InstBuilderBase, InstInserterBase, ReplaceBuilder,
+};
 pub use crate::ir::constant::{ConstantData, ConstantOffset, ConstantPool};
 pub use crate::ir::dfg::{DataFlowGraph, ValueDef};
 pub use crate::ir::entities::{


### PR DESCRIPTION
ReplaceBuilder is available in the public API through [`DataFlowGraph::replace`](https://docs.rs/cranelift-codegen/0.43.1/cranelift_codegen/ir/dfg/struct.DataFlowGraph.html#method.replace), however it's documentation is not available through rustdoc as the type isn't publicly importable.