### PR TITLE
Set speed-and-size optimization level for legalize-br-table-bb.clif test case.

### DIFF
--- a/filetests/isa/x86/legalize-br-table-bb.clif
+++ b/filetests/isa/x86/legalize-br-table-bb.clif
@@ -1,4 +1,5 @@
 test compile
+set opt_level=speed_and_size
 target x86_64
 feature "basic-blocks"
 ; regex: V=v\d+


### PR DESCRIPTION
Follow-up of #1044 for enabling basic blocks by default.