### PR TITLE
[codegen] legalize imul for 64-bit and 128-bit operands

### DIFF
--- a/filetests/isa/x86/imul-i128.clif
+++ b/filetests/isa/x86/imul-i128.clif
@@ -1,0 +1,20 @@
+test run
+target x86_64 haswell
+
+function %test_imul_i128() -> b1 {
+ebb0:
+    v11 = iconst.i64 0xf2347ac4503f1e24
+    v12 = iconst.i64 0x0098fe985354ab06
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0xf606ba453589ef89
+    v22 = iconst.i64 0x042e1f3054ca7432
+    v2 = iconcat v21, v22
+    v31 = iconst.i64 0xbe2044b2742ebd44
+    v32 = iconst.i64 0xa363ce3b6849f307
+    v3 = iconcat v31, v32
+    v4 = imul v1, v2
+    v5 = icmp eq v3, v4
+    return v5
+}
+
+; run

--- a/filetests/isa/x86/legalize-i128.clif
+++ b/filetests/isa/x86/legalize-i128.clif
@@ -1,0 +1,20 @@
+; Test the legalization of i128 instructions on x86_64.
+test legalizer
+target x86_64 haswell
+
+; regex: V=v\d+
+
+function %imul(i128, i128) -> i128 {
+ebb0(v1: i128, v2: i128):
+    v10 = imul v1, v2
+    ; check: v1 = iconcat $(v1_lsb=$V), $(v1_msb=$V)
+    ; nextln: v2 = iconcat $(v2_lsb=$V), $(v2_msb=$V)
+    ; nextln: $(v11=$V) = imul $v1_msb, $v2_lsb
+    ; nextln: $(v12=$V) = imul $v1_lsb, $v2_msb
+    ; nextln: $(v13=$V) = iadd $v11, $v12
+    ; nextln: $(v99=$V), $(v14=$V) = x86_umulx $v1_lsb, $v2_lsb
+    ; nextln: $(v10_msb=$V) = iadd $v13, $v14
+    ; nextln: $(v10_lsb=$V) = imul $v1_lsb, $v2_lsb
+    ; nextln: v10 = iconcat $v10_lsb, $v10_msb
+    return v10
+}

--- a/filetests/isa/x86/legalize-i64.clif
+++ b/filetests/isa/x86/legalize-i64.clif
@@ -26,6 +26,21 @@ ebb0(v1: i64, v2: i64):
     return v10
 }
 
+function %imul(i64, i64) -> i64 {
+ebb0(v1: i64, v2: i64):
+    v10 = imul v1, v2
+    ; check: v1 = iconcat $(v1_lsb=$V), $(v1_msb=$V)
+    ; nextln: v2 = iconcat $(v2_lsb=$V), $(v2_msb=$V)
+    ; nextln: $(v11=$V) = imul $v1_msb, $v2_lsb
+    ; nextln: $(v12=$V) = imul $v1_lsb, $v2_msb
+    ; nextln: $(v13=$V) = iadd $v11, $v12
+    ; nextln: $(v99=$V), $(v14=$V) = x86_umulx $v1_lsb, $v2_lsb
+    ; nextln: $(v10_msb=$V) = iadd $v13, $v14
+    ; nextln: $(v10_lsb=$V) = imul $v1_lsb, $v2_lsb
+    ; nextln: v10 = iconcat $v10_lsb, $v10_msb
+    return v10
+}
+
 function %icmp_eq(i64, i64) -> b1 {
 ebb0(v1: i64, v2: i64):
     v10 = icmp eq v1, v2


### PR DESCRIPTION
Add a legalization that legalizes imul.I64 for 32-bit ISAs.

Refs: https://github.com/bnjbvr/cranelift-x86/issues/4

/cc @wingo @caitp

@bnjbvr PTAL.

There's one small problem though, there's no existing way to handle carry output in `imul`. Good news? According to https://www.felixcloutier.com/x86/imul, `imul` does set the appropriate flags on x86-32 atleast, so I can just add an alternate `imul_ifcout` instruction, I guess? wdyt?