### PR TITLE
Make no std default

### DIFF
--- a/cranelift-bforest/Cargo.toml
+++ b/cranelift-bforest/Cargo.toml
@@ -14,11 +14,6 @@ edition = "2018"
 [dependencies]
 cranelift-entity = { path = "../cranelift-entity", version = "0.44.0", default-features = false }
 
-[features]
-default = ["std"]
-std = ["cranelift-entity/std"]
-core = []
-
 [badges]
 maintenance = { status = "experimental" }
 travis-ci = { repository = "CraneStation/cranelift" }

--- a/cranelift-bforest/src/lib.rs
+++ b/cranelift-bforest/src/lib.rs
@@ -15,7 +15,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "std", warn(unstable_features))]
 #![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
 #![cfg_attr(
@@ -34,13 +33,8 @@
 #![no_std]
 
 #[cfg(test)]
-#[cfg(not(feature = "std"))]
 #[macro_use]
-extern crate alloc as std;
-#[cfg(test)]
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate std;
+extern crate alloc;
 
 #[macro_use]
 extern crate cranelift_entity as entity;

--- a/cranelift-bforest/src/map.rs
+++ b/cranelift-bforest/src/map.rs
@@ -6,7 +6,7 @@ use crate::packed_option::PackedOption;
 use core::fmt;
 use core::marker::PhantomData;
 #[cfg(test)]
-use std::string::String;
+use alloc::string::String;
 
 /// Tag type defining forest types for a map.
 struct MapTypes<K, V>(PhantomData<(K, V)>);

--- a/cranelift-bforest/src/map.rs
+++ b/cranelift-bforest/src/map.rs
@@ -3,10 +3,10 @@
 use super::{Comparator, Forest, Node, NodeData, NodePool, Path, INNER_SIZE};
 use crate::packed_option::PackedOption;
 #[cfg(test)]
+use alloc::string::String;
+#[cfg(test)]
 use core::fmt;
 use core::marker::PhantomData;
-#[cfg(test)]
-use alloc::string::String;
 
 /// Tag type defining forest types for a map.
 struct MapTypes<K, V>(PhantomData<(K, V)>);

--- a/cranelift-bforest/src/map.rs
+++ b/cranelift-bforest/src/map.rs
@@ -231,7 +231,7 @@ where
 
     /// Get a text version of the path to `key`.
     fn tpath<C: Comparator<K>>(&self, key: K, forest: &MapForest<K, V>, comp: &C) -> String {
-        use std::string::ToString;
+        use alloc::string::ToString;
         match self.root.expand() {
             None => "map(empty)".to_string(),
             Some(root) => {
@@ -420,7 +420,7 @@ where
 
     /// Get a text version of the path to the current position.
     fn tpath(&self) -> String {
-        use std::string::ToString;
+        use alloc::string::ToString;
         self.path.to_string()
     }
 }
@@ -430,7 +430,7 @@ mod tests {
     use super::super::NodeData;
     use super::*;
     use core::mem;
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     #[test]
     fn node_size() {

--- a/cranelift-bforest/src/map.rs
+++ b/cranelift-bforest/src/map.rs
@@ -429,8 +429,8 @@ where
 mod tests {
     use super::super::NodeData;
     use super::*;
-    use core::mem;
     use alloc::vec::Vec;
+    use core::mem;
 
     #[test]
     fn node_size() {

--- a/cranelift-bforest/src/node.rs
+++ b/cranelift-bforest/src/node.rs
@@ -584,8 +584,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::mem;
     use alloc::string::ToString;
+    use core::mem;
 
     // Forest impl for a set implementation.
     struct TF();

--- a/cranelift-bforest/src/node.rs
+++ b/cranelift-bforest/src/node.rs
@@ -585,7 +585,7 @@ where
 mod tests {
     use super::*;
     use core::mem;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     // Forest impl for a set implementation.
     struct TF();

--- a/cranelift-bforest/src/pool.rs
+++ b/cranelift-bforest/src/pool.rs
@@ -86,7 +86,7 @@ impl<F: Forest> NodePool<F> {
         use crate::entity::EntitySet;
         use core::borrow::Borrow;
         use core::cmp::Ordering;
-        use std::vec::Vec;
+        use alloc::vec::Vec;
 
         // The root node can't be an inner node with just a single sub-tree. It should have been
         // pruned.

--- a/cranelift-bforest/src/pool.rs
+++ b/cranelift-bforest/src/pool.rs
@@ -84,9 +84,9 @@ impl<F: Forest> NodePool<F> {
         F::Key: fmt::Display,
     {
         use crate::entity::EntitySet;
+        use alloc::vec::Vec;
         use core::borrow::Borrow;
         use core::cmp::Ordering;
-        use alloc::vec::Vec;
 
         // The root node can't be an inner node with just a single sub-tree. It should have been
         // pruned.

--- a/cranelift-bforest/src/set.rs
+++ b/cranelift-bforest/src/set.rs
@@ -3,10 +3,10 @@
 use super::{Comparator, Forest, Node, NodeData, NodePool, Path, SetValue, INNER_SIZE};
 use crate::packed_option::PackedOption;
 #[cfg(test)]
+use alloc::string::String;
+#[cfg(test)]
 use core::fmt;
 use core::marker::PhantomData;
-#[cfg(test)]
-use alloc::string::String;
 
 /// Tag type defining forest types for a set.
 struct SetTypes<K>(PhantomData<K>);
@@ -357,8 +357,8 @@ where
 mod tests {
     use super::super::NodeData;
     use super::*;
-    use core::mem;
     use alloc::vec::Vec;
+    use core::mem;
 
     #[test]
     fn node_size() {

--- a/cranelift-bforest/src/set.rs
+++ b/cranelift-bforest/src/set.rs
@@ -6,7 +6,7 @@ use crate::packed_option::PackedOption;
 use core::fmt;
 use core::marker::PhantomData;
 #[cfg(test)]
-use std::string::String;
+use alloc::string::String;
 
 /// Tag type defining forest types for a set.
 struct SetTypes<K>(PhantomData<K>);
@@ -321,7 +321,7 @@ where
 
     /// Get a text version of the path to the current position.
     fn tpath(&self) -> String {
-        use std::string::ToString;
+        use alloc::string::ToString;
         self.path.to_string()
     }
 }
@@ -358,7 +358,7 @@ mod tests {
     use super::super::NodeData;
     use super::*;
     use core::mem;
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     #[test]
     fn node_size() {

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen-shared = { path = "./shared", version = "0.44.0" }
-cranelift-entity = { path = "../cranelift-entity", version = "0.44.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.44.0" }
 cranelift-bforest = { path = "../cranelift-bforest", version = "0.44.0" }
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }
@@ -37,10 +37,7 @@ default = ["std"]
 # The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two
 # features need to be enabled.
-std = [
-    "cranelift-entity/std",
-    "cranelift-codegen-meta/std"
-]
+std = ["cranelift-codegen-meta/std"]
 
 # The "core" features enables use of "hashbrown" since core doesn't have
 # a HashMap implementation, and a workaround for Cargo #4866.

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [dependencies]
 cranelift-codegen-shared = { path = "./shared", version = "0.44.0" }
 cranelift-entity = { path = "../cranelift-entity", version = "0.44.0", default-features = false }
-cranelift-bforest = { path = "../cranelift-bforest", version = "0.44.0", default-features = false }
+cranelift-bforest = { path = "../cranelift-bforest", version = "0.44.0" }
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }
 hashbrown = { version = "0.6", optional = true }
@@ -39,7 +39,6 @@ default = ["std"]
 # features need to be enabled.
 std = [
     "cranelift-entity/std",
-    "cranelift-bforest/std",
     "cranelift-codegen-meta/std"
 ]
 

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -29,7 +29,7 @@ smallvec = { version = "0.6.10" }
 # accomodated in `tests`.
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.44.0", default-features = false }
+cranelift-codegen-meta = { path = "meta", version = "0.44.0" }
 
 [features]
 default = ["std"]
@@ -37,14 +37,11 @@ default = ["std"]
 # The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two
 # features need to be enabled.
-std = ["cranelift-codegen-meta/std"]
+std = []
 
 # The "core" features enables use of "hashbrown" since core doesn't have
 # a HashMap implementation, and a workaround for Cargo #4866.
-core = [
-    "hashbrown",
-    "cranelift-codegen-meta/core"
-]
+core = ["hashbrown"]
 
 # This enables some additional functions useful for writing tests, but which
 # can significantly increase the size of the library.

--- a/cranelift-codegen/meta/Cargo.toml
+++ b/cranelift-codegen/meta/Cargo.toml
@@ -15,9 +15,3 @@ cranelift-entity = { path = "../../cranelift-entity", version = "0.44.0" }
 [badges]
 maintenance = { status = "experimental" }
 travis-ci = { repository = "CraneStation/cranelift" }
-
-[features]
-default = ["std"]
-std = []
-# The "core" feature enables a workaround for Cargo #4866.
-core = []

--- a/cranelift-codegen/meta/Cargo.toml
+++ b/cranelift-codegen/meta/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen-shared = { path = "../shared", version = "0.44.0" }
-cranelift-entity = { path = "../../cranelift-entity", version = "0.44.0", default-features = false }
+cranelift-entity = { path = "../../cranelift-entity", version = "0.44.0" }
 
 [badges]
 maintenance = { status = "experimental" }
@@ -18,6 +18,6 @@ travis-ci = { repository = "CraneStation/cranelift" }
 
 [features]
 default = ["std"]
-std = ["cranelift-entity/std"]
+std = []
 # The "core" feature enables a workaround for Cargo #4866.
-core = ["cranelift-entity/core"]
+core = []

--- a/cranelift-codegen/src/abi.rs
+++ b/cranelift-codegen/src/abi.rs
@@ -4,8 +4,8 @@
 //! `TargetIsa::legalize_signature()` method.
 
 use crate::ir::{AbiParam, ArgumentExtension, ArgumentLoc, Type};
-use core::cmp::Ordering;
 use alloc::vec::Vec;
+use core::cmp::Ordering;
 
 /// Legalization action to perform on a single argument or return value when converting a
 /// signature.

--- a/cranelift-codegen/src/abi.rs
+++ b/cranelift-codegen/src/abi.rs
@@ -5,7 +5,7 @@
 
 use crate::ir::{AbiParam, ArgumentExtension, ArgumentLoc, Type};
 use core::cmp::Ordering;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Legalization action to perform on a single argument or return value when converting a
 /// signature.

--- a/cranelift-codegen/src/binemit/relaxation.rs
+++ b/cranelift-codegen/src/binemit/relaxation.rs
@@ -227,7 +227,7 @@ fn try_fold_redundant_jump(
     }
 
     // Build a value list of first_args (unchanged) followed by second_params (rewritten).
-    let arguments_vec: std::vec::Vec<_> = first_args
+    let arguments_vec: alloc::vec::Vec<_> = first_args
         .iter()
         .chain(second_params.iter())
         .map(|x| *x)

--- a/cranelift-codegen/src/binemit/stackmap.rs
+++ b/cranelift-codegen/src/binemit/stackmap.rs
@@ -1,7 +1,7 @@
 use crate::bitset::BitSet;
 use crate::ir;
 use crate::isa::TargetIsa;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 type Num = u32;
 const NUM_BITS: usize = core::mem::size_of::<Num>() * 8;
@@ -42,7 +42,7 @@ impl Stackmap {
         let frame_size = stack.frame_size.unwrap();
         let word_size = ir::stackslot::StackSize::from(isa.pointer_bytes());
         let num_words = (frame_size / word_size) as usize;
-        let mut vec = std::vec::Vec::with_capacity(num_words);
+        let mut vec = alloc::vec::Vec::with_capacity(num_words);
 
         vec.resize(num_words, false);
 

--- a/cranelift-codegen/src/cfg_printer.rs
+++ b/cranelift-codegen/src/cfg_printer.rs
@@ -1,7 +1,7 @@
 //! The `CFGPrinter` utility.
 
 use core::fmt::{Display, Formatter, Result, Write};
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 use crate::entity::SecondaryMap;
 use crate::flowgraph::{BasicBlock, ControlFlowGraph};

--- a/cranelift-codegen/src/cfg_printer.rs
+++ b/cranelift-codegen/src/cfg_printer.rs
@@ -1,7 +1,7 @@
 //! The `CFGPrinter` utility.
 
-use core::fmt::{Display, Formatter, Result, Write};
 use alloc::vec::Vec;
+use core::fmt::{Display, Formatter, Result, Write};
 
 use crate::entity::SecondaryMap;
 use crate::flowgraph::{BasicBlock, ControlFlowGraph};

--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -33,8 +33,8 @@ use crate::timing;
 use crate::unreachable_code::eliminate_unreachable_code;
 use crate::value_label::{build_value_labels_ranges, ComparableSourceLoc, ValueLabelsRanges};
 use crate::verifier::{verify_context, verify_locations, VerifierErrors, VerifierResult};
-use log::debug;
 use alloc::vec::Vec;
+use log::debug;
 
 /// Persistent data structures and compilation pipeline.
 pub struct Context {

--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -34,7 +34,7 @@ use crate::unreachable_code::eliminate_unreachable_code;
 use crate::value_label::{build_value_labels_ranges, ComparableSourceLoc, ValueLabelsRanges};
 use crate::verifier::{verify_context, verify_locations, VerifierErrors, VerifierResult};
 use log::debug;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Persistent data structures and compilation pipeline.
 pub struct Context {

--- a/cranelift-codegen/src/dominator_tree.rs
+++ b/cranelift-codegen/src/dominator_tree.rs
@@ -6,10 +6,10 @@ use crate::ir::instructions::BranchInfo;
 use crate::ir::{Ebb, ExpandedProgramPoint, Function, Inst, Layout, ProgramOrder, Value};
 use crate::packed_option::PackedOption;
 use crate::timing;
+use alloc::vec::Vec;
 use core::cmp;
 use core::cmp::Ordering;
 use core::mem;
-use alloc::vec::Vec;
 
 /// RPO numbers are not first assigned in a contiguous way but as multiples of STRIDE, to leave
 /// room for modifications of the dominator tree.

--- a/cranelift-codegen/src/dominator_tree.rs
+++ b/cranelift-codegen/src/dominator_tree.rs
@@ -9,7 +9,7 @@ use crate::timing;
 use core::cmp;
 use core::cmp::Ordering;
 use core::mem;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// RPO numbers are not first assigned in a contiguous way but as multiples of STRIDE, to leave
 /// room for modifications of the dominator tree.

--- a/cranelift-codegen/src/flowgraph.rs
+++ b/cranelift-codegen/src/flowgraph.rs
@@ -214,7 +214,7 @@ mod tests {
     use super::*;
     use crate::cursor::{Cursor, FuncCursor};
     use crate::ir::{types, Function, InstBuilder};
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     #[test]
     fn empty() {

--- a/cranelift-codegen/src/ir/constant.rs
+++ b/cranelift-codegen/src/ir/constant.rs
@@ -11,8 +11,8 @@
 use crate::ir::Constant;
 use crate::HashMap;
 use cranelift_entity::EntityRef;
-use std::collections::BTreeMap;
-use std::vec::Vec;
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 
 /// This type describes the actual constant data.
 pub type ConstantData = Vec<u8>;

--- a/cranelift-codegen/src/ir/constant.rs
+++ b/cranelift-codegen/src/ir/constant.rs
@@ -10,9 +10,9 @@
 
 use crate::ir::Constant;
 use crate::HashMap;
-use cranelift_entity::EntityRef;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
+use cranelift_entity::EntityRef;
 
 /// This type describes the actual constant data.
 pub type ConstantData = Vec<u8>;

--- a/cranelift-codegen/src/ir/dfg.rs
+++ b/cranelift-codegen/src/ir/dfg.rs
@@ -19,7 +19,7 @@ use core::iter;
 use core::mem;
 use core::ops::{Index, IndexMut};
 use core::u16;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// A data flow graph defines all instructions and extended basic blocks in a function as well as
 /// the data flow dependencies between them. The DFG also tracks values which can be either
@@ -1093,7 +1093,7 @@ mod tests {
     use crate::cursor::{Cursor, FuncCursor};
     use crate::ir::types;
     use crate::ir::{Function, InstructionData, Opcode, TrapCode};
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn make_inst() {

--- a/cranelift-codegen/src/ir/dfg.rs
+++ b/cranelift-codegen/src/ir/dfg.rs
@@ -14,12 +14,12 @@ use crate::isa::TargetIsa;
 use crate::packed_option::ReservedValue;
 use crate::write::write_operands;
 use crate::HashMap;
+use alloc::vec::Vec;
 use core::fmt;
 use core::iter;
 use core::mem;
 use core::ops::{Index, IndexMut};
 use core::u16;
-use alloc::vec::Vec;
 
 /// A data flow graph defines all instructions and extended basic blocks in a function as well as
 /// the data flow dependencies between them. The DFG also tracks values which can be either

--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -455,8 +455,8 @@ impl From<Table> for AnyEntity {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::u32;
     use alloc::string::ToString;
+    use core::u32;
 
     #[test]
     fn value_with_number() {

--- a/cranelift-codegen/src/ir/entities.rs
+++ b/cranelift-codegen/src/ir/entities.rs
@@ -456,7 +456,7 @@ impl From<Table> for AnyEntity {
 mod tests {
     use super::*;
     use core::u32;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn value_with_number() {

--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -7,9 +7,9 @@
 
 use crate::ir::{ArgumentLoc, ExternalName, SigRef, Type};
 use crate::isa::{CallConv, RegInfo, RegUnit};
+use alloc::vec::Vec;
 use core::fmt;
 use core::str::FromStr;
-use alloc::vec::Vec;
 
 /// Function signature.
 ///

--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -9,7 +9,7 @@ use crate::ir::{ArgumentLoc, ExternalName, SigRef, Type};
 use crate::isa::{CallConv, RegInfo, RegUnit};
 use core::fmt;
 use core::str::FromStr;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Function signature.
 ///
@@ -335,7 +335,7 @@ impl fmt::Display for ExtFuncData {
 mod tests {
     use super::*;
     use crate::ir::types::{B8, F32, I32};
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn argument_type() {

--- a/cranelift-codegen/src/ir/extname.rs
+++ b/cranelift-codegen/src/ir/extname.rs
@@ -120,8 +120,8 @@ impl FromStr for ExternalName {
 mod tests {
     use super::ExternalName;
     use crate::ir::LibCall;
-    use core::u32;
     use alloc::string::ToString;
+    use core::u32;
 
     #[test]
     fn display_testcase() {

--- a/cranelift-codegen/src/ir/extname.rs
+++ b/cranelift-codegen/src/ir/extname.rs
@@ -121,7 +121,7 @@ mod tests {
     use super::ExternalName;
     use crate::ir::LibCall;
     use core::u32;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn display_testcase() {

--- a/cranelift-codegen/src/ir/immediates.rs
+++ b/cranelift-codegen/src/ir/immediates.rs
@@ -8,7 +8,7 @@ use core::fmt::{self, Display, Formatter};
 use core::iter::FromIterator;
 use core::str::{from_utf8, FromStr};
 use core::{i32, u32};
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Convert a type into a vector of bytes; all implementors in this file must use little-endian
 /// orderings of bytes to match WebAssembly's little-endianness.
@@ -933,7 +933,7 @@ mod tests {
     use core::mem;
     use core::str::FromStr;
     use core::{f32, f64};
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn format_imm64() {

--- a/cranelift-codegen/src/ir/immediates.rs
+++ b/cranelift-codegen/src/ir/immediates.rs
@@ -4,11 +4,11 @@
 //! Each type here should have a corresponding definition in the
 //! `cranelift-codegen/meta/src/shared/immediates` crate in the meta language.
 
+use alloc::vec::Vec;
 use core::fmt::{self, Display, Formatter};
 use core::iter::FromIterator;
 use core::str::{from_utf8, FromStr};
 use core::{i32, u32};
-use alloc::vec::Vec;
 
 /// Convert a type into a vector of bytes; all implementors in this file must use little-endian
 /// orderings of bytes to match WebAssembly's little-endianness.
@@ -929,11 +929,11 @@ impl IntoBytes for Ieee64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
     use core::fmt::Display;
     use core::mem;
     use core::str::FromStr;
     use core::{f32, f64};
-    use alloc::string::ToString;
 
     #[test]
     fn format_imm64() {

--- a/cranelift-codegen/src/ir/instructions.rs
+++ b/cranelift-codegen/src/ir/instructions.rs
@@ -6,10 +6,10 @@
 //! A large part of this module is auto-generated from the instruction descriptions in the meta
 //! directory.
 
+use alloc::vec::Vec;
 use core::fmt::{self, Display, Formatter};
 use core::ops::{Deref, DerefMut};
 use core::str::FromStr;
-use alloc::vec::Vec;
 
 use crate::ir;
 use crate::ir::types;

--- a/cranelift-codegen/src/ir/instructions.rs
+++ b/cranelift-codegen/src/ir/instructions.rs
@@ -9,7 +9,7 @@
 use core::fmt::{self, Display, Formatter};
 use core::ops::{Deref, DerefMut};
 use core::str::FromStr;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 use crate::ir;
 use crate::ir::types;
@@ -560,7 +560,7 @@ pub enum ResolvedConstraint {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn opcodes() {

--- a/cranelift-codegen/src/ir/jumptable.rs
+++ b/cranelift-codegen/src/ir/jumptable.rs
@@ -6,7 +6,7 @@
 use crate::ir::entities::Ebb;
 use core::fmt::{self, Display, Formatter};
 use core::slice::{Iter, IterMut};
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Contents of a jump table.
 ///
@@ -85,7 +85,7 @@ mod tests {
     use super::JumpTableData;
     use crate::entity::EntityRef;
     use crate::ir::Ebb;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn empty() {

--- a/cranelift-codegen/src/ir/jumptable.rs
+++ b/cranelift-codegen/src/ir/jumptable.rs
@@ -4,9 +4,9 @@
 //! The actual table of destinations is stored in a `JumpTableData` struct defined in this module.
 
 use crate::ir::entities::Ebb;
+use alloc::vec::Vec;
 use core::fmt::{self, Display, Formatter};
 use core::slice::{Iter, IterMut};
-use alloc::vec::Vec;
 
 /// Contents of a jump table.
 ///

--- a/cranelift-codegen/src/ir/layout.rs
+++ b/cranelift-codegen/src/ir/layout.rs
@@ -751,7 +751,7 @@ mod tests {
     use crate::entity::EntityRef;
     use crate::ir::{Ebb, Inst, ProgramOrder, SourceLoc};
     use core::cmp::Ordering;
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     struct LayoutCursor<'f> {
         /// Borrowed function layout. Public so it can be re-borrowed from this cursor.

--- a/cranelift-codegen/src/ir/layout.rs
+++ b/cranelift-codegen/src/ir/layout.rs
@@ -750,8 +750,8 @@ mod tests {
     use crate::cursor::{Cursor, CursorPosition};
     use crate::entity::EntityRef;
     use crate::ir::{Ebb, Inst, ProgramOrder, SourceLoc};
-    use core::cmp::Ordering;
     use alloc::vec::Vec;
+    use core::cmp::Ordering;
 
     struct LayoutCursor<'f> {
         /// Borrowed function layout. Public so it can be re-borrowed from this cursor.

--- a/cranelift-codegen/src/ir/libcall.rs
+++ b/cranelift-codegen/src/ir/libcall.rs
@@ -209,7 +209,7 @@ fn make_funcref(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn display() {

--- a/cranelift-codegen/src/ir/mod.rs
+++ b/cranelift-codegen/src/ir/mod.rs
@@ -98,7 +98,7 @@ pub struct ValueLabelStart {
 #[derive(Debug, Clone)]
 pub enum ValueLabelAssignments {
     /// Original value labels assigned at transform.
-    Starts(std::vec::Vec<ValueLabelStart>),
+    Starts(alloc::vec::Vec<ValueLabelStart>),
 
     /// A value alias to original value.
     Alias {

--- a/cranelift-codegen/src/ir/progpoint.rs
+++ b/cranelift-codegen/src/ir/progpoint.rs
@@ -148,7 +148,7 @@ mod tests {
     use super::*;
     use crate::entity::EntityRef;
     use crate::ir::{Ebb, Inst};
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn convert() {

--- a/cranelift-codegen/src/ir/sourceloc.rs
+++ b/cranelift-codegen/src/ir/sourceloc.rs
@@ -54,7 +54,7 @@ impl fmt::Display for SourceLoc {
 #[cfg(test)]
 mod tests {
     use crate::ir::SourceLoc;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn display() {

--- a/cranelift-codegen/src/ir/stackslot.rs
+++ b/cranelift-codegen/src/ir/stackslot.rs
@@ -11,7 +11,7 @@ use core::fmt;
 use core::ops::{Index, IndexMut};
 use core::slice;
 use core::str::FromStr;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
@@ -343,7 +343,7 @@ mod tests {
     use super::*;
     use crate::ir::types;
     use crate::ir::Function;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn stack_slot() {

--- a/cranelift-codegen/src/ir/stackslot.rs
+++ b/cranelift-codegen/src/ir/stackslot.rs
@@ -6,12 +6,12 @@
 use crate::entity::{Iter, IterMut, Keys, PrimaryMap};
 use crate::ir::{StackSlot, Type};
 use crate::packed_option::PackedOption;
+use alloc::vec::Vec;
 use core::cmp;
 use core::fmt;
 use core::ops::{Index, IndexMut};
 use core::slice;
 use core::str::FromStr;
-use alloc::vec::Vec;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};

--- a/cranelift-codegen/src/ir/trapcode.rs
+++ b/cranelift-codegen/src/ir/trapcode.rs
@@ -103,7 +103,7 @@ impl FromStr for TrapCode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     // Everything but user-defined codes.
     const CODES: [TrapCode; 11] = [

--- a/cranelift-codegen/src/ir/types.rs
+++ b/cranelift-codegen/src/ir/types.rs
@@ -363,7 +363,7 @@ impl Default for Type {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn basic_scalars() {

--- a/cranelift-codegen/src/isa/arm32/mod.rs
+++ b/cranelift-codegen/src/isa/arm32/mod.rs
@@ -15,8 +15,8 @@ use crate::isa::enc_tables::{self as shared_enc_tables, lookup_enclist, Encoding
 use crate::isa::Builder as IsaBuilder;
 use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
-use core::fmt;
 use alloc::boxed::Box;
+use core::fmt;
 use target_lexicon::{Architecture, Triple};
 
 #[allow(dead_code)]

--- a/cranelift-codegen/src/isa/arm32/mod.rs
+++ b/cranelift-codegen/src/isa/arm32/mod.rs
@@ -16,7 +16,7 @@ use crate::isa::Builder as IsaBuilder;
 use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
 use core::fmt;
-use std::boxed::Box;
+use alloc::boxed::Box;
 use target_lexicon::{Architecture, Triple};
 
 #[allow(dead_code)]

--- a/cranelift-codegen/src/isa/arm32/registers.rs
+++ b/cranelift-codegen/src/isa/arm32/registers.rs
@@ -8,7 +8,7 @@ include!(concat!(env!("OUT_DIR"), "/registers-arm32.rs"));
 mod tests {
     use super::{D, GPR, INFO, S};
     use crate::isa::RegUnit;
-    use std::string::{String, ToString};
+    use alloc::string::{String, ToString};
 
     #[test]
     fn unit_encodings() {

--- a/cranelift-codegen/src/isa/arm64/mod.rs
+++ b/cranelift-codegen/src/isa/arm64/mod.rs
@@ -16,7 +16,7 @@ use crate::isa::Builder as IsaBuilder;
 use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
 use core::fmt;
-use std::boxed::Box;
+use alloc::boxed::Box;
 use target_lexicon::Triple;
 
 #[allow(dead_code)]

--- a/cranelift-codegen/src/isa/arm64/mod.rs
+++ b/cranelift-codegen/src/isa/arm64/mod.rs
@@ -15,8 +15,8 @@ use crate::isa::enc_tables::{lookup_enclist, Encodings};
 use crate::isa::Builder as IsaBuilder;
 use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
-use core::fmt;
 use alloc::boxed::Box;
+use core::fmt;
 use target_lexicon::Triple;
 
 #[allow(dead_code)]

--- a/cranelift-codegen/src/isa/arm64/registers.rs
+++ b/cranelift-codegen/src/isa/arm64/registers.rs
@@ -8,7 +8,7 @@ include!(concat!(env!("OUT_DIR"), "/registers-arm64.rs"));
 mod tests {
     use super::INFO;
     use crate::isa::RegUnit;
-    use std::string::{String, ToString};
+    use alloc::string::{String, ToString};
 
     #[test]
     fn unit_encodings() {

--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -25,7 +25,7 @@
 //! # fn main() {
 //! use cranelift_codegen::isa;
 //! use cranelift_codegen::settings::{self, Configurable};
-//! use std::str::FromStr;
+//! use alloc::str::FromStr;
 //! use target_lexicon::Triple;
 //!
 //! let shared_builder = settings::builder();
@@ -65,7 +65,7 @@ use crate::settings::SetResult;
 use crate::timing;
 use core::fmt;
 use failure_derive::Fail;
-use std::boxed::Box;
+use alloc::boxed::Box;
 use target_lexicon::{triple, Architecture, PointerWidth, Triple};
 
 #[cfg(feature = "riscv")]
@@ -119,7 +119,7 @@ pub fn lookup(triple: Triple) -> Result<Builder, LookupError> {
 /// Look for a supported ISA with the given `name`.
 /// Return a builder that can create a corresponding `TargetIsa`.
 pub fn lookup_by_name(name: &str) -> Result<Builder, LookupError> {
-    use std::str::FromStr;
+    use alloc::str::FromStr;
     lookup(triple!(name))
 }
 

--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -25,7 +25,7 @@
 //! # fn main() {
 //! use cranelift_codegen::isa;
 //! use cranelift_codegen::settings::{self, Configurable};
-//! use alloc::str::FromStr;
+//! use std::str::FromStr;
 //! use target_lexicon::Triple;
 //!
 //! let shared_builder = settings::builder();

--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -63,9 +63,9 @@ use crate::result::CodegenResult;
 use crate::settings;
 use crate::settings::SetResult;
 use crate::timing;
+use alloc::boxed::Box;
 use core::fmt;
 use failure_derive::Fail;
-use alloc::boxed::Box;
 use target_lexicon::{triple, Architecture, PointerWidth, Triple};
 
 #[cfg(feature = "riscv")]

--- a/cranelift-codegen/src/isa/riscv/mod.rs
+++ b/cranelift-codegen/src/isa/riscv/mod.rs
@@ -15,8 +15,8 @@ use crate::isa::enc_tables::{self as shared_enc_tables, lookup_enclist, Encoding
 use crate::isa::Builder as IsaBuilder;
 use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
-use core::fmt;
 use alloc::boxed::Box;
+use core::fmt;
 use target_lexicon::{PointerWidth, Triple};
 
 #[allow(dead_code)]
@@ -137,8 +137,8 @@ mod tests {
     use crate::ir::{Function, InstructionData, Opcode};
     use crate::isa;
     use crate::settings::{self, Configurable};
-    use core::str::FromStr;
     use alloc::string::{String, ToString};
+    use core::str::FromStr;
     use target_lexicon::triple;
 
     fn encstr(isa: &dyn isa::TargetIsa, enc: Result<isa::Encoding, isa::Legalize>) -> String {

--- a/cranelift-codegen/src/isa/riscv/mod.rs
+++ b/cranelift-codegen/src/isa/riscv/mod.rs
@@ -16,7 +16,7 @@ use crate::isa::Builder as IsaBuilder;
 use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
 use core::fmt;
-use std::boxed::Box;
+use alloc::boxed::Box;
 use target_lexicon::{PointerWidth, Triple};
 
 #[allow(dead_code)]
@@ -138,7 +138,7 @@ mod tests {
     use crate::isa;
     use crate::settings::{self, Configurable};
     use core::str::FromStr;
-    use std::string::{String, ToString};
+    use alloc::string::{String, ToString};
     use target_lexicon::triple;
 
     fn encstr(isa: &dyn isa::TargetIsa, enc: Result<isa::Encoding, isa::Legalize>) -> String {

--- a/cranelift-codegen/src/isa/riscv/registers.rs
+++ b/cranelift-codegen/src/isa/riscv/registers.rs
@@ -8,7 +8,7 @@ include!(concat!(env!("OUT_DIR"), "/registers-riscv.rs"));
 mod tests {
     use super::{FPR, GPR, INFO};
     use crate::isa::RegUnit;
-    use std::string::{String, ToString};
+    use alloc::string::{String, ToString};
 
     #[test]
     fn unit_encodings() {

--- a/cranelift-codegen/src/isa/riscv/settings.rs
+++ b/cranelift-codegen/src/isa/riscv/settings.rs
@@ -12,7 +12,7 @@ include!(concat!(env!("OUT_DIR"), "/settings-riscv.rs"));
 mod tests {
     use super::{builder, Flags};
     use crate::settings::{self, Configurable};
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn display_default() {

--- a/cranelift-codegen/src/isa/x86/mod.rs
+++ b/cranelift-codegen/src/isa/x86/mod.rs
@@ -18,7 +18,7 @@ use crate::regalloc;
 use crate::result::CodegenResult;
 use crate::timing;
 use core::fmt;
-use std::boxed::Box;
+use alloc::boxed::Box;
 use target_lexicon::{PointerWidth, Triple};
 
 #[allow(dead_code)]

--- a/cranelift-codegen/src/isa/x86/mod.rs
+++ b/cranelift-codegen/src/isa/x86/mod.rs
@@ -17,8 +17,8 @@ use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
 use crate::result::CodegenResult;
 use crate::timing;
-use core::fmt;
 use alloc::boxed::Box;
+use core::fmt;
 use target_lexicon::{PointerWidth, Triple};
 
 #[allow(dead_code)]

--- a/cranelift-codegen/src/isa/x86/registers.rs
+++ b/cranelift-codegen/src/isa/x86/registers.rs
@@ -8,7 +8,7 @@ include!(concat!(env!("OUT_DIR"), "/registers-x86.rs"));
 mod tests {
     use super::*;
     use crate::isa::RegUnit;
-    use std::string::{String, ToString};
+    use alloc::string::{String, ToString};
 
     #[test]
     fn unit_encodings() {

--- a/cranelift-codegen/src/iterators.rs
+++ b/cranelift-codegen/src/iterators.rs
@@ -44,7 +44,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     #[test]
     fn adjpairs() {

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -28,7 +28,7 @@ use crate::ir::{
 use crate::isa::TargetIsa;
 use crate::legalizer::split::{isplit, vsplit};
 use log::debug;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Legalize all the function signatures in `func`.
 ///

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -27,8 +27,8 @@ use crate::ir::{
 };
 use crate::isa::TargetIsa;
 use crate::legalizer::split::{isplit, vsplit};
-use log::debug;
 use alloc::vec::Vec;
+use log::debug;
 
 /// Legalize all the function signatures in `func`.
 ///

--- a/cranelift-codegen/src/legalizer/libcall.rs
+++ b/cranelift-codegen/src/legalizer/libcall.rs
@@ -4,7 +4,7 @@ use crate::ir;
 use crate::ir::{get_libcall_funcref, InstBuilder};
 use crate::isa::{CallConv, TargetIsa};
 use crate::legalizer::boundary::legalize_libcall_signature;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Try to expand `inst` as a library call, returning true is successful.
 pub fn expand_as_libcall(inst: ir::Inst, func: &mut ir::Function, isa: &dyn TargetIsa) -> bool {

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -21,8 +21,8 @@ use crate::ir::{self, InstBuilder, MemFlags};
 use crate::isa::TargetIsa;
 use crate::predicates;
 use crate::timing;
-use std::collections::BTreeSet;
-use std::vec::Vec;
+use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
 
 mod boundary;
 mod call;
@@ -373,7 +373,7 @@ fn expand_br_table_conds(
     let table_size = func.jump_tables[table].len();
     let mut cond_failed_ebb = vec![];
     if table_size >= 1 {
-        cond_failed_ebb = std::vec::Vec::with_capacity(table_size - 1);
+        cond_failed_ebb = alloc::vec::Vec::with_capacity(table_size - 1);
         for _ in 0..table_size - 1 {
             cond_failed_ebb.push(func.dfg.make_ebb());
         }

--- a/cranelift-codegen/src/legalizer/split.rs
+++ b/cranelift-codegen/src/legalizer/split.rs
@@ -67,9 +67,9 @@
 use crate::cursor::{Cursor, CursorPosition, FuncCursor};
 use crate::flowgraph::{BasicBlock, ControlFlowGraph};
 use crate::ir::{self, Ebb, Inst, InstBuilder, InstructionData, Opcode, Type, Value, ValueDef};
+use alloc::vec::Vec;
 use core::iter;
 use smallvec::SmallVec;
-use alloc::vec::Vec;
 
 /// Split `value` into two values using the `isplit` semantics. Do this by reusing existing values
 /// if possible.

--- a/cranelift-codegen/src/legalizer/split.rs
+++ b/cranelift-codegen/src/legalizer/split.rs
@@ -69,7 +69,7 @@ use crate::flowgraph::{BasicBlock, ControlFlowGraph};
 use crate::ir::{self, Ebb, Inst, InstBuilder, InstructionData, Opcode, Type, Value, ValueDef};
 use core::iter;
 use smallvec::SmallVec;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Split `value` into two values using the `isplit` semantics. Do this by reusing existing values
 /// if possible.

--- a/cranelift-codegen/src/lib.rs
+++ b/cranelift-codegen/src/lib.rs
@@ -35,16 +35,15 @@
         clippy::nonminimal_bool,
         clippy::option_map_unwrap_or,
         clippy::option_map_unwrap_or_else,
-        clippy::print_stdout,
+        clippy::print_allocout,
         clippy::unicode_not_nfc,
         clippy::use_self
     )
 )]
 #![no_std]
 
-#[cfg(not(feature = "std"))]
-#[macro_use]
-extern crate alloc as std;
+extern crate alloc;
+
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;

--- a/cranelift-codegen/src/lib.rs
+++ b/cranelift-codegen/src/lib.rs
@@ -42,6 +42,8 @@
 )]
 #![no_std]
 
+#[allow(unused_imports)] // #[macro_use] is required for no_std
+#[macro_use]
 extern crate alloc;
 
 #[cfg(feature = "std")]

--- a/cranelift-codegen/src/licm.rs
+++ b/cranelift-codegen/src/licm.rs
@@ -11,7 +11,7 @@ use crate::ir::{
 use crate::isa::TargetIsa;
 use crate::loop_analysis::{Loop, LoopAnalysis};
 use crate::timing;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Performs the LICM pass by detecting loops within the CFG and moving
 /// loop-invariant instructions out of them.

--- a/cranelift-codegen/src/loop_analysis.rs
+++ b/cranelift-codegen/src/loop_analysis.rs
@@ -9,7 +9,7 @@ use crate::flowgraph::{BasicBlock, ControlFlowGraph};
 use crate::ir::{Ebb, Function, Layout};
 use crate::packed_option::PackedOption;
 use crate::timing;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// A opaque reference to a code loop.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
@@ -237,7 +237,7 @@ mod tests {
     use crate::flowgraph::ControlFlowGraph;
     use crate::ir::{types, Function, InstBuilder};
     use crate::loop_analysis::{Loop, LoopAnalysis};
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     #[test]
     fn nested_loops_detection() {

--- a/cranelift-codegen/src/partition_slice.rs
+++ b/cranelift-codegen/src/partition_slice.rs
@@ -53,7 +53,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::partition_slice;
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     fn check(x: &[u32], want: &[u32]) {
         assert_eq!(x.len(), want.len());

--- a/cranelift-codegen/src/print_errors.rs
+++ b/cranelift-codegen/src/print_errors.rs
@@ -10,9 +10,9 @@ use crate::verifier::{VerifierError, VerifierErrors};
 use crate::write::{decorate_function, FuncWriter, PlainWriter};
 use core::fmt;
 use core::fmt::Write;
-use std::boxed::Box;
-use std::string::{String, ToString};
-use std::vec::Vec;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 /// Pretty-print a verifier error.
 pub fn pretty_verifier_error<'a>(

--- a/cranelift-codegen/src/print_errors.rs
+++ b/cranelift-codegen/src/print_errors.rs
@@ -8,11 +8,11 @@ use crate::isa::TargetIsa;
 use crate::result::CodegenError;
 use crate::verifier::{VerifierError, VerifierErrors};
 use crate::write::{decorate_function, FuncWriter, PlainWriter};
-use core::fmt;
-use core::fmt::Write;
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use core::fmt;
+use core::fmt::Write;
 
 /// Pretty-print a verifier error.
 pub fn pretty_verifier_error<'a>(

--- a/cranelift-codegen/src/redundant_reload_remover.rs
+++ b/cranelift-codegen/src/redundant_reload_remover.rs
@@ -12,9 +12,9 @@ use crate::ir::{
 };
 use crate::isa::{RegInfo, RegUnit, TargetIsa};
 use crate::regalloc::RegDiversions;
+use alloc::vec::Vec;
 use core::convert::TryInto;
 use cranelift_entity::{PrimaryMap, SecondaryMap};
-use alloc::vec::Vec;
 
 // =============================================================================================
 // A description of the redundant-fill-removal algorithm

--- a/cranelift-codegen/src/redundant_reload_remover.rs
+++ b/cranelift-codegen/src/redundant_reload_remover.rs
@@ -14,7 +14,7 @@ use crate::isa::{RegInfo, RegUnit, TargetIsa};
 use crate::regalloc::RegDiversions;
 use core::convert::TryInto;
 use cranelift_entity::{PrimaryMap, SecondaryMap};
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 // =============================================================================================
 // A description of the redundant-fill-removal algorithm

--- a/cranelift-codegen/src/regalloc/branch_splitting.rs
+++ b/cranelift-codegen/src/regalloc/branch_splitting.rs
@@ -4,7 +4,7 @@
 //! between a conditional branch and the following terminator.
 #![cfg(feature = "basic-blocks")]
 
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 use crate::cursor::{Cursor, EncCursor};
 use crate::dominator_tree::DominatorTree;

--- a/cranelift-codegen/src/regalloc/coalescing.rs
+++ b/cranelift-codegen/src/regalloc/coalescing.rs
@@ -22,7 +22,7 @@ use core::fmt;
 use core::iter;
 use core::slice;
 use log::debug;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 // # Implementation
 //

--- a/cranelift-codegen/src/regalloc/coalescing.rs
+++ b/cranelift-codegen/src/regalloc/coalescing.rs
@@ -17,12 +17,12 @@ use crate::regalloc::affinity::Affinity;
 use crate::regalloc::liveness::Liveness;
 use crate::regalloc::virtregs::{VirtReg, VirtRegs};
 use crate::timing;
+use alloc::vec::Vec;
 use core::cmp;
 use core::fmt;
 use core::iter;
 use core::slice;
 use log::debug;
-use alloc::vec::Vec;
 
 // # Implementation
 //

--- a/cranelift-codegen/src/regalloc/live_value_tracker.rs
+++ b/cranelift-codegen/src/regalloc/live_value_tracker.rs
@@ -12,7 +12,7 @@ use crate::partition_slice::partition_slice;
 use crate::regalloc::affinity::Affinity;
 use crate::regalloc::liveness::Liveness;
 use crate::regalloc::liverange::LiveRange;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 type ValueList = EntityList<Value>;
 

--- a/cranelift-codegen/src/regalloc/liveness.rs
+++ b/cranelift-codegen/src/regalloc/liveness.rs
@@ -185,7 +185,7 @@ use crate::regalloc::liverange::{LiveRange, LiveRangeForest};
 use crate::timing;
 use core::mem;
 use core::ops::Index;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// A set of live ranges, indexed by value number.
 type LiveRangeSet = SparseMap<Value, LiveRange>;

--- a/cranelift-codegen/src/regalloc/liveness.rs
+++ b/cranelift-codegen/src/regalloc/liveness.rs
@@ -183,9 +183,9 @@ use crate::isa::{EncInfo, OperandConstraint, TargetIsa};
 use crate::regalloc::affinity::Affinity;
 use crate::regalloc::liverange::{LiveRange, LiveRangeForest};
 use crate::timing;
+use alloc::vec::Vec;
 use core::mem;
 use core::ops::Index;
-use alloc::vec::Vec;
 
 /// A set of live ranges, indexed by value number.
 type LiveRangeSet = SparseMap<Value, LiveRange>;

--- a/cranelift-codegen/src/regalloc/liverange.rs
+++ b/cranelift-codegen/src/regalloc/liverange.rs
@@ -449,7 +449,7 @@ mod tests {
     use crate::ir::{Ebb, Inst, Value};
     use crate::ir::{ExpandedProgramPoint, ProgramOrder};
     use core::cmp::Ordering;
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     // Dummy program order which simply compares indexes.
     // It is assumed that EBBs have indexes that are multiples of 10, and instructions have indexes

--- a/cranelift-codegen/src/regalloc/liverange.rs
+++ b/cranelift-codegen/src/regalloc/liverange.rs
@@ -448,8 +448,8 @@ mod tests {
     use crate::entity::EntityRef;
     use crate::ir::{Ebb, Inst, Value};
     use crate::ir::{ExpandedProgramPoint, ProgramOrder};
-    use core::cmp::Ordering;
     use alloc::vec::Vec;
+    use core::cmp::Ordering;
 
     // Dummy program order which simply compares indexes.
     // It is assumed that EBBs have indexes that are multiples of 10, and instructions have indexes

--- a/cranelift-codegen/src/regalloc/pressure.rs
+++ b/cranelift-codegen/src/regalloc/pressure.rs
@@ -277,7 +277,7 @@ mod tests {
     use crate::regalloc::RegisterSet;
     use core::borrow::Borrow;
     use core::str::FromStr;
-    use std::boxed::Box;
+    use alloc::boxed::Box;
     use target_lexicon::triple;
 
     // Make an arm32 `TargetIsa`, if possible.

--- a/cranelift-codegen/src/regalloc/pressure.rs
+++ b/cranelift-codegen/src/regalloc/pressure.rs
@@ -275,9 +275,9 @@ mod tests {
     use super::Pressure;
     use crate::isa::{RegClass, TargetIsa};
     use crate::regalloc::RegisterSet;
+    use alloc::boxed::Box;
     use core::borrow::Borrow;
     use core::str::FromStr;
-    use alloc::boxed::Box;
     use target_lexicon::triple;
 
     // Make an arm32 `TargetIsa`, if possible.

--- a/cranelift-codegen/src/regalloc/register_set.rs
+++ b/cranelift-codegen/src/regalloc/register_set.rs
@@ -255,7 +255,7 @@ impl fmt::Display for RegisterSet {
 mod tests {
     use super::*;
     use crate::isa::registers::{RegClass, RegClassData};
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     // Register classes for testing.
     const GPR: RegClass = &RegClassData {

--- a/cranelift-codegen/src/regalloc/reload.rs
+++ b/cranelift-codegen/src/regalloc/reload.rs
@@ -21,8 +21,8 @@ use crate::regalloc::live_value_tracker::{LiveValue, LiveValueTracker};
 use crate::regalloc::liveness::Liveness;
 use crate::timing;
 use crate::topo_order::TopoOrder;
-use log::debug;
 use alloc::vec::Vec;
+use log::debug;
 
 /// Reusable data structures for the reload pass.
 pub struct Reload {

--- a/cranelift-codegen/src/regalloc/reload.rs
+++ b/cranelift-codegen/src/regalloc/reload.rs
@@ -22,7 +22,7 @@ use crate::regalloc::liveness::Liveness;
 use crate::timing;
 use crate::topo_order::TopoOrder;
 use log::debug;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Reusable data structures for the reload pass.
 pub struct Reload {

--- a/cranelift-codegen/src/regalloc/safepoint.rs
+++ b/cranelift-codegen/src/regalloc/safepoint.rs
@@ -4,7 +4,7 @@ use crate::ir::{Function, InstBuilder, InstructionData, Opcode, TrapCode};
 use crate::isa::TargetIsa;
 use crate::regalloc::live_value_tracker::LiveValueTracker;
 use crate::regalloc::liveness::Liveness;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 fn insert_and_encode_safepoint<'f>(
     pos: &mut FuncCursor<'f>,

--- a/cranelift-codegen/src/regalloc/solver.rs
+++ b/cranelift-codegen/src/regalloc/solver.rs
@@ -109,7 +109,7 @@ use core::fmt;
 use core::mem;
 use core::u16;
 use log::debug;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// A variable in the constraint problem.
 ///
@@ -1160,7 +1160,7 @@ mod tests {
     use crate::isa::{RegClass, RegInfo, RegUnit, TargetIsa};
     use crate::regalloc::RegisterSet;
     use core::str::FromStr;
-    use std::boxed::Box;
+    use alloc::boxed::Box;
     use target_lexicon::triple;
 
     // Make an arm32 `TargetIsa`, if possible.

--- a/cranelift-codegen/src/regalloc/solver.rs
+++ b/cranelift-codegen/src/regalloc/solver.rs
@@ -104,12 +104,12 @@ use crate::entity::{SparseMap, SparseMapValue};
 use crate::ir::Value;
 use crate::isa::{RegClass, RegUnit};
 use crate::regalloc::register_set::RegSetIter;
+use alloc::vec::Vec;
 use core::cmp;
 use core::fmt;
 use core::mem;
 use core::u16;
 use log::debug;
-use alloc::vec::Vec;
 
 /// A variable in the constraint problem.
 ///
@@ -1159,8 +1159,8 @@ mod tests {
     use crate::ir::Value;
     use crate::isa::{RegClass, RegInfo, RegUnit, TargetIsa};
     use crate::regalloc::RegisterSet;
-    use core::str::FromStr;
     use alloc::boxed::Box;
+    use core::str::FromStr;
     use target_lexicon::triple;
 
     // Make an arm32 `TargetIsa`, if possible.

--- a/cranelift-codegen/src/regalloc/spilling.rs
+++ b/cranelift-codegen/src/regalloc/spilling.rs
@@ -27,9 +27,9 @@ use crate::regalloc::pressure::Pressure;
 use crate::regalloc::virtregs::VirtRegs;
 use crate::timing;
 use crate::topo_order::TopoOrder;
+use alloc::vec::Vec;
 use core::fmt;
 use log::debug;
-use alloc::vec::Vec;
 
 /// Return a top-level register class which contains `unit`.
 fn toprc_containing_regunit(unit: RegUnit, reginfo: &RegInfo) -> RegClass {

--- a/cranelift-codegen/src/regalloc/spilling.rs
+++ b/cranelift-codegen/src/regalloc/spilling.rs
@@ -29,7 +29,7 @@ use crate::timing;
 use crate::topo_order::TopoOrder;
 use core::fmt;
 use log::debug;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Return a top-level register class which contains `unit`.
 fn toprc_containing_regunit(unit: RegUnit, reginfo: &RegInfo) -> RegClass {

--- a/cranelift-codegen/src/regalloc/virtregs.rs
+++ b/cranelift-codegen/src/regalloc/virtregs.rs
@@ -18,11 +18,11 @@ use crate::entity::{EntityList, ListPool};
 use crate::entity::{Keys, PrimaryMap, SecondaryMap};
 use crate::ir::{Function, Value};
 use crate::packed_option::PackedOption;
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::fmt;
 use core::slice;
 use smallvec::SmallVec;
-use alloc::vec::Vec;
 
 /// A virtual register reference.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/cranelift-codegen/src/regalloc/virtregs.rs
+++ b/cranelift-codegen/src/regalloc/virtregs.rs
@@ -22,7 +22,7 @@ use core::cmp::Ordering;
 use core::fmt;
 use core::slice;
 use smallvec::SmallVec;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// A virtual register reference.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/cranelift-codegen/src/settings.rs
+++ b/cranelift-codegen/src/settings.rs
@@ -22,11 +22,11 @@
 
 use crate::constant_hash::{probe, simple_hash};
 use crate::isa::TargetIsa;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 use core::fmt;
 use core::str;
 use failure_derive::Fail;
-use alloc::boxed::Box;
-use alloc::string::{String, ToString};
 
 /// A string-based configurator for settings groups.
 ///

--- a/cranelift-codegen/src/settings.rs
+++ b/cranelift-codegen/src/settings.rs
@@ -25,8 +25,8 @@ use crate::isa::TargetIsa;
 use core::fmt;
 use core::str;
 use failure_derive::Fail;
-use std::boxed::Box;
-use std::string::{String, ToString};
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 
 /// A string-based configurator for settings groups.
 ///
@@ -369,7 +369,7 @@ mod tests {
     use super::Configurable;
     use super::SetError::*;
     use super::{builder, Flags};
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn display_default() {

--- a/cranelift-codegen/src/simple_gvn.rs
+++ b/cranelift-codegen/src/simple_gvn.rs
@@ -7,7 +7,7 @@ use crate::scoped_hash_map::ScopedHashMap;
 use crate::timing;
 use core::cell::{Ref, RefCell};
 use core::hash::{Hash, Hasher};
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Test whether the given opcode is unsafe to even consider for GVN.
 fn trivially_unsafe_for_gvn(opcode: Opcode) -> bool {

--- a/cranelift-codegen/src/simple_gvn.rs
+++ b/cranelift-codegen/src/simple_gvn.rs
@@ -5,9 +5,9 @@ use crate::dominator_tree::DominatorTree;
 use crate::ir::{Function, Inst, InstructionData, Opcode, Type};
 use crate::scoped_hash_map::ScopedHashMap;
 use crate::timing;
+use alloc::vec::Vec;
 use core::cell::{Ref, RefCell};
 use core::hash::{Hash, Hasher};
-use alloc::vec::Vec;
 
 /// Test whether the given opcode is unsafe to even consider for GVN.
 fn trivially_unsafe_for_gvn(opcode: Opcode) -> bool {

--- a/cranelift-codegen/src/timing.rs
+++ b/cranelift-codegen/src/timing.rs
@@ -252,7 +252,7 @@ mod details {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn display() {

--- a/cranelift-codegen/src/topo_order.rs
+++ b/cranelift-codegen/src/topo_order.rs
@@ -3,7 +3,7 @@
 use crate::dominator_tree::DominatorTree;
 use crate::entity::EntitySet;
 use crate::ir::{Ebb, Layout};
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Present EBBs in a topological order such that all dominating EBBs are guaranteed to be visited
 /// before the current EBB.

--- a/cranelift-codegen/src/value_label.rs
+++ b/cranelift-codegen/src/value_label.rs
@@ -6,8 +6,8 @@ use core::cmp::Ordering;
 use core::iter::Iterator;
 use core::ops::Bound::*;
 use core::ops::Deref;
-use std::collections::BTreeMap;
-use std::vec::Vec;
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};

--- a/cranelift-codegen/src/value_label.rs
+++ b/cranelift-codegen/src/value_label.rs
@@ -2,12 +2,12 @@ use crate::ir::{Function, SourceLoc, Value, ValueLabel, ValueLabelAssignments, V
 use crate::isa::TargetIsa;
 use crate::regalloc::{Context, RegDiversions};
 use crate::HashMap;
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::iter::Iterator;
 use core::ops::Bound::*;
 use core::ops::Deref;
-use alloc::collections::BTreeMap;
-use alloc::vec::Vec;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};

--- a/cranelift-codegen/src/verifier/mod.rs
+++ b/cranelift-codegen/src/verifier/mod.rs
@@ -72,12 +72,12 @@ use crate::isa::TargetIsa;
 use crate::iterators::IteratorExtras;
 use crate::settings::FlagsOrIsa;
 use crate::timing;
-use core::cmp::Ordering;
-use core::fmt::{self, Display, Formatter, Write};
-use failure_derive::Fail;
 use alloc::collections::BTreeSet;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::fmt::{self, Display, Formatter, Write};
+use failure_derive::Fail;
 
 pub use self::cssa::verify_cssa;
 pub use self::liveness::verify_liveness;

--- a/cranelift-codegen/src/verifier/mod.rs
+++ b/cranelift-codegen/src/verifier/mod.rs
@@ -75,9 +75,9 @@ use crate::timing;
 use core::cmp::Ordering;
 use core::fmt::{self, Display, Formatter, Write};
 use failure_derive::Fail;
-use std::collections::BTreeSet;
-use std::string::String;
-use std::vec::Vec;
+use alloc::collections::BTreeSet;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 pub use self::cssa::verify_cssa;
 pub use self::liveness::verify_liveness;

--- a/cranelift-codegen/src/write.rs
+++ b/cranelift-codegen/src/write.rs
@@ -14,9 +14,9 @@ use crate::isa::{RegInfo, TargetIsa};
 use crate::packed_option::ReservedValue;
 use crate::value_label::ValueLabelsRanges;
 use crate::HashSet;
-use core::fmt::{self, Write};
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::fmt::{self, Write};
 
 /// A `FuncWriter` used to decorate functions during printing.
 pub trait FuncWriter {

--- a/cranelift-codegen/src/write.rs
+++ b/cranelift-codegen/src/write.rs
@@ -15,8 +15,8 @@ use crate::packed_option::ReservedValue;
 use crate::value_label::ValueLabelsRanges;
 use crate::HashSet;
 use core::fmt::{self, Write};
-use std::string::String;
-use std::vec::Vec;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 /// A `FuncWriter` used to decorate functions during printing.
 pub trait FuncWriter {
@@ -759,7 +759,7 @@ mod tests {
     use crate::cursor::{Cursor, CursorPosition, FuncCursor};
     use crate::ir::types;
     use crate::ir::{ExternalName, Function, InstBuilder, StackSlotData, StackSlotKind};
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn basic() {

--- a/cranelift-entity/Cargo.toml
+++ b/cranelift-entity/Cargo.toml
@@ -15,9 +15,6 @@ edition = "2018"
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 
 [features]
-default = ["std"]
-std = []
-core = []
 enable-serde = ["serde"]
 
 [badges]

--- a/cranelift-entity/src/boxed_slice.rs
+++ b/cranelift-entity/src/boxed_slice.rs
@@ -3,10 +3,10 @@
 use crate::iter::{Iter, IterMut};
 use crate::keys::Keys;
 use crate::EntityRef;
+use alloc::boxed::Box;
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use core::slice;
-use alloc::boxed::Box;
 
 /// A slice mapping `K -> V` allocating dense entity references.
 ///

--- a/cranelift-entity/src/boxed_slice.rs
+++ b/cranelift-entity/src/boxed_slice.rs
@@ -6,7 +6,7 @@ use crate::EntityRef;
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use core::slice;
-use std::boxed::Box;
+use alloc::boxed::Box;
 
 /// A slice mapping `K -> V` allocating dense entity references.
 ///
@@ -141,7 +141,7 @@ where
 mod tests {
     use super::*;
     use crate::primary::PrimaryMap;
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     // `EntityRef` impl for testing.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/cranelift-entity/src/lib.rs
+++ b/cranelift-entity/src/lib.rs
@@ -31,7 +31,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "std", deny(unstable_features))]
 #![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
 #![cfg_attr(
     feature = "cargo-clippy",
@@ -52,12 +51,7 @@
 )]
 #![no_std]
 
-#[cfg(not(feature = "std"))]
-#[macro_use]
-extern crate alloc as std;
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate std;
+extern crate alloc;
 
 // Re-export core so that the macros works with both std and no_std crates
 #[doc(hidden)]

--- a/cranelift-entity/src/list.rs
+++ b/cranelift-entity/src/list.rs
@@ -3,7 +3,7 @@ use crate::packed_option::ReservedValue;
 use crate::EntityRef;
 use core::marker::PhantomData;
 use core::mem;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// A small list of entity references allocated from a pool.
 ///

--- a/cranelift-entity/src/list.rs
+++ b/cranelift-entity/src/list.rs
@@ -1,9 +1,9 @@
 //! Small lists of entity references.
 use crate::packed_option::ReservedValue;
 use crate::EntityRef;
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::mem;
-use alloc::vec::Vec;
 
 /// A small list of entity references allocated from a pool.
 ///

--- a/cranelift-entity/src/map.rs
+++ b/cranelift-entity/src/map.rs
@@ -13,7 +13,7 @@ use serde::{
     ser::{SerializeSeq, Serializer},
     Deserialize, Serialize,
 };
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// A mapping `K -> V` for densely indexed entity references.
 ///
@@ -222,7 +222,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        use std::fmt;
+        use alloc::fmt;
         struct SecondaryMapVisitor<K, V> {
             unused: PhantomData<fn(K) -> V>,
         }

--- a/cranelift-entity/src/map.rs
+++ b/cranelift-entity/src/map.rs
@@ -3,6 +3,7 @@
 use crate::iter::{Iter, IterMut};
 use crate::keys::Keys;
 use crate::EntityRef;
+use alloc::vec::Vec;
 use core::cmp::min;
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
@@ -13,7 +14,6 @@ use serde::{
     ser::{SerializeSeq, Serializer},
     Deserialize, Serialize,
 };
-use alloc::vec::Vec;
 
 /// A mapping `K -> V` for densely indexed entity references.
 ///

--- a/cranelift-entity/src/primary.rs
+++ b/cranelift-entity/src/primary.rs
@@ -9,8 +9,8 @@ use core::ops::{Index, IndexMut};
 use core::slice;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
-use std::boxed::Box;
-use std::vec::Vec;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 /// A primary mapping `K -> V` allocating dense entity references.
 ///

--- a/cranelift-entity/src/primary.rs
+++ b/cranelift-entity/src/primary.rs
@@ -3,14 +3,14 @@ use crate::boxed_slice::BoxedSlice;
 use crate::iter::{Iter, IterMut};
 use crate::keys::Keys;
 use crate::EntityRef;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::iter::FromIterator;
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use core::slice;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
-use alloc::boxed::Box;
-use alloc::vec::Vec;
 
 /// A primary mapping `K -> V` allocating dense entity references.
 ///

--- a/cranelift-entity/src/set.rs
+++ b/cranelift-entity/src/set.rs
@@ -2,8 +2,8 @@
 
 use crate::keys::Keys;
 use crate::EntityRef;
-use core::marker::PhantomData;
 use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 /// A set of `K` for densely indexed entity references.
 ///

--- a/cranelift-entity/src/set.rs
+++ b/cranelift-entity/src/set.rs
@@ -3,7 +3,7 @@
 use crate::keys::Keys;
 use crate::EntityRef;
 use core::marker::PhantomData;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// A set of `K` for densely indexed entity references.
 ///

--- a/cranelift-entity/src/sparse.rs
+++ b/cranelift-entity/src/sparse.rs
@@ -12,7 +12,7 @@ use crate::EntityRef;
 use core::mem;
 use core::slice;
 use core::u32;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Trait for extracting keys from values stored in a `SparseMap`.
 ///

--- a/cranelift-entity/src/sparse.rs
+++ b/cranelift-entity/src/sparse.rs
@@ -9,10 +9,10 @@
 
 use crate::map::SecondaryMap;
 use crate::EntityRef;
+use alloc::vec::Vec;
 use core::mem;
 use core::slice;
 use core::u32;
-use alloc::vec::Vec;
 
 /// Trait for extracting keys from values stored in a `SparseMap`.
 ///

--- a/cranelift-frontend/src/frontend.rs
+++ b/cranelift-frontend/src/frontend.rs
@@ -1,6 +1,7 @@
 //! A frontend for building Cranelift IR from other languages.
 use crate::ssa::{Block, SSABuilder, SideEffects};
 use crate::variable::Variable;
+use alloc::vec::Vec;
 use cranelift_codegen::cursor::{Cursor, FuncCursor};
 use cranelift_codegen::entity::{EntitySet, SecondaryMap};
 use cranelift_codegen::ir;
@@ -13,7 +14,6 @@ use cranelift_codegen::ir::{
 };
 use cranelift_codegen::isa::{TargetFrontendConfig, TargetIsa};
 use cranelift_codegen::packed_option::PackedOption;
-use alloc::vec::Vec;
 
 /// Structure used for translating a series of functions into Cranelift IR.
 ///
@@ -893,13 +893,13 @@ mod tests {
     use super::greatest_divisible_power_of_two;
     use crate::frontend::{FunctionBuilder, FunctionBuilderContext};
     use crate::Variable;
+    use alloc::string::ToString;
     use cranelift_codegen::entity::EntityRef;
     use cranelift_codegen::ir::types::*;
     use cranelift_codegen::ir::{AbiParam, ExternalName, Function, InstBuilder, Signature};
     use cranelift_codegen::isa::CallConv;
     use cranelift_codegen::settings;
     use cranelift_codegen::verifier::verify_function;
-    use alloc::string::ToString;
 
     fn sample_function(lazy_seal: bool) {
         let mut sig = Signature::new(CallConv::SystemV);

--- a/cranelift-frontend/src/frontend.rs
+++ b/cranelift-frontend/src/frontend.rs
@@ -13,7 +13,7 @@ use cranelift_codegen::ir::{
 };
 use cranelift_codegen::isa::{TargetFrontendConfig, TargetIsa};
 use cranelift_codegen::packed_option::PackedOption;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Structure used for translating a series of functions into Cranelift IR.
 ///
@@ -899,7 +899,7 @@ mod tests {
     use cranelift_codegen::isa::CallConv;
     use cranelift_codegen::settings;
     use cranelift_codegen::verifier::verify_function;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     fn sample_function(lazy_seal: bool) {
         let mut sig = Signature::new(CallConv::SystemV);

--- a/cranelift-frontend/src/lib.rs
+++ b/cranelift-frontend/src/lib.rs
@@ -183,9 +183,8 @@
 )]
 #![no_std]
 
-#[cfg(not(feature = "std"))]
-#[macro_use]
-extern crate alloc as std;
+extern crate alloc;
+
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;

--- a/cranelift-frontend/src/lib.rs
+++ b/cranelift-frontend/src/lib.rs
@@ -183,6 +183,8 @@
 )]
 #![no_std]
 
+#[allow(unused_imports)] // #[macro_use] is required for no_std
+#[macro_use]
 extern crate alloc;
 
 #[cfg(feature = "std")]

--- a/cranelift-frontend/src/ssa.rs
+++ b/cranelift-frontend/src/ssa.rs
@@ -6,6 +6,7 @@
 //! Lecture Notes in Computer Science, vol 7791. Springer, Berlin, Heidelberg
 
 use crate::Variable;
+use alloc::vec::Vec;
 use core::mem;
 use core::u32;
 use cranelift_codegen::cursor::{Cursor, FuncCursor};
@@ -17,7 +18,6 @@ use cranelift_codegen::ir::{Ebb, Function, Inst, InstBuilder, InstructionData, T
 use cranelift_codegen::packed_option::PackedOption;
 use cranelift_codegen::packed_option::ReservedValue;
 use smallvec::SmallVec;
-use alloc::vec::Vec;
 
 /// Structure containing the data relevant the construction of SSA for a given function.
 ///

--- a/cranelift-frontend/src/ssa.rs
+++ b/cranelift-frontend/src/ssa.rs
@@ -17,7 +17,7 @@ use cranelift_codegen::ir::{Ebb, Function, Inst, InstBuilder, InstructionData, T
 use cranelift_codegen::packed_option::PackedOption;
 use cranelift_codegen::packed_option::ReservedValue;
 use smallvec::SmallVec;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 /// Structure containing the data relevant the construction of SSA for a given function.
 ///

--- a/cranelift-frontend/src/switch.rs
+++ b/cranelift-frontend/src/switch.rs
@@ -3,7 +3,7 @@ use crate::frontend::FunctionBuilder;
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::*;
 use log::debug;
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 type EntryIndex = u64;
 
@@ -291,7 +291,7 @@ mod tests {
     use super::*;
     use crate::frontend::FunctionBuilderContext;
     use cranelift_codegen::ir::Function;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     macro_rules! setup {
         ($default:expr, [$($index:expr,)*]) => {{

--- a/cranelift-frontend/src/switch.rs
+++ b/cranelift-frontend/src/switch.rs
@@ -1,9 +1,9 @@
 use super::HashMap;
 use crate::frontend::FunctionBuilder;
+use alloc::vec::Vec;
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::*;
 use log::debug;
-use alloc::vec::Vec;
 
 type EntryIndex = u64;
 
@@ -290,8 +290,8 @@ impl ContiguousCaseRange {
 mod tests {
     use super::*;
     use crate::frontend::FunctionBuilderContext;
-    use cranelift_codegen::ir::Function;
     use alloc::string::ToString;
+    use cranelift_codegen::ir::Function;
 
     macro_rules! setup {
         ($default:expr, [$($index:expr,)*]) => {{

--- a/cranelift-module/Cargo.toml
+++ b/cranelift-module/Cargo.toml
@@ -12,14 +12,14 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.44.0", default-features = false }
-cranelift-entity = { path = "../cranelift-entity", version = "0.44.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.44.0" }
 hashbrown = { version = "0.6", optional = true }
 failure = { version = "0.1.1", default-features = false }
 log = { version = "0.4.6", default-features = false }
 
 [features]
 default = ["std"]
-std = ["cranelift-codegen/std", "cranelift-entity/std"]
+std = ["cranelift-codegen/std"]
 core = ["hashbrown", "cranelift-codegen/core"]
 
 [badges]

--- a/cranelift-preopt/Cargo.toml
+++ b/cranelift-preopt/Cargo.toml
@@ -18,11 +18,6 @@ cranelift-entity = { path = "../cranelift-entity", version = "0.44.0" }
 # cranelift currently supports.
 # rustc_apfloat = { version = "0.1.2", default-features = false }
 
-[features]
-default = ["std"]
-std = ["cranelift-codegen/std"]
-core = ["cranelift-codegen/core"]
-
 [badges]
 maintenance = { status = "experimental" }
 travis-ci = { repository = "CraneStation/cranelift" }

--- a/cranelift-preopt/Cargo.toml
+++ b/cranelift-preopt/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.44.0", default-features = false }
-cranelift-entity = { path = "../cranelift-entity", version = "0.44.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.44.0" }
 # This is commented out because it doesn't build on Rust 1.25.0, which
 # cranelift currently supports.
 # rustc_apfloat = { version = "0.1.2", default-features = false }
 
 [features]
 default = ["std"]
-std = ["cranelift-codegen/std", "cranelift-entity/std"]
+std = ["cranelift-codegen/std"]
 core = ["cranelift-codegen/core"]
 
 [badges]

--- a/cranelift-preopt/src/lib.rs
+++ b/cranelift-preopt/src/lib.rs
@@ -20,13 +20,6 @@
 )]
 #![no_std]
 
-#[cfg(not(feature = "std"))]
-#[macro_use]
-extern crate alloc as std;
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate std;
-
 mod constant_folding;
 
 use cranelift_codegen::{isa::TargetIsa, settings::FlagsOrIsa, CodegenResult, Context};

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 wasmparser = { version = "0.39.1", default-features = false }
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.44.0", default-features = false }
-cranelift-entity = { path = "../cranelift-entity", version = "0.44.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.44.0" }
 cranelift-frontend = { path = "../cranelift-frontend", version = "0.44.0", default-features = false }
 hashbrown = { version = "0.6", optional = true }
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }

--- a/test-no_std.sh
+++ b/test-no_std.sh
@@ -21,10 +21,10 @@ for LIB in $LIBS; do
     pushd "$LIB" >/dev/null
 
     # Test with just "core" enabled.
-    cargo +nightly test --no-default-features --features core
+    cargo +nightly test --no-default-features --features "core all-arch"
 
     # Test with "core" and "std" enabled at the same time.
-    cargo +nightly test --features core
+    cargo +nightly test --features "core all-arch"
 
     popd >/dev/null
 done


### PR DESCRIPTION
This removes the `std` feature flag where possible. liballoc is supported on stable since a few releases.