### PR TITLE
deps: bump wasmparser dependency to 0.39.2

### DIFF
--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.39.1", default-features = false }
+wasmparser = { version = "0.39.2", default-features = false }
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.44.0", default-features = false }
 cranelift-entity = { path = "../cranelift-entity", version = "0.44.0" }
 cranelift-frontend = { path = "../cranelift-frontend", version = "0.44.0", default-features = false }


### PR DESCRIPTION
This has [a bug fix](https://github.com/yurydelendik/wasmparser.rs/pull/135) for Wasm multi-value blocks that is necessary to getting the spec tests passing.