### PR TITLE
Enhance generated code for legalizations

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -63,7 +63,7 @@ impl Def {
             format!("({})", results.join(", "))
         };
 
-        format!("{} << {}", results, self.apply.to_comment_string(var_pool))
+        format!("{} := {}", results, self.apply.to_comment_string(var_pool))
     }
 }
 

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -18,12 +18,12 @@ use crate::shared::types::{Bool, Float, Int, Reference};
 use cranelift_codegen_shared::condcodes::IntCC;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct OpcodeNumber(u32);
+pub(crate) struct OpcodeNumber(u32);
 entity_impl!(OpcodeNumber);
 
-pub type AllInstructions = PrimaryMap<OpcodeNumber, Instruction>;
+pub(crate) type AllInstructions = PrimaryMap<OpcodeNumber, Instruction>;
 
-pub struct InstructionGroupBuilder<'format_reg, 'all_inst> {
+pub(crate) struct InstructionGroupBuilder<'format_reg, 'all_inst> {
     _name: &'static str,
     _doc: &'static str,
     format_registry: &'format_reg FormatRegistry,
@@ -67,7 +67,7 @@ impl<'format_reg, 'all_inst> InstructionGroupBuilder<'format_reg, 'all_inst> {
 /// Every instruction must belong to exactly one instruction group. A given
 /// target architecture can support instructions from multiple groups, and it
 /// does not necessarily support all instructions in a group.
-pub struct InstructionGroup {
+pub(crate) struct InstructionGroup {
     _name: &'static str,
     _doc: &'static str,
     instructions: Vec<Instruction>,
@@ -85,20 +85,20 @@ impl InstructionGroup {
 /// Instructions can have parameters bound to them to specialize them for more specific encodings
 /// (e.g. the encoding for adding two float types may be different than that of adding two
 /// integer types)
-pub trait Bindable {
+pub(crate) trait Bindable {
     /// Bind a parameter to an instruction
     fn bind(&self, parameter: impl Into<BindParameter>) -> BoundInstruction;
 }
 
 #[derive(Debug)]
-pub struct PolymorphicInfo {
+pub(crate) struct PolymorphicInfo {
     pub use_typevar_operand: bool,
     pub ctrl_typevar: TypeVar,
     pub other_typevars: Vec<TypeVar>,
 }
 
 #[derive(Debug)]
-pub struct InstructionContent {
+pub(crate) struct InstructionContent {
     /// Instruction mnemonic, also becomes opcode name.
     pub name: String,
     pub camel_name: String,
@@ -153,7 +153,7 @@ pub struct InstructionContent {
 }
 
 #[derive(Clone, Debug)]
-pub struct Instruction {
+pub(crate) struct Instruction {
     content: Rc<InstructionContent>,
 }
 
@@ -221,7 +221,7 @@ impl fmt::Display for Instruction {
     }
 }
 
-pub struct InstructionBuilder {
+pub(crate) struct InstructionBuilder {
     name: String,
     doc: String,
     operands_in: Option<Vec<Operand>>,
@@ -384,7 +384,7 @@ impl InstructionBuilder {
 
 /// A thin wrapper like Option<ValueType>, but with more precise semantics.
 #[derive(Clone)]
-pub enum ValueTypeOrAny {
+pub(crate) enum ValueTypeOrAny {
     ValueType(ValueType),
     Any,
 }
@@ -467,7 +467,7 @@ impl Display for Immediate {
 }
 
 #[derive(Clone)]
-pub struct BoundInstruction {
+pub(crate) struct BoundInstruction {
     pub inst: Instruction,
     pub value_types: Vec<ValueTypeOrAny>,
     pub immediate_values: Vec<Immediate>,
@@ -941,7 +941,7 @@ impl InstructionPredicateNode {
 }
 
 #[derive(Clone, Hash, PartialEq, Eq)]
-pub struct InstructionPredicate {
+pub(crate) struct InstructionPredicate {
     node: Option<InstructionPredicateNode>,
 }
 
@@ -1191,15 +1191,16 @@ impl InstructionPredicate {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct InstructionPredicateNumber(u32);
+pub(crate) struct InstructionPredicateNumber(u32);
 entity_impl!(InstructionPredicateNumber);
 
-pub type InstructionPredicateMap = PrimaryMap<InstructionPredicateNumber, InstructionPredicate>;
+pub(crate) type InstructionPredicateMap =
+    PrimaryMap<InstructionPredicateNumber, InstructionPredicate>;
 
 /// A registry of predicates to help deduplicating them, during Encodings construction. When the
 /// construction process is over, it needs to be extracted with `extract` and associated to the
 /// TargetIsa.
-pub struct InstructionPredicateRegistry {
+pub(crate) struct InstructionPredicateRegistry {
     /// Maps a predicate number to its actual predicate.
     map: InstructionPredicateMap,
 
@@ -1231,7 +1232,7 @@ impl InstructionPredicateRegistry {
 }
 
 /// An instruction specification, containing an instruction that has bound types or not.
-pub enum InstSpec {
+pub(crate) enum InstSpec {
     Inst(Instruction),
     Bound(BoundInstruction),
 }

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -856,14 +856,14 @@ pub enum TypePredicateNode {
 }
 
 impl TypePredicateNode {
-    fn rust_predicate(&self) -> String {
+    fn rust_predicate(&self, func_str: &str) -> String {
         match self {
             TypePredicateNode::TypeVarCheck(index, value_type_name) => format!(
-                "func.dfg.value_type(args[{}]) == {}",
-                index, value_type_name
+                "{}.dfg.value_type(args[{}]) == {}",
+                func_str, index, value_type_name
             ),
             TypePredicateNode::CtrlTypeVarCheck(value_type_name) => {
-                format!("func.dfg.ctrl_typevar(inst) == {}", value_type_name)
+                format!("{}.dfg.ctrl_typevar(inst) == {}", func_str, value_type_name)
             }
         }
     }
@@ -884,18 +884,18 @@ pub enum InstructionPredicateNode {
 }
 
 impl InstructionPredicateNode {
-    fn rust_predicate(&self) -> String {
+    fn rust_predicate(&self, func_str: &str) -> String {
         match self {
             InstructionPredicateNode::FormatPredicate(node) => node.rust_predicate(),
-            InstructionPredicateNode::TypePredicate(node) => node.rust_predicate(),
+            InstructionPredicateNode::TypePredicate(node) => node.rust_predicate(func_str),
             InstructionPredicateNode::And(nodes) => nodes
                 .iter()
-                .map(|x| x.rust_predicate())
+                .map(|x| x.rust_predicate(func_str))
                 .collect::<Vec<_>>()
                 .join(" && "),
             InstructionPredicateNode::Or(nodes) => nodes
                 .iter()
-                .map(|x| x.rust_predicate())
+                .map(|x| x.rust_predicate(func_str))
                 .collect::<Vec<_>>()
                 .join(" || "),
         }
@@ -1169,9 +1169,9 @@ impl InstructionPredicate {
         self
     }
 
-    pub fn rust_predicate(&self) -> String {
+    pub fn rust_predicate(&self, func_str: &str) -> String {
         match &self.node {
-            Some(root) => root.rust_predicate(),
+            Some(root) => root.rust_predicate(func_str),
             None => "true".into(),
         }
     }

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -1169,17 +1169,18 @@ impl InstructionPredicate {
         self
     }
 
-    pub fn rust_predicate(&self, func_str: &str) -> String {
-        match &self.node {
-            Some(root) => root.rust_predicate(func_str),
-            None => "true".into(),
-        }
+    pub fn rust_predicate(&self, func_str: &str) -> Option<String> {
+        self.node.as_ref().map(|root| root.rust_predicate(func_str))
     }
 
-    /// Returns true if the predicate only depends on type parameters (and not on an instruction
-    /// format).
-    pub fn is_type_predicate(&self) -> bool {
-        self.node.as_ref().unwrap().is_type_predicate()
+    /// Returns the type predicate if this is one, or None otherwise.
+    pub fn type_predicate(&self, func_str: &str) -> Option<String> {
+        let node = self.node.as_ref().unwrap();
+        if node.is_type_predicate() {
+            Some(node.rust_predicate(func_str))
+        } else {
+            None
+        }
     }
 
     /// Returns references to all the nodes that are leaves in the condition (i.e. by flattening

--- a/cranelift-codegen/meta/src/cdsl/recipes.rs
+++ b/cranelift-codegen/meta/src/cdsl/recipes.rs
@@ -103,7 +103,7 @@ impl Into<OperandConstraint> for Stack {
 /// branch instructions. It is an `(origin, bits)` tuple describing the exact
 /// range that can be encoded in a branch instruction.
 #[derive(Clone)]
-pub struct EncodingRecipe {
+pub(crate) struct EncodingRecipe {
     /// Short mnemonic name for this recipe.
     pub name: String,
 
@@ -158,13 +158,13 @@ impl PartialEq for EncodingRecipe {
 impl Eq for EncodingRecipe {}
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct EncodingRecipeNumber(u32);
+pub(crate) struct EncodingRecipeNumber(u32);
 entity_impl!(EncodingRecipeNumber);
 
-pub type Recipes = PrimaryMap<EncodingRecipeNumber, EncodingRecipe>;
+pub(crate) type Recipes = PrimaryMap<EncodingRecipeNumber, EncodingRecipe>;
 
 #[derive(Clone)]
-pub struct EncodingRecipeBuilder {
+pub(crate) struct EncodingRecipeBuilder {
     pub name: String,
     format: InstructionFormatIndex,
     pub base_size: u64,

--- a/cranelift-codegen/meta/src/cdsl/type_inference.rs
+++ b/cranelift-codegen/meta/src/cdsl/type_inference.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 
 #[derive(Debug, Hash, PartialEq, Eq)]
-pub enum Constraint {
+pub(crate) enum Constraint {
     /// Constraint specifying that a type var tv1 must be wider than or equal to type var tv2 at
     /// runtime. This requires that:
     /// 1) They have the same number of lanes

--- a/cranelift-codegen/meta/src/gen_encodings.rs
+++ b/cranelift-codegen/meta/src/gen_encodings.rs
@@ -76,9 +76,9 @@ use crate::unique_table::UniqueSeqTable;
 /// The generated code is an `if let` pattern match that falls through if the instruction has an
 /// unexpected format. This should lead to a panic.
 fn emit_instp(instp: &InstructionPredicate, has_func: bool, fmt: &mut Formatter) {
-    if instp.is_type_predicate() {
+    if let Some(type_predicate) = instp.type_predicate("func") {
         fmt.line("let args = inst.arguments(&func.dfg.value_lists);");
-        fmt.line(instp.rust_predicate("func"));
+        fmt.line(type_predicate);
         return;
     }
 
@@ -127,7 +127,7 @@ fn emit_instp(instp: &InstructionPredicate, has_func: bool, fmt: &mut Formatter)
             // Silence dead argument.
             fmt.line("let _ = func;");
         }
-        fmtln!(fmt, "return {};", instp.rust_predicate("func"));
+        fmtln!(fmt, "return {};", instp.rust_predicate("func").unwrap());
     });
     fmtln!(fmt, "}");
 

--- a/cranelift-codegen/meta/src/gen_encodings.rs
+++ b/cranelift-codegen/meta/src/gen_encodings.rs
@@ -78,7 +78,7 @@ use crate::unique_table::UniqueSeqTable;
 fn emit_instp(instp: &InstructionPredicate, has_func: bool, fmt: &mut Formatter) {
     if instp.is_type_predicate() {
         fmt.line("let args = inst.arguments(&func.dfg.value_lists);");
-        fmt.line(instp.rust_predicate());
+        fmt.line(instp.rust_predicate("func"));
         return;
     }
 
@@ -127,7 +127,7 @@ fn emit_instp(instp: &InstructionPredicate, has_func: bool, fmt: &mut Formatter)
             // Silence dead argument.
             fmt.line("let _ = func;");
         }
-        fmtln!(fmt, "return {};", instp.rust_predicate());
+        fmtln!(fmt, "return {};", instp.rust_predicate("func"));
     });
     fmtln!(fmt, "}");
 

--- a/cranelift-codegen/meta/src/isa/riscv/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/recipes.rs
@@ -7,7 +7,7 @@ use crate::cdsl::regs::IsaRegs;
 use crate::shared::Definitions as SharedDefinitions;
 
 /// An helper to create recipes and use them when defining the RISCV encodings.
-pub struct RecipeGroup<'formats> {
+pub(crate) struct RecipeGroup<'formats> {
     /// Memoized format registry, to pass it to the builders.
     formats: &'formats FormatRegistry,
 

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -212,7 +212,9 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
     );
 
     // Population count for baseline x86_64
-    let qv1 = var("qv1");
+    let x = var("x");
+    let r = var("r");
+
     let qv3 = var("qv3");
     let qv4 = var("qv4");
     let qv5 = var("qv5");
@@ -226,7 +228,6 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
     let qv13 = var("qv13");
     let qv14 = var("qv14");
     let qv15 = var("qv15");
-    let qv16 = var("qv16");
     let qc77 = var("qc77");
     #[allow(non_snake_case)]
     let qc0F = var("qc0F");
@@ -235,12 +236,12 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
     let imm64_1 = Literal::constant(&imm.imm64, 1);
     let imm64_4 = Literal::constant(&imm.imm64, 4);
     group.legalize(
-        def!(qv16 = popcnt.I64(qv1)),
+        def!(r = popcnt.I64(x)),
         vec![
-            def!(qv3 = ushr_imm(qv1, imm64_1)),
+            def!(qv3 = ushr_imm(x, imm64_1)),
             def!(qc77 = iconst(Literal::constant(&imm.imm64, 0x7777777777777777))),
             def!(qv4 = band(qv3, qc77)),
-            def!(qv5 = isub(qv1, qv4)),
+            def!(qv5 = isub(x, qv4)),
             def!(qv6 = ushr_imm(qv4, imm64_1)),
             def!(qv7 = band(qv6, qc77)),
             def!(qv8 = isub(qv5, qv7)),
@@ -253,11 +254,10 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
             def!(qv14 = band(qv13, qc0F)),
             def!(qc01 = iconst(Literal::constant(&imm.imm64, 0x0101010101010101))),
             def!(qv15 = imul(qv14, qc01)),
-            def!(qv16 = ushr_imm(qv15, Literal::constant(&imm.imm64, 56))),
+            def!(r = ushr_imm(qv15, Literal::constant(&imm.imm64, 56))),
         ],
     );
 
-    let lv1 = var("lv1");
     let lv3 = var("lv3");
     let lv4 = var("lv4");
     let lv5 = var("lv5");
@@ -271,19 +271,18 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
     let lv13 = var("lv13");
     let lv14 = var("lv14");
     let lv15 = var("lv15");
-    let lv16 = var("lv16");
     let lc77 = var("lc77");
     #[allow(non_snake_case)]
     let lc0F = var("lc0F");
     let lc01 = var("lc01");
 
     group.legalize(
-        def!(lv16 = popcnt.I32(lv1)),
+        def!(r = popcnt.I32(x)),
         vec![
-            def!(lv3 = ushr_imm(lv1, imm64_1)),
+            def!(lv3 = ushr_imm(x, imm64_1)),
             def!(lc77 = iconst(Literal::constant(&imm.imm64, 0x77777777))),
             def!(lv4 = band(lv3, lc77)),
-            def!(lv5 = isub(lv1, lv4)),
+            def!(lv5 = isub(x, lv4)),
             def!(lv6 = ushr_imm(lv4, imm64_1)),
             def!(lv7 = band(lv6, lc77)),
             def!(lv8 = isub(lv5, lv7)),
@@ -296,7 +295,7 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
             def!(lv14 = band(lv13, lc0F)),
             def!(lc01 = iconst(Literal::constant(&imm.imm64, 0x01010101))),
             def!(lv15 = imul(lv14, lc01)),
-            def!(lv16 = ushr_imm(lv15, Literal::constant(&imm.imm64, 24))),
+            def!(r = ushr_imm(lv15, Literal::constant(&imm.imm64, 24))),
         ],
     );
 

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -164,7 +164,7 @@ fn replace_nonrex_constraints(
 /// Encodings, in encodings.rs. This is an idiosyncrasy of the x86 meta-language, and could be
 /// reconsidered later.
 #[derive(Clone)]
-pub struct Template<'builder> {
+pub(crate) struct Template<'builder> {
     /// Mapping of format indexes to format data, used in the build() method.
     formats: &'builder FormatRegistry,
 


### PR DESCRIPTION
- First commit avoids unwrapping several times the InstructionData for each legalization of a specific opcode. Instead, we unwrap it once and, all the legalizations can look at the fields shared in the local scope. This required renaming a few variables in legalizations definitions, so they match in an opcode's legalization group.
- Second commit avoids the dumb "if true" statement in legalization's generated code.
- Third commit does a small refactoring of how we handle `varargs` in legalizations: before/after:
    <details>

    ```
            ir::Opcode::Brnz => {
                // Unwrap () << brnz.i128(x, ebb1, vararg)
                let (x, ebb1, vararg, predicate) = if let crate::ir::InstructionData::Branch {
                    destination,
                    ref args,
                    ..
                } = pos.func.dfg[inst] {
                    let func = &pos.func;
                    let args = args.as_slice(&func.dfg.value_lists);
                    (
                        func.dfg.resolve_aliases(args[0]),
                        destination,
                        args.iter().skip(2).map(|&arg| func.dfg.resolve_aliases(arg)).collect::<Vec<_>>(),
                        func.dfg.value_type(args[0]) == ir::types::I128
                    )
                } else {
                    unreachable!("bad instruction format")
                };
                let vararg = &vararg;
                // etc.
            }
   ```

    </details>
    <details>

    ```
                // Unwrap fields from instruction format () := brnz.i128(x, ebb1, vararg)
                let (x, ebb1, args) = if let ir::InstructionData::Branch {
                    destination,
                    ref args,
                    ..
                } = pos.func.dfg[inst] {
                    let args = args.as_slice(&pos.func.dfg.value_lists);
                    (
                        pos.func.dfg.resolve_aliases(args[0]),
                        destination,
                        args
                    )
                } else {
                    unreachable!("bad instruction format")
                };

                let vararg = &Vec::from(&args[1..]);
    ```
    </details>

    (Note the `skip()` call was off by one.)
- last commit makes more things `pub(crate)` instead of `pub`, finding one more dead method in the meta code.

Overall, this reduces the number of LOC in generated files as follows:

- legalizer.rs: from 5639 to 3826 non-blank LOC.
- legalize-x86.rs: from 828 to 502 non-blank LOC.

This measure is a good proxy for code size, thus time it takes for Rustc to compile cranelift-codegen, etc. I haven't seen a noticeable difference in compile time with the `time` command.