### PR TITLE
codegen: Assert that the calling convention supports multi return

### DIFF
--- a/cranelift-codegen/src/isa/call_conv.rs
+++ b/cranelift-codegen/src/isa/call_conv.rs
@@ -64,6 +64,27 @@ impl CallConv {
             _ => false,
         }
     }
+
+    /// Does this calling convention have first-class support for multiple
+    /// return values?
+    pub fn supports_multiple_return_values(&self) -> bool {
+        match self {
+            // With our internal calling conventions, we can do whatever we
+            // want!
+            CallConv::Fast | CallConv::Cold => true,
+            // Existing, stable calling conventions can return aggregate values
+            // as structs or arrays, but we don't have that concept in
+            // cranelift. We also can't really treat multiple return values as
+            // an aggregate because there are subtleties about layout, whether
+            // something is adderessable, and constructors/destructors that only
+            // the IR producer could have provided.
+            CallConv::SystemV
+            | CallConv::WindowsFastcall
+            | CallConv::BaldrdashSystemV
+            | CallConv::BaldrdashWindows
+            | CallConv::Probestack => false,
+        }
+    }
 }
 
 impl fmt::Display for CallConv {

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -57,6 +57,14 @@ pub fn legalize_libcall_signature(signature: &mut Signature, isa: &dyn TargetIsa
 ///
 /// `current` is true if this is the signature for the current function.
 fn legalize_signature(signature: &mut Signature, current: bool, isa: &dyn TargetIsa) {
+    if signature.returns.len() > 1 {
+        // TODO: this should be checked in the verifier instead, but we would
+        // need to verify pre-legalized returns, because legalization can split
+        // a single logical return value into multiple physical return
+        // registers.
+        assert!(signature.call_conv.supports_multiple_return_values());
+    }
+
     isa.legalize_signature(signature, current);
 }
 

--- a/filetests/verifier/invalid-multi-return.clif
+++ b/filetests/verifier/invalid-multi-return.clif
@@ -1,0 +1,10 @@
+test verifier
+
+;; TODO: Currently, this signature should panic when legalized, but it should
+;; instead be a verifier error.
+function %test_1() -> i64, i64 system_v {
+    ebb0:
+        v0 = iconst.i64 0
+        v1 = iconst.i64 1
+        return v0, v1
+}


### PR DESCRIPTION
If the pre-legalized function is returning multiple logical values, assert that the calling convention supports multiple return values.

Ideally, this check would happen in the verifier, rather than as an assertion during legalization. The problem is that legalization can (correctly!) split a single logical return value into multiple physical register returns, and the verifier will only see the multiple returns and doesn't know whether they are multiple logical return values, or a single logical value that's been split.