### PR TITLE
RedundantReloadRemover::run: use cached state rather than allocating …

### DIFF
--- a/cranelift-codegen/src/redundant_reload_remover.rs
+++ b/cranelift-codegen/src/redundant_reload_remover.rs
@@ -887,7 +887,7 @@ impl RedundantReloadRemover {
             cur: EncCursor::new(func, isa),
             reginfo: isa.register_info(),
             cfg: cfg,
-            state: &mut RedundantReloadRemover::new(),
+            state: self,
         };
         let mut total_regunits = 0;
         for rb in isa.register_info().banks {


### PR DESCRIPTION
…it new for each function.

RedundantReloadRemover participates in the state-recycling machinery
implemented in cranelift-codegen/src/context.rs, whose goal it is to cache
per-pass state so it can be used for compilation of multiple functions without
reallocation.  Unfortunately RedundantReloadRemover::run simply ignores the
cached state and reallocates it new for each function.  This patch fixes that.
This reduces the number of malloc'd blocks by about 2%.