### PR TITLE
cleanup: remove spurious macro_use in cranelift-bforest;

### DIFF
--- a/cranelift-bforest/src/lib.rs
+++ b/cranelift-bforest/src/lib.rs
@@ -33,7 +33,6 @@
 #![no_std]
 
 #[cfg(test)]
-#[macro_use]
 extern crate alloc;
 
 #[macro_use]


### PR DESCRIPTION
This removes a compile warning when compiling tests for cranelift-bforest. Andrew, PTAL :)