### PR TITLE
cranelift-wasm: upgrade to wasmparser 0.39.1

### DIFF
--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.37.0", default-features = false }
+wasmparser = { version = "0.39.1", default-features = false }
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.43.1", default-features = false }
 cranelift-entity = { path = "../cranelift-entity", version = "0.43.1", default-features = false }
 cranelift-frontend = { path = "../cranelift-frontend", version = "0.43.1", default-features = false }

--- a/cranelift-wasm/src/module_translator.rs
+++ b/cranelift-wasm/src/module_translator.rs
@@ -7,7 +7,7 @@ use crate::sections_translator::{
     parse_name_section, parse_start_section, parse_table_section, parse_type_section,
 };
 use cranelift_codegen::timing;
-use wasmparser::{CustomSectionKind, ModuleReader, SectionCode};
+use wasmparser::{CustomSectionContent, ModuleReader, SectionContent};
 
 /// Translate a sequence of bytes forming a valid Wasm binary into a list of valid Cranelift IR
 /// [`Function`](cranelift_codegen::ir::Function).
@@ -20,83 +20,73 @@ pub fn translate_module<'data>(
 
     while !reader.eof() {
         let section = reader.read()?;
-        match section.code {
-            SectionCode::Type => {
-                let types = section.get_type_section_reader()?;
+        match section.content()? {
+            SectionContent::Type(types) => {
                 parse_type_section(types, environ)?;
             }
 
-            SectionCode::Import => {
-                let imports = section.get_import_section_reader()?;
+            SectionContent::Import(imports) => {
                 parse_import_section(imports, environ)?;
             }
 
-            SectionCode::Function => {
-                let functions = section.get_function_section_reader()?;
+            SectionContent::Function(functions) => {
                 parse_function_section(functions, environ)?;
             }
 
-            SectionCode::Table => {
-                let tables = section.get_table_section_reader()?;
+            SectionContent::Table(tables) => {
                 parse_table_section(tables, environ)?;
             }
 
-            SectionCode::Memory => {
-                let memories = section.get_memory_section_reader()?;
+            SectionContent::Memory(memories) => {
                 parse_memory_section(memories, environ)?;
             }
 
-            SectionCode::Global => {
-                let globals = section.get_global_section_reader()?;
+            SectionContent::Global(globals) => {
                 parse_global_section(globals, environ)?;
             }
 
-            SectionCode::Export => {
-                let exports = section.get_export_section_reader()?;
+            SectionContent::Export(exports) => {
                 parse_export_section(exports, environ)?;
             }
 
-            SectionCode::Start => {
-                let start = section.get_start_section_content()?;
+            SectionContent::Start(start) => {
                 parse_start_section(start, environ)?;
             }
 
-            SectionCode::Element => {
-                let elements = section.get_element_section_reader()?;
+            SectionContent::Element(elements) => {
                 parse_element_section(elements, environ)?;
             }
 
-            SectionCode::Code => {
-                let code = section.get_code_section_reader()?;
+            SectionContent::Code(code) => {
                 parse_code_section(code, environ)?;
             }
 
-            SectionCode::Data => {
-                let data = section.get_data_section_reader()?;
+            SectionContent::Data(data) => {
                 parse_data_section(data, environ)?;
             }
 
-            SectionCode::DataCount => {
+            SectionContent::DataCount(_) => {
                 return Err(WasmError::InvalidWebAssembly {
                     message: "don't know how to handle the data count section yet",
                     offset: reader.current_position(),
                 });
             }
 
-            SectionCode::Custom {
-                kind: CustomSectionKind::Name,
-                name: _,
-            } => {
-                let names = section.get_name_section_reader()?;
-                parse_name_section(names, environ)?;
-            }
-
-            SectionCode::Custom { name, kind: _ } => {
-                let mut reader = section.get_binary_reader();
-                let len = reader.bytes_remaining();
-                let payload = reader.read_bytes(len)?;
-                environ.custom_section(name, payload)?;
-            }
+            SectionContent::Custom {
+                name,
+                binary,
+                content,
+            } => match content {
+                Some(CustomSectionContent::Name(names)) => {
+                    parse_name_section(names, environ)?;
+                }
+                _ => {
+                    let mut reader = binary.clone();
+                    let len = reader.bytes_remaining();
+                    let payload = reader.read_bytes(len)?;
+                    environ.custom_section(name, payload)?;
+                }
+            },
         }
     }
 


### PR DESCRIPTION
Uses new SectionContent api, which is simpler than matching on
SectionCode and then getting the right reader, & avoids possible panics