### PR TITLE
Add SIMD logical operators for x86; closes #1092

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1975,13 +1975,17 @@ pub(crate) fn define<'defs>(
 
     // SIMD logical operations
     for ty in ValueType::all_lane_types().filter(allowed_simd_type) {
-        // band
+        // and
         let band = band.bind(vector(ty, sse_vector_size));
         e.enc_32_64(band, rec_fa.opcodes(&PAND));
 
-        // bor
+        // or
         let bor = bor.bind(vector(ty, sse_vector_size));
-        e.enc_32_64(bor, rec_fa.nonrex().opcodes(&POR));
+        e.enc_32_64(bor, rec_fa.opcodes(&POR));
+
+        // xor
+        let bxor = bxor.bind(vector(ty, sse_vector_size));
+        e.enc_32_64(bxor, rec_fa.opcodes(&PXOR));
     }
 
     // SIMD icmp using PCMPEQ*

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1874,13 +1874,6 @@ pub(crate) fn define<'defs>(
         e.enc_32_64_maybe_isap(instruction, template, None); // from SSE
     }
 
-    // SIMD bor using ORPS
-    for ty in ValueType::all_lane_types().filter(allowed_simd_type) {
-        let instruction = bor.bind(vector(ty, sse_vector_size));
-        let template = rec_fa.nonrex().opcodes(&ORPS);
-        e.enc_32_64_maybe_isap(instruction, template, None); // from SSE
-    }
-
     // SIMD register movement: store, load, spill, fill, regmove. All of these use encodings of
     // MOVUPS and MOVAPS from SSE (TODO ideally all of these would either use MOVAPS when we have
     // alignment or type-specific encodings, see https://github.com/CraneStation/cranelift/issues/1039).
@@ -1978,6 +1971,12 @@ pub(crate) fn define<'defs>(
     ] {
         let imul = imul.bind(vector(ty.clone(), sse_vector_size));
         e.enc_32_64_maybe_isap(imul, rec_fa.opcodes(opcodes), *isap);
+    }
+
+    // SIMD bor
+    for ty in ValueType::all_lane_types().filter(allowed_simd_type) {
+        let bor = bor.bind(vector(ty, sse_vector_size));
+        e.enc_32_64(bor, rec_fa.nonrex().opcodes(&POR));
     }
 
     // SIMD icmp using PCMPEQ*

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1973,8 +1973,13 @@ pub(crate) fn define<'defs>(
         e.enc_32_64_maybe_isap(imul, rec_fa.opcodes(opcodes), *isap);
     }
 
-    // SIMD bor
+    // SIMD logical operations
     for ty in ValueType::all_lane_types().filter(allowed_simd_type) {
+        // band
+        let band = band.bind(vector(ty, sse_vector_size));
+        e.enc_32_64(band, rec_fa.opcodes(&PAND));
+
+        // bor
         let bor = bor.bind(vector(ty, sse_vector_size));
         e.enc_32_64(bor, rec_fa.nonrex().opcodes(&POR));
     }

--- a/cranelift-codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/opcodes.rs
@@ -307,6 +307,9 @@ pub static POP_REG: [u8; 1] = [0x58];
 /// Returns the count of number of bits set to 1.
 pub static POPCNT: [u8; 3] = [0xf3, 0x0f, 0xb8];
 
+/// Bitwise OR of xmm2/m128 and xmm1 (SSE2).
+pub static POR: [u8; 3] = [0x66, 0x0f, 0xeb];
+
 /// Shuffle bytes in xmm1 according to contents of xmm2/m128 (SSE3).
 pub static PSHUFB: [u8; 4] = [0x66, 0x0f, 0x38, 0x00];
 

--- a/cranelift-codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/opcodes.rs
@@ -263,6 +263,9 @@ pub static PADDUSB: [u8; 3] = [0x66, 0x0f, 0xdc];
 /// Add packed unsigned word integers from xmm2/m128 and xmm1 saturate the results (SSE).
 pub static PADDUSW: [u8; 3] = [0x66, 0x0f, 0xdd];
 
+/// Bitwise AND of xmm2/m128 and xmm1 (SSE2).
+pub static PAND: [u8; 3] = [0x66, 0x0f, 0xdb];
+
 /// Compare packed data for equal (SSE2).
 pub static PCMPEQB: [u8; 3] = [0x66, 0x0f, 0x74];
 

--- a/cranelift-codegen/src/ir/immediates.rs
+++ b/cranelift-codegen/src/ir/immediates.rs
@@ -302,17 +302,17 @@ impl FromStr for Uimm32 {
 pub struct V128Imm(pub [u8; 16]);
 
 impl V128Imm {
-    /// Iterate over the bytes in the constant
+    /// Iterate over the bytes in the constant.
     pub fn bytes(&self) -> impl Iterator<Item = &u8> {
         self.0.iter()
     }
 
-    /// Convert the immediate into a vector
+    /// Convert the immediate into a vector.
     pub fn to_vec(self) -> Vec<u8> {
         self.0.to_vec()
     }
 
-    /// Convert the immediate into a slice
+    /// Convert the immediate into a slice.
     pub fn as_slice(&self) -> &[u8] {
         &self.0[..]
     }

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -1083,6 +1083,22 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (a, b) = state.pop2();
             state.push1(builder.ins().imul(a, b))
         }
+        Operator::V128Not => {
+            let a = state.pop1();
+            state.push1(builder.ins().bnot(a));
+        }
+        Operator::V128And => {
+            let (a, b) = state.pop2();
+            state.push1(builder.ins().band(a, b));
+        }
+        Operator::V128Or => {
+            let (a, b) = state.pop2();
+            state.push1(builder.ins().bor(a, b));
+        }
+        Operator::V128Xor => {
+            let (a, b) = state.pop2();
+            state.push1(builder.ins().bxor(a, b));
+        }
         Operator::I8x16Eq
         | Operator::I8x16Ne
         | Operator::I8x16LtS
@@ -1125,10 +1141,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::F64x2Gt
         | Operator::F64x2Le
         | Operator::F64x2Ge
-        | Operator::V128Not
-        | Operator::V128And
-        | Operator::V128Or
-        | Operator::V128Xor
         | Operator::V128Bitselect
         | Operator::I8x16AnyTrue
         | Operator::I8x16AllTrue

--- a/filetests/isa/x86/simd-logical-binemit.clif
+++ b/filetests/isa/x86/simd-logical-binemit.clif
@@ -13,3 +13,9 @@ ebb0(v0: b64x2 [%xmm6], v1: b64x2 [%xmm3]):
 [-, %xmm6]  v2 = band v0, v1      ; bin: 66 0f db f3
             return v2
 }
+
+function %bxor_b32x4(b32x4, b32x4) -> b32x4 {
+ebb0(v0: b32x4 [%xmm4], v1: b32x4 [%xmm0]):
+[-, %xmm4]  v2 = bxor v0, v1      ; bin: 66 0f ef e0
+            return v2
+}

--- a/filetests/isa/x86/simd-logical-binemit.clif
+++ b/filetests/isa/x86/simd-logical-binemit.clif
@@ -1,0 +1,15 @@
+test binemit
+set enable_simd
+target x86_64 skylake
+
+function %bor_b16x8(b16x8, b16x8) -> b16x8 {
+ebb0(v0: b16x8 [%xmm2], v1: b16x8 [%xmm1]):
+[-, %xmm2]  v2 = bor v0, v1     ; bin: 66 0f eb d1
+            return v2
+}
+
+function %band_b64x2(b64x2, b64x2) -> b64x2 {
+ebb0(v0: b64x2 [%xmm6], v1: b64x2 [%xmm3]):
+[-, %xmm6]  v2 = band v0, v1      ; bin: 66 0f db f3
+            return v2
+}

--- a/filetests/isa/x86/simd-logical-legalize.clif
+++ b/filetests/isa/x86/simd-logical-legalize.clif
@@ -1,0 +1,11 @@
+test legalizer
+set enable_simd
+target x86_64 skylake
+
+function %bnot_b32x4(b32x4) -> b32x4 {
+ebb0(v0: b32x4):
+    v1 = bnot v0
+    ; check: v2 = vconst.b32x4 0xffffffffffffffffffffffffffffffff
+    ; nextln: v1 = bxor v2, v0
+    return v1
+}

--- a/filetests/isa/x86/simd-logical-rodata.clif
+++ b/filetests/isa/x86/simd-logical-rodata.clif
@@ -1,0 +1,11 @@
+test rodata
+set enable_simd
+target x86_64 skylake
+
+function %bnot_b32x4(b32x4) -> b32x4 {
+ebb0(v0: b32x4):
+    v1 = bnot v0
+    return v1
+}
+
+; sameln: [FF, FF, FF, FF, FF, FF, FF, FF, FF, FF, FF, FF, FF, FF, FF, FF]


### PR DESCRIPTION
This makes changes to SIMD `bor`, `band`, `bxor` and `bnot`. `bnot` is the most interesting in that it required changes in https://github.com/CraneStation/cranelift/commit/bc6c1244bc5e6cf2eae323b98b66d341460de6e0 to support constants during legalization. As discussed in #1092, custom legalizations sort of stomps on the regular legalizations (e.g. see `legalize.rs`) and before this change custom legalizations were the only way to add constants to the pool. 