### PR TITLE
Baldrdash: uses ECX for the WasmTableCallSigReg on x86 32-bits

### DIFF
--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -120,7 +120,14 @@ impl ArgAssigner for Args {
                     .into();
                 }
                 // This is SpiderMonkey's `WasmTableCallSigReg`.
-                ArgumentPurpose::SignatureId => return ArgumentLoc::Reg(RU::r10 as RegUnit).into(),
+                ArgumentPurpose::SignatureId => {
+                    return ArgumentLoc::Reg(if self.pointer_bits == 64 {
+                        RU::r10
+                    } else {
+                        RU::rcx
+                    } as RegUnit)
+                    .into()
+                }
                 _ => {}
             }
         }

--- a/filetests/isa/x86/baldrdash-table-sig-reg.clif
+++ b/filetests/isa/x86/baldrdash-table-sig-reg.clif
@@ -1,0 +1,14 @@
+test compile
+set probestack_enabled=false
+target i686
+
+function u0:0(i32 vmctx) baldrdash_system_v {
+    sig0 = (i32 vmctx, i32 sigid) baldrdash_system_v
+
+ebb0(v0: i32):
+    v2 = iconst.i32 0
+    v8 = iconst.i32 0
+    v9 = iconst.i32 0
+    call_indirect sig0, v8(v9, v2)
+    trap user0
+}


### PR DESCRIPTION
Fixes #1074; r10 was marked as the SignatureId parameter for call_indirect on x86 independently of 32 vs 64 bits, so we just need to tweak this to be platform specific.