### PR TITLE
[wasm] Make the WasmTypeMap constructor public

### DIFF
--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -115,8 +115,9 @@ pub struct WasmTypesMap {
 }
 
 impl WasmTypesMap {
-    pub(crate) fn new() -> Self {
-        WasmTypesMap {
+    /// Creates a new type map.
+    pub fn new() -> Self {
+        Self {
             inner: PrimaryMap::new(),
         }
     }


### PR DESCRIPTION
Spidermonkey actually makes use of the FuncTranslator API directly. Once there's ModuleTranslatorState, we should be able to use this and not have to deal with WasmTypeMap directly, but until then, it's better to make this ctor public, so we can bump the version of Cranelift there and keep on working on Spidermonkey integration.