### PR TITLE
Insert split-edge of conditional branches before the destination.

### DIFF
--- a/filetests/regalloc/coalesce-bb.clif
+++ b/filetests/regalloc/coalesce-bb.clif
@@ -103,20 +103,20 @@ ebb0(v0: i32):
     v2 = iconst.i32 2
     jump ebb1(v1, v2)
 
+    ; check:  $(splitEdge=$EBB):
+    ; check:    $(nv11b=$V) = copy.i32 v11
+    ; not:      copy
+    ; check:    jump ebb1($nv11b, v12)
+
 ebb1(v10: i32, v11: i32):
     ; v11 needs to be isolated because it interferes with v10.
     ; check: ebb1(v10: i32 [$LOC], $(nv11a=$V): i32 [$LOC])
     ; check: v11 = copy $nv11a
     v12 = iadd v10, v11
     v13 = icmp ult v12, v0
-    ; check:  brnz v13, $(splitEdge=$EBB)
+    ; check:  brnz v13, $splitEdge
     brnz v13, ebb1(v11, v12)
     jump ebb2
-
-    ; check:  $splitEdge:
-    ; check:    $(nv11b=$V) = copy.i32 v11
-    ; not:      copy
-    ; check:   jump ebb1($nv11b, v12)
 
 ebb2:
     return v12

--- a/filetests/regalloc/reload-208-bb.clif
+++ b/filetests/regalloc/reload-208-bb.clif
@@ -44,6 +44,11 @@ ebb5:
     brnz v6, ebb2
     jump ebb3(v4)
 
+    ; check: ebb5:
+    ; check:   jump ebb3(v4)
+    ; check: $(splitEdge=$EBB):
+    ; nextln:  jump ebb3(v9)
+
 ebb3(v7: i32):
     call fn1(v0, v7)
     v26 = iconst.i32 0x4ffe
@@ -61,12 +66,9 @@ ebb6:
     v8 = iadd v25, v23
     v9 = load.i32 v8+56
     ; check: v9 = spill
-    ; check: brnz $V, $(splitEdge=$EBB)
+    ; check: brnz $V, $splitEdge
     brnz v9, ebb3(v9)
     jump ebb4
-
-    ; check: $splitEdge:
-    ; nextln:  jump ebb3(v9)
 
 ebb4:
     jump ebb2

--- a/filetests/regalloc/x86-regres-bb.clif
+++ b/filetests/regalloc/x86-regres-bb.clif
@@ -19,6 +19,9 @@ ebb0(v0: i32):
     v3 = iconst.i32 0
     jump ebb2(v3, v2, v0)
 
+    ; check: $(splitEdge=$EBB):
+    ; check:   jump ebb2($V, $V, v9)
+
 ebb2(v4: i32, v5: i32, v7: i32):
     ; check: ebb2
     v6 = iadd v4, v5
@@ -33,11 +36,9 @@ ebb2(v4: i32, v5: i32, v7: i32):
     ;
     ; We should be able to handle this situation without making copies of v9.
     brnz v9, ebb2(v5, v6, v9)
-    ; check:   brnz v9, $(splitEdge=$EBB)
+    ; check:   brnz v9, $splitEdge
     jump ebb3
 
-    ; check: $splitEdge:
-    ; check:   jump ebb2($V, $V, v9)
 ebb3:
     return v5
 }

--- a/filetests/safepoint/basic-bb.clif
+++ b/filetests/safepoint/basic-bb.clif
@@ -32,10 +32,19 @@ function %test(i32, r64, r64) -> r64 {
 ; nextln:   v10 = copy v0
 ; nextln:   jump ebb1(v10)
 ; nextln: 
+; nextln: ebb7:
+; nextln:   regmove.i32 v5, %rcx -> %rax
+; nextln:   jump ebb1(v5)
+; nextln: 
 ; nextln: ebb1(v3: i32 [%rax]):
 ; nextln:   v8 = iconst.i32 1
 ; nextln:   v4 = isub v8, v3
 ; nextln:   jump ebb2(v4)
+; nextln: 
+; nextln: ebb8:
+; nextln:   v9 = copy.i32 v0
+; nextln:   regmove v9, %rax -> %rcx
+; nextln:   jump ebb2(v9)
 ; nextln: 
 ; nextln: ebb2(v5: i32 [%rcx]):
 ; nextln:   safepoint v1, v2
@@ -60,13 +69,4 @@ function %test(i32, r64, r64) -> r64 {
 ; nextln: ebb6:
 ; nextln:   regmove.r64 v2, %rdx -> %rax
 ; nextln:   return v2
-; nextln: 
-; nextln: ebb7:
-; nextln:   regmove.i32 v5, %rcx -> %rax
-; nextln:   jump ebb1(v5)
-; nextln: 
-; nextln: ebb8:
-; nextln:   v9 = copy.i32 v0
-; nextln:   regmove v9, %rax -> %rcx
-; nextln:   jump ebb2(v9)
 ; nextln: }


### PR DESCRIPTION
This patch changes the logic for the insertion of new blocks when splitting conditional branches.

Until now we added at the end or before the last block, which tend to mislead the branch predictor and resulted in bad benchmark results.

This patch change the logic to insert such edges before the destination. This has some advantages, such as when dealing with tight loop, to reduce the number of cache lines which are loaded for executing loops, as well as playing well with branch predictors.