### PR TITLE
Replace V128Imm functionality with ConstantData; fixes #1027

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -734,10 +734,10 @@ pub enum FormatPredicateKind {
     IsZero64BitFloat,
 
     /// Is the immediate format field member equal zero in all lanes?
-    IsAllZeroes128Bit,
+    IsAllZeroes,
 
     /// Does the immediate format field member have ones in all bits of all lanes?
-    IsAllOnes128Bit,
+    IsAllOnes,
 
     /// Has the value list (in member_name) the size specified in parameter?
     LengthEquals(usize),
@@ -818,12 +818,12 @@ impl FormatPredicateNode {
             FormatPredicateKind::IsZero64BitFloat => {
                 format!("predicates::is_zero_64_bit_float({})", self.member_name)
             }
-            FormatPredicateKind::IsAllZeroes128Bit => format!(
-                "predicates::is_all_zeroes_128_bit(func.dfg.constants.get({}))",
+            FormatPredicateKind::IsAllZeroes => format!(
+                "predicates::is_all_zeroes(func.dfg.constants.get({}))",
                 self.member_name
             ),
-            FormatPredicateKind::IsAllOnes128Bit => format!(
-                "predicates::is_all_ones_128_bit(func.dfg.constants.get({}))",
+            FormatPredicateKind::IsAllOnes => format!(
+                "predicates::is_all_ones(func.dfg.constants.get({}))",
                 self.member_name
             ),
             FormatPredicateKind::LengthEquals(num) => format!(
@@ -1069,25 +1069,25 @@ impl InstructionPredicate {
         ))
     }
 
-    pub fn new_is_all_zeroes_128bit(
+    pub fn new_is_all_zeroes(
         format: &InstructionFormat,
         field_name: &'static str,
     ) -> InstructionPredicateNode {
         InstructionPredicateNode::FormatPredicate(FormatPredicateNode::new(
             format,
             field_name,
-            FormatPredicateKind::IsAllZeroes128Bit,
+            FormatPredicateKind::IsAllZeroes,
         ))
     }
 
-    pub fn new_is_all_ones_128bit(
+    pub fn new_is_all_ones(
         format: &InstructionFormat,
         field_name: &'static str,
     ) -> InstructionPredicateNode {
         InstructionPredicateNode::FormatPredicate(FormatPredicateNode::new(
             format,
             field_name,
-            FormatPredicateKind::IsAllOnes128Bit,
+            FormatPredicateKind::IsAllOnes,
         ))
     }
 

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -470,7 +470,7 @@ fn gen_transform<'a>(
         for (name, value) in transform.const_pool.iter() {
             fmtln!(
                 fmt,
-                "let {} = pos.func.dfg.constants.insert(vec!{:?});",
+                "let {} = pos.func.dfg.constants.insert(vec!{:?}.into());",
                 name,
                 value
             );

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1848,14 +1848,14 @@ pub(crate) fn define<'defs>(
         let instruction = vconst.bind(vector(ty, sse_vector_size));
 
         let is_zero_128bit =
-            InstructionPredicate::new_is_all_zeroes_128bit(f_unary_const, "constant_handle");
+            InstructionPredicate::new_is_all_zeroes(f_unary_const, "constant_handle");
         let template = rec_vconst_optimized.nonrex().opcodes(&PXOR);
         e.enc_32_64_func(instruction.clone(), template, |builder| {
             builder.inst_predicate(is_zero_128bit)
         });
 
         let is_ones_128bit =
-            InstructionPredicate::new_is_all_ones_128bit(f_unary_const, "constant_handle");
+            InstructionPredicate::new_is_all_ones(f_unary_const, "constant_handle");
         let template = rec_vconst_optimized.nonrex().opcodes(&PCMPEQB);
         e.enc_32_64_func(instruction, template, |builder| {
             builder.inst_predicate(is_ones_128bit)

--- a/cranelift-codegen/src/ir/dfg.rs
+++ b/cranelift-codegen/src/ir/dfg.rs
@@ -5,7 +5,7 @@ use crate::ir;
 use crate::ir::builder::ReplaceBuilder;
 use crate::ir::extfunc::ExtFuncData;
 use crate::ir::instructions::{BranchInfo, CallInfo, InstructionData};
-use crate::ir::{types, ConstantPool, Immediate};
+use crate::ir::{types, ConstantData, ConstantPool, Immediate};
 use crate::ir::{
     Ebb, FuncRef, Inst, SigRef, Signature, Type, Value, ValueLabelAssignments, ValueList,
     ValueListPool,
@@ -14,7 +14,6 @@ use crate::isa::TargetIsa;
 use crate::packed_option::ReservedValue;
 use crate::write::write_operands;
 use crate::HashMap;
-use alloc::vec::Vec;
 use core::fmt;
 use core::iter;
 use core::mem;
@@ -73,7 +72,7 @@ pub struct DataFlowGraph {
     pub constants: ConstantPool,
 
     /// Stores large immediates that otherwise will not fit on InstructionData
-    pub immediates: PrimaryMap<Immediate, Vec<u8>>,
+    pub immediates: PrimaryMap<Immediate, ConstantData>,
 }
 
 impl DataFlowGraph {

--- a/cranelift-codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift-codegen/src/isa/x86/enc_tables.rs
@@ -6,7 +6,7 @@ use crate::cursor::{Cursor, FuncCursor};
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir::condcodes::{FloatCC, IntCC};
 use crate::ir::types::*;
-use crate::ir::{self, ConstantData, Function, Inst, InstBuilder};
+use crate::ir::{self, Function, Inst, InstBuilder};
 use crate::isa::constraints::*;
 use crate::isa::enc_tables::*;
 use crate::isa::encoding::base_size;
@@ -15,7 +15,6 @@ use crate::isa::RegUnit;
 use crate::isa::{self, TargetIsa};
 use crate::predicates;
 use crate::regalloc::RegDiversions;
-use std::vec::Vec;
 
 include!(concat!(env!("OUT_DIR"), "/encoding-x86.rs"));
 include!(concat!(env!("OUT_DIR"), "/legalize-x86.rs"));
@@ -928,7 +927,7 @@ fn convert_shuffle(
             .clone();
         if a == b {
             // PSHUFB the first argument (since it is the same as the second).
-            let constructed_mask: Vec<u8> = mask
+            let constructed_mask = mask
                 .iter()
                 // If the mask is greater than 15 it still may be referring to a lane in b.
                 .map(|&b| if b > 15 { b.wrapping_sub(16) } else { b })
@@ -942,8 +941,7 @@ fn convert_shuffle(
             pos.func.dfg.replace(inst).x86_pshufb(a, mask_value);
         } else {
             // PSHUFB the first argument, placing zeroes for unused lanes.
-            let constructed_mask: Vec<u8> =
-                mask.iter().cloned().map(zero_unknown_lane_index).collect();
+            let constructed_mask = mask.iter().cloned().map(zero_unknown_lane_index).collect();
             let handle = pos.func.dfg.constants.insert(constructed_mask);
             // Move the built mask into another XMM register.
             let a_type = pos.func.dfg.value_type(a);
@@ -952,7 +950,7 @@ fn convert_shuffle(
             let shuffled_first_arg = pos.ins().x86_pshufb(a, mask_value);
 
             // PSHUFB the second argument, placing zeroes for unused lanes.
-            let constructed_mask: Vec<u8> = mask
+            let constructed_mask = mask
                 .iter()
                 .map(|b| b.wrapping_sub(16))
                 .map(zero_unknown_lane_index)
@@ -1110,11 +1108,7 @@ fn convert_ineg(
     {
         let value_type = pos.func.dfg.value_type(arg);
         if value_type.is_vector() && value_type.lane_type().is_int() {
-            let zero_immediate = pos
-                .func
-                .dfg
-                .constants
-                .insert(ConstantData::from(vec![0; 16]));
+            let zero_immediate = pos.func.dfg.constants.insert(vec![0; 16].into());
             let zero_value = pos.ins().vconst(value_type, zero_immediate); // this should be legalized to a PXOR
             pos.func.dfg.replace(inst).isub(zero_value, arg);
         }

--- a/cranelift-codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift-codegen/src/isa/x86/enc_tables.rs
@@ -5,9 +5,8 @@ use crate::bitset::BitSet;
 use crate::cursor::{Cursor, FuncCursor};
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir::condcodes::{FloatCC, IntCC};
-use crate::ir::immediates::V128Imm;
 use crate::ir::types::*;
-use crate::ir::{self, Function, Inst, InstBuilder};
+use crate::ir::{self, ConstantData, Function, Inst, InstBuilder};
 use crate::isa::constraints::*;
 use crate::isa::enc_tables::*;
 use crate::isa::encoding::base_size;
@@ -1111,7 +1110,11 @@ fn convert_ineg(
     {
         let value_type = pos.func.dfg.value_type(arg);
         if value_type.is_vector() && value_type.lane_type().is_int() {
-            let zero_immediate = pos.func.dfg.constants.insert(V128Imm::from(0).to_vec());
+            let zero_immediate = pos
+                .func
+                .dfg
+                .constants
+                .insert(ConstantData::from(vec![0; 16]));
             let zero_value = pos.ins().vconst(value_type, zero_immediate); // this should be legalized to a PXOR
             pos.func.dfg.replace(inst).isub(zero_value, arg);
         }

--- a/cranelift-codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift-codegen/src/isa/x86/enc_tables.rs
@@ -16,6 +16,7 @@ use crate::isa::RegUnit;
 use crate::isa::{self, TargetIsa};
 use crate::predicates;
 use crate::regalloc::RegDiversions;
+use std::vec::Vec;
 
 include!(concat!(env!("OUT_DIR"), "/encoding-x86.rs"));
 include!(concat!(env!("OUT_DIR"), "/legalize-x86.rs"));
@@ -928,7 +929,7 @@ fn convert_shuffle(
             .clone();
         if a == b {
             // PSHUFB the first argument (since it is the same as the second).
-            let constructed_mask = mask
+            let constructed_mask: Vec<u8> = mask
                 .iter()
                 // If the mask is greater than 15 it still may be referring to a lane in b.
                 .map(|&b| if b > 15 { b.wrapping_sub(16) } else { b })
@@ -942,7 +943,8 @@ fn convert_shuffle(
             pos.func.dfg.replace(inst).x86_pshufb(a, mask_value);
         } else {
             // PSHUFB the first argument, placing zeroes for unused lanes.
-            let constructed_mask = mask.iter().cloned().map(zero_unknown_lane_index).collect();
+            let constructed_mask: Vec<u8> =
+                mask.iter().cloned().map(zero_unknown_lane_index).collect();
             let handle = pos.func.dfg.constants.insert(constructed_mask);
             // Move the built mask into another XMM register.
             let a_type = pos.func.dfg.value_type(a);
@@ -951,7 +953,7 @@ fn convert_shuffle(
             let shuffled_first_arg = pos.ins().x86_pshufb(a, mask_value);
 
             // PSHUFB the second argument, placing zeroes for unused lanes.
-            let constructed_mask = mask
+            let constructed_mask: Vec<u8> = mask
                 .iter()
                 .map(|b| b.wrapping_sub(16))
                 .map(zero_unknown_lane_index)

--- a/cranelift-codegen/src/predicates.rs
+++ b/cranelift-codegen/src/predicates.rs
@@ -10,6 +10,7 @@
 //! dead code warning.
 
 use crate::ir;
+use crate::ir::ConstantData;
 
 /// Check that an integer value is zero.
 #[allow(dead_code)]
@@ -33,14 +34,14 @@ pub fn is_zero_32_bit_float<T: Into<ir::immediates::Ieee32>>(x: T) -> bool {
 
 /// Check that a 128-bit vector contains all zeroes.
 #[allow(dead_code)]
-pub fn is_all_zeroes_128_bit<'b, T: PartialEq<&'b [u8; 16]>>(x: T) -> bool {
-    x.eq(&&[0; 16])
+pub fn is_all_zeroes(x: &ConstantData) -> bool {
+    x.iter().all(|&f| f == 0)
 }
 
 /// Check that a 128-bit vector contains all ones.
 #[allow(dead_code)]
-pub fn is_all_ones_128_bit<'b, T: PartialEq<&'b [u8; 16]>>(x: T) -> bool {
-    x.eq(&&[0xff; 16])
+pub fn is_all_ones(x: &ConstantData) -> bool {
+    x.iter().all(|&f| f == 0xff)
 }
 
 /// Check that `x` is the same as `y`.
@@ -123,17 +124,17 @@ mod tests {
     }
 
     #[test]
-    fn is_all_zeroes() {
-        assert!(is_all_zeroes_128_bit(&[0; 16]));
-        assert!(is_all_zeroes_128_bit(vec![
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ]));
-        assert!(!is_all_zeroes_128_bit(&[1; 16]));
+    fn check_is_all_zeroes() {
+        assert!(is_all_zeroes(&[0; 16].as_ref().into()));
+        assert!(is_all_zeroes(
+            &vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0].into()
+        ));
+        assert!(!is_all_zeroes(&[1; 16].as_ref().into()));
     }
 
     #[test]
-    fn is_all_ones() {
-        assert!(!is_all_ones_128_bit(&[0; 16]));
-        assert!(is_all_ones_128_bit(&[0xff; 16]));
+    fn check_is_all_ones() {
+        assert!(!is_all_ones(&[0; 16].as_ref().into()));
+        assert!(is_all_ones(&[0xff; 16].as_ref().into()));
     }
 }

--- a/cranelift-codegen/src/predicates.rs
+++ b/cranelift-codegen/src/predicates.rs
@@ -32,13 +32,13 @@ pub fn is_zero_32_bit_float<T: Into<ir::immediates::Ieee32>>(x: T) -> bool {
     x32.bits() == 0
 }
 
-/// Check that a 128-bit vector contains all zeroes.
+/// Check that a constant contains all zeroes.
 #[allow(dead_code)]
 pub fn is_all_zeroes(x: &ConstantData) -> bool {
     x.iter().all(|&f| f == 0)
 }
 
-/// Check that a 128-bit vector contains all ones.
+/// Check that a constant contains all ones.
 #[allow(dead_code)]
 pub fn is_all_ones(x: &ConstantData) -> bool {
     x.iter().all(|&f| f == 0xff)

--- a/cranelift-codegen/src/write.rs
+++ b/cranelift-codegen/src/write.rs
@@ -508,9 +508,8 @@ pub fn write_operands(
         UnaryConst {
             constant_handle, ..
         } => {
-            let data = dfg.constants.get(constant_handle);
-            let v128 = V128Imm::from(&data[..]);
-            write!(w, " {}", v128)
+            let constant_data = dfg.constants.get(constant_handle);
+            write!(w, " {}", constant_data)
         }
         Shuffle { mask, args, .. } => {
             let data = dfg.immediates.get(mask).expect(

--- a/cranelift-codegen/src/write.rs
+++ b/cranelift-codegen/src/write.rs
@@ -5,7 +5,6 @@
 
 use crate::entity::SecondaryMap;
 use crate::ir::entities::AnyEntity;
-use crate::ir::immediates::V128Imm;
 use crate::ir::{
     DataFlowGraph, DisplayFunctionAnnotations, Ebb, Function, Inst, SigRef, Type, Value, ValueDef,
     ValueLoc,
@@ -515,8 +514,7 @@ pub fn write_operands(
             let data = dfg.immediates.get(mask).expect(
                 "Expected the shuffle mask to already be inserted into the immediates table",
             );
-            let v128 = V128Imm::from(&data[..]);
-            write!(w, " {}, {}, {}", args[0], args[1], v128)
+            write!(w, " {}, {}, {}", args[0], args[1], data)
         }
         IntCompare { cond, args, .. } => write!(w, " {} {}, {}", cond, args[0], args[1]),
         IntCompareImm { cond, arg, imm, .. } => write!(w, " {} {}, {}", cond, arg, imm),

--- a/cranelift-reader/src/parser.rs
+++ b/cranelift-reader/src/parser.rs
@@ -9,20 +9,19 @@ use crate::testfile::{Comment, Details, Feature, TestFile};
 use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::entities::AnyEntity;
-use cranelift_codegen::ir::immediates::{Ieee32, Ieee64, Imm64, Offset32, Uimm32, Uimm64, V128Imm};
+use cranelift_codegen::ir::immediates::{Ieee32, Ieee64, Imm64, Offset32, Uimm32, Uimm64};
 use cranelift_codegen::ir::instructions::{InstructionData, InstructionFormat, VariableArgs};
 use cranelift_codegen::ir::types::INVALID;
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{
-    AbiParam, ArgumentExtension, ArgumentLoc, Ebb, ExtFuncData, ExternalName, FuncRef, Function,
-    GlobalValue, GlobalValueData, Heap, HeapData, HeapStyle, JumpTable, JumpTableData, MemFlags,
-    Opcode, SigRef, Signature, StackSlot, StackSlotData, StackSlotKind, Table, TableData, Type,
-    Value, ValueLoc,
+    AbiParam, ArgumentExtension, ArgumentLoc, ConstantData, Ebb, ExtFuncData, ExternalName,
+    FuncRef, Function, GlobalValue, GlobalValueData, Heap, HeapData, HeapStyle, JumpTable,
+    JumpTableData, MemFlags, Opcode, SigRef, Signature, StackSlot, StackSlotData, StackSlotKind,
+    Table, TableData, Type, Value, ValueLoc,
 };
 use cranelift_codegen::isa::{self, CallConv, Encoding, RegUnit, TargetIsa};
 use cranelift_codegen::packed_option::ReservedValue;
 use cranelift_codegen::{settings, timing};
-use std::iter::FromIterator;
 use std::mem;
 use std::str::FromStr;
 use std::{u16, u32};
@@ -595,16 +594,13 @@ impl<'a> Parser<'a> {
         }
     }
 
-    // Match and consume a Uimm128 immediate; due to size restrictions on InstructionData, Uimm128
-    // is boxed in cranelift-codegen/meta/src/shared/immediates.rs
-    fn match_uimm128(&mut self, err_msg: &str) -> ParseResult<V128Imm> {
+    // Match and consume a hexadeximal immediate
+    fn match_hexadecimal_constant(&mut self, err_msg: &str) -> ParseResult<ConstantData> {
         if let Some(Token::Integer(text)) = self.token() {
             self.consume();
-            // Lexer just gives us raw text that looks like hex code.
-            // Parse it as an Uimm128 to check for overflow and other issues.
             text.parse().map_err(|e| {
                 self.error(&format!(
-                    "expected u128 hexadecimal immediate, failed to parse: {}",
+                    "expected hexadecimal immediate, failed to parse: {}",
                     e
                 ))
             })
@@ -614,15 +610,27 @@ impl<'a> Parser<'a> {
     }
 
     // Match and consume either a hexadecimal Uimm128 immediate (e.g. 0x000102...) or its literal list form (e.g. [0 1 2...])
-    fn match_uimm128_or_literals(&mut self, controlling_type: Type) -> ParseResult<V128Imm> {
-        if self.optional(Token::LBracket) {
+    fn match_constant_data(&mut self, controlling_type: Type) -> ParseResult<ConstantData> {
+        let expected_size = controlling_type.bytes() as usize;
+        let constant_data = if self.optional(Token::LBracket) {
             // parse using a list of values, e.g. vconst.i32x4 [0 1 2 3]
             let uimm128 = self.parse_literals_to_uimm128(controlling_type)?;
             self.match_token(Token::RBracket, "expected a terminating right bracket")?;
-            Ok(uimm128)
+            uimm128
         } else {
-            // parse using a hexadecimal value
-            self.match_uimm128("expected an immediate hexadecimal operand")
+            // parse using a hexadecimal value, e.g. 0x000102...
+            let uimm128 =
+                self.match_hexadecimal_constant("expected an immediate hexadecimal operand")?;
+            uimm128.expand_to(expected_size)
+        };
+
+        if constant_data.len() == expected_size {
+            Ok(constant_data)
+        } else {
+            Err(self.error(&format!(
+                "expected parsed constant to have {} bytes",
+                expected_size
+            )))
         }
     }
 
@@ -851,29 +859,42 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a list of literals (i.e. integers, floats, booleans); e.g.
-    fn parse_literals_to_uimm128(&mut self, ty: Type) -> ParseResult<V128Imm> {
+    fn parse_literals_to_uimm128(&mut self, ty: Type) -> ParseResult<ConstantData> {
         macro_rules! consume {
             ( $ty:ident, $match_fn:expr ) => {{
                 assert!($ty.is_vector());
-                let mut v = Vec::with_capacity($ty.lane_count() as usize);
+                let mut data = ConstantData::default();
                 for _ in 0..$ty.lane_count() {
-                    v.push($match_fn?);
+                    data = data.append($match_fn);
                 }
-                V128Imm::from_iter(v)
+                data
             }};
+        }
+
+        fn boolean_to_vec(value: bool, ty: Type) -> Vec<u8> {
+            let lane_size = ty.bytes() / u32::from(ty.lane_count());
+            if lane_size < 1 {
+                panic!("The boolean lane must have a byte size greater than zero.");
+            }
+            let mut buffer = vec![0; lane_size as usize];
+            buffer[0] = if value { 1 } else { 0 };
+            buffer
         }
 
         if !ty.is_vector() {
             err!(self.loc, "Expected a controlling vector type, not {}", ty)
         } else {
             let uimm128 = match ty.lane_type() {
-                I8 => consume!(ty, self.match_uimm8("Expected an 8-bit unsigned integer")),
-                I16 => consume!(ty, self.match_imm16("Expected a 16-bit integer")),
-                I32 => consume!(ty, self.match_imm32("Expected a 32-bit integer")),
-                I64 => consume!(ty, self.match_imm64("Expected a 64-bit integer")),
-                F32 => consume!(ty, self.match_ieee32("Expected a 32-bit float...")),
-                F64 => consume!(ty, self.match_ieee64("Expected a 64-bit float")),
-                b if b.is_bool() => consume!(ty, self.match_bool("Expected a boolean")),
+                I8 => consume!(ty, self.match_uimm8("Expected an 8-bit unsigned integer")?),
+                I16 => consume!(ty, self.match_imm16("Expected a 16-bit integer")?),
+                I32 => consume!(ty, self.match_imm32("Expected a 32-bit integer")?),
+                I64 => consume!(ty, self.match_imm64("Expected a 64-bit integer")?),
+                F32 => consume!(ty, self.match_ieee32("Expected a 32-bit float...")?),
+                F64 => consume!(ty, self.match_ieee64("Expected a 64-bit float")?),
+                b if b.is_bool() => consume!(
+                    ty,
+                    boolean_to_vec(self.match_bool("Expected a boolean")?, ty)
+                ),
                 _ => return err!(self.loc, "Expected a type of: float, int, bool"),
             };
             Ok(uimm128)
@@ -2447,8 +2468,8 @@ impl<'a> Parser<'a> {
                     )
                 }
                 Some(controlling_type) => {
-                    let uimm128 = self.match_uimm128_or_literals(controlling_type)?;
-                    let constant_handle = ctx.function.dfg.constants.insert(uimm128.to_vec());
+                    let uimm128 = self.match_constant_data(controlling_type)?;
+                    let constant_handle = ctx.function.dfg.constants.insert(uimm128);
                     InstructionData::UnaryConst {
                         opcode,
                         constant_handle,
@@ -2460,8 +2481,8 @@ impl<'a> Parser<'a> {
                 self.match_token(Token::Comma, "expected ',' between operands")?;
                 let b = self.match_value("expected SSA value second operand")?;
                 self.match_token(Token::Comma, "expected ',' between operands")?;
-                let uimm128 = self.match_uimm128_or_literals(I8X16)?;
-                let mask = ctx.function.dfg.immediates.push(uimm128.to_vec());
+                let uimm128 = self.match_constant_data(I8X16)?;
+                let mask = ctx.function.dfg.immediates.push(uimm128);
                 InstructionData::Shuffle {
                     opcode,
                     mask,
@@ -3262,5 +3283,13 @@ mod tests {
         cannot_parse_as_uimm128!("0x0 0x1 0x2 0x3", I32X4);
         cannot_parse_as_uimm128!("1 2 3", I32X4);
         cannot_parse_as_uimm128!(" ", F32X4);
+    }
+
+    #[test]
+    fn parse_constant_from_booleans() {
+        let c = Parser::new("true false true false")
+            .parse_literals_to_uimm128(B32X4)
+            .unwrap();
+        assert_eq!(c.to_vec(), [1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0])
     }
 }

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -33,7 +33,9 @@ use crate::wasm_unsupported;
 use core::{i32, u32};
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::types::*;
-use cranelift_codegen::ir::{self, InstBuilder, JumpTableData, MemFlags, Value, ValueLabel};
+use cranelift_codegen::ir::{
+    self, ConstantData, InstBuilder, JumpTableData, MemFlags, Value, ValueLabel,
+};
 use cranelift_codegen::packed_option::ReservedValue;
 use cranelift_frontend::{FunctionBuilder, Variable};
 use wasmparser::{MemoryImmediate, Operator};
@@ -1044,7 +1046,8 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (vector_a, vector_b) = state.pop2();
             let a = optionally_bitcast_vector(vector_a, I8X16, builder);
             let b = optionally_bitcast_vector(vector_b, I8X16, builder);
-            let mask = builder.func.dfg.immediates.push(lanes.to_vec());
+            let lanes = ConstantData::from(lanes.as_ref());
+            let mask = builder.func.dfg.immediates.push(lanes);
             let shuffled = builder.ins().shuffle(a, b, mask);
             state.push1(shuffled)
             // At this point the original types of a and b are lost; users of this value (i.e. this

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -991,7 +991,8 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             return Err(wasm_unsupported!("proposed bulk memory operator {:?}", op));
         }
         Operator::V128Const { value } => {
-            let handle = builder.func.dfg.constants.insert(value.bytes().to_vec());
+            let data = value.bytes().to_vec().into();
+            let handle = builder.func.dfg.constants.insert(data);
             let value = builder.ins().vconst(I8X16, handle);
             // the v128.const is typed in CLIF as a I8x16 but raw_bitcast to a different type before use
             state.push1(value)

--- a/cranelift-wasm/src/func_translator.rs
+++ b/cranelift-wasm/src/func_translator.rs
@@ -189,7 +189,7 @@ fn declare_locals<FE: FuncEnvironment + ?Sized>(
         F32 => builder.ins().f32const(ir::immediates::Ieee32::with_bits(0)),
         F64 => builder.ins().f64const(ir::immediates::Ieee64::with_bits(0)),
         V128 => {
-            let constant_handle = builder.func.dfg.constants.insert([0; 16].to_vec());
+            let constant_handle = builder.func.dfg.constants.insert([0; 16].to_vec().into());
             builder.ins().vconst(ir::types::I8X16, constant_handle)
         }
         AnyRef => builder.ins().null(environ.reference_type()),


### PR DESCRIPTION
As described in more detail in #1027, this re-factoring makes it possible to use constants of various sizes in the `ConstantPool`. This may not be advisable yet due to lack of alignment, etc. but is a necessary first step. The commits in this PR could be optionally squashed together. The `V128Imm` container is retained for uses such as in `GlobalInit::V128Const` that expect a constant of a specific size.