### PR TITLE
Allow wrap-around when subtracting type size to immediate in try_fold_extended_move

### DIFF
--- a/cranelift-codegen/src/simple_preopt.rs
+++ b/cranelift-codegen/src/simple_preopt.rs
@@ -508,7 +508,7 @@ fn try_fold_extended_move(
             }
 
             let imm_bits: i64 = imm.into();
-            let ireduce_ty = match dest_ty.lane_bits() as i64 - imm_bits {
+            let ireduce_ty = match (dest_ty.lane_bits() as i64).wrapping_sub(imm_bits) {
                 8 => I8,
                 16 => I16,
                 32 => I32,

--- a/filetests/simple_preopt/fold-extended-move-wraparound.clif
+++ b/filetests/simple_preopt/fold-extended-move-wraparound.clif
@@ -1,0 +1,14 @@
+test simple_preopt
+target x86_64
+
+function %wraparound(i64 vmctx) -> f32 system_v {
+    gv0 = vmctx
+    gv1 = iadd_imm.i64 gv0, 48
+
+ebb35(v0: i64):
+    v88 = iconst.i64 0
+    v89 = iconst.i64 0x8000_0000_0000_0000
+    v90 = ishl_imm v88, 0x8000_0000_0000_0000
+    v91 = sshr v90, v89; check: sshr_imm v90, 0x8000_0000_0000_0000
+    trap user0
+}


### PR DESCRIPTION
Simple fuzz bug found on Spidermonkey. Wrapping around is correct and safe, here, so let's do this instead.