### PR TITLE
cranelift-wasm: Jump to the destination block at end of consequent

### DIFF
--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -203,6 +203,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                     else_data: ElseData::NoElse { branch_inst },
                     ref mut reachable_from_top,
                     blocktype,
+                    destination,
                     ..
                 } => {
                     // We take the control frame pushed by the if, use its ebb
@@ -215,7 +216,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
 
                     let (params, _results) = blocktype_params_results(wasm_types, blocktype)?;
                     let else_ebb = ebb_with_params(builder, params)?;
-                    builder.ins().jump(else_ebb, state.peekn(params.len()));
+                    builder.ins().jump(destination, state.peekn(params.len()));
                     state.popn(params.len());
 
                     // You might be expecting that we push the parameters for this

--- a/wasmtests/multi-16.wat
+++ b/wasmtests/multi-16.wat
@@ -1,0 +1,9 @@
+(module
+  (func (export "param") (param i32) (result i32)
+    (i32.const 1)
+    (if (param i32) (result i32) (local.get 0)
+      (then (i32.const 2) (i32.add))
+      (else (i32.const -2) (i32.add))
+    )
+  )
+)


### PR DESCRIPTION
This commit fixes a bug where at the end of an `if..else..end`'s consequent block, we would sometimes erroneously jump to the `else` block instead of to the following destination block. Not good!