### PR TITLE
[wasm] Include more large tests

### DIFF
--- a/wasmtests/embenchen_fannkuch.wat
+++ b/wasmtests/embenchen_fannkuch.wat
@@ -1,0 +1,16725 @@
+(module
+ (type $0 (func (param i32 i32 i32) (result i32)))
+ (type $1 (func (param i32) (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (param i32 i32)))
+ (type $6 (func))
+ (type $7 (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $8 (func (param i32 i32 i32)))
+ (type $9 (func (param i64 i32) (result i32)))
+ (type $10 (func (param i32 i32 i32 i32 i32)))
+ (type $11 (func (param f64 i32) (result f64)))
+ (type $12 (func (param i32 i32 i32 i32) (result i32)))
+ (import "env" "memory" (memory $16 2048 2048))
+ (data (i32.const 1024) "\04\04\00\00\05")
+ (data (i32.const 1040) "\01")
+ (data (i32.const 1064) "\01\00\00\00\02\00\00\00<\10\00\00\00\04")
+ (data (i32.const 1088) "\01")
+ (data (i32.const 1103) "\n\ff\ff\ff\ff")
+ (data (i32.const 1140) "error: %d\n\00Pfannkuchen(%d) = %d.\n\00%d\00\11\00\n\00\11\11\11\00\00\00\00\05\00\00\00\00\00\00\t\00\00\00\00\0b")
+ (data (i32.const 1209) "\11\00\0f\n\11\11\11\03\n\07\00\01\13\t\0b\0b\00\00\t\06\0b\00\00\0b\00\06\11\00\00\00\11\11\11")
+ (data (i32.const 1258) "\0b")
+ (data (i32.const 1267) "\11\00\n\n\11\11\11\00\n\00\00\02\00\t\0b\00\00\00\t\00\0b\00\00\0b")
+ (data (i32.const 1316) "\0c")
+ (data (i32.const 1328) "\0c\00\00\00\00\0c\00\00\00\00\t\0c\00\00\00\00\00\0c\00\00\0c")
+ (data (i32.const 1374) "\0e")
+ (data (i32.const 1386) "\0d\00\00\00\04\0d\00\00\00\00\t\0e\00\00\00\00\00\0e\00\00\0e")
+ (data (i32.const 1432) "\10")
+ (data (i32.const 1444) "\0f\00\00\00\00\0f\00\00\00\00\t\10\00\00\00\00\00\10\00\00\10\00\00\12\00\00\00\12\12\12")
+ (data (i32.const 1499) "\12\00\00\00\12\12\12\00\00\00\00\00\00\t")
+ (data (i32.const 1548) "\0b")
+ (data (i32.const 1560) "\n\00\00\00\00\n\00\00\00\00\t\0b\00\00\00\00\00\0b\00\00\0b")
+ (data (i32.const 1606) "\0c")
+ (data (i32.const 1618) "\0c\00\00\00\00\0c\00\00\00\00\t\0c\00\00\00\00\00\0c\00\00\0c\00\000123456789ABCDEF-+   0X0x\00(null)\00-0X+0X 0X-0x+0x 0x\00inf\00INF\00nan\00NAN\00.\00T!\"\19\0d\01\02\03\11K\1c\0c\10\04\0b\1d\12\1e\'hnopqb \05\06\0f\13\14\15\1a\08\16\07($\17\18\t\n\0e\1b\1f%#\83\82}&*+<=>?CGJMXYZ[\\]^_`acdefgijklrstyz{|\00Illegal byte sequence\00Domain error\00Result not representable\00Not a tty\00Permission denied\00Operation not permitted\00No such file or directory\00No such process\00File exists\00Value too large for data type\00No space left on device\00Out of memory\00Resource busy\00Interrupted system call\00Resource temporarily unavailable\00Invalid seek\00Cross-device link\00Read-only file system\00Directory not empty\00Connection reset by peer\00Operation timed out\00Connection refused\00Host is down\00Host is unreachable\00Address in use\00Broken pipe\00I/O error\00No such device or address\00Block device required\00No such device\00Not a directory\00Is a directory\00Text file busy\00Exec format error\00Invalid argument\00Argument list too long\00Symbolic link loop\00Filename too long\00Too many open files in system\00No file descriptors available\00Bad file descriptor\00No child process\00Bad address\00File too large\00Too many links\00No locks available\00Resource deadlock would occur\00State not recoverable\00Previous owner died\00Operation canceled\00Function not implemented\00No message of desired type\00Identifier removed\00Device not a stream\00No data available\00Device timeout\00Out of streams resources\00Link has been severed\00Protocol error\00Bad message\00File descriptor in bad state\00Not a socket\00Destination address required\00Message too large\00Protocol wrong type for socket\00Protocol not available\00Protocol not supported\00Socket type not supported\00Not supported\00Protocol family not supported\00Address family not supported by protocol\00Address not available\00Network is down\00Network unreachable\00Connection reset by network\00Connection aborted\00No buffer space available\00Socket is connected\00Socket not connected\00Cannot send after socket shutdown\00Operation already in progress\00Operation in progress\00Stale file handle\00Remote I/O error\00Quota exceeded\00No medium found\00Wrong medium type\00No error information")
+ (import "env" "table" (table $timport$17 8 8 funcref))
+ (elem (global.get $gimport$19) $45 $9 $46 $14 $10 $15 $47 $16)
+ (import "env" "DYNAMICTOP_PTR" (global $gimport$0 i32))
+ (import "env" "STACKTOP" (global $gimport$1 i32))
+ (import "env" "STACK_MAX" (global $gimport$2 i32))
+ (import "env" "memoryBase" (global $gimport$18 i32))
+ (import "env" "tableBase" (global $gimport$19 i32))
+ (import "env" "abort" (func $fimport$3 (param i32)))
+ (import "env" "enlargeMemory" (func $fimport$4 (result i32)))
+ (import "env" "getTotalMemory" (func $fimport$5 (result i32)))
+ (import "env" "abortOnCannotGrowMemory" (func $fimport$6 (result i32)))
+ (import "env" "_pthread_cleanup_pop" (func $fimport$7 (param i32)))
+ (import "env" "___syscall6" (func $fimport$8 (param i32 i32) (result i32)))
+ (import "env" "_pthread_cleanup_push" (func $fimport$9 (param i32 i32)))
+ (import "env" "_abort" (func $fimport$10))
+ (import "env" "___setErrNo" (func $fimport$11 (param i32)))
+ (import "env" "_emscripten_memcpy_big" (func $fimport$12 (param i32 i32 i32) (result i32)))
+ (import "env" "___syscall54" (func $fimport$13 (param i32 i32) (result i32)))
+ (import "env" "___syscall140" (func $fimport$14 (param i32 i32) (result i32)))
+ (import "env" "___syscall146" (func $fimport$15 (param i32 i32) (result i32)))
+ (global $global$0 (mut i32) (global.get $gimport$0))
+ (global $global$1 (mut i32) (global.get $gimport$1))
+ (global $global$2 (mut i32) (global.get $gimport$2))
+ (global $global$3 (mut i32) (i32.const 0))
+ (global $global$4 (mut i32) (i32.const 0))
+ (global $global$5 (mut i32) (i32.const 0))
+ (export "_sbrk" (func $38))
+ (export "_free" (func $36))
+ (export "_main" (func $8))
+ (export "_pthread_self" (func $41))
+ (export "_memset" (func $39))
+ (export "_malloc" (func $35))
+ (export "_memcpy" (func $40))
+ (export "___errno_location" (func $12))
+ (export "runPostSets" (func $37))
+ (export "stackAlloc" (func $0))
+ (export "stackSave" (func $1))
+ (export "stackRestore" (func $2))
+ (export "establishStackSpace" (func $3))
+ (export "setThrew" (func $4))
+ (export "setTempRet0" (func $5))
+ (export "getTempRet0" (func $6))
+ (export "dynCall_ii" (func $42))
+ (export "dynCall_iiii" (func $43))
+ (export "dynCall_vi" (func $44))
+ (func $0 (; 13 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (local.get $0)
+    )
+   )
+   (global.set $global$1
+    (i32.and
+     (i32.add
+      (global.get $global$1)
+      (i32.const 15)
+     )
+     (i32.const -16)
+    )
+   )
+   (local.get $1)
+  )
+ )
+ (func $1 (; 14 ;) (type $3) (result i32)
+  (global.get $global$1)
+ )
+ (func $2 (; 15 ;) (type $2) (param $0 i32)
+  (global.set $global$1
+   (local.get $0)
+  )
+ )
+ (func $3 (; 16 ;) (type $5) (param $0 i32) (param $1 i32)
+  (block $label$1
+   (global.set $global$1
+    (local.get $0)
+   )
+   (global.set $global$2
+    (local.get $1)
+   )
+  )
+ )
+ (func $4 (; 17 ;) (type $5) (param $0 i32) (param $1 i32)
+  (if
+   (i32.eqz
+    (global.get $global$3)
+   )
+   (block
+    (global.set $global$3
+     (local.get $0)
+    )
+    (global.set $global$4
+     (local.get $1)
+    )
+   )
+  )
+ )
+ (func $5 (; 18 ;) (type $2) (param $0 i32)
+  (global.set $global$5
+   (local.get $0)
+  )
+ )
+ (func $6 (; 19 ;) (type $3) (result i32)
+  (global.get $global$5)
+ )
+ (func $7 (; 20 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (block $label$1 (result i32)
+   (local.set $3
+    (call $35
+     (local.tee $15
+      (i32.shl
+       (local.tee $4
+        (i32.load offset=4
+         (local.get $0)
+        )
+       )
+       (i32.const 2)
+      )
+     )
+    )
+   )
+   (local.set $6
+    (call $35
+     (local.get $15)
+    )
+   )
+   (local.set $10
+    (call $35
+     (local.get $15)
+    )
+   )
+   (if
+    (local.tee $2
+     (i32.gt_s
+      (local.get $4)
+      (i32.const 0)
+     )
+    )
+    (block
+     (local.set $1
+      (i32.const 0)
+     )
+     (loop $label$3
+      (i32.store
+       (i32.add
+        (local.get $3)
+        (i32.shl
+         (local.get $1)
+         (i32.const 2)
+        )
+       )
+       (local.get $1)
+      )
+      (br_if $label$3
+       (i32.ne
+        (local.tee $1
+         (i32.add
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (local.get $4)
+       )
+      )
+     )
+     (i32.store
+      (i32.add
+       (local.get $3)
+       (i32.shl
+        (local.tee $0
+         (i32.load
+          (local.get $0)
+         )
+        )
+        (i32.const 2)
+       )
+      )
+      (local.tee $11
+       (i32.add
+        (local.get $4)
+        (i32.const -1)
+       )
+      )
+     )
+     (i32.store
+      (local.tee $14
+       (i32.add
+        (local.get $3)
+        (i32.shl
+         (local.get $11)
+         (i32.const 2)
+        )
+       )
+      )
+      (local.get $0)
+     )
+     (if
+      (local.get $2)
+      (block
+       (local.set $0
+        (i32.const 0)
+       )
+       (local.set $1
+        (local.get $4)
+       )
+       (loop $label$5
+        (block $label$6
+         (if
+          (i32.gt_s
+           (local.get $1)
+           (i32.const 1)
+          )
+          (loop $label$8
+           (i32.store
+            (i32.add
+             (local.get $10)
+             (i32.shl
+              (local.tee $2
+               (i32.add
+                (local.get $1)
+                (i32.const -1)
+               )
+              )
+              (i32.const 2)
+             )
+            )
+            (local.get $1)
+           )
+           (if
+            (i32.gt_s
+             (local.get $2)
+             (i32.const 1)
+            )
+            (block
+             (local.set $1
+              (local.get $2)
+             )
+             (br $label$8)
+            )
+            (local.set $2
+             (i32.const 1)
+            )
+           )
+          )
+          (local.set $2
+           (local.get $1)
+          )
+         )
+         (if
+          (local.tee $7
+           (i32.load
+            (local.get $3)
+           )
+          )
+          (if
+           (i32.ne
+            (i32.load
+             (local.get $14)
+            )
+            (local.get $11)
+           )
+           (block
+            (drop
+             (call $40
+              (local.get $6)
+              (local.get $3)
+              (local.get $15)
+             )
+            )
+            (local.set $8
+             (i32.const 0)
+            )
+            (local.set $9
+             (i32.load
+              (local.get $6)
+             )
+            )
+            (loop $label$14
+             (if
+              (i32.gt_s
+               (local.tee $1
+                (i32.add
+                 (local.get $9)
+                 (i32.const -1)
+                )
+               )
+               (i32.const 1)
+              )
+              (block
+               (local.set $5
+                (i32.const 1)
+               )
+               (loop $label$16
+                (local.set $17
+                 (i32.load
+                  (local.tee $12
+                   (i32.add
+                    (local.get $6)
+                    (i32.shl
+                     (local.get $5)
+                     (i32.const 2)
+                    )
+                   )
+                  )
+                 )
+                )
+                (i32.store
+                 (local.get $12)
+                 (i32.load
+                  (local.tee $12
+                   (i32.add
+                    (local.get $6)
+                    (i32.shl
+                     (local.get $1)
+                     (i32.const 2)
+                    )
+                   )
+                  )
+                 )
+                )
+                (i32.store
+                 (local.get $12)
+                 (local.get $17)
+                )
+                (br_if $label$16
+                 (i32.lt_s
+                  (local.tee $5
+                   (i32.add
+                    (local.get $5)
+                    (i32.const 1)
+                   )
+                  )
+                  (local.tee $1
+                   (i32.add
+                    (local.get $1)
+                    (i32.const -1)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (local.set $5
+              (i32.add
+               (local.get $8)
+               (i32.const 1)
+              )
+             )
+             (local.set $1
+              (i32.load
+               (local.tee $12
+                (i32.add
+                 (local.get $6)
+                 (i32.shl
+                  (local.get $9)
+                  (i32.const 2)
+                 )
+                )
+               )
+              )
+             )
+             (i32.store
+              (local.get $12)
+              (local.get $9)
+             )
+             (if
+              (local.get $1)
+              (block
+               (local.set $8
+                (local.get $5)
+               )
+               (local.set $9
+                (local.get $1)
+               )
+               (br $label$14)
+              )
+             )
+            )
+            (if
+             (i32.le_s
+              (local.get $0)
+              (local.get $8)
+             )
+             (local.set $0
+              (local.get $5)
+             )
+            )
+           )
+          )
+         )
+         (if
+          (i32.lt_s
+           (local.get $2)
+           (local.get $11)
+          )
+          (local.set $1
+           (local.get $2)
+          )
+          (block
+           (local.set $1
+            (i32.const 31)
+           )
+           (br $label$6)
+          )
+         )
+         (loop $label$21
+          (if
+           (i32.gt_s
+            (local.get $1)
+            (i32.const 0)
+           )
+           (block
+            (local.set $2
+             (i32.const 0)
+            )
+            (loop $label$23
+             (i32.store
+              (i32.add
+               (local.get $3)
+               (i32.shl
+                (local.get $2)
+                (i32.const 2)
+               )
+              )
+              (i32.load
+               (i32.add
+                (local.get $3)
+                (i32.shl
+                 (local.tee $2
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 1)
+                  )
+                 )
+                 (i32.const 2)
+                )
+               )
+              )
+             )
+             (br_if $label$23
+              (i32.lt_s
+               (local.get $2)
+               (local.get $1)
+              )
+             )
+             (local.set $2
+              (local.get $1)
+             )
+            )
+           )
+           (local.set $2
+            (i32.const 0)
+           )
+          )
+          (i32.store
+           (i32.add
+            (local.get $3)
+            (i32.shl
+             (local.get $2)
+             (i32.const 2)
+            )
+           )
+           (local.get $7)
+          )
+          (local.set $5
+           (i32.load
+            (local.tee $2
+             (i32.add
+              (local.get $10)
+              (i32.shl
+               (local.get $1)
+               (i32.const 2)
+              )
+             )
+            )
+           )
+          )
+          (i32.store
+           (local.get $2)
+           (i32.add
+            (local.get $5)
+            (i32.const -1)
+           )
+          )
+          (br_if $label$5
+           (i32.gt_s
+            (local.get $5)
+            (i32.const 1)
+           )
+          )
+          (if
+           (i32.lt_s
+            (local.tee $1
+             (i32.add
+              (local.get $1)
+              (i32.const 1)
+             )
+            )
+            (local.get $11)
+           )
+           (block
+            (local.set $7
+             (i32.load
+              (local.get $3)
+             )
+            )
+            (br $label$21)
+           )
+           (block
+            (local.set $1
+             (i32.const 31)
+            )
+            (br $label$6)
+           )
+          )
+         )
+        )
+       )
+       (if
+        (i32.eq
+         (local.get $1)
+         (i32.const 31)
+        )
+        (block
+         (call $36
+          (local.get $3)
+         )
+         (call $36
+          (local.get $6)
+         )
+         (call $36
+          (local.get $10)
+         )
+         (return
+          (local.get $0)
+         )
+        )
+       )
+      )
+      (block
+       (local.set $16
+        (local.get $14)
+       )
+       (local.set $13
+        (local.get $11)
+       )
+      )
+     )
+    )
+    (block
+     (i32.store
+      (i32.add
+       (local.get $3)
+       (i32.shl
+        (local.tee $0
+         (i32.load
+          (local.get $0)
+         )
+        )
+        (i32.const 2)
+       )
+      )
+      (local.tee $13
+       (i32.add
+        (local.get $4)
+        (i32.const -1)
+       )
+      )
+     )
+     (i32.store
+      (local.tee $16
+       (i32.add
+        (local.get $3)
+        (i32.shl
+         (local.get $13)
+         (i32.const 2)
+        )
+       )
+      )
+      (local.get $0)
+     )
+    )
+   )
+   (local.set $0
+    (i32.const 0)
+   )
+   (local.set $1
+    (local.get $4)
+   )
+   (loop $label$30
+    (block $label$31
+     (if
+      (i32.gt_s
+       (local.get $1)
+       (i32.const 1)
+      )
+      (loop $label$33
+       (i32.store
+        (i32.add
+         (local.get $10)
+         (i32.shl
+          (local.tee $2
+           (i32.add
+            (local.get $1)
+            (i32.const -1)
+           )
+          )
+          (i32.const 2)
+         )
+        )
+        (local.get $1)
+       )
+       (if
+        (i32.gt_s
+         (local.get $2)
+         (i32.const 1)
+        )
+        (block
+         (local.set $1
+          (local.get $2)
+         )
+         (br $label$33)
+        )
+        (local.set $2
+         (i32.const 1)
+        )
+       )
+      )
+      (local.set $2
+       (local.get $1)
+      )
+     )
+     (if
+      (local.tee $9
+       (i32.load
+        (local.get $3)
+       )
+      )
+      (if
+       (i32.ne
+        (i32.load
+         (local.get $16)
+        )
+        (local.get $13)
+       )
+       (block
+        (local.set $5
+         (i32.const 0)
+        )
+        (local.set $8
+         (i32.load
+          (local.get $6)
+         )
+        )
+        (loop $label$39
+         (if
+          (i32.gt_s
+           (local.tee $1
+            (i32.add
+             (local.get $8)
+             (i32.const -1)
+            )
+           )
+           (i32.const 1)
+          )
+          (block
+           (local.set $4
+            (i32.const 1)
+           )
+           (loop $label$41
+            (local.set $14
+             (i32.load
+              (local.tee $7
+               (i32.add
+                (local.get $6)
+                (i32.shl
+                 (local.get $4)
+                 (i32.const 2)
+                )
+               )
+              )
+             )
+            )
+            (i32.store
+             (local.get $7)
+             (i32.load
+              (local.tee $7
+               (i32.add
+                (local.get $6)
+                (i32.shl
+                 (local.get $1)
+                 (i32.const 2)
+                )
+               )
+              )
+             )
+            )
+            (i32.store
+             (local.get $7)
+             (local.get $14)
+            )
+            (br_if $label$41
+             (i32.lt_s
+              (local.tee $4
+               (i32.add
+                (local.get $4)
+                (i32.const 1)
+               )
+              )
+              (local.tee $1
+               (i32.add
+                (local.get $1)
+                (i32.const -1)
+               )
+              )
+             )
+            )
+           )
+          )
+         )
+         (local.set $4
+          (i32.add
+           (local.get $5)
+           (i32.const 1)
+          )
+         )
+         (local.set $1
+          (i32.load
+           (local.tee $7
+            (i32.add
+             (local.get $6)
+             (i32.shl
+              (local.get $8)
+              (i32.const 2)
+             )
+            )
+           )
+          )
+         )
+         (i32.store
+          (local.get $7)
+          (local.get $8)
+         )
+         (if
+          (local.get $1)
+          (block
+           (local.set $5
+            (local.get $4)
+           )
+           (local.set $8
+            (local.get $1)
+           )
+           (br $label$39)
+          )
+         )
+        )
+        (if
+         (i32.le_s
+          (local.get $0)
+          (local.get $5)
+         )
+         (local.set $0
+          (local.get $4)
+         )
+        )
+       )
+      )
+     )
+     (if
+      (i32.lt_s
+       (local.get $2)
+       (local.get $13)
+      )
+      (local.set $1
+       (local.get $2)
+      )
+      (block
+       (local.set $1
+        (i32.const 31)
+       )
+       (br $label$31)
+      )
+     )
+     (loop $label$46
+      (if
+       (i32.gt_s
+        (local.get $1)
+        (i32.const 0)
+       )
+       (block
+        (local.set $2
+         (i32.const 0)
+        )
+        (loop $label$48
+         (i32.store
+          (i32.add
+           (local.get $3)
+           (i32.shl
+            (local.get $2)
+            (i32.const 2)
+           )
+          )
+          (i32.load
+           (i32.add
+            (local.get $3)
+            (i32.shl
+             (local.tee $2
+              (i32.add
+               (local.get $2)
+               (i32.const 1)
+              )
+             )
+             (i32.const 2)
+            )
+           )
+          )
+         )
+         (br_if $label$48
+          (i32.lt_s
+           (local.get $2)
+           (local.get $1)
+          )
+         )
+         (local.set $2
+          (local.get $1)
+         )
+        )
+       )
+       (local.set $2
+        (i32.const 0)
+       )
+      )
+      (i32.store
+       (i32.add
+        (local.get $3)
+        (i32.shl
+         (local.get $2)
+         (i32.const 2)
+        )
+       )
+       (local.get $9)
+      )
+      (local.set $4
+       (i32.load
+        (local.tee $2
+         (i32.add
+          (local.get $10)
+          (i32.shl
+           (local.get $1)
+           (i32.const 2)
+          )
+         )
+        )
+       )
+      )
+      (i32.store
+       (local.get $2)
+       (i32.add
+        (local.get $4)
+        (i32.const -1)
+       )
+      )
+      (br_if $label$30
+       (i32.gt_s
+        (local.get $4)
+        (i32.const 1)
+       )
+      )
+      (if
+       (i32.lt_s
+        (local.tee $1
+         (i32.add
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (local.get $13)
+       )
+       (block
+        (local.set $9
+         (i32.load
+          (local.get $3)
+         )
+        )
+        (br $label$46)
+       )
+       (block
+        (local.set $1
+         (i32.const 31)
+        )
+        (br $label$31)
+       )
+      )
+     )
+    )
+   )
+   (if
+    (i32.eq
+     (local.get $1)
+     (i32.const 31)
+    )
+    (block
+     (call $36
+      (local.get $3)
+     )
+     (call $36
+      (local.get $6)
+     )
+     (call $36
+      (local.get $10)
+     )
+     (return
+      (local.get $0)
+     )
+    )
+   )
+   (i32.const 0)
+  )
+ )
+ (func $8 (; 21 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (block $label$1 (result i32)
+   (local.set $5
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 32)
+    )
+   )
+   (local.set $7
+    (i32.add
+     (local.get $5)
+     (i32.const 16)
+    )
+   )
+   (local.set $10
+    (i32.add
+     (local.get $5)
+     (i32.const 8)
+    )
+   )
+   (local.set $2
+    (local.get $5)
+   )
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (i32.le_s
+       (local.get $0)
+       (i32.const 1)
+      )
+     )
+     (block $label$4
+      (block $label$5
+       (block $label$6
+        (block $label$7
+         (block $label$8
+          (block $label$9
+           (block $label$10
+            (br_table $label$5 $label$10 $label$8 $label$9 $label$7 $label$6 $label$4
+             (i32.sub
+              (local.tee $0
+               (i32.load8_s
+                (i32.load offset=4
+                 (local.get $1)
+                )
+               )
+              )
+              (i32.const 48)
+             )
+            )
+           )
+           (local.set $3
+            (i32.const 9)
+           )
+           (br $label$2)
+          )
+          (br $label$3)
+         )
+         (local.set $3
+          (i32.const 10)
+         )
+         (br $label$2)
+        )
+        (local.set $3
+         (i32.const 11)
+        )
+        (br $label$2)
+       )
+       (local.set $3
+        (i32.const 12)
+       )
+       (br $label$2)
+      )
+      (global.set $global$1
+       (local.get $5)
+      )
+      (return
+       (i32.const 0)
+      )
+     )
+     (i32.store
+      (local.get $2)
+      (i32.add
+       (local.get $0)
+       (i32.const -48)
+      )
+     )
+     (drop
+      (call $33
+       (i32.const 1140)
+       (local.get $2)
+      )
+     )
+     (global.set $global$1
+      (local.get $5)
+     )
+     (return
+      (i32.const -1)
+     )
+    )
+    (local.set $3
+     (i32.const 11)
+    )
+   )
+   (local.set $6
+    (i32.add
+     (local.get $3)
+     (i32.const -1)
+    )
+   )
+   (local.set $2
+    (i32.const 0)
+   )
+   (local.set $0
+    (i32.const 0)
+   )
+   (loop $label$11
+    (i32.store
+     (local.tee $1
+      (call $35
+       (i32.const 12)
+      )
+     )
+     (local.get $0)
+    )
+    (i32.store offset=4
+     (local.get $1)
+     (local.get $3)
+    )
+    (i32.store offset=8
+     (local.get $1)
+     (local.get $2)
+    )
+    (if
+     (i32.ne
+      (local.tee $0
+       (i32.add
+        (local.get $0)
+        (i32.const 1)
+       )
+      )
+      (local.get $6)
+     )
+     (block
+      (local.set $2
+       (local.get $1)
+      )
+      (br $label$11)
+     )
+    )
+   )
+   (local.set $4
+    (call $35
+     (local.tee $0
+      (i32.shl
+       (local.get $3)
+       (i32.const 2)
+      )
+     )
+    )
+   )
+   (local.set $8
+    (call $35
+     (local.get $0)
+    )
+   )
+   (local.set $0
+    (i32.const 0)
+   )
+   (loop $label$13
+    (i32.store
+     (i32.add
+      (local.get $4)
+      (i32.shl
+       (local.get $0)
+       (i32.const 2)
+      )
+     )
+     (local.get $0)
+    )
+    (br_if $label$13
+     (i32.ne
+      (local.tee $0
+       (i32.add
+        (local.get $0)
+        (i32.const 1)
+       )
+      )
+      (local.get $3)
+     )
+    )
+   )
+   (local.set $0
+    (local.get $3)
+   )
+   (local.set $6
+    (i32.const 30)
+   )
+   (loop $label$14
+    (block $label$15
+     (local.set $2
+      (i32.const 0)
+     )
+     (loop $label$16
+      (i32.store
+       (local.get $10)
+       (i32.add
+        (i32.load
+         (i32.add
+          (local.get $4)
+          (i32.shl
+           (local.get $2)
+           (i32.const 2)
+          )
+         )
+        )
+        (i32.const 1)
+       )
+      )
+      (drop
+       (call $33
+        (i32.const 1174)
+        (local.get $10)
+       )
+      )
+      (br_if $label$16
+       (i32.ne
+        (local.tee $2
+         (i32.add
+          (local.get $2)
+          (i32.const 1)
+         )
+        )
+        (local.get $3)
+       )
+      )
+     )
+     (drop
+      (call $34
+       (i32.const 10)
+      )
+     )
+     (if
+      (i32.gt_s
+       (local.get $0)
+       (i32.const 1)
+      )
+      (loop $label$18
+       (i32.store
+        (i32.add
+         (local.get $8)
+         (i32.shl
+          (local.tee $2
+           (i32.add
+            (local.get $0)
+            (i32.const -1)
+           )
+          )
+          (i32.const 2)
+         )
+        )
+        (local.get $0)
+       )
+       (if
+        (i32.gt_s
+         (local.get $2)
+         (i32.const 1)
+        )
+        (block
+         (local.set $0
+          (local.get $2)
+         )
+         (br $label$18)
+        )
+        (local.set $0
+         (i32.const 1)
+        )
+       )
+      )
+      (br_if $label$15
+       (i32.eq
+        (local.get $0)
+        (local.get $3)
+       )
+      )
+     )
+     (local.set $6
+      (i32.add
+       (local.get $6)
+       (i32.const -1)
+      )
+     )
+     (loop $label$22
+      (block $label$23
+       (local.set $9
+        (i32.load
+         (local.get $4)
+        )
+       )
+       (if
+        (i32.gt_s
+         (local.get $0)
+         (i32.const 0)
+        )
+        (block
+         (local.set $2
+          (i32.const 0)
+         )
+         (loop $label$25
+          (i32.store
+           (i32.add
+            (local.get $4)
+            (i32.shl
+             (local.get $2)
+             (i32.const 2)
+            )
+           )
+           (i32.load
+            (i32.add
+             (local.get $4)
+             (i32.shl
+              (local.tee $2
+               (i32.add
+                (local.get $2)
+                (i32.const 1)
+               )
+              )
+              (i32.const 2)
+             )
+            )
+           )
+          )
+          (br_if $label$25
+           (i32.lt_s
+            (local.get $2)
+            (local.get $0)
+           )
+          )
+          (local.set $2
+           (local.get $0)
+          )
+         )
+        )
+        (local.set $2
+         (i32.const 0)
+        )
+       )
+       (i32.store
+        (i32.add
+         (local.get $4)
+         (i32.shl
+          (local.get $2)
+          (i32.const 2)
+         )
+        )
+        (local.get $9)
+       )
+       (local.set $2
+        (i32.load
+         (local.tee $9
+          (i32.add
+           (local.get $8)
+           (i32.shl
+            (local.get $0)
+            (i32.const 2)
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $9)
+        (i32.add
+         (local.get $2)
+         (i32.const -1)
+        )
+       )
+       (br_if $label$23
+        (i32.gt_s
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (br_if $label$22
+        (i32.ne
+         (local.tee $0
+          (i32.add
+           (local.get $0)
+           (i32.const 1)
+          )
+         )
+         (local.get $3)
+        )
+       )
+       (br $label$15)
+      )
+     )
+     (br_if $label$14
+      (local.get $6)
+     )
+    )
+   )
+   (call $36
+    (local.get $4)
+   )
+   (call $36
+    (local.get $8)
+   )
+   (if
+    (local.get $1)
+    (block
+     (local.set $0
+      (i32.const 0)
+     )
+     (loop $label$28
+      (if
+       (i32.lt_s
+        (local.get $0)
+        (local.tee $2
+         (call $7
+          (local.get $1)
+         )
+        )
+       )
+       (local.set $0
+        (local.get $2)
+       )
+      )
+      (local.set $2
+       (i32.load offset=8
+        (local.get $1)
+       )
+      )
+      (call $36
+       (local.get $1)
+      )
+      (if
+       (local.get $2)
+       (block
+        (local.set $1
+         (local.get $2)
+        )
+        (br $label$28)
+       )
+      )
+     )
+    )
+    (local.set $0
+     (i32.const 0)
+    )
+   )
+   (i32.store
+    (local.get $7)
+    (local.get $3)
+   )
+   (i32.store offset=4
+    (local.get $7)
+    (local.get $0)
+   )
+   (drop
+    (call $33
+     (i32.const 1151)
+     (local.get $7)
+    )
+   )
+   (global.set $global$1
+    (local.get $5)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $9 (; 22 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store
+    (local.tee $2
+     (local.get $1)
+    )
+    (i32.load offset=60
+     (local.get $0)
+    )
+   )
+   (local.set $0
+    (call $11
+     (call $fimport$8
+      (i32.const 6)
+      (local.get $2)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $1)
+   )
+   (local.get $0)
+  )
+ )
+ (func $10 (; 23 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 32)
+    )
+   )
+   (i32.store
+    (local.tee $3
+     (local.get $4)
+    )
+    (i32.load offset=60
+     (local.get $0)
+    )
+   )
+   (i32.store offset=4
+    (local.get $3)
+    (i32.const 0)
+   )
+   (i32.store offset=8
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=12
+    (local.get $3)
+    (local.tee $0
+     (i32.add
+      (local.get $4)
+      (i32.const 20)
+     )
+    )
+   )
+   (i32.store offset=16
+    (local.get $3)
+    (local.get $2)
+   )
+   (local.set $0
+    (if (result i32)
+     (i32.lt_s
+      (call $11
+       (call $fimport$14
+        (i32.const 140)
+        (local.get $3)
+       )
+      )
+      (i32.const 0)
+     )
+     (block (result i32)
+      (i32.store
+       (local.get $0)
+       (i32.const -1)
+      )
+      (i32.const -1)
+     )
+     (i32.load
+      (local.get $0)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $0)
+  )
+ )
+ (func $11 (; 24 ;) (type $1) (param $0 i32) (result i32)
+  (if (result i32)
+   (i32.gt_u
+    (local.get $0)
+    (i32.const -4096)
+   )
+   (block (result i32)
+    (i32.store
+     (call $12)
+     (i32.sub
+      (i32.const 0)
+      (local.get $0)
+     )
+    )
+    (i32.const -1)
+   )
+   (local.get $0)
+  )
+ )
+ (func $12 (; 25 ;) (type $3) (result i32)
+  (i32.const 3648)
+ )
+ (func $13 (; 26 ;) (type $2) (param $0 i32)
+  (nop)
+ )
+ (func $14 (; 27 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 80)
+    )
+   )
+   (local.set $3
+    (local.get $4)
+   )
+   (local.set $5
+    (i32.add
+     (local.get $4)
+     (i32.const 12)
+    )
+   )
+   (i32.store offset=36
+    (local.get $0)
+    (i32.const 3)
+   )
+   (if
+    (i32.eqz
+     (i32.and
+      (i32.load
+       (local.get $0)
+      )
+      (i32.const 64)
+     )
+    )
+    (block
+     (i32.store
+      (local.get $3)
+      (i32.load offset=60
+       (local.get $0)
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.const 21505)
+     )
+     (i32.store offset=8
+      (local.get $3)
+      (local.get $5)
+     )
+     (if
+      (call $fimport$13
+       (i32.const 54)
+       (local.get $3)
+      )
+      (i32.store8 offset=75
+       (local.get $0)
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (local.set $0
+    (call $15
+     (local.get $0)
+     (local.get $1)
+     (local.get $2)
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $0)
+  )
+ )
+ (func $15 (; 28 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (block $label$1 (result i32)
+   (local.set $8
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 48)
+    )
+   )
+   (local.set $9
+    (i32.add
+     (local.get $8)
+     (i32.const 16)
+    )
+   )
+   (local.set $10
+    (local.get $8)
+   )
+   (i32.store
+    (local.tee $3
+     (i32.add
+      (local.get $8)
+      (i32.const 32)
+     )
+    )
+    (local.tee $4
+     (i32.load
+      (local.tee $6
+       (i32.add
+        (local.get $0)
+        (i32.const 28)
+       )
+      )
+     )
+    )
+   )
+   (i32.store offset=4
+    (local.get $3)
+    (local.tee $5
+     (i32.sub
+      (i32.load
+       (local.tee $11
+        (i32.add
+         (local.get $0)
+         (i32.const 20)
+        )
+       )
+      )
+      (local.get $4)
+     )
+    )
+   )
+   (i32.store offset=8
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=12
+    (local.get $3)
+    (local.get $2)
+   )
+   (local.set $13
+    (i32.add
+     (local.get $0)
+     (i32.const 60)
+    )
+   )
+   (local.set $14
+    (i32.add
+     (local.get $0)
+     (i32.const 44)
+    )
+   )
+   (local.set $1
+    (local.get $3)
+   )
+   (local.set $4
+    (i32.const 2)
+   )
+   (local.set $12
+    (i32.add
+     (local.get $5)
+     (local.get $2)
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (loop $label$5
+       (if
+        (i32.load
+         (i32.const 3604)
+        )
+        (block
+         (call $fimport$9
+          (i32.const 1)
+          (local.get $0)
+         )
+         (i32.store
+          (local.get $10)
+          (i32.load
+           (local.get $13)
+          )
+         )
+         (i32.store offset=4
+          (local.get $10)
+          (local.get $1)
+         )
+         (i32.store offset=8
+          (local.get $10)
+          (local.get $4)
+         )
+         (local.set $3
+          (call $11
+           (call $fimport$15
+            (i32.const 146)
+            (local.get $10)
+           )
+          )
+         )
+         (call $fimport$7
+          (i32.const 0)
+         )
+        )
+        (block
+         (i32.store
+          (local.get $9)
+          (i32.load
+           (local.get $13)
+          )
+         )
+         (i32.store offset=4
+          (local.get $9)
+          (local.get $1)
+         )
+         (i32.store offset=8
+          (local.get $9)
+          (local.get $4)
+         )
+         (local.set $3
+          (call $11
+           (call $fimport$15
+            (i32.const 146)
+            (local.get $9)
+           )
+          )
+         )
+        )
+       )
+       (br_if $label$4
+        (i32.eq
+         (local.get $12)
+         (local.get $3)
+        )
+       )
+       (br_if $label$3
+        (i32.lt_s
+         (local.get $3)
+         (i32.const 0)
+        )
+       )
+       (local.set $5
+        (if (result i32)
+         (i32.gt_u
+          (local.get $3)
+          (local.tee $5
+           (i32.load offset=4
+            (local.get $1)
+           )
+          )
+         )
+         (block (result i32)
+          (i32.store
+           (local.get $6)
+           (local.tee $7
+            (i32.load
+             (local.get $14)
+            )
+           )
+          )
+          (i32.store
+           (local.get $11)
+           (local.get $7)
+          )
+          (local.set $7
+           (i32.load offset=12
+            (local.get $1)
+           )
+          )
+          (local.set $1
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+          (local.set $4
+           (i32.add
+            (local.get $4)
+            (i32.const -1)
+           )
+          )
+          (i32.sub
+           (local.get $3)
+           (local.get $5)
+          )
+         )
+         (if (result i32)
+          (i32.eq
+           (local.get $4)
+           (i32.const 2)
+          )
+          (block (result i32)
+           (i32.store
+            (local.get $6)
+            (i32.add
+             (i32.load
+              (local.get $6)
+             )
+             (local.get $3)
+            )
+           )
+           (local.set $7
+            (local.get $5)
+           )
+           (local.set $4
+            (i32.const 2)
+           )
+           (local.get $3)
+          )
+          (block (result i32)
+           (local.set $7
+            (local.get $5)
+           )
+           (local.get $3)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $1)
+        (i32.add
+         (i32.load
+          (local.get $1)
+         )
+         (local.get $5)
+        )
+       )
+       (i32.store offset=4
+        (local.get $1)
+        (i32.sub
+         (local.get $7)
+         (local.get $5)
+        )
+       )
+       (local.set $12
+        (i32.sub
+         (local.get $12)
+         (local.get $3)
+        )
+       )
+       (br $label$5)
+      )
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (i32.add
+       (local.tee $1
+        (i32.load
+         (local.get $14)
+        )
+       )
+       (i32.load offset=48
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (local.get $6)
+      (local.get $1)
+     )
+     (i32.store
+      (local.get $11)
+      (local.get $1)
+     )
+     (br $label$2)
+    )
+    (i32.store offset=16
+     (local.get $0)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $6)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $11)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $0)
+     (i32.or
+      (i32.load
+       (local.get $0)
+      )
+      (i32.const 32)
+     )
+    )
+    (local.set $2
+     (if (result i32)
+      (i32.eq
+       (local.get $4)
+       (i32.const 2)
+      )
+      (i32.const 0)
+      (i32.sub
+       (local.get $2)
+       (i32.load offset=4
+        (local.get $1)
+       )
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $8)
+   )
+   (local.get $2)
+  )
+ )
+ (func $16 (; 29 ;) (type $2) (param $0 i32)
+  (if
+   (i32.eqz
+    (i32.load offset=68
+     (local.get $0)
+    )
+   )
+   (call $13
+    (local.get $0)
+   )
+  )
+ )
+ (func $17 (; 30 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $5
+    (i32.and
+     (local.get $1)
+     (i32.const 255)
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (if
+       (i32.and
+        (local.tee $4
+         (i32.ne
+          (local.get $2)
+          (i32.const 0)
+         )
+        )
+        (i32.ne
+         (i32.and
+          (local.get $0)
+          (i32.const 3)
+         )
+         (i32.const 0)
+        )
+       )
+       (block
+        (local.set $4
+         (i32.and
+          (local.get $1)
+          (i32.const 255)
+         )
+        )
+        (local.set $3
+         (local.get $2)
+        )
+        (local.set $2
+         (local.get $0)
+        )
+        (loop $label$6
+         (if
+          (i32.eq
+           (i32.load8_s
+            (local.get $2)
+           )
+           (i32.shr_s
+            (i32.shl
+             (local.get $4)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+          )
+          (block
+           (local.set $0
+            (local.get $3)
+           )
+           (br $label$3)
+          )
+         )
+         (br_if $label$6
+          (i32.and
+           (local.tee $0
+            (i32.ne
+             (local.tee $3
+              (i32.add
+               (local.get $3)
+               (i32.const -1)
+              )
+             )
+             (i32.const 0)
+            )
+           )
+           (i32.ne
+            (i32.and
+             (local.tee $2
+              (i32.add
+               (local.get $2)
+               (i32.const 1)
+              )
+             )
+             (i32.const 3)
+            )
+            (i32.const 0)
+           )
+          )
+         )
+         (br $label$4)
+        )
+       )
+       (block
+        (local.set $3
+         (local.get $2)
+        )
+        (local.set $2
+         (local.get $0)
+        )
+        (local.set $0
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (if
+      (local.get $0)
+      (block
+       (local.set $0
+        (local.get $3)
+       )
+       (br $label$3)
+      )
+      (local.set $0
+       (i32.const 0)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.ne
+      (i32.load8_s
+       (local.get $2)
+      )
+      (i32.shr_s
+       (i32.shl
+        (local.tee $1
+         (i32.and
+          (local.get $1)
+          (i32.const 255)
+         )
+        )
+        (i32.const 24)
+       )
+       (i32.const 24)
+      )
+     )
+     (block
+      (local.set $3
+       (i32.mul
+        (local.get $5)
+        (i32.const 16843009)
+       )
+      )
+      (block $label$12
+       (block $label$13
+        (br_if $label$13
+         (i32.le_u
+          (local.get $0)
+          (i32.const 3)
+         )
+        )
+        (loop $label$14
+         (if
+          (i32.eqz
+           (i32.and
+            (i32.xor
+             (i32.and
+              (local.tee $4
+               (i32.xor
+                (i32.load
+                 (local.get $2)
+                )
+                (local.get $3)
+               )
+              )
+              (i32.const -2139062144)
+             )
+             (i32.const -2139062144)
+            )
+            (i32.add
+             (local.get $4)
+             (i32.const -16843009)
+            )
+           )
+          )
+          (block
+           (local.set $2
+            (i32.add
+             (local.get $2)
+             (i32.const 4)
+            )
+           )
+           (br_if $label$14
+            (i32.gt_u
+             (local.tee $0
+              (i32.add
+               (local.get $0)
+               (i32.const -4)
+              )
+             )
+             (i32.const 3)
+            )
+           )
+           (br $label$13)
+          )
+         )
+        )
+        (br $label$12)
+       )
+       (if
+        (i32.eqz
+         (local.get $0)
+        )
+        (block
+         (local.set $0
+          (i32.const 0)
+         )
+         (br $label$2)
+        )
+       )
+      )
+      (loop $label$17
+       (br_if $label$2
+        (i32.eq
+         (i32.load8_s
+          (local.get $2)
+         )
+         (i32.shr_s
+          (i32.shl
+           (local.get $1)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (local.set $2
+        (i32.add
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (br_if $label$17
+        (local.tee $0
+         (i32.add
+          (local.get $0)
+          (i32.const -1)
+         )
+        )
+       )
+       (local.set $0
+        (i32.const 0)
+       )
+      )
+     )
+    )
+   )
+   (if (result i32)
+    (local.get $0)
+    (local.get $2)
+    (i32.const 0)
+   )
+  )
+ )
+ (func $18 (; 31 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 224)
+    )
+   )
+   (local.set $5
+    (i32.add
+     (local.get $4)
+     (i32.const 136)
+    )
+   )
+   (i64.store align=4
+    (local.tee $3
+     (i32.add
+      (local.get $4)
+      (i32.const 80)
+     )
+    )
+    (i64.const 0)
+   )
+   (i64.store offset=8 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=16 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=24 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=32 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i32.store
+    (local.tee $6
+     (i32.add
+      (local.get $4)
+      (i32.const 120)
+     )
+    )
+    (i32.load
+     (local.get $2)
+    )
+   )
+   (if
+    (i32.lt_s
+     (call $19
+      (i32.const 0)
+      (local.get $1)
+      (local.get $6)
+      (local.tee $2
+       (local.get $4)
+      )
+      (local.get $3)
+     )
+     (i32.const 0)
+    )
+    (local.set $1
+     (i32.const -1)
+    )
+    (block
+     (local.set $12
+      (if (result i32)
+       (i32.gt_s
+        (i32.load offset=76
+         (local.get $0)
+        )
+        (i32.const -1)
+       )
+       (call $20
+        (local.get $0)
+       )
+       (i32.const 0)
+      )
+     )
+     (local.set $7
+      (i32.load
+       (local.get $0)
+      )
+     )
+     (if
+      (i32.lt_s
+       (i32.load8_s offset=74
+        (local.get $0)
+       )
+       (i32.const 1)
+      )
+      (i32.store
+       (local.get $0)
+       (i32.and
+        (local.get $7)
+        (i32.const -33)
+       )
+      )
+     )
+     (if
+      (i32.load
+       (local.tee $8
+        (i32.add
+         (local.get $0)
+         (i32.const 48)
+        )
+       )
+      )
+      (local.set $1
+       (call $19
+        (local.get $0)
+        (local.get $1)
+        (local.get $6)
+        (local.get $2)
+        (local.get $3)
+       )
+      )
+      (block
+       (local.set $10
+        (i32.load
+         (local.tee $9
+          (i32.add
+           (local.get $0)
+           (i32.const 44)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $9)
+        (local.get $5)
+       )
+       (i32.store
+        (local.tee $13
+         (i32.add
+          (local.get $0)
+          (i32.const 28)
+         )
+        )
+        (local.get $5)
+       )
+       (i32.store
+        (local.tee $11
+         (i32.add
+          (local.get $0)
+          (i32.const 20)
+         )
+        )
+        (local.get $5)
+       )
+       (i32.store
+        (local.get $8)
+        (i32.const 80)
+       )
+       (i32.store
+        (local.tee $14
+         (i32.add
+          (local.get $0)
+          (i32.const 16)
+         )
+        )
+        (i32.add
+         (local.get $5)
+         (i32.const 80)
+        )
+       )
+       (local.set $1
+        (call $19
+         (local.get $0)
+         (local.get $1)
+         (local.get $6)
+         (local.get $2)
+         (local.get $3)
+        )
+       )
+       (if
+        (local.get $10)
+        (block
+         (drop
+          (call_indirect (type $0)
+           (local.get $0)
+           (i32.const 0)
+           (i32.const 0)
+           (i32.add
+            (i32.and
+             (i32.load offset=36
+              (local.get $0)
+             )
+             (i32.const 3)
+            )
+            (i32.const 2)
+           )
+          )
+         )
+         (if
+          (i32.eqz
+           (i32.load
+            (local.get $11)
+           )
+          )
+          (local.set $1
+           (i32.const -1)
+          )
+         )
+         (i32.store
+          (local.get $9)
+          (local.get $10)
+         )
+         (i32.store
+          (local.get $8)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $14)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $13)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $11)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (i32.store
+      (local.get $0)
+      (i32.or
+       (local.tee $2
+        (i32.load
+         (local.get $0)
+        )
+       )
+       (i32.and
+        (local.get $7)
+        (i32.const 32)
+       )
+      )
+     )
+     (if
+      (local.get $12)
+      (call $13
+       (local.get $0)
+      )
+     )
+     (if
+      (i32.and
+       (local.get $2)
+       (i32.const 32)
+      )
+      (local.set $1
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $1)
+  )
+ )
+ (func $19 (; 32 ;) (type $7) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 f64)
+  (local $53 f64)
+  (block $label$1 (result i32)
+   (local.set $23
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 624)
+    )
+   )
+   (local.set $20
+    (i32.add
+     (local.get $23)
+     (i32.const 16)
+    )
+   )
+   (local.set $16
+    (local.get $23)
+   )
+   (local.set $36
+    (i32.add
+     (local.get $23)
+     (i32.const 528)
+    )
+   )
+   (local.set $30
+    (i32.ne
+     (local.get $0)
+     (i32.const 0)
+    )
+   )
+   (local.set $38
+    (local.tee $21
+     (i32.add
+      (local.tee $17
+       (i32.add
+        (local.get $23)
+        (i32.const 536)
+       )
+      )
+      (i32.const 40)
+     )
+    )
+   )
+   (local.set $39
+    (i32.add
+     (local.get $17)
+     (i32.const 39)
+    )
+   )
+   (local.set $42
+    (i32.add
+     (local.tee $37
+      (i32.add
+       (local.get $23)
+       (i32.const 8)
+      )
+     )
+     (i32.const 4)
+    )
+   )
+   (local.set $43
+    (i32.sub
+     (i32.const 0)
+     (local.tee $27
+      (local.tee $19
+       (i32.add
+        (local.get $23)
+        (i32.const 588)
+       )
+      )
+     )
+    )
+   )
+   (local.set $33
+    (i32.add
+     (local.tee $17
+      (i32.add
+       (local.get $23)
+       (i32.const 576)
+      )
+     )
+     (i32.const 12)
+    )
+   )
+   (local.set $40
+    (i32.add
+     (local.get $17)
+     (i32.const 11)
+    )
+   )
+   (local.set $44
+    (i32.sub
+     (local.tee $28
+      (local.get $33)
+     )
+     (local.get $27)
+    )
+   )
+   (local.set $45
+    (i32.sub
+     (i32.const -2)
+     (local.get $27)
+    )
+   )
+   (local.set $46
+    (i32.add
+     (local.get $28)
+     (i32.const 2)
+    )
+   )
+   (local.set $48
+    (i32.add
+     (local.tee $47
+      (i32.add
+       (local.get $23)
+       (i32.const 24)
+      )
+     )
+     (i32.const 288)
+    )
+   )
+   (local.set $41
+    (local.tee $31
+     (i32.add
+      (local.get $19)
+      (i32.const 9)
+     )
+    )
+   )
+   (local.set $34
+    (i32.add
+     (local.get $19)
+     (i32.const 8)
+    )
+   )
+   (local.set $15
+    (i32.const 0)
+   )
+   (local.set $10
+    (i32.const 0)
+   )
+   (local.set $17
+    (i32.const 0)
+   )
+   (block $label$2
+    (block $label$3
+     (loop $label$4
+      (block $label$5
+       (if
+        (i32.gt_s
+         (local.get $15)
+         (i32.const -1)
+        )
+        (local.set $15
+         (if (result i32)
+          (i32.gt_s
+           (local.get $10)
+           (i32.sub
+            (i32.const 2147483647)
+            (local.get $15)
+           )
+          )
+          (block (result i32)
+           (i32.store
+            (call $12)
+            (i32.const 75)
+           )
+           (i32.const -1)
+          )
+          (i32.add
+           (local.get $10)
+           (local.get $15)
+          )
+         )
+        )
+       )
+       (br_if $label$3
+        (i32.eqz
+         (i32.shr_s
+          (i32.shl
+           (local.tee $5
+            (i32.load8_s
+             (local.get $1)
+            )
+           )
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (local.set $11
+        (local.get $1)
+       )
+       (block $label$9
+        (block $label$10
+         (loop $label$11
+          (block $label$12
+           (block $label$13
+            (block $label$14
+             (block $label$15
+              (br_table $label$14 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$15 $label$13
+               (i32.sub
+                (i32.shr_s
+                 (i32.shl
+                  (local.get $5)
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const 0)
+               )
+              )
+             )
+             (local.set $5
+              (local.get $11)
+             )
+             (br $label$10)
+            )
+            (local.set $5
+             (local.get $11)
+            )
+            (br $label$12)
+           )
+           (local.set $5
+            (i32.load8_s
+             (local.tee $11
+              (i32.add
+               (local.get $11)
+               (i32.const 1)
+              )
+             )
+            )
+           )
+           (br $label$11)
+          )
+         )
+         (br $label$9)
+        )
+        (loop $label$16
+         (br_if $label$9
+          (i32.ne
+           (i32.load8_s offset=1
+            (local.get $5)
+           )
+           (i32.const 37)
+          )
+         )
+         (local.set $11
+          (i32.add
+           (local.get $11)
+           (i32.const 1)
+          )
+         )
+         (br_if $label$16
+          (i32.eq
+           (i32.load8_s
+            (local.tee $5
+             (i32.add
+              (local.get $5)
+              (i32.const 2)
+             )
+            )
+           )
+           (i32.const 37)
+          )
+         )
+        )
+       )
+       (local.set $10
+        (i32.sub
+         (local.get $11)
+         (local.get $1)
+        )
+       )
+       (if
+        (local.get $30)
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.load
+            (local.get $0)
+           )
+           (i32.const 32)
+          )
+         )
+         (drop
+          (call $21
+           (local.get $1)
+           (local.get $10)
+           (local.get $0)
+          )
+         )
+        )
+       )
+       (if
+        (local.get $10)
+        (block
+         (local.set $1
+          (local.get $5)
+         )
+         (br $label$4)
+        )
+       )
+       (local.set $10
+        (if (result i32)
+         (i32.lt_u
+          (local.tee $9
+           (i32.add
+            (i32.shr_s
+             (i32.shl
+              (local.tee $10
+               (i32.load8_s
+                (local.tee $11
+                 (i32.add
+                  (local.get $5)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const -48)
+           )
+          )
+          (i32.const 10)
+         )
+         (block (result i32)
+          (local.set $10
+           (i32.add
+            (local.get $5)
+            (i32.const 3)
+           )
+          )
+          (if
+           (local.tee $12
+            (i32.eq
+             (i32.load8_s offset=2
+              (local.get $5)
+             )
+             (i32.const 36)
+            )
+           )
+           (local.set $11
+            (local.get $10)
+           )
+          )
+          (if
+           (local.get $12)
+           (local.set $17
+            (i32.const 1)
+           )
+          )
+          (local.set $5
+           (i32.load8_s
+            (local.get $11)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.get $12)
+           )
+           (local.set $9
+            (i32.const -1)
+           )
+          )
+          (local.get $17)
+         )
+         (block (result i32)
+          (local.set $5
+           (local.get $10)
+          )
+          (local.set $9
+           (i32.const -1)
+          )
+          (local.get $17)
+         )
+        )
+       )
+       (block $label$25
+        (if
+         (i32.lt_u
+          (local.tee $12
+           (i32.add
+            (i32.shr_s
+             (i32.shl
+              (local.get $5)
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const -32)
+           )
+          )
+          (i32.const 32)
+         )
+         (block
+          (local.set $17
+           (i32.const 0)
+          )
+          (loop $label$27
+           (br_if $label$25
+            (i32.eqz
+             (i32.and
+              (i32.shl
+               (i32.const 1)
+               (local.get $12)
+              )
+              (i32.const 75913)
+             )
+            )
+           )
+           (local.set $17
+            (i32.or
+             (i32.shl
+              (i32.const 1)
+              (i32.add
+               (i32.shr_s
+                (i32.shl
+                 (local.get $5)
+                 (i32.const 24)
+                )
+                (i32.const 24)
+               )
+               (i32.const -32)
+              )
+             )
+             (local.get $17)
+            )
+           )
+           (br_if $label$27
+            (i32.lt_u
+             (local.tee $12
+              (i32.add
+               (i32.shr_s
+                (i32.shl
+                 (local.tee $5
+                  (i32.load8_s
+                   (local.tee $11
+                    (i32.add
+                     (local.get $11)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 24)
+                )
+                (i32.const 24)
+               )
+               (i32.const -32)
+              )
+             )
+             (i32.const 32)
+            )
+           )
+          )
+         )
+         (local.set $17
+          (i32.const 0)
+         )
+        )
+       )
+       (block $label$29
+        (if
+         (i32.eq
+          (i32.shr_s
+           (i32.shl
+            (local.get $5)
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+          (i32.const 42)
+         )
+         (block
+          (local.set $11
+           (block $label$31 (result i32)
+            (block $label$32
+             (br_if $label$32
+              (i32.ge_u
+               (local.tee $12
+                (i32.add
+                 (i32.shr_s
+                  (i32.shl
+                   (local.tee $5
+                    (i32.load8_s
+                     (local.tee $7
+                      (i32.add
+                       (local.get $11)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                   )
+                   (i32.const 24)
+                  )
+                  (i32.const 24)
+                 )
+                 (i32.const -48)
+                )
+               )
+               (i32.const 10)
+              )
+             )
+             (br_if $label$32
+              (i32.ne
+               (i32.load8_s offset=2
+                (local.get $11)
+               )
+               (i32.const 36)
+              )
+             )
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $12)
+                (i32.const 2)
+               )
+              )
+              (i32.const 10)
+             )
+             (local.set $8
+              (i32.const 1)
+             )
+             (local.set $10
+              (i32.wrap_i64
+               (i64.load
+                (i32.add
+                 (local.get $3)
+                 (i32.shl
+                  (i32.add
+                   (i32.load8_s
+                    (local.get $7)
+                   )
+                   (i32.const -48)
+                  )
+                  (i32.const 3)
+                 )
+                )
+               )
+              )
+             )
+             (br $label$31
+              (i32.add
+               (local.get $11)
+               (i32.const 3)
+              )
+             )
+            )
+            (if
+             (local.get $10)
+             (block
+              (local.set $15
+               (i32.const -1)
+              )
+              (br $label$5)
+             )
+            )
+            (if
+             (i32.eqz
+              (local.get $30)
+             )
+             (block
+              (local.set $12
+               (local.get $17)
+              )
+              (local.set $17
+               (i32.const 0)
+              )
+              (local.set $11
+               (local.get $7)
+              )
+              (local.set $10
+               (i32.const 0)
+              )
+              (br $label$29)
+             )
+            )
+            (local.set $10
+             (i32.load
+              (local.tee $11
+               (i32.and
+                (i32.add
+                 (i32.load
+                  (local.get $2)
+                 )
+                 (i32.const 3)
+                )
+                (i32.const -4)
+               )
+              )
+             )
+            )
+            (i32.store
+             (local.get $2)
+             (i32.add
+              (local.get $11)
+              (i32.const 4)
+             )
+            )
+            (local.set $8
+             (i32.const 0)
+            )
+            (local.get $7)
+           )
+          )
+          (local.set $12
+           (i32.or
+            (local.get $17)
+            (i32.const 8192)
+           )
+          )
+          (local.set $7
+           (i32.sub
+            (i32.const 0)
+            (local.get $10)
+           )
+          )
+          (local.set $5
+           (i32.load8_s
+            (local.get $11)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.tee $6
+             (i32.lt_s
+              (local.get $10)
+              (i32.const 0)
+             )
+            )
+           )
+           (local.set $12
+            (local.get $17)
+           )
+          )
+          (local.set $17
+           (local.get $8)
+          )
+          (if
+           (local.get $6)
+           (local.set $10
+            (local.get $7)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.tee $12
+            (i32.add
+             (i32.shr_s
+              (i32.shl
+               (local.get $5)
+               (i32.const 24)
+              )
+              (i32.const 24)
+             )
+             (i32.const -48)
+            )
+           )
+           (i32.const 10)
+          )
+          (block
+           (local.set $7
+            (i32.const 0)
+           )
+           (local.set $5
+            (local.get $12)
+           )
+           (loop $label$39
+            (local.set $7
+             (i32.add
+              (i32.mul
+               (local.get $7)
+               (i32.const 10)
+              )
+              (local.get $5)
+             )
+            )
+            (br_if $label$39
+             (i32.lt_u
+              (local.tee $5
+               (i32.add
+                (i32.shr_s
+                 (i32.shl
+                  (local.tee $12
+                   (i32.load8_s
+                    (local.tee $11
+                     (i32.add
+                      (local.get $11)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                  )
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+            )
+           )
+           (if
+            (i32.lt_s
+             (local.get $7)
+             (i32.const 0)
+            )
+            (block
+             (local.set $15
+              (i32.const -1)
+             )
+             (br $label$5)
+            )
+            (block
+             (local.set $5
+              (local.get $12)
+             )
+             (local.set $12
+              (local.get $17)
+             )
+             (local.set $17
+              (local.get $10)
+             )
+             (local.set $10
+              (local.get $7)
+             )
+            )
+           )
+          )
+          (block
+           (local.set $12
+            (local.get $17)
+           )
+           (local.set $17
+            (local.get $10)
+           )
+           (local.set $10
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (block $label$43
+        (if
+         (i32.eq
+          (i32.shr_s
+           (i32.shl
+            (local.get $5)
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+          (i32.const 46)
+         )
+         (block
+          (if
+           (i32.ne
+            (i32.shr_s
+             (i32.shl
+              (local.tee $5
+               (i32.load8_s
+                (local.tee $7
+                 (i32.add
+                  (local.get $11)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const 42)
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.tee $5
+               (i32.add
+                (i32.shr_s
+                 (i32.shl
+                  (local.get $5)
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+             (block
+              (local.set $11
+               (local.get $7)
+              )
+              (local.set $7
+               (i32.const 0)
+              )
+             )
+             (block
+              (local.set $5
+               (i32.const 0)
+              )
+              (local.set $11
+               (local.get $7)
+              )
+              (br $label$43)
+             )
+            )
+            (loop $label$48
+             (local.set $5
+              (i32.add
+               (i32.mul
+                (local.get $7)
+                (i32.const 10)
+               )
+               (local.get $5)
+              )
+             )
+             (br_if $label$43
+              (i32.ge_u
+               (local.tee $8
+                (i32.add
+                 (i32.load8_s
+                  (local.tee $11
+                   (i32.add
+                    (local.get $11)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (i32.const -48)
+                )
+               )
+               (i32.const 10)
+              )
+             )
+             (local.set $7
+              (local.get $5)
+             )
+             (local.set $5
+              (local.get $8)
+             )
+             (br $label$48)
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.tee $5
+             (i32.add
+              (i32.load8_s
+               (local.tee $7
+                (i32.add
+                 (local.get $11)
+                 (i32.const 2)
+                )
+               )
+              )
+              (i32.const -48)
+             )
+            )
+            (i32.const 10)
+           )
+           (if
+            (i32.eq
+             (i32.load8_s offset=3
+              (local.get $11)
+             )
+             (i32.const 36)
+            )
+            (block
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $5)
+                (i32.const 2)
+               )
+              )
+              (i32.const 10)
+             )
+             (local.set $5
+              (i32.wrap_i64
+               (i64.load
+                (i32.add
+                 (local.get $3)
+                 (i32.shl
+                  (i32.add
+                   (i32.load8_s
+                    (local.get $7)
+                   )
+                   (i32.const -48)
+                  )
+                  (i32.const 3)
+                 )
+                )
+               )
+              )
+             )
+             (local.set $11
+              (i32.add
+               (local.get $11)
+               (i32.const 4)
+              )
+             )
+             (br $label$43)
+            )
+           )
+          )
+          (if
+           (local.get $17)
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+          )
+          (local.set $11
+           (if (result i32)
+            (local.get $30)
+            (block (result i32)
+             (local.set $5
+              (i32.load
+               (local.tee $11
+                (i32.and
+                 (i32.add
+                  (i32.load
+                   (local.get $2)
+                  )
+                  (i32.const 3)
+                 )
+                 (i32.const -4)
+                )
+               )
+              )
+             )
+             (i32.store
+              (local.get $2)
+              (i32.add
+               (local.get $11)
+               (i32.const 4)
+              )
+             )
+             (local.get $7)
+            )
+            (block (result i32)
+             (local.set $5
+              (i32.const 0)
+             )
+             (local.get $7)
+            )
+           )
+          )
+         )
+         (local.set $5
+          (i32.const -1)
+         )
+        )
+       )
+       (local.set $7
+        (local.get $11)
+       )
+       (local.set $8
+        (i32.const 0)
+       )
+       (loop $label$55
+        (if
+         (i32.gt_u
+          (local.tee $6
+           (i32.add
+            (i32.load8_s
+             (local.get $7)
+            )
+            (i32.const -65)
+           )
+          )
+          (i32.const 57)
+         )
+         (block
+          (local.set $15
+           (i32.const -1)
+          )
+          (br $label$5)
+         )
+        )
+        (local.set $11
+         (i32.add
+          (local.get $7)
+          (i32.const 1)
+         )
+        )
+        (if
+         (i32.lt_u
+          (i32.add
+           (local.tee $6
+            (i32.and
+             (local.tee $13
+              (i32.load8_s
+               (i32.add
+                (i32.add
+                 (i32.mul
+                  (local.get $8)
+                  (i32.const 58)
+                 )
+                 (i32.const 1177)
+                )
+                (local.get $6)
+               )
+              )
+             )
+             (i32.const 255)
+            )
+           )
+           (i32.const -1)
+          )
+          (i32.const 8)
+         )
+         (block
+          (local.set $7
+           (local.get $11)
+          )
+          (local.set $8
+           (local.get $6)
+          )
+          (br $label$55)
+         )
+        )
+       )
+       (if
+        (i32.eqz
+         (i32.shr_s
+          (i32.shl
+           (local.get $13)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+        (block
+         (local.set $15
+          (i32.const -1)
+         )
+         (br $label$5)
+        )
+       )
+       (local.set $14
+        (i32.gt_s
+         (local.get $9)
+         (i32.const -1)
+        )
+       )
+       (block $label$59
+        (block $label$60
+         (if
+          (i32.eq
+           (i32.shr_s
+            (i32.shl
+             (local.get $13)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+           (i32.const 19)
+          )
+          (if
+           (local.get $14)
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+           (br $label$60)
+          )
+          (block
+           (if
+            (local.get $14)
+            (block
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $9)
+                (i32.const 2)
+               )
+              )
+              (local.get $6)
+             )
+             (i64.store
+              (local.get $16)
+              (i64.load
+               (i32.add
+                (local.get $3)
+                (i32.shl
+                 (local.get $9)
+                 (i32.const 3)
+                )
+               )
+              )
+             )
+             (br $label$60)
+            )
+           )
+           (if
+            (i32.eqz
+             (local.get $30)
+            )
+            (block
+             (local.set $15
+              (i32.const 0)
+             )
+             (br $label$5)
+            )
+           )
+           (call $22
+            (local.get $16)
+            (local.get $6)
+            (local.get $2)
+           )
+          )
+         )
+         (br $label$59)
+        )
+        (if
+         (i32.eqz
+          (local.get $30)
+         )
+         (block
+          (local.set $10
+           (i32.const 0)
+          )
+          (local.set $1
+           (local.get $11)
+          )
+          (br $label$4)
+         )
+        )
+       )
+       (local.set $9
+        (i32.and
+         (local.tee $7
+          (i32.load8_s
+           (local.get $7)
+          )
+         )
+         (i32.const -33)
+        )
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.ne
+           (local.get $8)
+           (i32.const 0)
+          )
+          (i32.eq
+           (i32.and
+            (local.get $7)
+            (i32.const 15)
+           )
+           (i32.const 3)
+          )
+         )
+        )
+        (local.set $9
+         (local.get $7)
+        )
+       )
+       (local.set $7
+        (i32.and
+         (local.get $12)
+         (i32.const -65537)
+        )
+       )
+       (if
+        (i32.and
+         (local.get $12)
+         (i32.const 8192)
+        )
+        (local.set $12
+         (local.get $7)
+        )
+       )
+       (block $label$70
+        (block $label$71
+         (block $label$72
+          (block $label$73
+           (block $label$74
+            (block $label$75
+             (block $label$76
+              (block $label$77
+               (block $label$78
+                (block $label$79
+                 (block $label$80
+                  (block $label$81
+                   (block $label$82
+                    (block $label$83
+                     (block $label$84
+                      (block $label$85
+                       (block $label$86
+                        (block $label$87
+                         (block $label$88
+                          (block $label$89
+                           (br_table $label$78 $label$77 $label$80 $label$77 $label$78 $label$78 $label$78 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$79 $label$77 $label$77 $label$77 $label$77 $label$87 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$78 $label$77 $label$83 $label$85 $label$78 $label$78 $label$78 $label$77 $label$85 $label$77 $label$77 $label$77 $label$82 $label$89 $label$86 $label$88 $label$77 $label$77 $label$81 $label$77 $label$84 $label$77 $label$77 $label$87 $label$77
+                            (i32.sub
+                             (local.get $9)
+                             (i32.const 65)
+                            )
+                           )
+                          )
+                          (block $label$90
+                           (block $label$91
+                            (block $label$92
+                             (block $label$93
+                              (block $label$94
+                               (block $label$95
+                                (block $label$96
+                                 (block $label$97
+                                  (br_table $label$97 $label$96 $label$95 $label$94 $label$93 $label$90 $label$92 $label$91 $label$90
+                                   (i32.sub
+                                    (i32.shr_s
+                                     (i32.shl
+                                      (i32.and
+                                       (local.get $8)
+                                       (i32.const 255)
+                                      )
+                                      (i32.const 24)
+                                     )
+                                     (i32.const 24)
+                                    )
+                                    (i32.const 0)
+                                   )
+                                  )
+                                 )
+                                 (i32.store
+                                  (i32.load
+                                   (local.get $16)
+                                  )
+                                  (local.get $15)
+                                 )
+                                 (local.set $10
+                                  (i32.const 0)
+                                 )
+                                 (local.set $1
+                                  (local.get $11)
+                                 )
+                                 (br $label$4)
+                                )
+                                (i32.store
+                                 (i32.load
+                                  (local.get $16)
+                                 )
+                                 (local.get $15)
+                                )
+                                (local.set $10
+                                 (i32.const 0)
+                                )
+                                (local.set $1
+                                 (local.get $11)
+                                )
+                                (br $label$4)
+                               )
+                               (i64.store
+                                (i32.load
+                                 (local.get $16)
+                                )
+                                (i64.extend_i32_s
+                                 (local.get $15)
+                                )
+                               )
+                               (local.set $10
+                                (i32.const 0)
+                               )
+                               (local.set $1
+                                (local.get $11)
+                               )
+                               (br $label$4)
+                              )
+                              (i32.store16
+                               (i32.load
+                                (local.get $16)
+                               )
+                               (local.get $15)
+                              )
+                              (local.set $10
+                               (i32.const 0)
+                              )
+                              (local.set $1
+                               (local.get $11)
+                              )
+                              (br $label$4)
+                             )
+                             (i32.store8
+                              (i32.load
+                               (local.get $16)
+                              )
+                              (local.get $15)
+                             )
+                             (local.set $10
+                              (i32.const 0)
+                             )
+                             (local.set $1
+                              (local.get $11)
+                             )
+                             (br $label$4)
+                            )
+                            (i32.store
+                             (i32.load
+                              (local.get $16)
+                             )
+                             (local.get $15)
+                            )
+                            (local.set $10
+                             (i32.const 0)
+                            )
+                            (local.set $1
+                             (local.get $11)
+                            )
+                            (br $label$4)
+                           )
+                           (i64.store
+                            (i32.load
+                             (local.get $16)
+                            )
+                            (i64.extend_i32_s
+                             (local.get $15)
+                            )
+                           )
+                           (local.set $10
+                            (i32.const 0)
+                           )
+                           (local.set $1
+                            (local.get $11)
+                           )
+                           (br $label$4)
+                          )
+                          (local.set $10
+                           (i32.const 0)
+                          )
+                          (local.set $1
+                           (local.get $11)
+                          )
+                          (br $label$4)
+                         )
+                         (local.set $12
+                          (i32.or
+                           (local.get $12)
+                           (i32.const 8)
+                          )
+                         )
+                         (if
+                          (i32.le_u
+                           (local.get $5)
+                           (i32.const 8)
+                          )
+                          (local.set $5
+                           (i32.const 8)
+                          )
+                         )
+                         (local.set $9
+                          (i32.const 120)
+                         )
+                         (br $label$76)
+                        )
+                        (br $label$76)
+                       )
+                       (if
+                        (i64.eq
+                         (local.tee $50
+                          (i64.load
+                           (local.get $16)
+                          )
+                         )
+                         (i64.const 0)
+                        )
+                        (local.set $7
+                         (local.get $21)
+                        )
+                        (block
+                         (local.set $1
+                          (local.get $21)
+                         )
+                         (loop $label$101
+                          (i64.store8
+                           (local.tee $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const -1)
+                            )
+                           )
+                           (i64.or
+                            (i64.and
+                             (local.get $50)
+                             (i64.const 7)
+                            )
+                            (i64.const 48)
+                           )
+                          )
+                          (br_if $label$101
+                           (i64.ne
+                            (local.tee $50
+                             (i64.shr_u
+                              (local.get $50)
+                              (i64.const 3)
+                             )
+                            )
+                            (i64.const 0)
+                           )
+                          )
+                          (local.set $7
+                           (local.get $1)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.and
+                         (local.get $12)
+                         (i32.const 8)
+                        )
+                        (block
+                         (local.set $8
+                          (i32.add
+                           (local.tee $1
+                            (i32.sub
+                             (local.get $38)
+                             (local.get $7)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                         )
+                         (if
+                          (i32.le_s
+                           (local.get $5)
+                           (local.get $1)
+                          )
+                          (local.set $5
+                           (local.get $8)
+                          )
+                         )
+                         (local.set $6
+                          (i32.const 0)
+                         )
+                         (local.set $8
+                          (i32.const 1657)
+                         )
+                         (br $label$71)
+                        )
+                        (block
+                         (local.set $6
+                          (i32.const 0)
+                         )
+                         (local.set $8
+                          (i32.const 1657)
+                         )
+                         (br $label$71)
+                        )
+                       )
+                      )
+                      (if
+                       (i64.lt_s
+                        (local.tee $50
+                         (i64.load
+                          (local.get $16)
+                         )
+                        )
+                        (i64.const 0)
+                       )
+                       (block
+                        (i64.store
+                         (local.get $16)
+                         (local.tee $50
+                          (i64.sub
+                           (i64.const 0)
+                           (local.get $50)
+                          )
+                         )
+                        )
+                        (local.set $6
+                         (i32.const 1)
+                        )
+                        (local.set $8
+                         (i32.const 1657)
+                        )
+                        (br $label$75)
+                       )
+                      )
+                      (if
+                       (i32.and
+                        (local.get $12)
+                        (i32.const 2048)
+                       )
+                       (block
+                        (local.set $6
+                         (i32.const 1)
+                        )
+                        (local.set $8
+                         (i32.const 1658)
+                        )
+                        (br $label$75)
+                       )
+                       (block
+                        (local.set $6
+                         (local.tee $1
+                          (i32.and
+                           (local.get $12)
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (local.set $8
+                         (if (result i32)
+                          (local.get $1)
+                          (i32.const 1659)
+                          (i32.const 1657)
+                         )
+                        )
+                        (br $label$75)
+                       )
+                      )
+                     )
+                     (local.set $50
+                      (i64.load
+                       (local.get $16)
+                      )
+                     )
+                     (local.set $6
+                      (i32.const 0)
+                     )
+                     (local.set $8
+                      (i32.const 1657)
+                     )
+                     (br $label$75)
+                    )
+                    (i64.store8
+                     (local.get $39)
+                     (i64.load
+                      (local.get $16)
+                     )
+                    )
+                    (local.set $1
+                     (local.get $39)
+                    )
+                    (local.set $12
+                     (local.get $7)
+                    )
+                    (local.set $7
+                     (i32.const 1)
+                    )
+                    (local.set $6
+                     (i32.const 0)
+                    )
+                    (local.set $8
+                     (i32.const 1657)
+                    )
+                    (local.set $5
+                     (local.get $21)
+                    )
+                    (br $label$70)
+                   )
+                   (local.set $1
+                    (call $24
+                     (i32.load
+                      (call $12)
+                     )
+                    )
+                   )
+                   (br $label$74)
+                  )
+                  (if
+                   (i32.eqz
+                    (local.tee $1
+                     (i32.load
+                      (local.get $16)
+                     )
+                    )
+                   )
+                   (local.set $1
+                    (i32.const 1667)
+                   )
+                  )
+                  (br $label$74)
+                 )
+                 (i64.store32
+                  (local.get $37)
+                  (i64.load
+                   (local.get $16)
+                  )
+                 )
+                 (i32.store
+                  (local.get $42)
+                  (i32.const 0)
+                 )
+                 (i32.store
+                  (local.get $16)
+                  (local.get $37)
+                 )
+                 (local.set $7
+                  (local.get $37)
+                 )
+                 (local.set $6
+                  (i32.const -1)
+                 )
+                 (br $label$73)
+                )
+                (local.set $7
+                 (i32.load
+                  (local.get $16)
+                 )
+                )
+                (if
+                 (local.get $5)
+                 (block
+                  (local.set $6
+                   (local.get $5)
+                  )
+                  (br $label$73)
+                 )
+                 (block
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (i32.const 0)
+                   (local.get $12)
+                  )
+                  (local.set $1
+                   (i32.const 0)
+                  )
+                  (br $label$72)
+                 )
+                )
+               )
+               (local.set $52
+                (f64.load
+                 (local.get $16)
+                )
+               )
+               (i32.store
+                (local.get $20)
+                (i32.const 0)
+               )
+               (local.set $26
+                (if (result i32)
+                 (i64.lt_s
+                  (i64.reinterpret_f64
+                   (local.get $52)
+                  )
+                  (i64.const 0)
+                 )
+                 (block (result i32)
+                  (local.set $24
+                   (i32.const 1)
+                  )
+                  (local.set $52
+                   (f64.neg
+                    (local.get $52)
+                   )
+                  )
+                  (i32.const 1674)
+                 )
+                 (block (result i32)
+                  (local.set $1
+                   (i32.and
+                    (local.get $12)
+                    (i32.const 1)
+                   )
+                  )
+                  (if (result i32)
+                   (i32.and
+                    (local.get $12)
+                    (i32.const 2048)
+                   )
+                   (block (result i32)
+                    (local.set $24
+                     (i32.const 1)
+                    )
+                    (i32.const 1677)
+                   )
+                   (block (result i32)
+                    (local.set $24
+                     (local.get $1)
+                    )
+                    (if (result i32)
+                     (local.get $1)
+                     (i32.const 1680)
+                     (i32.const 1675)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+               (block $label$119
+                (if
+                 (i64.lt_u
+                  (i64.and
+                   (i64.reinterpret_f64
+                    (local.get $52)
+                   )
+                   (i64.const 9218868437227405312)
+                  )
+                  (i64.const 9218868437227405312)
+                 )
+                 (block
+                  (if
+                   (local.tee $1
+                    (f64.ne
+                     (local.tee $52
+                      (f64.mul
+                       (call $27
+                        (local.get $52)
+                        (local.get $20)
+                       )
+                       (f64.const 2)
+                      )
+                     )
+                     (f64.const 0)
+                    )
+                   )
+                   (i32.store
+                    (local.get $20)
+                    (i32.add
+                     (i32.load
+                      (local.get $20)
+                     )
+                     (i32.const -1)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (local.tee $22
+                     (i32.or
+                      (local.get $9)
+                      (i32.const 32)
+                     )
+                    )
+                    (i32.const 97)
+                   )
+                   (block
+                    (local.set $1
+                     (i32.add
+                      (local.get $26)
+                      (i32.const 9)
+                     )
+                    )
+                    (if
+                     (local.tee $6
+                      (i32.and
+                       (local.get $9)
+                       (i32.const 32)
+                      )
+                     )
+                     (local.set $26
+                      (local.get $1)
+                     )
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.or
+                       (i32.gt_u
+                        (local.get $5)
+                        (i32.const 11)
+                       )
+                       (i32.eqz
+                        (local.tee $1
+                         (i32.sub
+                          (i32.const 12)
+                          (local.get $5)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (block
+                      (local.set $53
+                       (f64.const 8)
+                      )
+                      (loop $label$125
+                       (local.set $53
+                        (f64.mul
+                         (local.get $53)
+                         (f64.const 16)
+                        )
+                       )
+                       (br_if $label$125
+                        (local.tee $1
+                         (i32.add
+                          (local.get $1)
+                          (i32.const -1)
+                         )
+                        )
+                       )
+                      )
+                      (local.set $52
+                       (if (result f64)
+                        (i32.eq
+                         (i32.load8_s
+                          (local.get $26)
+                         )
+                         (i32.const 45)
+                        )
+                        (f64.neg
+                         (f64.add
+                          (local.get $53)
+                          (f64.sub
+                           (f64.neg
+                            (local.get $52)
+                           )
+                           (local.get $53)
+                          )
+                         )
+                        )
+                        (f64.sub
+                         (f64.add
+                          (local.get $52)
+                          (local.get $53)
+                         )
+                         (local.get $53)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $1
+                     (i32.sub
+                      (i32.const 0)
+                      (local.tee $7
+                       (i32.load
+                        (local.get $20)
+                       )
+                      )
+                     )
+                    )
+                    (if
+                     (i32.eq
+                      (local.tee $1
+                       (call $23
+                        (i64.extend_i32_s
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.get $7)
+                           (i32.const 0)
+                          )
+                          (local.get $1)
+                          (local.get $7)
+                         )
+                        )
+                        (local.get $33)
+                       )
+                      )
+                      (local.get $33)
+                     )
+                     (block
+                      (i32.store8
+                       (local.get $40)
+                       (i32.const 48)
+                      )
+                      (local.set $1
+                       (local.get $40)
+                      )
+                     )
+                    )
+                    (local.set $13
+                     (i32.or
+                      (local.get $24)
+                      (i32.const 2)
+                     )
+                    )
+                    (i32.store8
+                     (i32.add
+                      (local.get $1)
+                      (i32.const -1)
+                     )
+                     (i32.add
+                      (i32.and
+                       (i32.shr_s
+                        (local.get $7)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 43)
+                     )
+                    )
+                    (i32.store8
+                     (local.tee $8
+                      (i32.add
+                       (local.get $1)
+                       (i32.const -2)
+                      )
+                     )
+                     (i32.add
+                      (local.get $9)
+                      (i32.const 15)
+                     )
+                    )
+                    (local.set $9
+                     (i32.lt_s
+                      (local.get $5)
+                      (i32.const 1)
+                     )
+                    )
+                    (local.set $14
+                     (i32.eqz
+                      (i32.and
+                       (local.get $12)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                    (local.set $1
+                     (local.get $19)
+                    )
+                    (loop $label$131
+                     (i32.store8
+                      (local.get $1)
+                      (i32.or
+                       (i32.load8_u
+                        (i32.add
+                         (local.tee $7
+                          (i32.trunc_f64_s
+                           (local.get $52)
+                          )
+                         )
+                         (i32.const 1641)
+                        )
+                       )
+                       (local.get $6)
+                      )
+                     )
+                     (local.set $52
+                      (f64.mul
+                       (f64.sub
+                        (local.get $52)
+                        (f64.convert_i32_s
+                         (local.get $7)
+                        )
+                       )
+                       (f64.const 16)
+                      )
+                     )
+                     (local.set $1
+                      (block $label$132 (result i32)
+                       (if (result i32)
+                        (i32.eq
+                         (i32.sub
+                          (local.tee $7
+                           (i32.add
+                            (local.get $1)
+                            (i32.const 1)
+                           )
+                          )
+                          (local.get $27)
+                         )
+                         (i32.const 1)
+                        )
+                        (block (result i32)
+                         (drop
+                          (br_if $label$132
+                           (local.get $7)
+                           (i32.and
+                            (local.get $14)
+                            (i32.and
+                             (local.get $9)
+                             (f64.eq
+                              (local.get $52)
+                              (f64.const 0)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.store8
+                          (local.get $7)
+                          (i32.const 46)
+                         )
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 2)
+                         )
+                        )
+                        (local.get $7)
+                       )
+                      )
+                     )
+                     (br_if $label$131
+                      (f64.ne
+                       (local.get $52)
+                       (f64.const 0)
+                      )
+                     )
+                    )
+                    (local.set $6
+                     (i32.sub
+                      (i32.add
+                       (local.get $46)
+                       (local.get $5)
+                      )
+                      (local.tee $7
+                       (local.get $8)
+                      )
+                     )
+                    )
+                    (local.set $9
+                     (i32.add
+                      (i32.sub
+                       (local.get $44)
+                       (local.get $7)
+                      )
+                      (local.get $1)
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 32)
+                     (local.get $10)
+                     (local.tee $5
+                      (i32.add
+                       (if (result i32)
+                        (i32.and
+                         (i32.ne
+                          (local.get $5)
+                          (i32.const 0)
+                         )
+                         (i32.lt_s
+                          (i32.add
+                           (local.get $45)
+                           (local.get $1)
+                          )
+                          (local.get $5)
+                         )
+                        )
+                        (local.get $6)
+                        (local.tee $6
+                         (local.get $9)
+                        )
+                       )
+                       (local.get $13)
+                      )
+                     )
+                     (local.get $12)
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $26)
+                       (local.get $13)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 48)
+                     (local.get $10)
+                     (local.get $5)
+                     (i32.xor
+                      (local.get $12)
+                      (i32.const 65536)
+                     )
+                    )
+                    (local.set $1
+                     (i32.sub
+                      (local.get $1)
+                      (local.get $27)
+                     )
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $19)
+                       (local.get $1)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 48)
+                     (i32.sub
+                      (local.get $6)
+                      (i32.add
+                       (local.get $1)
+                       (local.tee $1
+                        (i32.sub
+                         (local.get $28)
+                         (local.get $7)
+                        )
+                       )
+                      )
+                     )
+                     (i32.const 0)
+                     (i32.const 0)
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $8)
+                       (local.get $1)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 32)
+                     (local.get $10)
+                     (local.get $5)
+                     (i32.xor
+                      (local.get $12)
+                      (i32.const 8192)
+                     )
+                    )
+                    (if
+                     (i32.ge_s
+                      (local.get $5)
+                      (local.get $10)
+                     )
+                     (local.set $10
+                      (local.get $5)
+                     )
+                    )
+                    (br $label$119)
+                   )
+                  )
+                  (if
+                   (local.get $1)
+                   (block
+                    (i32.store
+                     (local.get $20)
+                     (local.tee $6
+                      (i32.add
+                       (i32.load
+                        (local.get $20)
+                       )
+                       (i32.const -28)
+                      )
+                     )
+                    )
+                    (local.set $52
+                     (f64.mul
+                      (local.get $52)
+                      (f64.const 268435456)
+                     )
+                    )
+                   )
+                   (local.set $6
+                    (i32.load
+                     (local.get $20)
+                    )
+                   )
+                  )
+                  (local.set $8
+                   (local.tee $7
+                    (if (result i32)
+                     (i32.lt_s
+                      (local.get $6)
+                      (i32.const 0)
+                     )
+                     (local.get $47)
+                     (local.get $48)
+                    )
+                   )
+                  )
+                  (loop $label$145
+                   (i32.store
+                    (local.get $8)
+                    (local.tee $1
+                     (i32.trunc_f64_s
+                      (local.get $52)
+                     )
+                    )
+                   )
+                   (local.set $8
+                    (i32.add
+                     (local.get $8)
+                     (i32.const 4)
+                    )
+                   )
+                   (br_if $label$145
+                    (f64.ne
+                     (local.tee $52
+                      (f64.mul
+                       (f64.sub
+                        (local.get $52)
+                        (f64.convert_i32_u
+                         (local.get $1)
+                        )
+                       )
+                       (f64.const 1e9)
+                      )
+                     )
+                     (f64.const 0)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.gt_s
+                    (local.get $6)
+                    (i32.const 0)
+                   )
+                   (block
+                    (local.set $1
+                     (local.get $7)
+                    )
+                    (loop $label$147
+                     (local.set $14
+                      (if (result i32)
+                       (i32.gt_s
+                        (local.get $6)
+                        (i32.const 29)
+                       )
+                       (i32.const 29)
+                       (local.get $6)
+                      )
+                     )
+                     (block $label$150
+                      (if
+                       (i32.ge_u
+                        (local.tee $6
+                         (i32.add
+                          (local.get $8)
+                          (i32.const -4)
+                         )
+                        )
+                        (local.get $1)
+                       )
+                       (block
+                        (local.set $50
+                         (i64.extend_i32_u
+                          (local.get $14)
+                         )
+                        )
+                        (local.set $13
+                         (i32.const 0)
+                        )
+                        (loop $label$152
+                         (i64.store32
+                          (local.get $6)
+                          (i64.rem_u
+                           (local.tee $51
+                            (i64.add
+                             (i64.shl
+                              (i64.extend_i32_u
+                               (i32.load
+                                (local.get $6)
+                               )
+                              )
+                              (local.get $50)
+                             )
+                             (i64.extend_i32_u
+                              (local.get $13)
+                             )
+                            )
+                           )
+                           (i64.const 1000000000)
+                          )
+                         )
+                         (local.set $13
+                          (i32.wrap_i64
+                           (i64.div_u
+                            (local.get $51)
+                            (i64.const 1000000000)
+                           )
+                          )
+                         )
+                         (br_if $label$152
+                          (i32.ge_u
+                           (local.tee $6
+                            (i32.add
+                             (local.get $6)
+                             (i32.const -4)
+                            )
+                           )
+                           (local.get $1)
+                          )
+                         )
+                        )
+                        (br_if $label$150
+                         (i32.eqz
+                          (local.get $13)
+                         )
+                        )
+                        (i32.store
+                         (local.tee $1
+                          (i32.add
+                           (local.get $1)
+                           (i32.const -4)
+                          )
+                         )
+                         (local.get $13)
+                        )
+                       )
+                      )
+                     )
+                     (loop $label$153
+                      (if
+                       (i32.gt_u
+                        (local.get $8)
+                        (local.get $1)
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.load
+                          (local.tee $6
+                           (i32.add
+                            (local.get $8)
+                            (i32.const -4)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (local.set $8
+                          (local.get $6)
+                         )
+                         (br $label$153)
+                        )
+                       )
+                      )
+                     )
+                     (i32.store
+                      (local.get $20)
+                      (local.tee $6
+                       (i32.sub
+                        (i32.load
+                         (local.get $20)
+                        )
+                        (local.get $14)
+                       )
+                      )
+                     )
+                     (br_if $label$147
+                      (i32.gt_s
+                       (local.get $6)
+                       (i32.const 0)
+                      )
+                     )
+                    )
+                   )
+                   (local.set $1
+                    (local.get $7)
+                   )
+                  )
+                  (local.set $18
+                   (if (result i32)
+                    (i32.lt_s
+                     (local.get $5)
+                     (i32.const 0)
+                    )
+                    (i32.const 6)
+                    (local.get $5)
+                   )
+                  )
+                  (if
+                   (i32.lt_s
+                    (local.get $6)
+                    (i32.const 0)
+                   )
+                   (block
+                    (local.set $14
+                     (i32.add
+                      (i32.div_s
+                       (i32.add
+                        (local.get $18)
+                        (i32.const 25)
+                       )
+                       (i32.const 9)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                    (local.set $25
+                     (i32.eq
+                      (local.get $22)
+                      (i32.const 102)
+                     )
+                    )
+                    (local.set $5
+                     (local.get $8)
+                    )
+                    (loop $label$160
+                     (if
+                      (i32.gt_s
+                       (local.tee $13
+                        (i32.sub
+                         (i32.const 0)
+                         (local.get $6)
+                        )
+                       )
+                       (i32.const 9)
+                      )
+                      (local.set $13
+                       (i32.const 9)
+                      )
+                     )
+                     (block $label$162
+                      (if
+                       (i32.lt_u
+                        (local.get $1)
+                        (local.get $5)
+                       )
+                       (block
+                        (local.set $29
+                         (i32.add
+                          (i32.shl
+                           (i32.const 1)
+                           (local.get $13)
+                          )
+                          (i32.const -1)
+                         )
+                        )
+                        (local.set $35
+                         (i32.shr_u
+                          (i32.const 1000000000)
+                          (local.get $13)
+                         )
+                        )
+                        (local.set $6
+                         (i32.const 0)
+                        )
+                        (local.set $8
+                         (local.get $1)
+                        )
+                        (loop $label$164
+                         (i32.store
+                          (local.get $8)
+                          (i32.add
+                           (i32.shr_u
+                            (local.tee $32
+                             (i32.load
+                              (local.get $8)
+                             )
+                            )
+                            (local.get $13)
+                           )
+                           (local.get $6)
+                          )
+                         )
+                         (local.set $6
+                          (i32.mul
+                           (i32.and
+                            (local.get $32)
+                            (local.get $29)
+                           )
+                           (local.get $35)
+                          )
+                         )
+                         (br_if $label$164
+                          (i32.lt_u
+                           (local.tee $8
+                            (i32.add
+                             (local.get $8)
+                             (i32.const 4)
+                            )
+                           )
+                           (local.get $5)
+                          )
+                         )
+                        )
+                        (local.set $8
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 4)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (local.set $1
+                          (local.get $8)
+                         )
+                        )
+                        (br_if $label$162
+                         (i32.eqz
+                          (local.get $6)
+                         )
+                        )
+                        (i32.store
+                         (local.get $5)
+                         (local.get $6)
+                        )
+                        (local.set $5
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 4)
+                         )
+                        )
+                       )
+                       (block
+                        (local.set $8
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 4)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (local.set $1
+                          (local.get $8)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (local.set $6
+                      (i32.add
+                       (local.tee $8
+                        (if (result i32)
+                         (local.get $25)
+                         (local.get $7)
+                         (local.get $1)
+                        )
+                       )
+                       (i32.shl
+                        (local.get $14)
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                     (if
+                      (i32.gt_s
+                       (i32.shr_s
+                        (i32.sub
+                         (local.get $5)
+                         (local.get $8)
+                        )
+                        (i32.const 2)
+                       )
+                       (local.get $14)
+                      )
+                      (local.set $5
+                       (local.get $6)
+                      )
+                     )
+                     (i32.store
+                      (local.get $20)
+                      (local.tee $6
+                       (i32.add
+                        (i32.load
+                         (local.get $20)
+                        )
+                        (local.get $13)
+                       )
+                      )
+                     )
+                     (br_if $label$160
+                      (i32.lt_s
+                       (local.get $6)
+                       (i32.const 0)
+                      )
+                     )
+                     (local.set $13
+                      (local.get $5)
+                     )
+                    )
+                   )
+                   (local.set $13
+                    (local.get $8)
+                   )
+                  )
+                  (local.set $25
+                   (local.get $7)
+                  )
+                  (block $label$172
+                   (if
+                    (i32.lt_u
+                     (local.get $1)
+                     (local.get $13)
+                    )
+                    (block
+                     (local.set $5
+                      (i32.mul
+                       (i32.shr_s
+                        (i32.sub
+                         (local.get $25)
+                         (local.get $1)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 9)
+                      )
+                     )
+                     (br_if $label$172
+                      (i32.lt_u
+                       (local.tee $6
+                        (i32.load
+                         (local.get $1)
+                        )
+                       )
+                       (i32.const 10)
+                      )
+                     )
+                     (local.set $8
+                      (i32.const 10)
+                     )
+                     (loop $label$174
+                      (local.set $5
+                       (i32.add
+                        (local.get $5)
+                        (i32.const 1)
+                       )
+                      )
+                      (br_if $label$174
+                       (i32.ge_u
+                        (local.get $6)
+                        (local.tee $8
+                         (i32.mul
+                          (local.get $8)
+                          (i32.const 10)
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $5
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                  (local.set $29
+                   (i32.eq
+                    (local.get $22)
+                    (i32.const 103)
+                   )
+                  )
+                  (local.set $35
+                   (i32.ne
+                    (local.get $18)
+                    (i32.const 0)
+                   )
+                  )
+                  (if
+                   (i32.lt_s
+                    (local.tee $8
+                     (i32.add
+                      (i32.sub
+                       (local.get $18)
+                       (if (result i32)
+                        (i32.ne
+                         (local.get $22)
+                         (i32.const 102)
+                        )
+                        (local.get $5)
+                        (i32.const 0)
+                       )
+                      )
+                      (i32.shr_s
+                       (i32.shl
+                        (i32.and
+                         (local.get $35)
+                         (local.get $29)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                    )
+                    (i32.add
+                     (i32.mul
+                      (i32.shr_s
+                       (i32.sub
+                        (local.get $13)
+                        (local.get $25)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 9)
+                     )
+                     (i32.const -9)
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_s
+                      (local.tee $8
+                       (i32.add
+                        (i32.rem_s
+                         (local.tee $14
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 9216)
+                          )
+                         )
+                         (i32.const 9)
+                        )
+                        (i32.const 1)
+                       )
+                      )
+                      (i32.const 9)
+                     )
+                     (block
+                      (local.set $6
+                       (i32.const 10)
+                      )
+                      (loop $label$180
+                       (local.set $6
+                        (i32.mul
+                         (local.get $6)
+                         (i32.const 10)
+                        )
+                       )
+                       (br_if $label$180
+                        (i32.ne
+                         (local.tee $8
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 1)
+                          )
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                      )
+                     )
+                     (local.set $6
+                      (i32.const 10)
+                     )
+                    )
+                    (local.set $14
+                     (i32.rem_u
+                      (local.tee $22
+                       (i32.load
+                        (local.tee $8
+                         (i32.add
+                          (i32.add
+                           (local.get $7)
+                           (i32.const 4)
+                          )
+                          (i32.shl
+                           (i32.add
+                            (i32.div_s
+                             (local.get $14)
+                             (i32.const 9)
+                            )
+                            (i32.const -1024)
+                           )
+                           (i32.const 2)
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (local.get $6)
+                     )
+                    )
+                    (block $label$182
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (local.tee $32
+                         (i32.eq
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 4)
+                          )
+                          (local.get $13)
+                         )
+                        )
+                        (i32.eqz
+                         (local.get $14)
+                        )
+                       )
+                      )
+                      (block
+                       (local.set $52
+                        (if (result f64)
+                         (i32.lt_u
+                          (local.get $14)
+                          (local.tee $49
+                           (i32.div_s
+                            (local.get $6)
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                         (f64.const 0.5)
+                         (if (result f64)
+                          (i32.and
+                           (local.get $32)
+                           (i32.eq
+                            (local.get $14)
+                            (local.get $49)
+                           )
+                          )
+                          (f64.const 1)
+                          (f64.const 1.5)
+                         )
+                        )
+                       )
+                       (local.set $53
+                        (if (result f64)
+                         (i32.and
+                          (i32.div_u
+                           (local.get $22)
+                           (local.get $6)
+                          )
+                          (i32.const 1)
+                         )
+                         (f64.const 9007199254740994)
+                         (f64.const 9007199254740992)
+                        )
+                       )
+                       (block $label$190
+                        (if
+                         (local.get $24)
+                         (block
+                          (br_if $label$190
+                           (i32.ne
+                            (i32.load8_s
+                             (local.get $26)
+                            )
+                            (i32.const 45)
+                           )
+                          )
+                          (local.set $53
+                           (f64.neg
+                            (local.get $53)
+                           )
+                          )
+                          (local.set $52
+                           (f64.neg
+                            (local.get $52)
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (i32.store
+                        (local.get $8)
+                        (local.tee $14
+                         (i32.sub
+                          (local.get $22)
+                          (local.get $14)
+                         )
+                        )
+                       )
+                       (br_if $label$182
+                        (f64.eq
+                         (f64.add
+                          (local.get $53)
+                          (local.get $52)
+                         )
+                         (local.get $53)
+                        )
+                       )
+                       (i32.store
+                        (local.get $8)
+                        (local.tee $5
+                         (i32.add
+                          (local.get $14)
+                          (local.get $6)
+                         )
+                        )
+                       )
+                       (if
+                        (i32.gt_u
+                         (local.get $5)
+                         (i32.const 999999999)
+                        )
+                        (loop $label$193
+                         (i32.store
+                          (local.get $8)
+                          (i32.const 0)
+                         )
+                         (if
+                          (i32.lt_u
+                           (local.tee $8
+                            (i32.add
+                             (local.get $8)
+                             (i32.const -4)
+                            )
+                           )
+                           (local.get $1)
+                          )
+                          (i32.store
+                           (local.tee $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const -4)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                         )
+                         (i32.store
+                          (local.get $8)
+                          (local.tee $5
+                           (i32.add
+                            (i32.load
+                             (local.get $8)
+                            )
+                            (i32.const 1)
+                           )
+                          )
+                         )
+                         (br_if $label$193
+                          (i32.gt_u
+                           (local.get $5)
+                           (i32.const 999999999)
+                          )
+                         )
+                        )
+                       )
+                       (local.set $5
+                        (i32.mul
+                         (i32.shr_s
+                          (i32.sub
+                           (local.get $25)
+                           (local.get $1)
+                          )
+                          (i32.const 2)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (br_if $label$182
+                        (i32.lt_u
+                         (local.tee $14
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (i32.const 10)
+                        )
+                       )
+                       (local.set $6
+                        (i32.const 10)
+                       )
+                       (loop $label$195
+                        (local.set $5
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 1)
+                         )
+                        )
+                        (br_if $label$195
+                         (i32.ge_u
+                          (local.get $14)
+                          (local.tee $6
+                           (i32.mul
+                            (local.get $6)
+                            (i32.const 10)
+                           )
+                          )
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $14
+                     (local.get $1)
+                    )
+                    (local.set $6
+                     (local.get $5)
+                    )
+                    (if
+                     (i32.le_u
+                      (local.get $13)
+                      (local.tee $8
+                       (i32.add
+                        (local.get $8)
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.set $8
+                      (local.get $13)
+                     )
+                    )
+                   )
+                   (block
+                    (local.set $14
+                     (local.get $1)
+                    )
+                    (local.set $6
+                     (local.get $5)
+                    )
+                    (local.set $8
+                     (local.get $13)
+                    )
+                   )
+                  )
+                  (local.set $32
+                   (i32.sub
+                    (i32.const 0)
+                    (local.get $6)
+                   )
+                  )
+                  (loop $label$198
+                   (block $label$199
+                    (if
+                     (i32.le_u
+                      (local.get $8)
+                      (local.get $14)
+                     )
+                     (block
+                      (local.set $22
+                       (i32.const 0)
+                      )
+                      (br $label$199)
+                     )
+                    )
+                    (if
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $8)
+                        (i32.const -4)
+                       )
+                      )
+                     )
+                     (local.set $22
+                      (i32.const 1)
+                     )
+                     (block
+                      (local.set $8
+                       (local.get $1)
+                      )
+                      (br $label$198)
+                     )
+                    )
+                   )
+                  )
+                  (block $label$203
+                   (if
+                    (local.get $29)
+                    (block
+                     (local.set $1
+                      (if (result i32)
+                       (i32.and
+                        (i32.gt_s
+                         (local.tee $1
+                          (i32.add
+                           (i32.xor
+                            (i32.and
+                             (local.get $35)
+                             (i32.const 1)
+                            )
+                            (i32.const 1)
+                           )
+                           (local.get $18)
+                          )
+                         )
+                         (local.get $6)
+                        )
+                        (i32.gt_s
+                         (local.get $6)
+                         (i32.const -5)
+                        )
+                       )
+                       (block (result i32)
+                        (local.set $5
+                         (i32.add
+                          (local.get $9)
+                          (i32.const -1)
+                         )
+                        )
+                        (i32.sub
+                         (i32.add
+                          (local.get $1)
+                          (i32.const -1)
+                         )
+                         (local.get $6)
+                        )
+                       )
+                       (block (result i32)
+                        (local.set $5
+                         (i32.add
+                          (local.get $9)
+                          (i32.const -2)
+                         )
+                        )
+                        (i32.add
+                         (local.get $1)
+                         (i32.const -1)
+                        )
+                       )
+                      )
+                     )
+                     (br_if $label$203
+                      (local.tee $13
+                       (i32.and
+                        (local.get $12)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (block $label$207
+                      (if
+                       (local.get $22)
+                       (block
+                        (if
+                         (i32.eqz
+                          (local.tee $18
+                           (i32.load
+                            (i32.add
+                             (local.get $8)
+                             (i32.const -4)
+                            )
+                           )
+                          )
+                         )
+                         (block
+                          (local.set $9
+                           (i32.const 9)
+                          )
+                          (br $label$207)
+                         )
+                        )
+                        (if
+                         (i32.rem_u
+                          (local.get $18)
+                          (i32.const 10)
+                         )
+                         (block
+                          (local.set $9
+                           (i32.const 0)
+                          )
+                          (br $label$207)
+                         )
+                         (block
+                          (local.set $13
+                           (i32.const 10)
+                          )
+                          (local.set $9
+                           (i32.const 0)
+                          )
+                         )
+                        )
+                        (loop $label$212
+                         (local.set $9
+                          (i32.add
+                           (local.get $9)
+                           (i32.const 1)
+                          )
+                         )
+                         (br_if $label$212
+                          (i32.eqz
+                           (i32.rem_u
+                            (local.get $18)
+                            (local.tee $13
+                             (i32.mul
+                              (local.get $13)
+                              (i32.const 10)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (local.set $9
+                        (i32.const 9)
+                       )
+                      )
+                     )
+                     (local.set $18
+                      (i32.add
+                       (i32.mul
+                        (i32.shr_s
+                         (i32.sub
+                          (local.get $8)
+                          (local.get $25)
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 9)
+                       )
+                       (i32.const -9)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (i32.or
+                        (local.get $5)
+                        (i32.const 32)
+                       )
+                       (i32.const 102)
+                      )
+                      (block
+                       (local.set $13
+                        (i32.const 0)
+                       )
+                       (if
+                        (i32.ge_s
+                         (local.get $1)
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.tee $9
+                            (i32.sub
+                             (local.get $18)
+                             (local.get $9)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                          (local.tee $9
+                           (i32.const 0)
+                          )
+                          (local.get $9)
+                         )
+                        )
+                        (local.set $1
+                         (local.get $9)
+                        )
+                       )
+                      )
+                      (block
+                       (local.set $13
+                        (i32.const 0)
+                       )
+                       (if
+                        (i32.ge_s
+                         (local.get $1)
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.tee $9
+                            (i32.sub
+                             (i32.add
+                              (local.get $18)
+                              (local.get $6)
+                             )
+                             (local.get $9)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                          (local.tee $9
+                           (i32.const 0)
+                          )
+                          (local.get $9)
+                         )
+                        )
+                        (local.set $1
+                         (local.get $9)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (block
+                     (local.set $13
+                      (i32.and
+                       (local.get $12)
+                       (i32.const 8)
+                      )
+                     )
+                     (local.set $1
+                      (local.get $18)
+                     )
+                     (local.set $5
+                      (local.get $9)
+                     )
+                    )
+                   )
+                  )
+                  (if
+                   (local.tee $25
+                    (i32.eq
+                     (i32.or
+                      (local.get $5)
+                      (i32.const 32)
+                     )
+                     (i32.const 102)
+                    )
+                   )
+                   (block
+                    (local.set $9
+                     (i32.const 0)
+                    )
+                    (if
+                     (i32.le_s
+                      (local.get $6)
+                      (i32.const 0)
+                     )
+                     (local.set $6
+                      (i32.const 0)
+                     )
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_s
+                      (i32.sub
+                       (local.get $28)
+                       (local.tee $9
+                        (call $23
+                         (i64.extend_i32_s
+                          (if (result i32)
+                           (i32.lt_s
+                            (local.get $6)
+                            (i32.const 0)
+                           )
+                           (local.get $32)
+                           (local.get $6)
+                          )
+                         )
+                         (local.get $33)
+                        )
+                       )
+                      )
+                      (i32.const 2)
+                     )
+                     (loop $label$229
+                      (i32.store8
+                       (local.tee $9
+                        (i32.add
+                         (local.get $9)
+                         (i32.const -1)
+                        )
+                       )
+                       (i32.const 48)
+                      )
+                      (br_if $label$229
+                       (i32.lt_s
+                        (i32.sub
+                         (local.get $28)
+                         (local.get $9)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                    (i32.store8
+                     (i32.add
+                      (local.get $9)
+                      (i32.const -1)
+                     )
+                     (i32.add
+                      (i32.and
+                       (i32.shr_s
+                        (local.get $6)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 43)
+                     )
+                    )
+                    (i32.store8
+                     (local.tee $6
+                      (i32.add
+                       (local.get $9)
+                       (i32.const -2)
+                      )
+                     )
+                     (local.get $5)
+                    )
+                    (local.set $9
+                     (local.get $6)
+                    )
+                    (local.set $6
+                     (i32.sub
+                      (local.get $28)
+                      (local.get $6)
+                     )
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.tee $18
+                    (i32.add
+                     (i32.add
+                      (i32.add
+                       (i32.add
+                        (local.get $24)
+                        (i32.const 1)
+                       )
+                       (local.get $1)
+                      )
+                      (i32.ne
+                       (local.tee $29
+                        (i32.or
+                         (local.get $1)
+                         (local.get $13)
+                        )
+                       )
+                       (i32.const 0)
+                      )
+                     )
+                     (local.get $6)
+                    )
+                   )
+                   (local.get $12)
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (i32.load
+                      (local.get $0)
+                     )
+                     (i32.const 32)
+                    )
+                   )
+                   (drop
+                    (call $21
+                     (local.get $26)
+                     (local.get $24)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 48)
+                   (local.get $10)
+                   (local.get $18)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 65536)
+                   )
+                  )
+                  (block $label$231
+                   (if
+                    (local.get $25)
+                    (block
+                     (local.set $6
+                      (local.tee $9
+                       (if (result i32)
+                        (i32.gt_u
+                         (local.get $14)
+                         (local.get $7)
+                        )
+                        (local.get $7)
+                        (local.get $14)
+                       )
+                      )
+                     )
+                     (loop $label$235
+                      (local.set $5
+                       (call $23
+                        (i64.extend_i32_u
+                         (i32.load
+                          (local.get $6)
+                         )
+                        )
+                        (local.get $31)
+                       )
+                      )
+                      (block $label$236
+                       (if
+                        (i32.eq
+                         (local.get $6)
+                         (local.get $9)
+                        )
+                        (block
+                         (br_if $label$236
+                          (i32.ne
+                           (local.get $5)
+                           (local.get $31)
+                          )
+                         )
+                         (i32.store8
+                          (local.get $34)
+                          (i32.const 48)
+                         )
+                         (local.set $5
+                          (local.get $34)
+                         )
+                        )
+                        (block
+                         (br_if $label$236
+                          (i32.le_u
+                           (local.get $5)
+                           (local.get $19)
+                          )
+                         )
+                         (drop
+                          (call $39
+                           (local.get $19)
+                           (i32.const 48)
+                           (i32.sub
+                            (local.get $5)
+                            (local.get $27)
+                           )
+                          )
+                         )
+                         (loop $label$239
+                          (br_if $label$239
+                           (i32.gt_u
+                            (local.tee $5
+                             (i32.add
+                              (local.get $5)
+                              (i32.const -1)
+                             )
+                            )
+                            (local.get $19)
+                           )
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (local.get $0)
+                         )
+                         (i32.const 32)
+                        )
+                       )
+                       (drop
+                        (call $21
+                         (local.get $5)
+                         (i32.sub
+                          (local.get $41)
+                          (local.get $5)
+                         )
+                         (local.get $0)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.le_u
+                        (local.tee $5
+                         (i32.add
+                          (local.get $6)
+                          (i32.const 4)
+                         )
+                        )
+                        (local.get $7)
+                       )
+                       (block
+                        (local.set $6
+                         (local.get $5)
+                        )
+                        (br $label$235)
+                       )
+                      )
+                     )
+                     (block $label$242
+                      (if
+                       (local.get $29)
+                       (block
+                        (br_if $label$242
+                         (i32.and
+                          (i32.load
+                           (local.get $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $21
+                          (i32.const 1709)
+                          (i32.const 1)
+                          (local.get $0)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.and
+                       (i32.gt_s
+                        (local.get $1)
+                        (i32.const 0)
+                       )
+                       (i32.lt_u
+                        (local.get $5)
+                        (local.get $8)
+                       )
+                      )
+                      (loop $label$245
+                       (if
+                        (i32.gt_u
+                         (local.tee $7
+                          (call $23
+                           (i64.extend_i32_u
+                            (i32.load
+                             (local.get $5)
+                            )
+                           )
+                           (local.get $31)
+                          )
+                         )
+                         (local.get $19)
+                        )
+                        (block
+                         (drop
+                          (call $39
+                           (local.get $19)
+                           (i32.const 48)
+                           (i32.sub
+                            (local.get $7)
+                            (local.get $27)
+                           )
+                          )
+                         )
+                         (loop $label$247
+                          (br_if $label$247
+                           (i32.gt_u
+                            (local.tee $7
+                             (i32.add
+                              (local.get $7)
+                              (i32.const -1)
+                             )
+                            )
+                            (local.get $19)
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (i32.load
+                           (local.get $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $21
+                          (local.get $7)
+                          (if (result i32)
+                           (i32.gt_s
+                            (local.get $1)
+                            (i32.const 9)
+                           )
+                           (i32.const 9)
+                           (local.get $1)
+                          )
+                          (local.get $0)
+                         )
+                        )
+                       )
+                       (local.set $7
+                        (i32.add
+                         (local.get $1)
+                         (i32.const -9)
+                        )
+                       )
+                       (if
+                        (i32.and
+                         (i32.gt_s
+                          (local.get $1)
+                          (i32.const 9)
+                         )
+                         (i32.lt_u
+                          (local.tee $5
+                           (i32.add
+                            (local.get $5)
+                            (i32.const 4)
+                           )
+                          )
+                          (local.get $8)
+                         )
+                        )
+                        (block
+                         (local.set $1
+                          (local.get $7)
+                         )
+                         (br $label$245)
+                        )
+                        (local.set $1
+                         (local.get $7)
+                        )
+                       )
+                      )
+                     )
+                     (call $25
+                      (local.get $0)
+                      (i32.const 48)
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 9)
+                      )
+                      (i32.const 9)
+                      (i32.const 0)
+                     )
+                    )
+                    (block
+                     (local.set $5
+                      (i32.add
+                       (local.get $14)
+                       (i32.const 4)
+                      )
+                     )
+                     (if
+                      (i32.eqz
+                       (local.get $22)
+                      )
+                      (local.set $8
+                       (local.get $5)
+                      )
+                     )
+                     (if
+                      (i32.gt_s
+                       (local.get $1)
+                       (i32.const -1)
+                      )
+                      (block
+                       (local.set $13
+                        (i32.eqz
+                         (local.get $13)
+                        )
+                       )
+                       (local.set $7
+                        (local.get $14)
+                       )
+                       (local.set $5
+                        (local.get $1)
+                       )
+                       (loop $label$256
+                        (if
+                         (i32.eq
+                          (local.tee $1
+                           (call $23
+                            (i64.extend_i32_u
+                             (i32.load
+                              (local.get $7)
+                             )
+                            )
+                            (local.get $31)
+                           )
+                          )
+                          (local.get $31)
+                         )
+                         (block
+                          (i32.store8
+                           (local.get $34)
+                           (i32.const 48)
+                          )
+                          (local.set $1
+                           (local.get $34)
+                          )
+                         )
+                        )
+                        (block $label$258
+                         (if
+                          (i32.eq
+                           (local.get $7)
+                           (local.get $14)
+                          )
+                          (block
+                           (if
+                            (i32.eqz
+                             (i32.and
+                              (i32.load
+                               (local.get $0)
+                              )
+                              (i32.const 32)
+                             )
+                            )
+                            (drop
+                             (call $21
+                              (local.get $1)
+                              (i32.const 1)
+                              (local.get $0)
+                             )
+                            )
+                           )
+                           (local.set $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const 1)
+                            )
+                           )
+                           (br_if $label$258
+                            (i32.and
+                             (local.get $13)
+                             (i32.lt_s
+                              (local.get $5)
+                              (i32.const 1)
+                             )
+                            )
+                           )
+                           (br_if $label$258
+                            (i32.and
+                             (i32.load
+                              (local.get $0)
+                             )
+                             (i32.const 32)
+                            )
+                           )
+                           (drop
+                            (call $21
+                             (i32.const 1709)
+                             (i32.const 1)
+                             (local.get $0)
+                            )
+                           )
+                          )
+                          (block
+                           (br_if $label$258
+                            (i32.le_u
+                             (local.get $1)
+                             (local.get $19)
+                            )
+                           )
+                           (drop
+                            (call $39
+                             (local.get $19)
+                             (i32.const 48)
+                             (i32.add
+                              (local.get $1)
+                              (local.get $43)
+                             )
+                            )
+                           )
+                           (loop $label$262
+                            (br_if $label$262
+                             (i32.gt_u
+                              (local.tee $1
+                               (i32.add
+                                (local.get $1)
+                                (i32.const -1)
+                               )
+                              )
+                              (local.get $19)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                        (local.set $6
+                         (i32.sub
+                          (local.get $41)
+                          (local.get $1)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.and
+                           (i32.load
+                            (local.get $0)
+                           )
+                           (i32.const 32)
+                          )
+                         )
+                         (drop
+                          (call $21
+                           (local.get $1)
+                           (if (result i32)
+                            (i32.gt_s
+                             (local.get $5)
+                             (local.get $6)
+                            )
+                            (local.get $6)
+                            (local.get $5)
+                           )
+                           (local.get $0)
+                          )
+                         )
+                        )
+                        (br_if $label$256
+                         (i32.and
+                          (i32.lt_u
+                           (local.tee $7
+                            (i32.add
+                             (local.get $7)
+                             (i32.const 4)
+                            )
+                           )
+                           (local.get $8)
+                          )
+                          (i32.gt_s
+                           (local.tee $5
+                            (i32.sub
+                             (local.get $5)
+                             (local.get $6)
+                            )
+                           )
+                           (i32.const -1)
+                          )
+                         )
+                        )
+                        (local.set $1
+                         (local.get $5)
+                        )
+                       )
+                      )
+                     )
+                     (call $25
+                      (local.get $0)
+                      (i32.const 48)
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 18)
+                      )
+                      (i32.const 18)
+                      (i32.const 0)
+                     )
+                     (br_if $label$231
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $9)
+                       (i32.sub
+                        (local.get $28)
+                        (local.get $9)
+                       )
+                       (local.get $0)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.get $18)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 8192)
+                   )
+                  )
+                  (if
+                   (i32.ge_s
+                    (local.get $18)
+                    (local.get $10)
+                   )
+                   (local.set $10
+                    (local.get $18)
+                   )
+                  )
+                 )
+                 (block
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.tee $8
+                    (i32.add
+                     (if (result i32)
+                      (local.tee $6
+                       (i32.or
+                        (f64.ne
+                         (local.get $52)
+                         (local.get $52)
+                        )
+                        (i32.const 0)
+                       )
+                      )
+                      (local.tee $24
+                       (i32.const 0)
+                      )
+                      (local.get $24)
+                     )
+                     (i32.const 3)
+                    )
+                   )
+                   (local.get $7)
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (local.tee $1
+                      (i32.load
+                       (local.get $0)
+                      )
+                     )
+                     (i32.const 32)
+                    )
+                   )
+                   (block
+                    (drop
+                     (call $21
+                      (local.get $26)
+                      (local.get $24)
+                      (local.get $0)
+                     )
+                    )
+                    (local.set $1
+                     (i32.load
+                      (local.get $0)
+                     )
+                    )
+                   )
+                  )
+                  (local.set $7
+                   (if (result i32)
+                    (local.tee $5
+                     (i32.ne
+                      (i32.and
+                       (local.get $9)
+                       (i32.const 32)
+                      )
+                      (i32.const 0)
+                     )
+                    )
+                    (i32.const 1693)
+                    (i32.const 1697)
+                   )
+                  )
+                  (local.set $5
+                   (if (result i32)
+                    (local.get $5)
+                    (i32.const 1701)
+                    (i32.const 1705)
+                   )
+                  )
+                  (if
+                   (i32.eqz
+                    (local.get $6)
+                   )
+                   (local.set $5
+                    (local.get $7)
+                   )
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (local.get $1)
+                     (i32.const 32)
+                    )
+                   )
+                   (drop
+                    (call $21
+                     (local.get $5)
+                     (i32.const 3)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.get $8)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 8192)
+                   )
+                  )
+                  (if
+                   (i32.ge_s
+                    (local.get $8)
+                    (local.get $10)
+                   )
+                   (local.set $10
+                    (local.get $8)
+                   )
+                  )
+                 )
+                )
+               )
+               (local.set $1
+                (local.get $11)
+               )
+               (br $label$4)
+              )
+              (local.set $7
+               (local.get $5)
+              )
+              (local.set $6
+               (i32.const 0)
+              )
+              (local.set $8
+               (i32.const 1657)
+              )
+              (local.set $5
+               (local.get $21)
+              )
+              (br $label$70)
+             )
+             (local.set $7
+              (i32.and
+               (local.get $9)
+               (i32.const 32)
+              )
+             )
+             (local.set $7
+              (if (result i32)
+               (i64.eq
+                (local.tee $50
+                 (i64.load
+                  (local.get $16)
+                 )
+                )
+                (i64.const 0)
+               )
+               (block (result i32)
+                (local.set $50
+                 (i64.const 0)
+                )
+                (local.get $21)
+               )
+               (block (result i32)
+                (local.set $1
+                 (local.get $21)
+                )
+                (loop $label$280
+                 (i32.store8
+                  (local.tee $1
+                   (i32.add
+                    (local.get $1)
+                    (i32.const -1)
+                   )
+                  )
+                  (i32.or
+                   (i32.load8_u
+                    (i32.add
+                     (i32.and
+                      (i32.wrap_i64
+                       (local.get $50)
+                      )
+                      (i32.const 15)
+                     )
+                     (i32.const 1641)
+                    )
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (br_if $label$280
+                  (i64.ne
+                   (local.tee $50
+                    (i64.shr_u
+                     (local.get $50)
+                     (i64.const 4)
+                    )
+                   )
+                   (i64.const 0)
+                  )
+                 )
+                )
+                (local.set $50
+                 (i64.load
+                  (local.get $16)
+                 )
+                )
+                (local.get $1)
+               )
+              )
+             )
+             (local.set $8
+              (i32.add
+               (i32.shr_s
+                (local.get $9)
+                (i32.const 4)
+               )
+               (i32.const 1657)
+              )
+             )
+             (if
+              (local.tee $1
+               (i32.or
+                (i32.eqz
+                 (i32.and
+                  (local.get $12)
+                  (i32.const 8)
+                 )
+                )
+                (i64.eq
+                 (local.get $50)
+                 (i64.const 0)
+                )
+               )
+              )
+              (local.set $8
+               (i32.const 1657)
+              )
+             )
+             (local.set $6
+              (if (result i32)
+               (local.get $1)
+               (i32.const 0)
+               (i32.const 2)
+              )
+             )
+             (br $label$71)
+            )
+            (local.set $7
+             (call $23
+              (local.get $50)
+              (local.get $21)
+             )
+            )
+            (br $label$71)
+           )
+           (local.set $14
+            (i32.eqz
+             (local.tee $13
+              (call $17
+               (local.get $1)
+               (i32.const 0)
+               (local.get $5)
+              )
+             )
+            )
+           )
+           (local.set $8
+            (i32.sub
+             (local.get $13)
+             (local.get $1)
+            )
+           )
+           (local.set $9
+            (i32.add
+             (local.get $1)
+             (local.get $5)
+            )
+           )
+           (local.set $12
+            (local.get $7)
+           )
+           (local.set $7
+            (if (result i32)
+             (local.get $14)
+             (local.get $5)
+             (local.get $8)
+            )
+           )
+           (local.set $6
+            (i32.const 0)
+           )
+           (local.set $8
+            (i32.const 1657)
+           )
+           (local.set $5
+            (if (result i32)
+             (local.get $14)
+             (local.get $9)
+             (local.get $13)
+            )
+           )
+           (br $label$70)
+          )
+          (local.set $1
+           (i32.const 0)
+          )
+          (local.set $5
+           (i32.const 0)
+          )
+          (local.set $8
+           (local.get $7)
+          )
+          (loop $label$288
+           (block $label$289
+            (br_if $label$289
+             (i32.eqz
+              (local.tee $9
+               (i32.load
+                (local.get $8)
+               )
+              )
+             )
+            )
+            (br_if $label$289
+             (i32.or
+              (i32.lt_s
+               (local.tee $5
+                (call $26
+                 (local.get $36)
+                 (local.get $9)
+                )
+               )
+               (i32.const 0)
+              )
+              (i32.gt_u
+               (local.get $5)
+               (i32.sub
+                (local.get $6)
+                (local.get $1)
+               )
+              )
+             )
+            )
+            (local.set $8
+             (i32.add
+              (local.get $8)
+              (i32.const 4)
+             )
+            )
+            (br_if $label$288
+             (i32.gt_u
+              (local.get $6)
+              (local.tee $1
+               (i32.add
+                (local.get $5)
+                (local.get $1)
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_s
+            (local.get $5)
+            (i32.const 0)
+           )
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+          )
+          (call $25
+           (local.get $0)
+           (i32.const 32)
+           (local.get $10)
+           (local.get $1)
+           (local.get $12)
+          )
+          (if
+           (local.get $1)
+           (block
+            (local.set $5
+             (i32.const 0)
+            )
+            (loop $label$292
+             (br_if $label$72
+              (i32.eqz
+               (local.tee $8
+                (i32.load
+                 (local.get $7)
+                )
+               )
+              )
+             )
+             (br_if $label$72
+              (i32.gt_s
+               (local.tee $5
+                (i32.add
+                 (local.tee $8
+                  (call $26
+                   (local.get $36)
+                   (local.get $8)
+                  )
+                 )
+                 (local.get $5)
+                )
+               )
+               (local.get $1)
+              )
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (i32.load
+                 (local.get $0)
+                )
+                (i32.const 32)
+               )
+              )
+              (drop
+               (call $21
+                (local.get $36)
+                (local.get $8)
+                (local.get $0)
+               )
+              )
+             )
+             (local.set $7
+              (i32.add
+               (local.get $7)
+               (i32.const 4)
+              )
+             )
+             (br_if $label$292
+              (i32.lt_u
+               (local.get $5)
+               (local.get $1)
+              )
+             )
+             (br $label$72)
+            )
+           )
+           (block
+            (local.set $1
+             (i32.const 0)
+            )
+            (br $label$72)
+           )
+          )
+         )
+         (call $25
+          (local.get $0)
+          (i32.const 32)
+          (local.get $10)
+          (local.get $1)
+          (i32.xor
+           (local.get $12)
+           (i32.const 8192)
+          )
+         )
+         (if
+          (i32.le_s
+           (local.get $10)
+           (local.get $1)
+          )
+          (local.set $10
+           (local.get $1)
+          )
+         )
+         (local.set $1
+          (local.get $11)
+         )
+         (br $label$4)
+        )
+        (local.set $1
+         (i32.and
+          (local.get $12)
+          (i32.const -65537)
+         )
+        )
+        (if
+         (i32.gt_s
+          (local.get $5)
+          (i32.const -1)
+         )
+         (local.set $12
+          (local.get $1)
+         )
+        )
+        (local.set $5
+         (if (result i32)
+          (i32.or
+           (local.get $5)
+           (local.tee $9
+            (i64.ne
+             (i64.load
+              (local.get $16)
+             )
+             (i64.const 0)
+            )
+           )
+          )
+          (block (result i32)
+           (local.set $1
+            (local.get $7)
+           )
+           (if
+            (i32.gt_s
+             (local.get $5)
+             (local.tee $7
+              (i32.add
+               (i32.xor
+                (i32.and
+                 (local.get $9)
+                 (i32.const 1)
+                )
+                (i32.const 1)
+               )
+               (i32.sub
+                (local.get $38)
+                (local.get $7)
+               )
+              )
+             )
+            )
+            (local.set $7
+             (local.get $5)
+            )
+           )
+           (local.get $21)
+          )
+          (block (result i32)
+           (local.set $1
+            (local.get $21)
+           )
+           (local.set $7
+            (i32.const 0)
+           )
+           (local.get $21)
+          )
+         )
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 32)
+        (if (result i32)
+         (i32.lt_s
+          (local.get $10)
+          (local.tee $5
+           (i32.add
+            (if (result i32)
+             (i32.lt_s
+              (local.get $7)
+              (local.tee $9
+               (i32.sub
+                (local.get $5)
+                (local.get $1)
+               )
+              )
+             )
+             (local.tee $7
+              (local.get $9)
+             )
+             (local.get $7)
+            )
+            (local.get $6)
+           )
+          )
+         )
+         (local.tee $10
+          (local.get $5)
+         )
+         (local.get $10)
+        )
+        (local.get $5)
+        (local.get $12)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 32)
+         )
+        )
+        (drop
+         (call $21
+          (local.get $8)
+          (local.get $6)
+          (local.get $0)
+         )
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 48)
+        (local.get $10)
+        (local.get $5)
+        (i32.xor
+         (local.get $12)
+         (i32.const 65536)
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 48)
+        (local.get $7)
+        (local.get $9)
+        (i32.const 0)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 32)
+         )
+        )
+        (drop
+         (call $21
+          (local.get $1)
+          (local.get $9)
+          (local.get $0)
+         )
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 32)
+        (local.get $10)
+        (local.get $5)
+        (i32.xor
+         (local.get $12)
+         (i32.const 8192)
+        )
+       )
+       (local.set $1
+        (local.get $11)
+       )
+       (br $label$4)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.eqz
+      (local.get $0)
+     )
+     (if
+      (local.get $17)
+      (block
+       (local.set $0
+        (i32.const 1)
+       )
+       (loop $label$308
+        (if
+         (local.tee $1
+          (i32.load
+           (i32.add
+            (local.get $4)
+            (i32.shl
+             (local.get $0)
+             (i32.const 2)
+            )
+           )
+          )
+         )
+         (block
+          (call $22
+           (i32.add
+            (local.get $3)
+            (i32.shl
+             (local.get $0)
+             (i32.const 3)
+            )
+           )
+           (local.get $1)
+           (local.get $2)
+          )
+          (br_if $label$308
+           (i32.lt_s
+            (local.tee $0
+             (i32.add
+              (local.get $0)
+              (i32.const 1)
+             )
+            )
+            (i32.const 10)
+           )
+          )
+          (local.set $15
+           (i32.const 1)
+          )
+          (br $label$2)
+         )
+        )
+       )
+       (loop $label$310
+        (if
+         (i32.load
+          (i32.add
+           (local.get $4)
+           (i32.shl
+            (local.get $0)
+            (i32.const 2)
+           )
+          )
+         )
+         (block
+          (local.set $15
+           (i32.const -1)
+          )
+          (br $label$2)
+         )
+        )
+        (br_if $label$310
+         (i32.lt_s
+          (local.tee $0
+           (i32.add
+            (local.get $0)
+            (i32.const 1)
+           )
+          )
+          (i32.const 10)
+         )
+        )
+        (local.set $15
+         (i32.const 1)
+        )
+       )
+      )
+      (local.set $15
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $23)
+   )
+   (local.get $15)
+  )
+ )
+ (func $20 (; 33 ;) (type $1) (param $0 i32) (result i32)
+  (i32.const 0)
+ )
+ (func $21 (; 34 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (block $label$1 (result i32)
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (local.tee $3
+       (i32.load
+        (local.tee $4
+         (i32.add
+          (local.get $2)
+          (i32.const 16)
+         )
+        )
+       )
+      )
+     )
+     (if
+      (call $30
+       (local.get $2)
+      )
+      (local.set $3
+       (i32.const 0)
+      )
+      (block
+       (local.set $3
+        (i32.load
+         (local.get $4)
+        )
+       )
+       (br $label$3)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.lt_u
+      (i32.sub
+       (local.get $3)
+       (local.tee $4
+        (i32.load
+         (local.tee $5
+          (i32.add
+           (local.get $2)
+           (i32.const 20)
+          )
+         )
+        )
+       )
+      )
+      (local.get $1)
+     )
+     (block
+      (local.set $3
+       (call_indirect (type $0)
+        (local.get $2)
+        (local.get $0)
+        (local.get $1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (local.get $2)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (br $label$2)
+     )
+    )
+    (local.set $2
+     (block $label$7 (result i32)
+      (if (result i32)
+       (i32.gt_s
+        (i32.load8_s offset=75
+         (local.get $2)
+        )
+        (i32.const -1)
+       )
+       (block (result i32)
+        (local.set $3
+         (local.get $1)
+        )
+        (loop $label$9
+         (drop
+          (br_if $label$7
+           (i32.const 0)
+           (i32.eqz
+            (local.get $3)
+           )
+          )
+         )
+         (if
+          (i32.ne
+           (i32.load8_s
+            (i32.add
+             (local.get $0)
+             (local.tee $6
+              (i32.add
+               (local.get $3)
+               (i32.const -1)
+              )
+             )
+            )
+           )
+           (i32.const 10)
+          )
+          (block
+           (local.set $3
+            (local.get $6)
+           )
+           (br $label$9)
+          )
+         )
+        )
+        (br_if $label$2
+         (i32.lt_u
+          (call_indirect (type $0)
+           (local.get $2)
+           (local.get $0)
+           (local.get $3)
+           (i32.add
+            (i32.and
+             (i32.load offset=36
+              (local.get $2)
+             )
+             (i32.const 3)
+            )
+            (i32.const 2)
+           )
+          )
+          (local.get $3)
+         )
+        )
+        (local.set $4
+         (i32.load
+          (local.get $5)
+         )
+        )
+        (local.set $1
+         (i32.sub
+          (local.get $1)
+          (local.get $3)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (local.get $3)
+         )
+        )
+        (local.get $3)
+       )
+       (i32.const 0)
+      )
+     )
+    )
+    (drop
+     (call $40
+      (local.get $4)
+      (local.get $0)
+      (local.get $1)
+     )
+    )
+    (i32.store
+     (local.get $5)
+     (i32.add
+      (i32.load
+       (local.get $5)
+      )
+      (local.get $1)
+     )
+    )
+    (local.set $3
+     (i32.add
+      (local.get $2)
+      (local.get $1)
+     )
+    )
+   )
+   (local.get $3)
+  )
+ )
+ (func $22 (; 35 ;) (type $8) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i64)
+  (local $5 f64)
+  (block $label$1
+   (if
+    (i32.le_u
+     (local.get $1)
+     (i32.const 20)
+    )
+    (block $label$3
+     (block $label$4
+      (block $label$5
+       (block $label$6
+        (block $label$7
+         (block $label$8
+          (block $label$9
+           (block $label$10
+            (block $label$11
+             (block $label$12
+              (block $label$13
+               (br_table $label$13 $label$12 $label$11 $label$10 $label$9 $label$8 $label$7 $label$6 $label$5 $label$4 $label$3
+                (i32.sub
+                 (local.get $1)
+                 (i32.const 9)
+                )
+               )
+              )
+              (local.set $3
+               (i32.load
+                (local.tee $1
+                 (i32.and
+                  (i32.add
+                   (i32.load
+                    (local.get $2)
+                   )
+                   (i32.const 3)
+                  )
+                  (i32.const -4)
+                 )
+                )
+               )
+              )
+              (i32.store
+               (local.get $2)
+               (i32.add
+                (local.get $1)
+                (i32.const 4)
+               )
+              )
+              (i32.store
+               (local.get $0)
+               (local.get $3)
+              )
+              (br $label$1)
+             )
+             (local.set $3
+              (i32.load
+               (local.tee $1
+                (i32.and
+                 (i32.add
+                  (i32.load
+                   (local.get $2)
+                  )
+                  (i32.const 3)
+                 )
+                 (i32.const -4)
+                )
+               )
+              )
+             )
+             (i32.store
+              (local.get $2)
+              (i32.add
+               (local.get $1)
+               (i32.const 4)
+              )
+             )
+             (i64.store
+              (local.get $0)
+              (i64.extend_i32_s
+               (local.get $3)
+              )
+             )
+             (br $label$1)
+            )
+            (local.set $3
+             (i32.load
+              (local.tee $1
+               (i32.and
+                (i32.add
+                 (i32.load
+                  (local.get $2)
+                 )
+                 (i32.const 3)
+                )
+                (i32.const -4)
+               )
+              )
+             )
+            )
+            (i32.store
+             (local.get $2)
+             (i32.add
+              (local.get $1)
+              (i32.const 4)
+             )
+            )
+            (i64.store
+             (local.get $0)
+             (i64.extend_i32_u
+              (local.get $3)
+             )
+            )
+            (br $label$1)
+           )
+           (local.set $4
+            (i64.load
+             (local.tee $1
+              (i32.and
+               (i32.add
+                (i32.load
+                 (local.get $2)
+                )
+                (i32.const 7)
+               )
+               (i32.const -8)
+              )
+             )
+            )
+           )
+           (i32.store
+            (local.get $2)
+            (i32.add
+             (local.get $1)
+             (i32.const 8)
+            )
+           )
+           (i64.store
+            (local.get $0)
+            (local.get $4)
+           )
+           (br $label$1)
+          )
+          (local.set $3
+           (i32.load
+            (local.tee $1
+             (i32.and
+              (i32.add
+               (i32.load
+                (local.get $2)
+               )
+               (i32.const 3)
+              )
+              (i32.const -4)
+             )
+            )
+           )
+          )
+          (i32.store
+           (local.get $2)
+           (i32.add
+            (local.get $1)
+            (i32.const 4)
+           )
+          )
+          (i64.store
+           (local.get $0)
+           (i64.extend_i32_s
+            (i32.shr_s
+             (i32.shl
+              (i32.and
+               (local.get $3)
+               (i32.const 65535)
+              )
+              (i32.const 16)
+             )
+             (i32.const 16)
+            )
+           )
+          )
+          (br $label$1)
+         )
+         (local.set $3
+          (i32.load
+           (local.tee $1
+            (i32.and
+             (i32.add
+              (i32.load
+               (local.get $2)
+              )
+              (i32.const 3)
+             )
+             (i32.const -4)
+            )
+           )
+          )
+         )
+         (i32.store
+          (local.get $2)
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+         )
+         (i64.store
+          (local.get $0)
+          (i64.extend_i32_u
+           (i32.and
+            (local.get $3)
+            (i32.const 65535)
+           )
+          )
+         )
+         (br $label$1)
+        )
+        (local.set $3
+         (i32.load
+          (local.tee $1
+           (i32.and
+            (i32.add
+             (i32.load
+              (local.get $2)
+             )
+             (i32.const 3)
+            )
+            (i32.const -4)
+           )
+          )
+         )
+        )
+        (i32.store
+         (local.get $2)
+         (i32.add
+          (local.get $1)
+          (i32.const 4)
+         )
+        )
+        (i64.store
+         (local.get $0)
+         (i64.extend_i32_s
+          (i32.shr_s
+           (i32.shl
+            (i32.and
+             (local.get $3)
+             (i32.const 255)
+            )
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+         )
+        )
+        (br $label$1)
+       )
+       (local.set $3
+        (i32.load
+         (local.tee $1
+          (i32.and
+           (i32.add
+            (i32.load
+             (local.get $2)
+            )
+            (i32.const 3)
+           )
+           (i32.const -4)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $2)
+        (i32.add
+         (local.get $1)
+         (i32.const 4)
+        )
+       )
+       (i64.store
+        (local.get $0)
+        (i64.extend_i32_u
+         (i32.and
+          (local.get $3)
+          (i32.const 255)
+         )
+        )
+       )
+       (br $label$1)
+      )
+      (local.set $5
+       (f64.load
+        (local.tee $1
+         (i32.and
+          (i32.add
+           (i32.load
+            (local.get $2)
+           )
+           (i32.const 7)
+          )
+          (i32.const -8)
+         )
+        )
+       )
+      )
+      (i32.store
+       (local.get $2)
+       (i32.add
+        (local.get $1)
+        (i32.const 8)
+       )
+      )
+      (f64.store
+       (local.get $0)
+       (local.get $5)
+      )
+      (br $label$1)
+     )
+     (local.set $5
+      (f64.load
+       (local.tee $1
+        (i32.and
+         (i32.add
+          (i32.load
+           (local.get $2)
+          )
+          (i32.const 7)
+         )
+         (i32.const -8)
+        )
+       )
+      )
+     )
+     (i32.store
+      (local.get $2)
+      (i32.add
+       (local.get $1)
+       (i32.const 8)
+      )
+     )
+     (f64.store
+      (local.get $0)
+      (local.get $5)
+     )
+    )
+   )
+  )
+ )
+ (func $23 (; 36 ;) (type $9) (param $0 i64) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i64)
+  (block $label$1 (result i32)
+   (local.set $2
+    (i32.wrap_i64
+     (local.get $0)
+    )
+   )
+   (if
+    (i64.gt_u
+     (local.get $0)
+     (i64.const 4294967295)
+    )
+    (block
+     (loop $label$3
+      (i64.store8
+       (local.tee $1
+        (i32.add
+         (local.get $1)
+         (i32.const -1)
+        )
+       )
+       (i64.or
+        (i64.rem_u
+         (local.get $0)
+         (i64.const 10)
+        )
+        (i64.const 48)
+       )
+      )
+      (local.set $4
+       (i64.div_u
+        (local.get $0)
+        (i64.const 10)
+       )
+      )
+      (if
+       (i64.gt_u
+        (local.get $0)
+        (i64.const 42949672959)
+       )
+       (block
+        (local.set $0
+         (local.get $4)
+        )
+        (br $label$3)
+       )
+      )
+     )
+     (local.set $2
+      (i32.wrap_i64
+       (local.get $4)
+      )
+     )
+    )
+   )
+   (if
+    (local.get $2)
+    (loop $label$6
+     (i32.store8
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const -1)
+       )
+      )
+      (i32.or
+       (i32.rem_u
+        (local.get $2)
+        (i32.const 10)
+       )
+       (i32.const 48)
+      )
+     )
+     (local.set $3
+      (i32.div_u
+       (local.get $2)
+       (i32.const 10)
+      )
+     )
+     (if
+      (i32.ge_u
+       (local.get $2)
+       (i32.const 10)
+      )
+      (block
+       (local.set $2
+        (local.get $3)
+       )
+       (br $label$6)
+      )
+     )
+    )
+   )
+   (local.get $1)
+  )
+ )
+ (func $24 (; 37 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.const 0)
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (loop $label$5
+       (br_if $label$4
+        (i32.eq
+         (i32.load8_u
+          (i32.add
+           (local.get $1)
+           (i32.const 1711)
+          )
+         )
+         (local.get $0)
+        )
+       )
+       (br_if $label$5
+        (i32.ne
+         (local.tee $1
+          (i32.add
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (i32.const 87)
+        )
+       )
+       (local.set $1
+        (i32.const 87)
+       )
+       (local.set $0
+        (i32.const 1799)
+       )
+       (br $label$3)
+      )
+     )
+     (if
+      (local.get $1)
+      (block
+       (local.set $0
+        (i32.const 1799)
+       )
+       (br $label$3)
+      )
+      (local.set $0
+       (i32.const 1799)
+      )
+     )
+     (br $label$2)
+    )
+    (loop $label$8
+     (local.set $2
+      (local.get $0)
+     )
+     (loop $label$9
+      (local.set $0
+       (i32.add
+        (local.get $2)
+        (i32.const 1)
+       )
+      )
+      (if
+       (i32.load8_s
+        (local.get $2)
+       )
+       (block
+        (local.set $2
+         (local.get $0)
+        )
+        (br $label$9)
+       )
+      )
+     )
+     (br_if $label$8
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const -1)
+       )
+      )
+     )
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $25 (; 38 ;) (type $10) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (block $label$1
+   (local.set $7
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 256)
+    )
+   )
+   (local.set $6
+    (local.get $7)
+   )
+   (block $label$2
+    (if
+     (i32.and
+      (i32.gt_s
+       (local.get $2)
+       (local.get $3)
+      )
+      (i32.eqz
+       (i32.and
+        (local.get $4)
+        (i32.const 73728)
+       )
+      )
+     )
+     (block
+      (drop
+       (call $39
+        (local.get $6)
+        (local.get $1)
+        (if (result i32)
+         (i32.gt_u
+          (local.tee $5
+           (i32.sub
+            (local.get $2)
+            (local.get $3)
+           )
+          )
+          (i32.const 256)
+         )
+         (i32.const 256)
+         (local.get $5)
+        )
+       )
+      )
+      (local.set $4
+       (i32.eqz
+        (i32.and
+         (local.tee $1
+          (i32.load
+           (local.get $0)
+          )
+         )
+         (i32.const 32)
+        )
+       )
+      )
+      (if
+       (i32.gt_u
+        (local.get $5)
+        (i32.const 255)
+       )
+       (block
+        (loop $label$7
+         (if
+          (local.get $4)
+          (block
+           (drop
+            (call $21
+             (local.get $6)
+             (i32.const 256)
+             (local.get $0)
+            )
+           )
+           (local.set $1
+            (i32.load
+             (local.get $0)
+            )
+           )
+          )
+         )
+         (local.set $4
+          (i32.eqz
+           (i32.and
+            (local.get $1)
+            (i32.const 32)
+           )
+          )
+         )
+         (br_if $label$7
+          (i32.gt_u
+           (local.tee $5
+            (i32.add
+             (local.get $5)
+             (i32.const -256)
+            )
+           )
+           (i32.const 255)
+          )
+         )
+        )
+        (br_if $label$2
+         (i32.eqz
+          (local.get $4)
+         )
+        )
+        (local.set $5
+         (i32.and
+          (i32.sub
+           (local.get $2)
+           (local.get $3)
+          )
+          (i32.const 255)
+         )
+        )
+       )
+       (br_if $label$2
+        (i32.eqz
+         (local.get $4)
+        )
+       )
+      )
+      (drop
+       (call $21
+        (local.get $6)
+        (local.get $5)
+        (local.get $0)
+       )
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $7)
+   )
+  )
+ )
+ (func $26 (; 39 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (if (result i32)
+   (local.get $0)
+   (call $29
+    (local.get $0)
+    (local.get $1)
+    (i32.const 0)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $27 (; 40 ;) (type $11) (param $0 f64) (param $1 i32) (result f64)
+  (call $28
+   (local.get $0)
+   (local.get $1)
+  )
+ )
+ (func $28 (; 41 ;) (type $11) (param $0 f64) (param $1 i32) (result f64)
+  (local $2 i64)
+  (local $3 i64)
+  (block $label$1 (result f64)
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (block $label$5
+       (br_table $label$5 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$4 $label$3
+        (i32.sub
+         (i32.shr_s
+          (i32.shl
+           (i32.and
+            (i32.and
+             (i32.wrap_i64
+              (local.tee $3
+               (i64.shr_u
+                (local.tee $2
+                 (i64.reinterpret_f64
+                  (local.get $0)
+                 )
+                )
+                (i64.const 52)
+               )
+              )
+             )
+             (i32.const 65535)
+            )
+            (i32.const 2047)
+           )
+           (i32.const 16)
+          )
+          (i32.const 16)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.store
+       (local.get $1)
+       (if (result i32)
+        (f64.ne
+         (local.get $0)
+         (f64.const 0)
+        )
+        (block (result i32)
+         (local.set $0
+          (call $28
+           (f64.mul
+            (local.get $0)
+            (f64.const 18446744073709551615)
+           )
+           (local.get $1)
+          )
+         )
+         (i32.add
+          (i32.load
+           (local.get $1)
+          )
+          (i32.const -64)
+         )
+        )
+        (i32.const 0)
+       )
+      )
+      (br $label$2)
+     )
+     (br $label$2)
+    )
+    (i32.store
+     (local.get $1)
+     (i32.add
+      (i32.and
+       (i32.wrap_i64
+        (local.get $3)
+       )
+       (i32.const 2047)
+      )
+      (i32.const -1022)
+     )
+    )
+    (local.set $0
+     (f64.reinterpret_i64
+      (i64.or
+       (i64.and
+        (local.get $2)
+        (i64.const -9218868437227405313)
+       )
+       (i64.const 4602678819172646912)
+      )
+     )
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $29 (; 42 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (block $label$1 (result i32)
+   (if (result i32)
+    (local.get $0)
+    (block (result i32)
+     (if
+      (i32.lt_u
+       (local.get $1)
+       (i32.const 128)
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (local.get $1)
+       )
+       (br $label$1
+        (i32.const 1)
+       )
+      )
+     )
+     (if
+      (i32.lt_u
+       (local.get $1)
+       (i32.const 2048)
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 6)
+         )
+         (i32.const 192)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (br $label$1
+        (i32.const 2)
+       )
+      )
+     )
+     (if
+      (i32.or
+       (i32.lt_u
+        (local.get $1)
+        (i32.const 55296)
+       )
+       (i32.eq
+        (i32.and
+         (local.get $1)
+         (i32.const -8192)
+        )
+        (i32.const 57344)
+       )
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 12)
+         )
+         (i32.const 224)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 6)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=2
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (br $label$1
+        (i32.const 3)
+       )
+      )
+     )
+     (if (result i32)
+      (i32.lt_u
+       (i32.add
+        (local.get $1)
+        (i32.const -65536)
+       )
+       (i32.const 1048576)
+      )
+      (block (result i32)
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 18)
+         )
+         (i32.const 240)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 12)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=2
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 6)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=3
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.const 4)
+      )
+      (block (result i32)
+       (i32.store
+        (call $12)
+        (i32.const 84)
+       )
+       (i32.const -1)
+      )
+     )
+    )
+    (i32.const 1)
+   )
+  )
+ )
+ (func $30 (; 43 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.load8_s
+     (local.tee $2
+      (i32.add
+       (local.get $0)
+       (i32.const 74)
+      )
+     )
+    )
+   )
+   (i32.store8
+    (local.get $2)
+    (i32.or
+     (i32.add
+      (local.get $1)
+      (i32.const 255)
+     )
+     (local.get $1)
+    )
+   )
+   (local.tee $0
+    (if (result i32)
+     (i32.and
+      (local.tee $1
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (i32.const 8)
+     )
+     (block (result i32)
+      (i32.store
+       (local.get $0)
+       (i32.or
+        (local.get $1)
+        (i32.const 32)
+       )
+      )
+      (i32.const -1)
+     )
+     (block (result i32)
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.store offset=28
+       (local.get $0)
+       (local.tee $1
+        (i32.load offset=44
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store offset=20
+       (local.get $0)
+       (local.get $1)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.add
+        (local.get $1)
+        (i32.load offset=48
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 0)
+     )
+    )
+   )
+  )
+ )
+ (func $31 (; 44 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (block $label$1 (result i32)
+   (local.set $3
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store8
+    (local.tee $4
+     (local.get $3)
+    )
+    (local.tee $7
+     (i32.and
+      (local.get $1)
+      (i32.const 255)
+     )
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (local.tee $5
+       (i32.load
+        (local.tee $2
+         (i32.add
+          (local.get $0)
+          (i32.const 16)
+         )
+        )
+       )
+      )
+     )
+     (if
+      (call $30
+       (local.get $0)
+      )
+      (local.set $1
+       (i32.const -1)
+      )
+      (block
+       (local.set $5
+        (i32.load
+         (local.get $2)
+        )
+       )
+       (br $label$3)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.lt_u
+      (local.tee $6
+       (i32.load
+        (local.tee $2
+         (i32.add
+          (local.get $0)
+          (i32.const 20)
+         )
+        )
+       )
+      )
+      (local.get $5)
+     )
+     (if
+      (i32.ne
+       (local.tee $1
+        (i32.and
+         (local.get $1)
+         (i32.const 255)
+        )
+       )
+       (i32.load8_s offset=75
+        (local.get $0)
+       )
+      )
+      (block
+       (i32.store
+        (local.get $2)
+        (i32.add
+         (local.get $6)
+         (i32.const 1)
+        )
+       )
+       (i32.store8
+        (local.get $6)
+        (local.get $7)
+       )
+       (br $label$2)
+      )
+     )
+    )
+    (local.set $1
+     (if (result i32)
+      (i32.eq
+       (call_indirect (type $0)
+        (local.get $0)
+        (local.get $4)
+        (i32.const 1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (local.get $0)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
+       )
+       (i32.const 1)
+      )
+      (i32.load8_u
+       (local.get $4)
+      )
+      (i32.const -1)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $3)
+   )
+   (local.get $1)
+  )
+ )
+ (func $32 (; 45 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (i32.lt_s
+       (i32.load offset=76
+        (local.get $1)
+       )
+       (i32.const 0)
+      )
+     )
+     (br_if $label$3
+      (i32.eqz
+       (call $20
+        (local.get $1)
+       )
+      )
+     )
+     (local.set $0
+      (block $label$4 (result i32)
+       (block $label$5
+        (br_if $label$5
+         (i32.eq
+          (i32.load8_s offset=75
+           (local.get $1)
+          )
+          (local.get $0)
+         )
+        )
+        (br_if $label$5
+         (i32.ge_u
+          (local.tee $2
+           (i32.load
+            (local.tee $3
+             (i32.add
+              (local.get $1)
+              (i32.const 20)
+             )
+            )
+           )
+          )
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+        )
+        (i32.store
+         (local.get $3)
+         (i32.add
+          (local.get $2)
+          (i32.const 1)
+         )
+        )
+        (i32.store8
+         (local.get $2)
+         (local.get $0)
+        )
+        (br $label$4
+         (i32.and
+          (local.get $0)
+          (i32.const 255)
+         )
+        )
+       )
+       (call $31
+        (local.get $1)
+        (local.get $0)
+       )
+      )
+     )
+     (call $13
+      (local.get $1)
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.ne
+      (i32.load8_s offset=75
+       (local.get $1)
+      )
+      (local.get $0)
+     )
+     (if
+      (i32.lt_u
+       (local.tee $2
+        (i32.load
+         (local.tee $3
+          (i32.add
+           (local.get $1)
+           (i32.const 20)
+          )
+         )
+        )
+       )
+       (i32.load offset=16
+        (local.get $1)
+       )
+      )
+      (block
+       (i32.store
+        (local.get $3)
+        (i32.add
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (i32.store8
+        (local.get $2)
+        (local.get $0)
+       )
+       (local.set $0
+        (i32.and
+         (local.get $0)
+         (i32.const 255)
+        )
+       )
+       (br $label$2)
+      )
+     )
+    )
+    (local.set $0
+     (call $31
+      (local.get $1)
+      (local.get $0)
+     )
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $33 (; 46 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (local.set $2
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store
+    (local.tee $3
+     (local.get $2)
+    )
+    (local.get $1)
+   )
+   (local.set $0
+    (call $18
+     (i32.load
+      (i32.const 1024)
+     )
+     (local.get $0)
+     (local.get $3)
+    )
+   )
+   (global.set $global$1
+    (local.get $2)
+   )
+   (local.get $0)
+  )
+ )
+ (func $34 (; 47 ;) (type $1) (param $0 i32) (result i32)
+  (call $32
+   (local.get $0)
+   (i32.load
+    (i32.const 1024)
+   )
+  )
+ )
+ (func $35 (; 48 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (block $label$1 (result i32)
+   (local.set $14
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (local.set $18
+    (local.get $14)
+   )
+   (block $label$2
+    (if
+     (i32.lt_u
+      (local.get $0)
+      (i32.const 245)
+     )
+     (block
+      (local.set $3
+       (i32.and
+        (i32.add
+         (local.get $0)
+         (i32.const 11)
+        )
+        (i32.const -8)
+       )
+      )
+      (if
+       (i32.and
+        (local.tee $0
+         (i32.shr_u
+          (local.tee $8
+           (i32.load
+            (i32.const 3652)
+           )
+          )
+          (local.tee $2
+           (i32.shr_u
+            (if (result i32)
+             (i32.lt_u
+              (local.get $0)
+              (i32.const 11)
+             )
+             (local.tee $3
+              (i32.const 16)
+             )
+             (local.get $3)
+            )
+            (i32.const 3)
+           )
+          )
+         )
+        )
+        (i32.const 3)
+       )
+       (block
+        (local.set $4
+         (i32.load
+          (local.tee $1
+           (i32.add
+            (local.tee $7
+             (i32.load
+              (local.tee $3
+               (i32.add
+                (local.tee $2
+                 (i32.add
+                  (i32.shl
+                   (i32.shl
+                    (local.tee $5
+                     (i32.add
+                      (i32.xor
+                       (i32.and
+                        (local.get $0)
+                        (i32.const 1)
+                       )
+                       (i32.const 1)
+                      )
+                      (local.get $2)
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (i32.const 2)
+                  )
+                  (i32.const 3692)
+                 )
+                )
+                (i32.const 8)
+               )
+              )
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $4)
+         )
+         (i32.store
+          (i32.const 3652)
+          (i32.and
+           (local.get $8)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (local.get $5)
+            )
+            (i32.const -1)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $4)
+            (i32.load
+             (i32.const 3668)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $0
+              (i32.add
+               (local.get $4)
+               (i32.const 12)
+              )
+             )
+            )
+            (local.get $7)
+           )
+           (block
+            (i32.store
+             (local.get $0)
+             (local.get $2)
+            )
+            (i32.store
+             (local.get $3)
+             (local.get $4)
+            )
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (i32.store offset=4
+         (local.get $7)
+         (i32.or
+          (local.tee $0
+           (i32.shl
+            (local.get $5)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (local.tee $0
+          (i32.add
+           (i32.add
+            (local.get $7)
+            (local.get $0)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 1)
+         )
+        )
+        (global.set $global$1
+         (local.get $14)
+        )
+        (return
+         (local.get $1)
+        )
+       )
+      )
+      (if
+       (i32.gt_u
+        (local.get $3)
+        (local.tee $16
+         (i32.load
+          (i32.const 3660)
+         )
+        )
+       )
+       (block
+        (if
+         (local.get $0)
+         (block
+          (local.set $5
+           (i32.and
+            (i32.shr_u
+             (local.tee $0
+              (i32.add
+               (i32.and
+                (local.tee $0
+                 (i32.and
+                  (i32.shl
+                   (local.get $0)
+                   (local.get $2)
+                  )
+                  (i32.or
+                   (local.tee $0
+                    (i32.shl
+                     (i32.const 2)
+                     (local.get $2)
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (local.get $0)
+                   )
+                  )
+                 )
+                )
+                (i32.sub
+                 (i32.const 0)
+                 (local.get $0)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (local.set $12
+           (i32.load
+            (local.tee $5
+             (i32.add
+              (local.tee $9
+               (i32.load
+                (local.tee $2
+                 (i32.add
+                  (local.tee $4
+                   (i32.add
+                    (i32.shl
+                     (i32.shl
+                      (local.tee $11
+                       (i32.add
+                        (i32.or
+                         (i32.or
+                          (i32.or
+                           (i32.or
+                            (local.tee $0
+                             (i32.and
+                              (i32.shr_u
+                               (local.tee $2
+                                (i32.shr_u
+                                 (local.get $0)
+                                 (local.get $5)
+                                )
+                               )
+                               (i32.const 5)
+                              )
+                              (i32.const 8)
+                             )
+                            )
+                            (local.get $5)
+                           )
+                           (local.tee $0
+                            (i32.and
+                             (i32.shr_u
+                              (local.tee $2
+                               (i32.shr_u
+                                (local.get $2)
+                                (local.get $0)
+                               )
+                              )
+                              (i32.const 2)
+                             )
+                             (i32.const 4)
+                            )
+                           )
+                          )
+                          (local.tee $0
+                           (i32.and
+                            (i32.shr_u
+                             (local.tee $2
+                              (i32.shr_u
+                               (local.get $2)
+                               (local.get $0)
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                         (local.tee $0
+                          (i32.and
+                           (i32.shr_u
+                            (local.tee $2
+                             (i32.shr_u
+                              (local.get $2)
+                              (local.get $0)
+                             )
+                            )
+                            (i32.const 1)
+                           )
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (i32.shr_u
+                         (local.get $2)
+                         (local.get $0)
+                        )
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 2)
+                    )
+                    (i32.const 3692)
+                   )
+                  )
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (if
+           (i32.eq
+            (local.get $4)
+            (local.get $12)
+           )
+           (i32.store
+            (i32.const 3652)
+            (local.tee $7
+             (i32.and
+              (local.get $8)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (local.get $11)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $12)
+              (i32.load
+               (i32.const 3668)
+              )
+             )
+             (call $fimport$10)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (local.tee $0
+                (i32.add
+                 (local.get $12)
+                 (i32.const 12)
+                )
+               )
+              )
+              (local.get $9)
+             )
+             (block
+              (i32.store
+               (local.get $0)
+               (local.get $4)
+              )
+              (i32.store
+               (local.get $2)
+               (local.get $12)
+              )
+              (local.set $7
+               (local.get $8)
+              )
+             )
+             (call $fimport$10)
+            )
+           )
+          )
+          (i32.store offset=4
+           (local.get $9)
+           (i32.or
+            (local.get $3)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (local.tee $4
+            (i32.add
+             (local.get $9)
+             (local.get $3)
+            )
+           )
+           (i32.or
+            (local.tee $11
+             (i32.sub
+              (i32.shl
+               (local.get $11)
+               (i32.const 3)
+              )
+              (local.get $3)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (local.get $4)
+            (local.get $11)
+           )
+           (local.get $11)
+          )
+          (if
+           (local.get $16)
+           (block
+            (local.set $9
+             (i32.load
+              (i32.const 3672)
+             )
+            )
+            (local.set $2
+             (i32.add
+              (i32.shl
+               (i32.shl
+                (local.tee $0
+                 (i32.shr_u
+                  (local.get $16)
+                  (i32.const 3)
+                 )
+                )
+                (i32.const 1)
+               )
+               (i32.const 2)
+              )
+              (i32.const 3692)
+             )
+            )
+            (if
+             (i32.and
+              (local.get $7)
+              (local.tee $0
+               (i32.shl
+                (i32.const 1)
+                (local.get $0)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.tee $0
+                (i32.load
+                 (local.tee $3
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 8)
+                  )
+                 )
+                )
+               )
+               (i32.load
+                (i32.const 3668)
+               )
+              )
+              (call $fimport$10)
+              (block
+               (local.set $6
+                (local.get $3)
+               )
+               (local.set $1
+                (local.get $0)
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 3652)
+               (i32.or
+                (local.get $7)
+                (local.get $0)
+               )
+              )
+              (local.set $6
+               (i32.add
+                (local.get $2)
+                (i32.const 8)
+               )
+              )
+              (local.set $1
+               (local.get $2)
+              )
+             )
+            )
+            (i32.store
+             (local.get $6)
+             (local.get $9)
+            )
+            (i32.store offset=12
+             (local.get $1)
+             (local.get $9)
+            )
+            (i32.store offset=8
+             (local.get $9)
+             (local.get $1)
+            )
+            (i32.store offset=12
+             (local.get $9)
+             (local.get $2)
+            )
+           )
+          )
+          (i32.store
+           (i32.const 3660)
+           (local.get $11)
+          )
+          (i32.store
+           (i32.const 3672)
+           (local.get $4)
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (local.get $5)
+          )
+         )
+        )
+        (if
+         (local.tee $6
+          (i32.load
+           (i32.const 3656)
+          )
+         )
+         (block
+          (local.set $2
+           (i32.and
+            (i32.shr_u
+             (local.tee $0
+              (i32.add
+               (i32.and
+                (local.get $6)
+                (i32.sub
+                 (i32.const 0)
+                 (local.get $6)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (local.set $9
+           (i32.sub
+            (i32.and
+             (i32.load offset=4
+              (local.tee $2
+               (i32.load
+                (i32.add
+                 (i32.shl
+                  (i32.add
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (i32.or
+                       (local.tee $0
+                        (i32.and
+                         (i32.shr_u
+                          (local.tee $1
+                           (i32.shr_u
+                            (local.get $0)
+                            (local.get $2)
+                           )
+                          )
+                          (i32.const 5)
+                         )
+                         (i32.const 8)
+                        )
+                       )
+                       (local.get $2)
+                      )
+                      (local.tee $0
+                       (i32.and
+                        (i32.shr_u
+                         (local.tee $1
+                          (i32.shr_u
+                           (local.get $1)
+                           (local.get $0)
+                          )
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (local.tee $1
+                         (i32.shr_u
+                          (local.get $1)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 1)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (local.tee $1
+                        (i32.shr_u
+                         (local.get $1)
+                         (local.get $0)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.shr_u
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3956)
+                )
+               )
+              )
+             )
+             (i32.const -8)
+            )
+            (local.get $3)
+           )
+          )
+          (local.set $1
+           (local.get $2)
+          )
+          (loop $label$25
+           (block $label$26
+            (if
+             (i32.eqz
+              (local.tee $0
+               (i32.load offset=16
+                (local.get $1)
+               )
+              )
+             )
+             (br_if $label$26
+              (i32.eqz
+               (local.tee $0
+                (i32.load offset=20
+                 (local.get $1)
+                )
+               )
+              )
+             )
+            )
+            (if
+             (local.tee $7
+              (i32.lt_u
+               (local.tee $1
+                (i32.sub
+                 (i32.and
+                  (i32.load offset=4
+                   (local.get $0)
+                  )
+                  (i32.const -8)
+                 )
+                 (local.get $3)
+                )
+               )
+               (local.get $9)
+              )
+             )
+             (local.set $9
+              (local.get $1)
+             )
+            )
+            (local.set $1
+             (local.get $0)
+            )
+            (if
+             (local.get $7)
+             (local.set $2
+              (local.get $0)
+             )
+            )
+            (br $label$25)
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $2)
+            (local.tee $12
+             (i32.load
+              (i32.const 3668)
+             )
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.ge_u
+            (local.get $2)
+            (local.tee $13
+             (i32.add
+              (local.get $2)
+              (local.get $3)
+             )
+            )
+           )
+           (call $fimport$10)
+          )
+          (local.set $15
+           (i32.load offset=24
+            (local.get $2)
+           )
+          )
+          (block $label$32
+           (if
+            (i32.eq
+             (local.tee $0
+              (i32.load offset=12
+               (local.get $2)
+              )
+             )
+             (local.get $2)
+            )
+            (block
+             (if
+              (i32.eqz
+               (local.tee $0
+                (i32.load
+                 (local.tee $1
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+              )
+              (if
+               (i32.eqz
+                (local.tee $0
+                 (i32.load
+                  (local.tee $1
+                   (i32.add
+                    (local.get $2)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $4
+                 (i32.const 0)
+                )
+                (br $label$32)
+               )
+              )
+             )
+             (loop $label$36
+              (if
+               (local.tee $7
+                (i32.load
+                 (local.tee $11
+                  (i32.add
+                   (local.get $0)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $0
+                 (local.get $7)
+                )
+                (local.set $1
+                 (local.get $11)
+                )
+                (br $label$36)
+               )
+              )
+              (if
+               (local.tee $7
+                (i32.load
+                 (local.tee $11
+                  (i32.add
+                   (local.get $0)
+                   (i32.const 16)
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $0
+                 (local.get $7)
+                )
+                (local.set $1
+                 (local.get $11)
+                )
+                (br $label$36)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $1)
+               (local.get $12)
+              )
+              (call $fimport$10)
+              (block
+               (i32.store
+                (local.get $1)
+                (i32.const 0)
+               )
+               (local.set $4
+                (local.get $0)
+               )
+              )
+             )
+            )
+            (block
+             (if
+              (i32.lt_u
+               (local.tee $11
+                (i32.load offset=8
+                 (local.get $2)
+                )
+               )
+               (local.get $12)
+              )
+              (call $fimport$10)
+             )
+             (if
+              (i32.ne
+               (i32.load
+                (local.tee $7
+                 (i32.add
+                  (local.get $11)
+                  (i32.const 12)
+                 )
+                )
+               )
+               (local.get $2)
+              )
+              (call $fimport$10)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (local.tee $1
+                 (i32.add
+                  (local.get $0)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (local.get $2)
+              )
+              (block
+               (i32.store
+                (local.get $7)
+                (local.get $0)
+               )
+               (i32.store
+                (local.get $1)
+                (local.get $11)
+               )
+               (local.set $4
+                (local.get $0)
+               )
+              )
+              (call $fimport$10)
+             )
+            )
+           )
+          )
+          (block $label$46
+           (if
+            (local.get $15)
+            (block
+             (if
+              (i32.eq
+               (local.get $2)
+               (i32.load
+                (local.tee $0
+                 (i32.add
+                  (i32.shl
+                   (local.tee $1
+                    (i32.load offset=28
+                     (local.get $2)
+                    )
+                   )
+                   (i32.const 2)
+                  )
+                  (i32.const 3956)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (local.get $0)
+                (local.get $4)
+               )
+               (if
+                (i32.eqz
+                 (local.get $4)
+                )
+                (block
+                 (i32.store
+                  (i32.const 3656)
+                  (i32.and
+                   (local.get $6)
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (local.get $1)
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                 )
+                 (br $label$46)
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (local.get $15)
+                 (i32.load
+                  (i32.const 3668)
+                 )
+                )
+                (call $fimport$10)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (local.tee $0
+                   (i32.add
+                    (local.get $15)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                 (local.get $2)
+                )
+                (i32.store
+                 (local.get $0)
+                 (local.get $4)
+                )
+                (i32.store offset=20
+                 (local.get $15)
+                 (local.get $4)
+                )
+               )
+               (br_if $label$46
+                (i32.eqz
+                 (local.get $4)
+                )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $4)
+               (local.tee $0
+                (i32.load
+                 (i32.const 3668)
+                )
+               )
+              )
+              (call $fimport$10)
+             )
+             (i32.store offset=24
+              (local.get $4)
+              (local.get $15)
+             )
+             (if
+              (local.tee $1
+               (i32.load offset=16
+                (local.get $2)
+               )
+              )
+              (if
+               (i32.lt_u
+                (local.get $1)
+                (local.get $0)
+               )
+               (call $fimport$10)
+               (block
+                (i32.store offset=16
+                 (local.get $4)
+                 (local.get $1)
+                )
+                (i32.store offset=24
+                 (local.get $1)
+                 (local.get $4)
+                )
+               )
+              )
+             )
+             (if
+              (local.tee $0
+               (i32.load offset=20
+                (local.get $2)
+               )
+              )
+              (if
+               (i32.lt_u
+                (local.get $0)
+                (i32.load
+                 (i32.const 3668)
+                )
+               )
+               (call $fimport$10)
+               (block
+                (i32.store offset=20
+                 (local.get $4)
+                 (local.get $0)
+                )
+                (i32.store offset=24
+                 (local.get $0)
+                 (local.get $4)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $9)
+            (i32.const 16)
+           )
+           (block
+            (i32.store offset=4
+             (local.get $2)
+             (i32.or
+              (local.tee $0
+               (i32.add
+                (local.get $9)
+                (local.get $3)
+               )
+              )
+              (i32.const 3)
+             )
+            )
+            (i32.store
+             (local.tee $0
+              (i32.add
+               (i32.add
+                (local.get $2)
+                (local.get $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (local.get $0)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block
+            (i32.store offset=4
+             (local.get $2)
+             (i32.or
+              (local.get $3)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (local.get $13)
+             (i32.or
+              (local.get $9)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (local.get $13)
+              (local.get $9)
+             )
+             (local.get $9)
+            )
+            (if
+             (local.get $16)
+             (block
+              (local.set $7
+               (i32.load
+                (i32.const 3672)
+               )
+              )
+              (local.set $3
+               (i32.add
+                (i32.shl
+                 (i32.shl
+                  (local.tee $0
+                   (i32.shr_u
+                    (local.get $16)
+                    (i32.const 3)
+                   )
+                  )
+                  (i32.const 1)
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 3692)
+               )
+              )
+              (if
+               (i32.and
+                (local.get $8)
+                (local.tee $0
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $0)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.tee $0
+                  (i32.load
+                   (local.tee $1
+                    (i32.add
+                     (local.get $3)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (i32.load
+                  (i32.const 3668)
+                 )
+                )
+                (call $fimport$10)
+                (block
+                 (local.set $10
+                  (local.get $1)
+                 )
+                 (local.set $5
+                  (local.get $0)
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (i32.const 3652)
+                 (i32.or
+                  (local.get $8)
+                  (local.get $0)
+                 )
+                )
+                (local.set $10
+                 (i32.add
+                  (local.get $3)
+                  (i32.const 8)
+                 )
+                )
+                (local.set $5
+                 (local.get $3)
+                )
+               )
+              )
+              (i32.store
+               (local.get $10)
+               (local.get $7)
+              )
+              (i32.store offset=12
+               (local.get $5)
+               (local.get $7)
+              )
+              (i32.store offset=8
+               (local.get $7)
+               (local.get $5)
+              )
+              (i32.store offset=12
+               (local.get $7)
+               (local.get $3)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 3660)
+             (local.get $9)
+            )
+            (i32.store
+             (i32.const 3672)
+             (local.get $13)
+            )
+           )
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (i32.add
+            (local.get $2)
+            (i32.const 8)
+           )
+          )
+         )
+         (local.set $0
+          (local.get $3)
+         )
+        )
+       )
+       (local.set $0
+        (local.get $3)
+       )
+      )
+     )
+     (if
+      (i32.gt_u
+       (local.get $0)
+       (i32.const -65)
+      )
+      (local.set $0
+       (i32.const -1)
+      )
+      (block
+       (local.set $7
+        (i32.and
+         (local.tee $0
+          (i32.add
+           (local.get $0)
+           (i32.const 11)
+          )
+         )
+         (i32.const -8)
+        )
+       )
+       (if
+        (local.tee $5
+         (i32.load
+          (i32.const 3656)
+         )
+        )
+        (block
+         (local.set $17
+          (if (result i32)
+           (local.tee $0
+            (i32.shr_u
+             (local.get $0)
+             (i32.const 8)
+            )
+           )
+           (if (result i32)
+            (i32.gt_u
+             (local.get $7)
+             (i32.const 16777215)
+            )
+            (i32.const 31)
+            (i32.or
+             (i32.and
+              (i32.shr_u
+               (local.get $7)
+               (i32.add
+                (local.tee $0
+                 (i32.add
+                  (i32.sub
+                   (i32.const 14)
+                   (i32.or
+                    (i32.or
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (i32.add
+                         (local.tee $1
+                          (i32.shl
+                           (local.get $0)
+                           (local.tee $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 1048320)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 8)
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 520192)
+                        )
+                        (i32.const 16)
+                       )
+                       (i32.const 4)
+                      )
+                     )
+                     (local.get $3)
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (i32.add
+                        (local.tee $1
+                         (i32.shl
+                          (local.get $1)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 245760)
+                       )
+                       (i32.const 16)
+                      )
+                      (i32.const 2)
+                     )
+                    )
+                   )
+                  )
+                  (i32.shr_u
+                   (i32.shl
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                   (i32.const 15)
+                  )
+                 )
+                )
+                (i32.const 7)
+               )
+              )
+              (i32.const 1)
+             )
+             (i32.shl
+              (local.get $0)
+              (i32.const 1)
+             )
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (local.set $3
+          (i32.sub
+           (i32.const 0)
+           (local.get $7)
+          )
+         )
+         (block $label$78
+          (block $label$79
+           (block $label$80
+            (if
+             (local.tee $1
+              (i32.load
+               (i32.add
+                (i32.shl
+                 (local.get $17)
+                 (i32.const 2)
+                )
+                (i32.const 3956)
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (i32.sub
+                (i32.const 25)
+                (i32.shr_u
+                 (local.get $17)
+                 (i32.const 1)
+                )
+               )
+              )
+              (local.set $4
+               (i32.const 0)
+              )
+              (local.set $10
+               (i32.shl
+                (local.get $7)
+                (if (result i32)
+                 (i32.eq
+                  (local.get $17)
+                  (i32.const 31)
+                 )
+                 (i32.const 0)
+                 (local.get $0)
+                )
+               )
+              )
+              (local.set $0
+               (i32.const 0)
+              )
+              (loop $label$84
+               (if
+                (i32.lt_u
+                 (local.tee $6
+                  (i32.sub
+                   (i32.and
+                    (i32.load offset=4
+                     (local.get $1)
+                    )
+                    (i32.const -8)
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (local.get $3)
+                )
+                (if
+                 (local.get $6)
+                 (block
+                  (local.set $3
+                   (local.get $6)
+                  )
+                  (local.set $0
+                   (local.get $1)
+                  )
+                 )
+                 (block
+                  (local.set $3
+                   (i32.const 0)
+                  )
+                  (local.set $0
+                   (local.get $1)
+                  )
+                  (br $label$79)
+                 )
+                )
+               )
+               (local.set $1
+                (if (result i32)
+                 (i32.or
+                  (i32.eqz
+                   (local.tee $19
+                    (i32.load offset=20
+                     (local.get $1)
+                    )
+                   )
+                  )
+                  (i32.eq
+                   (local.get $19)
+                   (local.tee $6
+                    (i32.load
+                     (i32.add
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 16)
+                      )
+                      (i32.shl
+                       (i32.shr_u
+                        (local.get $10)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (local.get $4)
+                 (local.get $19)
+                )
+               )
+               (local.set $10
+                (i32.shl
+                 (local.get $10)
+                 (i32.xor
+                  (i32.and
+                   (local.tee $4
+                    (i32.eqz
+                     (local.get $6)
+                    )
+                   )
+                   (i32.const 1)
+                  )
+                  (i32.const 1)
+                 )
+                )
+               )
+               (if
+                (local.get $4)
+                (block
+                 (local.set $4
+                  (local.get $1)
+                 )
+                 (local.set $1
+                  (local.get $0)
+                 )
+                 (br $label$80)
+                )
+                (block
+                 (local.set $4
+                  (local.get $1)
+                 )
+                 (local.set $1
+                  (local.get $6)
+                 )
+                 (br $label$84)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $4
+               (i32.const 0)
+              )
+              (local.set $1
+               (i32.const 0)
+              )
+             )
+            )
+           )
+           (br_if $label$79
+            (local.tee $0
+             (if (result i32)
+              (i32.and
+               (i32.eqz
+                (local.get $4)
+               )
+               (i32.eqz
+                (local.get $1)
+               )
+              )
+              (block (result i32)
+               (if
+                (i32.eqz
+                 (local.tee $0
+                  (i32.and
+                   (local.get $5)
+                   (i32.or
+                    (local.tee $0
+                     (i32.shl
+                      (i32.const 2)
+                      (local.get $17)
+                     )
+                    )
+                    (i32.sub
+                     (i32.const 0)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                 )
+                )
+                (block
+                 (local.set $0
+                  (local.get $7)
+                 )
+                 (br $label$2)
+                )
+               )
+               (local.set $10
+                (i32.and
+                 (i32.shr_u
+                  (local.tee $0
+                   (i32.add
+                    (i32.and
+                     (local.get $0)
+                     (i32.sub
+                      (i32.const 0)
+                      (local.get $0)
+                     )
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                  (i32.const 12)
+                 )
+                 (i32.const 16)
+                )
+               )
+               (i32.load
+                (i32.add
+                 (i32.shl
+                  (i32.add
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (i32.or
+                       (local.tee $0
+                        (i32.and
+                         (i32.shr_u
+                          (local.tee $4
+                           (i32.shr_u
+                            (local.get $0)
+                            (local.get $10)
+                           )
+                          )
+                          (i32.const 5)
+                         )
+                         (i32.const 8)
+                        )
+                       )
+                       (local.get $10)
+                      )
+                      (local.tee $0
+                       (i32.and
+                        (i32.shr_u
+                         (local.tee $4
+                          (i32.shr_u
+                           (local.get $4)
+                           (local.get $0)
+                          )
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (local.tee $4
+                         (i32.shr_u
+                          (local.get $4)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 1)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (local.tee $4
+                        (i32.shr_u
+                         (local.get $4)
+                         (local.get $0)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.shr_u
+                    (local.get $4)
+                    (local.get $0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3956)
+                )
+               )
+              )
+              (local.get $4)
+             )
+            )
+           )
+           (local.set $4
+            (local.get $1)
+           )
+           (br $label$78)
+          )
+          (loop $label$96
+           (if
+            (local.tee $10
+             (i32.lt_u
+              (local.tee $4
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (local.get $0)
+                 )
+                 (i32.const -8)
+                )
+                (local.get $7)
+               )
+              )
+              (local.get $3)
+             )
+            )
+            (local.set $3
+             (local.get $4)
+            )
+           )
+           (if
+            (local.get $10)
+            (local.set $1
+             (local.get $0)
+            )
+           )
+           (if
+            (local.tee $4
+             (i32.load offset=16
+              (local.get $0)
+             )
+            )
+            (block
+             (local.set $0
+              (local.get $4)
+             )
+             (br $label$96)
+            )
+           )
+           (br_if $label$96
+            (local.tee $0
+             (i32.load offset=20
+              (local.get $0)
+             )
+            )
+           )
+           (local.set $4
+            (local.get $1)
+           )
+          )
+         )
+         (if
+          (local.get $4)
+          (if
+           (i32.lt_u
+            (local.get $3)
+            (i32.sub
+             (i32.load
+              (i32.const 3660)
+             )
+             (local.get $7)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $4)
+              (local.tee $12
+               (i32.load
+                (i32.const 3668)
+               )
+              )
+             )
+             (call $fimport$10)
+            )
+            (if
+             (i32.ge_u
+              (local.get $4)
+              (local.tee $6
+               (i32.add
+                (local.get $4)
+                (local.get $7)
+               )
+              )
+             )
+             (call $fimport$10)
+            )
+            (local.set $10
+             (i32.load offset=24
+              (local.get $4)
+             )
+            )
+            (block $label$104
+             (if
+              (i32.eq
+               (local.tee $0
+                (i32.load offset=12
+                 (local.get $4)
+                )
+               )
+               (local.get $4)
+              )
+              (block
+               (if
+                (i32.eqz
+                 (local.tee $0
+                  (i32.load
+                   (local.tee $1
+                    (i32.add
+                     (local.get $4)
+                     (i32.const 20)
+                    )
+                   )
+                  )
+                 )
+                )
+                (if
+                 (i32.eqz
+                  (local.tee $0
+                   (i32.load
+                    (local.tee $1
+                     (i32.add
+                      (local.get $4)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $13
+                   (i32.const 0)
+                  )
+                  (br $label$104)
+                 )
+                )
+               )
+               (loop $label$108
+                (if
+                 (local.tee $11
+                  (i32.load
+                   (local.tee $9
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 20)
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $0
+                   (local.get $11)
+                  )
+                  (local.set $1
+                   (local.get $9)
+                  )
+                  (br $label$108)
+                 )
+                )
+                (if
+                 (local.tee $11
+                  (i32.load
+                   (local.tee $9
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $0
+                   (local.get $11)
+                  )
+                  (local.set $1
+                   (local.get $9)
+                  )
+                  (br $label$108)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $1)
+                 (local.get $12)
+                )
+                (call $fimport$10)
+                (block
+                 (i32.store
+                  (local.get $1)
+                  (i32.const 0)
+                 )
+                 (local.set $13
+                  (local.get $0)
+                 )
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (local.tee $9
+                  (i32.load offset=8
+                   (local.get $4)
+                  )
+                 )
+                 (local.get $12)
+                )
+                (call $fimport$10)
+               )
+               (if
+                (i32.ne
+                 (i32.load
+                  (local.tee $11
+                   (i32.add
+                    (local.get $9)
+                    (i32.const 12)
+                   )
+                  )
+                 )
+                 (local.get $4)
+                )
+                (call $fimport$10)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (local.tee $1
+                   (i32.add
+                    (local.get $0)
+                    (i32.const 8)
+                   )
+                  )
+                 )
+                 (local.get $4)
+                )
+                (block
+                 (i32.store
+                  (local.get $11)
+                  (local.get $0)
+                 )
+                 (i32.store
+                  (local.get $1)
+                  (local.get $9)
+                 )
+                 (local.set $13
+                  (local.get $0)
+                 )
+                )
+                (call $fimport$10)
+               )
+              )
+             )
+            )
+            (block $label$118
+             (if
+              (local.get $10)
+              (block
+               (if
+                (i32.eq
+                 (local.get $4)
+                 (i32.load
+                  (local.tee $0
+                   (i32.add
+                    (i32.shl
+                     (local.tee $1
+                      (i32.load offset=28
+                       (local.get $4)
+                      )
+                     )
+                     (i32.const 2)
+                    )
+                    (i32.const 3956)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (local.get $0)
+                  (local.get $13)
+                 )
+                 (if
+                  (i32.eqz
+                   (local.get $13)
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 3656)
+                    (local.tee $2
+                     (i32.and
+                      (local.get $5)
+                      (i32.xor
+                       (i32.shl
+                        (i32.const 1)
+                        (local.get $1)
+                       )
+                       (i32.const -1)
+                      )
+                     )
+                    )
+                   )
+                   (br $label$118)
+                  )
+                 )
+                )
+                (block
+                 (if
+                  (i32.lt_u
+                   (local.get $10)
+                   (i32.load
+                    (i32.const 3668)
+                   )
+                  )
+                  (call $fimport$10)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (local.tee $0
+                     (i32.add
+                      (local.get $10)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                   (local.get $4)
+                  )
+                  (i32.store
+                   (local.get $0)
+                   (local.get $13)
+                  )
+                  (i32.store offset=20
+                   (local.get $10)
+                   (local.get $13)
+                  )
+                 )
+                 (if
+                  (i32.eqz
+                   (local.get $13)
+                  )
+                  (block
+                   (local.set $2
+                    (local.get $5)
+                   )
+                   (br $label$118)
+                  )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $13)
+                 (local.tee $0
+                  (i32.load
+                   (i32.const 3668)
+                  )
+                 )
+                )
+                (call $fimport$10)
+               )
+               (i32.store offset=24
+                (local.get $13)
+                (local.get $10)
+               )
+               (if
+                (local.tee $1
+                 (i32.load offset=16
+                  (local.get $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (local.get $1)
+                  (local.get $0)
+                 )
+                 (call $fimport$10)
+                 (block
+                  (i32.store offset=16
+                   (local.get $13)
+                   (local.get $1)
+                  )
+                  (i32.store offset=24
+                   (local.get $1)
+                   (local.get $13)
+                  )
+                 )
+                )
+               )
+               (if
+                (local.tee $0
+                 (i32.load offset=20
+                  (local.get $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (local.get $0)
+                  (i32.load
+                   (i32.const 3668)
+                  )
+                 )
+                 (call $fimport$10)
+                 (block
+                  (i32.store offset=20
+                   (local.get $13)
+                   (local.get $0)
+                  )
+                  (i32.store offset=24
+                   (local.get $0)
+                   (local.get $13)
+                  )
+                  (local.set $2
+                   (local.get $5)
+                  )
+                 )
+                )
+                (local.set $2
+                 (local.get $5)
+                )
+               )
+              )
+              (local.set $2
+               (local.get $5)
+              )
+             )
+            )
+            (block $label$136
+             (if
+              (i32.lt_u
+               (local.get $3)
+               (i32.const 16)
+              )
+              (block
+               (i32.store offset=4
+                (local.get $4)
+                (i32.or
+                 (local.tee $0
+                  (i32.add
+                   (local.get $3)
+                   (local.get $7)
+                  )
+                 )
+                 (i32.const 3)
+                )
+               )
+               (i32.store
+                (local.tee $0
+                 (i32.add
+                  (i32.add
+                   (local.get $4)
+                   (local.get $0)
+                  )
+                  (i32.const 4)
+                 )
+                )
+                (i32.or
+                 (i32.load
+                  (local.get $0)
+                 )
+                 (i32.const 1)
+                )
+               )
+              )
+              (block
+               (i32.store offset=4
+                (local.get $4)
+                (i32.or
+                 (local.get $7)
+                 (i32.const 3)
+                )
+               )
+               (i32.store offset=4
+                (local.get $6)
+                (i32.or
+                 (local.get $3)
+                 (i32.const 1)
+                )
+               )
+               (i32.store
+                (i32.add
+                 (local.get $6)
+                 (local.get $3)
+                )
+                (local.get $3)
+               )
+               (local.set $0
+                (i32.shr_u
+                 (local.get $3)
+                 (i32.const 3)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $3)
+                 (i32.const 256)
+                )
+                (block
+                 (local.set $3
+                  (i32.add
+                   (i32.shl
+                    (i32.shl
+                     (local.get $0)
+                     (i32.const 1)
+                    )
+                    (i32.const 2)
+                   )
+                   (i32.const 3692)
+                  )
+                 )
+                 (if
+                  (i32.and
+                   (local.tee $1
+                    (i32.load
+                     (i32.const 3652)
+                    )
+                   )
+                   (local.tee $0
+                    (i32.shl
+                     (i32.const 1)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.lt_u
+                    (local.tee $0
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $3)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                    )
+                    (i32.load
+                     (i32.const 3668)
+                    )
+                   )
+                   (call $fimport$10)
+                   (block
+                    (local.set $16
+                     (local.get $1)
+                    )
+                    (local.set $8
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 3652)
+                    (i32.or
+                     (local.get $1)
+                     (local.get $0)
+                    )
+                   )
+                   (local.set $16
+                    (i32.add
+                     (local.get $3)
+                     (i32.const 8)
+                    )
+                   )
+                   (local.set $8
+                    (local.get $3)
+                   )
+                  )
+                 )
+                 (i32.store
+                  (local.get $16)
+                  (local.get $6)
+                 )
+                 (i32.store offset=12
+                  (local.get $8)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $8)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $3)
+                 )
+                 (br $label$136)
+                )
+               )
+               (local.set $1
+                (i32.add
+                 (i32.shl
+                  (local.tee $5
+                   (if (result i32)
+                    (local.tee $0
+                     (i32.shr_u
+                      (local.get $3)
+                      (i32.const 8)
+                     )
+                    )
+                    (if (result i32)
+                     (i32.gt_u
+                      (local.get $3)
+                      (i32.const 16777215)
+                     )
+                     (i32.const 31)
+                     (i32.or
+                      (i32.and
+                       (i32.shr_u
+                        (local.get $3)
+                        (i32.add
+                         (local.tee $0
+                          (i32.add
+                           (i32.sub
+                            (i32.const 14)
+                            (i32.or
+                             (i32.or
+                              (local.tee $0
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (local.tee $1
+                                   (i32.shl
+                                    (local.get $0)
+                                    (local.tee $5
+                                     (i32.and
+                                      (i32.shr_u
+                                       (i32.add
+                                        (local.get $0)
+                                        (i32.const 1048320)
+                                       )
+                                       (i32.const 16)
+                                      )
+                                      (i32.const 8)
+                                     )
+                                    )
+                                   )
+                                  )
+                                  (i32.const 520192)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 4)
+                               )
+                              )
+                              (local.get $5)
+                             )
+                             (local.tee $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (local.tee $1
+                                  (i32.shl
+                                   (local.get $1)
+                                   (local.get $0)
+                                  )
+                                 )
+                                 (i32.const 245760)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 2)
+                              )
+                             )
+                            )
+                           )
+                           (i32.shr_u
+                            (i32.shl
+                             (local.get $1)
+                             (local.get $0)
+                            )
+                            (i32.const 15)
+                           )
+                          )
+                         )
+                         (i32.const 7)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.shl
+                       (local.get $0)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (i32.const 0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3956)
+                )
+               )
+               (i32.store offset=28
+                (local.get $6)
+                (local.get $5)
+               )
+               (i32.store offset=4
+                (local.tee $0
+                 (i32.add
+                  (local.get $6)
+                  (i32.const 16)
+                 )
+                )
+                (i32.const 0)
+               )
+               (i32.store
+                (local.get $0)
+                (i32.const 0)
+               )
+               (if
+                (i32.eqz
+                 (i32.and
+                  (local.get $2)
+                  (local.tee $0
+                   (i32.shl
+                    (i32.const 1)
+                    (local.get $5)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (i32.const 3656)
+                  (i32.or
+                   (local.get $2)
+                   (local.get $0)
+                  )
+                 )
+                 (i32.store
+                  (local.get $1)
+                  (local.get $6)
+                 )
+                 (i32.store offset=24
+                  (local.get $6)
+                  (local.get $1)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (br $label$136)
+                )
+               )
+               (local.set $0
+                (i32.load
+                 (local.get $1)
+                )
+               )
+               (local.set $1
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (local.get $5)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (local.set $5
+                (i32.shl
+                 (local.get $3)
+                 (if (result i32)
+                  (i32.eq
+                   (local.get $5)
+                   (i32.const 31)
+                  )
+                  (i32.const 0)
+                  (local.get $1)
+                 )
+                )
+               )
+               (block $label$151
+                (block $label$152
+                 (block $label$153
+                  (loop $label$154
+                   (br_if $label$152
+                    (i32.eq
+                     (i32.and
+                      (i32.load offset=4
+                       (local.get $0)
+                      )
+                      (i32.const -8)
+                     )
+                     (local.get $3)
+                    )
+                   )
+                   (local.set $2
+                    (i32.shl
+                     (local.get $5)
+                     (i32.const 1)
+                    )
+                   )
+                   (br_if $label$153
+                    (i32.eqz
+                     (local.tee $1
+                      (i32.load
+                       (local.tee $5
+                        (i32.add
+                         (i32.add
+                          (local.get $0)
+                          (i32.const 16)
+                         )
+                         (i32.shl
+                          (i32.shr_u
+                           (local.get $5)
+                           (i32.const 31)
+                          )
+                          (i32.const 2)
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (local.set $5
+                    (local.get $2)
+                   )
+                   (local.set $0
+                    (local.get $1)
+                   )
+                   (br $label$154)
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (local.get $5)
+                   (i32.load
+                    (i32.const 3668)
+                   )
+                  )
+                  (call $fimport$10)
+                  (block
+                   (i32.store
+                    (local.get $5)
+                    (local.get $6)
+                   )
+                   (i32.store offset=24
+                    (local.get $6)
+                    (local.get $0)
+                   )
+                   (i32.store offset=12
+                    (local.get $6)
+                    (local.get $6)
+                   )
+                   (i32.store offset=8
+                    (local.get $6)
+                    (local.get $6)
+                   )
+                   (br $label$136)
+                  )
+                 )
+                 (br $label$151)
+                )
+                (if
+                 (i32.and
+                  (i32.ge_u
+                   (local.tee $2
+                    (i32.load
+                     (local.tee $3
+                      (i32.add
+                       (local.get $0)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (local.tee $1
+                    (i32.load
+                     (i32.const 3668)
+                    )
+                   )
+                  )
+                  (i32.ge_u
+                   (local.get $0)
+                   (local.get $1)
+                  )
+                 )
+                 (block
+                  (i32.store offset=12
+                   (local.get $2)
+                   (local.get $6)
+                  )
+                  (i32.store
+                   (local.get $3)
+                   (local.get $6)
+                  )
+                  (i32.store offset=8
+                   (local.get $6)
+                   (local.get $2)
+                  )
+                  (i32.store offset=12
+                   (local.get $6)
+                   (local.get $0)
+                  )
+                  (i32.store offset=24
+                   (local.get $6)
+                   (i32.const 0)
+                  )
+                 )
+                 (call $fimport$10)
+                )
+               )
+              )
+             )
+            )
+            (global.set $global$1
+             (local.get $14)
+            )
+            (return
+             (i32.add
+              (local.get $4)
+              (i32.const 8)
+             )
+            )
+           )
+           (local.set $0
+            (local.get $7)
+           )
+          )
+          (local.set $0
+           (local.get $7)
+          )
+         )
+        )
+        (local.set $0
+         (local.get $7)
+        )
+       )
+      )
+     )
+    )
+   )
+   (if
+    (i32.ge_u
+     (local.tee $1
+      (i32.load
+       (i32.const 3660)
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (local.set $2
+      (i32.load
+       (i32.const 3672)
+      )
+     )
+     (if
+      (i32.gt_u
+       (local.tee $3
+        (i32.sub
+         (local.get $1)
+         (local.get $0)
+        )
+       )
+       (i32.const 15)
+      )
+      (block
+       (i32.store
+        (i32.const 3672)
+        (local.tee $1
+         (i32.add
+          (local.get $2)
+          (local.get $0)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3660)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $1)
+        (i32.or
+         (local.get $3)
+         (i32.const 1)
+        )
+       )
+       (i32.store
+        (i32.add
+         (local.get $1)
+         (local.get $3)
+        )
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $2)
+        (i32.or
+         (local.get $0)
+         (i32.const 3)
+        )
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3660)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 3672)
+        (i32.const 0)
+       )
+       (i32.store offset=4
+        (local.get $2)
+        (i32.or
+         (local.get $1)
+         (i32.const 3)
+        )
+       )
+       (i32.store
+        (local.tee $0
+         (i32.add
+          (i32.add
+           (local.get $2)
+           (local.get $1)
+          )
+          (i32.const 4)
+         )
+        )
+        (i32.or
+         (i32.load
+          (local.get $0)
+         )
+         (i32.const 1)
+        )
+       )
+      )
+     )
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+     )
+    )
+   )
+   (if
+    (i32.gt_u
+     (local.tee $10
+      (i32.load
+       (i32.const 3664)
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (i32.store
+      (i32.const 3664)
+      (local.tee $3
+       (i32.sub
+        (local.get $10)
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (i32.const 3676)
+      (local.tee $1
+       (i32.add
+        (local.tee $2
+         (i32.load
+          (i32.const 3676)
+         )
+        )
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store offset=4
+      (local.get $1)
+      (i32.or
+       (local.get $3)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=4
+      (local.get $2)
+      (i32.or
+       (local.get $0)
+       (i32.const 3)
+      )
+     )
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+     )
+    )
+   )
+   (if
+    (i32.le_u
+     (local.tee $6
+      (i32.and
+       (local.tee $8
+        (i32.add
+         (local.tee $1
+          (if (result i32)
+           (i32.load
+            (i32.const 4124)
+           )
+           (i32.load
+            (i32.const 4132)
+           )
+           (block (result i32)
+            (i32.store
+             (i32.const 4132)
+             (i32.const 4096)
+            )
+            (i32.store
+             (i32.const 4128)
+             (i32.const 4096)
+            )
+            (i32.store
+             (i32.const 4136)
+             (i32.const -1)
+            )
+            (i32.store
+             (i32.const 4140)
+             (i32.const -1)
+            )
+            (i32.store
+             (i32.const 4144)
+             (i32.const 0)
+            )
+            (i32.store
+             (i32.const 4096)
+             (i32.const 0)
+            )
+            (i32.store
+             (local.get $18)
+             (local.tee $1
+              (i32.xor
+               (i32.and
+                (local.get $18)
+                (i32.const -16)
+               )
+               (i32.const 1431655768)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 4124)
+             (local.get $1)
+            )
+            (i32.const 4096)
+           )
+          )
+         )
+         (local.tee $13
+          (i32.add
+           (local.get $0)
+           (i32.const 47)
+          )
+         )
+        )
+       )
+       (local.tee $4
+        (i32.sub
+         (i32.const 0)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.const 0)
+     )
+    )
+   )
+   (if
+    (local.tee $2
+     (i32.load
+      (i32.const 4092)
+     )
+    )
+    (if
+     (i32.or
+      (i32.le_u
+       (local.tee $1
+        (i32.add
+         (local.tee $3
+          (i32.load
+           (i32.const 4084)
+          )
+         )
+         (local.get $6)
+        )
+       )
+       (local.get $3)
+      )
+      (i32.gt_u
+       (local.get $1)
+       (local.get $2)
+      )
+     )
+     (block
+      (global.set $global$1
+       (local.get $14)
+      )
+      (return
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (local.set $7
+    (i32.add
+     (local.get $0)
+     (i32.const 48)
+    )
+   )
+   (block $label$171
+    (block $label$172
+     (if
+      (i32.eqz
+       (i32.and
+        (i32.load
+         (i32.const 4096)
+        )
+        (i32.const 4)
+       )
+      )
+      (block
+       (block $label$174
+        (block $label$175
+         (block $label$176
+          (br_if $label$176
+           (i32.eqz
+            (local.tee $3
+             (i32.load
+              (i32.const 3676)
+             )
+            )
+           )
+          )
+          (local.set $2
+           (i32.const 4100)
+          )
+          (loop $label$177
+           (block $label$178
+            (if
+             (i32.le_u
+              (local.tee $1
+               (i32.load
+                (local.get $2)
+               )
+              )
+              (local.get $3)
+             )
+             (br_if $label$178
+              (i32.gt_u
+               (i32.add
+                (local.get $1)
+                (i32.load
+                 (local.tee $5
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 4)
+                  )
+                 )
+                )
+               )
+               (local.get $3)
+              )
+             )
+            )
+            (br_if $label$176
+             (i32.eqz
+              (local.tee $1
+               (i32.load offset=8
+                (local.get $2)
+               )
+              )
+             )
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$177)
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.tee $3
+             (i32.and
+              (i32.sub
+               (local.get $8)
+               (local.get $10)
+              )
+              (local.get $4)
+             )
+            )
+            (i32.const 2147483647)
+           )
+           (if
+            (i32.eq
+             (local.tee $1
+              (call $38
+               (local.get $3)
+              )
+             )
+             (i32.add
+              (i32.load
+               (local.get $2)
+              )
+              (i32.load
+               (local.get $5)
+              )
+             )
+            )
+            (br_if $label$172
+             (i32.ne
+              (local.get $1)
+              (i32.const -1)
+             )
+            )
+            (block
+             (local.set $2
+              (local.get $1)
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$175)
+            )
+           )
+          )
+          (br $label$174)
+         )
+         (if
+          (i32.ne
+           (local.tee $1
+            (call $38
+             (i32.const 0)
+            )
+           )
+           (i32.const -1)
+          )
+          (block
+           (local.set $2
+            (i32.sub
+             (i32.and
+              (i32.add
+               (local.tee $5
+                (i32.add
+                 (local.tee $2
+                  (i32.load
+                   (i32.const 4128)
+                  )
+                 )
+                 (i32.const -1)
+                )
+               )
+               (local.tee $3
+                (local.get $1)
+               )
+              )
+              (i32.sub
+               (i32.const 0)
+               (local.get $2)
+              )
+             )
+             (local.get $3)
+            )
+           )
+           (local.set $4
+            (i32.add
+             (local.tee $3
+              (i32.add
+               (if (result i32)
+                (i32.and
+                 (local.get $5)
+                 (local.get $3)
+                )
+                (local.get $2)
+                (i32.const 0)
+               )
+               (local.get $6)
+              )
+             )
+             (local.tee $5
+              (i32.load
+               (i32.const 4084)
+              )
+             )
+            )
+           )
+           (if
+            (i32.and
+             (i32.gt_u
+              (local.get $3)
+              (local.get $0)
+             )
+             (i32.lt_u
+              (local.get $3)
+              (i32.const 2147483647)
+             )
+            )
+            (block
+             (if
+              (local.tee $2
+               (i32.load
+                (i32.const 4092)
+               )
+              )
+              (br_if $label$174
+               (i32.or
+                (i32.le_u
+                 (local.get $4)
+                 (local.get $5)
+                )
+                (i32.gt_u
+                 (local.get $4)
+                 (local.get $2)
+                )
+               )
+              )
+             )
+             (br_if $label$172
+              (i32.eq
+               (local.tee $2
+                (call $38
+                 (local.get $3)
+                )
+               )
+               (local.get $1)
+              )
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$175)
+            )
+           )
+          )
+         )
+         (br $label$174)
+        )
+        (local.set $5
+         (i32.sub
+          (i32.const 0)
+          (local.get $1)
+         )
+        )
+        (if
+         (i32.and
+          (i32.gt_u
+           (local.get $7)
+           (local.get $1)
+          )
+          (i32.and
+           (i32.lt_u
+            (local.get $1)
+            (i32.const 2147483647)
+           )
+           (i32.ne
+            (local.get $2)
+            (i32.const -1)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.tee $3
+            (i32.and
+             (i32.add
+              (i32.sub
+               (local.get $13)
+               (local.get $1)
+              )
+              (local.tee $3
+               (i32.load
+                (i32.const 4132)
+               )
+              )
+             )
+             (i32.sub
+              (i32.const 0)
+              (local.get $3)
+             )
+            )
+           )
+           (i32.const 2147483647)
+          )
+          (if
+           (i32.eq
+            (call $38
+             (local.get $3)
+            )
+            (i32.const -1)
+           )
+           (block
+            (drop
+             (call $38
+              (local.get $5)
+             )
+            )
+            (br $label$174)
+           )
+           (local.set $3
+            (i32.add
+             (local.get $3)
+             (local.get $1)
+            )
+           )
+          )
+          (local.set $3
+           (local.get $1)
+          )
+         )
+         (local.set $3
+          (local.get $1)
+         )
+        )
+        (if
+         (i32.ne
+          (local.get $2)
+          (i32.const -1)
+         )
+         (block
+          (local.set $1
+           (local.get $2)
+          )
+          (br $label$172)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 4096)
+        (i32.or
+         (i32.load
+          (i32.const 4096)
+         )
+         (i32.const 4)
+        )
+       )
+      )
+     )
+     (if
+      (i32.lt_u
+       (local.get $6)
+       (i32.const 2147483647)
+      )
+      (if
+       (i32.and
+        (i32.lt_u
+         (local.tee $1
+          (call $38
+           (local.get $6)
+          )
+         )
+         (local.tee $3
+          (call $38
+           (i32.const 0)
+          )
+         )
+        )
+        (i32.and
+         (i32.ne
+          (local.get $1)
+          (i32.const -1)
+         )
+         (i32.ne
+          (local.get $3)
+          (i32.const -1)
+         )
+        )
+       )
+       (br_if $label$172
+        (i32.gt_u
+         (local.tee $3
+          (i32.sub
+           (local.get $3)
+           (local.get $1)
+          )
+         )
+         (i32.add
+          (local.get $0)
+          (i32.const 40)
+         )
+        )
+       )
+      )
+     )
+     (br $label$171)
+    )
+    (i32.store
+     (i32.const 4084)
+     (local.tee $2
+      (i32.add
+       (i32.load
+        (i32.const 4084)
+       )
+       (local.get $3)
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (local.get $2)
+      (i32.load
+       (i32.const 4088)
+      )
+     )
+     (i32.store
+      (i32.const 4088)
+      (local.get $2)
+     )
+    )
+    (block $label$198
+     (if
+      (local.tee $8
+       (i32.load
+        (i32.const 3676)
+       )
+      )
+      (block
+       (local.set $2
+        (i32.const 4100)
+       )
+       (block $label$200
+        (block $label$201
+         (loop $label$202
+          (br_if $label$201
+           (i32.eq
+            (local.get $1)
+            (i32.add
+             (local.tee $4
+              (i32.load
+               (local.get $2)
+              )
+             )
+             (local.tee $5
+              (i32.load
+               (local.tee $7
+                (i32.add
+                 (local.get $2)
+                 (i32.const 4)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (br_if $label$202
+           (local.tee $2
+            (i32.load offset=8
+             (local.get $2)
+            )
+           )
+          )
+         )
+         (br $label$200)
+        )
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.load offset=12
+            (local.get $2)
+           )
+           (i32.const 8)
+          )
+         )
+         (if
+          (i32.and
+           (i32.lt_u
+            (local.get $8)
+            (local.get $1)
+           )
+           (i32.ge_u
+            (local.get $8)
+            (local.get $4)
+           )
+          )
+          (block
+           (i32.store
+            (local.get $7)
+            (i32.add
+             (local.get $5)
+             (local.get $3)
+            )
+           )
+           (local.set $5
+            (i32.load
+             (i32.const 3664)
+            )
+           )
+           (local.set $1
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (local.tee $2
+               (i32.add
+                (local.get $8)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+           )
+           (i32.store
+            (i32.const 3676)
+            (local.tee $2
+             (i32.add
+              (local.get $8)
+              (if (result i32)
+               (i32.and
+                (local.get $2)
+                (i32.const 7)
+               )
+               (local.get $1)
+               (local.tee $1
+                (i32.const 0)
+               )
+              )
+             )
+            )
+           )
+           (i32.store
+            (i32.const 3664)
+            (local.tee $1
+             (i32.add
+              (i32.sub
+               (local.get $3)
+               (local.get $1)
+              )
+              (local.get $5)
+             )
+            )
+           )
+           (i32.store offset=4
+            (local.get $2)
+            (i32.or
+             (local.get $1)
+             (i32.const 1)
+            )
+           )
+           (i32.store offset=4
+            (i32.add
+             (local.get $2)
+             (local.get $1)
+            )
+            (i32.const 40)
+           )
+           (i32.store
+            (i32.const 3680)
+            (i32.load
+             (i32.const 4140)
+            )
+           )
+           (br $label$198)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (local.get $1)
+         (local.tee $2
+          (i32.load
+           (i32.const 3668)
+          )
+         )
+        )
+        (block
+         (i32.store
+          (i32.const 3668)
+          (local.get $1)
+         )
+         (local.set $2
+          (local.get $1)
+         )
+        )
+       )
+       (local.set $10
+        (i32.add
+         (local.get $1)
+         (local.get $3)
+        )
+       )
+       (local.set $5
+        (i32.const 4100)
+       )
+       (block $label$208
+        (block $label$209
+         (loop $label$210
+          (br_if $label$209
+           (i32.eq
+            (i32.load
+             (local.get $5)
+            )
+            (local.get $10)
+           )
+          )
+          (br_if $label$210
+           (local.tee $5
+            (i32.load offset=8
+             (local.get $5)
+            )
+           )
+          )
+          (local.set $5
+           (i32.const 4100)
+          )
+         )
+         (br $label$208)
+        )
+        (if
+         (i32.and
+          (i32.load offset=12
+           (local.get $5)
+          )
+          (i32.const 8)
+         )
+         (local.set $5
+          (i32.const 4100)
+         )
+         (block
+          (i32.store
+           (local.get $5)
+           (local.get $1)
+          )
+          (i32.store
+           (local.tee $5
+            (i32.add
+             (local.get $5)
+             (i32.const 4)
+            )
+           )
+           (i32.add
+            (i32.load
+             (local.get $5)
+            )
+            (local.get $3)
+           )
+          )
+          (local.set $7
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (local.tee $4
+              (i32.add
+               (local.get $1)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+          )
+          (local.set $3
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (local.tee $5
+              (i32.add
+               (local.get $10)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+          )
+          (local.set $6
+           (i32.add
+            (local.tee $13
+             (i32.add
+              (local.get $1)
+              (if (result i32)
+               (i32.and
+                (local.get $4)
+                (i32.const 7)
+               )
+               (local.get $7)
+               (i32.const 0)
+              )
+             )
+            )
+            (local.get $0)
+           )
+          )
+          (local.set $7
+           (i32.sub
+            (i32.sub
+             (local.tee $4
+              (i32.add
+               (local.get $10)
+               (if (result i32)
+                (i32.and
+                 (local.get $5)
+                 (i32.const 7)
+                )
+                (local.get $3)
+                (i32.const 0)
+               )
+              )
+             )
+             (local.get $13)
+            )
+            (local.get $0)
+           )
+          )
+          (i32.store offset=4
+           (local.get $13)
+           (i32.or
+            (local.get $0)
+            (i32.const 3)
+           )
+          )
+          (block $label$217
+           (if
+            (i32.eq
+             (local.get $4)
+             (local.get $8)
+            )
+            (block
+             (i32.store
+              (i32.const 3664)
+              (local.tee $0
+               (i32.add
+                (i32.load
+                 (i32.const 3664)
+                )
+                (local.get $7)
+               )
+              )
+             )
+             (i32.store
+              (i32.const 3676)
+              (local.get $6)
+             )
+             (i32.store offset=4
+              (local.get $6)
+              (i32.or
+               (local.get $0)
+               (i32.const 1)
+              )
+             )
+            )
+            (block
+             (if
+              (i32.eq
+               (local.get $4)
+               (i32.load
+                (i32.const 3672)
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 3660)
+                (local.tee $0
+                 (i32.add
+                  (i32.load
+                   (i32.const 3660)
+                  )
+                  (local.get $7)
+                 )
+                )
+               )
+               (i32.store
+                (i32.const 3672)
+                (local.get $6)
+               )
+               (i32.store offset=4
+                (local.get $6)
+                (i32.or
+                 (local.get $0)
+                 (i32.const 1)
+                )
+               )
+               (i32.store
+                (i32.add
+                 (local.get $6)
+                 (local.get $0)
+                )
+                (local.get $0)
+               )
+               (br $label$217)
+              )
+             )
+             (i32.store
+              (local.tee $0
+               (i32.add
+                (local.tee $0
+                 (if (result i32)
+                  (i32.eq
+                   (i32.and
+                    (local.tee $0
+                     (i32.load offset=4
+                      (local.get $4)
+                     )
+                    )
+                    (i32.const 3)
+                   )
+                   (i32.const 1)
+                  )
+                  (block (result i32)
+                   (local.set $11
+                    (i32.and
+                     (local.get $0)
+                     (i32.const -8)
+                    )
+                   )
+                   (local.set $1
+                    (i32.shr_u
+                     (local.get $0)
+                     (i32.const 3)
+                    )
+                   )
+                   (block $label$222
+                    (if
+                     (i32.lt_u
+                      (local.get $0)
+                      (i32.const 256)
+                     )
+                     (block
+                      (local.set $5
+                       (i32.load offset=12
+                        (local.get $4)
+                       )
+                      )
+                      (block $label$224
+                       (if
+                        (i32.ne
+                         (local.tee $3
+                          (i32.load offset=8
+                           (local.get $4)
+                          )
+                         )
+                         (local.tee $0
+                          (i32.add
+                           (i32.shl
+                            (i32.shl
+                             (local.get $1)
+                             (i32.const 1)
+                            )
+                            (i32.const 2)
+                           )
+                           (i32.const 3692)
+                          )
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $3)
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                         )
+                         (br_if $label$224
+                          (i32.eq
+                           (i32.load offset=12
+                            (local.get $3)
+                           )
+                           (local.get $4)
+                          )
+                         )
+                         (call $fimport$10)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.eq
+                        (local.get $5)
+                        (local.get $3)
+                       )
+                       (block
+                        (i32.store
+                         (i32.const 3652)
+                         (i32.and
+                          (i32.load
+                           (i32.const 3652)
+                          )
+                          (i32.xor
+                           (i32.shl
+                            (i32.const 1)
+                            (local.get $1)
+                           )
+                           (i32.const -1)
+                          )
+                         )
+                        )
+                        (br $label$222)
+                       )
+                      )
+                      (block $label$228
+                       (if
+                        (i32.eq
+                         (local.get $5)
+                         (local.get $0)
+                        )
+                        (local.set $20
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 8)
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $5)
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $0
+                             (i32.add
+                              (local.get $5)
+                              (i32.const 8)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (block
+                           (local.set $20
+                            (local.get $0)
+                           )
+                           (br $label$228)
+                          )
+                         )
+                         (call $fimport$10)
+                        )
+                       )
+                      )
+                      (i32.store offset=12
+                       (local.get $3)
+                       (local.get $5)
+                      )
+                      (i32.store
+                       (local.get $20)
+                       (local.get $3)
+                      )
+                     )
+                     (block
+                      (local.set $8
+                       (i32.load offset=24
+                        (local.get $4)
+                       )
+                      )
+                      (block $label$234
+                       (if
+                        (i32.eq
+                         (local.tee $0
+                          (i32.load offset=12
+                           (local.get $4)
+                          )
+                         )
+                         (local.get $4)
+                        )
+                        (block
+                         (if
+                          (i32.eqz
+                           (local.tee $0
+                            (i32.load
+                             (local.tee $1
+                              (i32.add
+                               (local.tee $3
+                                (i32.add
+                                 (local.get $4)
+                                 (i32.const 16)
+                                )
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (if
+                           (local.tee $0
+                            (i32.load
+                             (local.get $3)
+                            )
+                           )
+                           (local.set $1
+                            (local.get $3)
+                           )
+                           (block
+                            (local.set $12
+                             (i32.const 0)
+                            )
+                            (br $label$234)
+                           )
+                          )
+                         )
+                         (loop $label$239
+                          (if
+                           (local.tee $3
+                            (i32.load
+                             (local.tee $5
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 20)
+                              )
+                             )
+                            )
+                           )
+                           (block
+                            (local.set $0
+                             (local.get $3)
+                            )
+                            (local.set $1
+                             (local.get $5)
+                            )
+                            (br $label$239)
+                           )
+                          )
+                          (if
+                           (local.tee $3
+                            (i32.load
+                             (local.tee $5
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 16)
+                              )
+                             )
+                            )
+                           )
+                           (block
+                            (local.set $0
+                             (local.get $3)
+                            )
+                            (local.set $1
+                             (local.get $5)
+                            )
+                            (br $label$239)
+                           )
+                          )
+                         )
+                         (if
+                          (i32.lt_u
+                           (local.get $1)
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                          (block
+                           (i32.store
+                            (local.get $1)
+                            (i32.const 0)
+                           )
+                           (local.set $12
+                            (local.get $0)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.tee $5
+                            (i32.load offset=8
+                             (local.get $4)
+                            )
+                           )
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.ne
+                           (i32.load
+                            (local.tee $3
+                             (i32.add
+                              (local.get $5)
+                              (i32.const 12)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $1
+                             (i32.add
+                              (local.get $0)
+                              (i32.const 8)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (block
+                           (i32.store
+                            (local.get $3)
+                            (local.get $0)
+                           )
+                           (i32.store
+                            (local.get $1)
+                            (local.get $5)
+                           )
+                           (local.set $12
+                            (local.get $0)
+                           )
+                          )
+                          (call $fimport$10)
+                         )
+                        )
+                       )
+                      )
+                      (br_if $label$222
+                       (i32.eqz
+                        (local.get $8)
+                       )
+                      )
+                      (block $label$249
+                       (if
+                        (i32.eq
+                         (local.get $4)
+                         (i32.load
+                          (local.tee $0
+                           (i32.add
+                            (i32.shl
+                             (local.tee $1
+                              (i32.load offset=28
+                               (local.get $4)
+                              )
+                             )
+                             (i32.const 2)
+                            )
+                            (i32.const 3956)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (i32.store
+                          (local.get $0)
+                          (local.get $12)
+                         )
+                         (br_if $label$249
+                          (local.get $12)
+                         )
+                         (i32.store
+                          (i32.const 3656)
+                          (i32.and
+                           (i32.load
+                            (i32.const 3656)
+                           )
+                           (i32.xor
+                            (i32.shl
+                             (i32.const 1)
+                             (local.get $1)
+                            )
+                            (i32.const -1)
+                           )
+                          )
+                         )
+                         (br $label$222)
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $8)
+                           (i32.load
+                            (i32.const 3668)
+                           )
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $0
+                             (i32.add
+                              (local.get $8)
+                              (i32.const 16)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (i32.store
+                           (local.get $0)
+                           (local.get $12)
+                          )
+                          (i32.store offset=20
+                           (local.get $8)
+                           (local.get $12)
+                          )
+                         )
+                         (br_if $label$222
+                          (i32.eqz
+                           (local.get $12)
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (local.get $12)
+                        (local.tee $1
+                         (i32.load
+                          (i32.const 3668)
+                         )
+                        )
+                       )
+                       (call $fimport$10)
+                      )
+                      (i32.store offset=24
+                       (local.get $12)
+                       (local.get $8)
+                      )
+                      (if
+                       (local.tee $3
+                        (i32.load
+                         (local.tee $0
+                          (i32.add
+                           (local.get $4)
+                           (i32.const 16)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.lt_u
+                         (local.get $3)
+                         (local.get $1)
+                        )
+                        (call $fimport$10)
+                        (block
+                         (i32.store offset=16
+                          (local.get $12)
+                          (local.get $3)
+                         )
+                         (i32.store offset=24
+                          (local.get $3)
+                          (local.get $12)
+                         )
+                        )
+                       )
+                      )
+                      (br_if $label$222
+                       (i32.eqz
+                        (local.tee $0
+                         (i32.load offset=4
+                          (local.get $0)
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (local.get $0)
+                        (i32.load
+                         (i32.const 3668)
+                        )
+                       )
+                       (call $fimport$10)
+                       (block
+                        (i32.store offset=20
+                         (local.get $12)
+                         (local.get $0)
+                        )
+                        (i32.store offset=24
+                         (local.get $0)
+                         (local.get $12)
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (local.set $7
+                    (i32.add
+                     (local.get $11)
+                     (local.get $7)
+                    )
+                   )
+                   (i32.add
+                    (local.get $4)
+                    (local.get $11)
+                   )
+                  )
+                  (local.get $4)
+                 )
+                )
+                (i32.const 4)
+               )
+              )
+              (i32.and
+               (i32.load
+                (local.get $0)
+               )
+               (i32.const -2)
+              )
+             )
+             (i32.store offset=4
+              (local.get $6)
+              (i32.or
+               (local.get $7)
+               (i32.const 1)
+              )
+             )
+             (i32.store
+              (i32.add
+               (local.get $6)
+               (local.get $7)
+              )
+              (local.get $7)
+             )
+             (local.set $0
+              (i32.shr_u
+               (local.get $7)
+               (i32.const 3)
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $7)
+               (i32.const 256)
+              )
+              (block
+               (local.set $3
+                (i32.add
+                 (i32.shl
+                  (i32.shl
+                   (local.get $0)
+                   (i32.const 1)
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3692)
+                )
+               )
+               (block $label$263
+                (if
+                 (i32.and
+                  (local.tee $1
+                   (i32.load
+                    (i32.const 3652)
+                   )
+                  )
+                  (local.tee $0
+                   (i32.shl
+                    (i32.const 1)
+                    (local.get $0)
+                   )
+                  )
+                 )
+                 (block
+                  (if
+                   (i32.ge_u
+                    (local.tee $0
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $3)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                    )
+                    (i32.load
+                     (i32.const 3668)
+                    )
+                   )
+                   (block
+                    (local.set $21
+                     (local.get $1)
+                    )
+                    (local.set $9
+                     (local.get $0)
+                    )
+                    (br $label$263)
+                   )
+                  )
+                  (call $fimport$10)
+                 )
+                 (block
+                  (i32.store
+                   (i32.const 3652)
+                   (i32.or
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                  )
+                  (local.set $21
+                   (i32.add
+                    (local.get $3)
+                    (i32.const 8)
+                   )
+                  )
+                  (local.set $9
+                   (local.get $3)
+                  )
+                 )
+                )
+               )
+               (i32.store
+                (local.get $21)
+                (local.get $6)
+               )
+               (i32.store offset=12
+                (local.get $9)
+                (local.get $6)
+               )
+               (i32.store offset=8
+                (local.get $6)
+                (local.get $9)
+               )
+               (i32.store offset=12
+                (local.get $6)
+                (local.get $3)
+               )
+               (br $label$217)
+              )
+             )
+             (local.set $3
+              (i32.add
+               (i32.shl
+                (local.tee $2
+                 (block $label$267 (result i32)
+                  (if (result i32)
+                   (local.tee $0
+                    (i32.shr_u
+                     (local.get $7)
+                     (i32.const 8)
+                    )
+                   )
+                   (block (result i32)
+                    (drop
+                     (br_if $label$267
+                      (i32.const 31)
+                      (i32.gt_u
+                       (local.get $7)
+                       (i32.const 16777215)
+                      )
+                     )
+                    )
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (local.get $7)
+                       (i32.add
+                        (local.tee $0
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
+                            (i32.or
+                             (local.tee $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (local.tee $1
+                                  (i32.shl
+                                   (local.get $0)
+                                   (local.tee $3
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (local.get $0)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (i32.const 520192)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                             (local.get $3)
+                            )
+                            (local.tee $0
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (local.tee $1
+                                 (i32.shl
+                                  (local.get $1)
+                                  (local.get $0)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (local.get $1)
+                            (local.get $0)
+                           )
+                           (i32.const 15)
+                          )
+                         )
+                        )
+                        (i32.const 7)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.shl
+                      (local.get $0)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.const 0)
+                  )
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 3956)
+              )
+             )
+             (i32.store offset=28
+              (local.get $6)
+              (local.get $2)
+             )
+             (i32.store offset=4
+              (local.tee $0
+               (i32.add
+                (local.get $6)
+                (i32.const 16)
+               )
+              )
+              (i32.const 0)
+             )
+             (i32.store
+              (local.get $0)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (local.tee $1
+                 (i32.load
+                  (i32.const 3656)
+                 )
+                )
+                (local.tee $0
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $2)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 3656)
+                (i32.or
+                 (local.get $1)
+                 (local.get $0)
+                )
+               )
+               (i32.store
+                (local.get $3)
+                (local.get $6)
+               )
+               (i32.store offset=24
+                (local.get $6)
+                (local.get $3)
+               )
+               (i32.store offset=12
+                (local.get $6)
+                (local.get $6)
+               )
+               (i32.store offset=8
+                (local.get $6)
+                (local.get $6)
+               )
+               (br $label$217)
+              )
+             )
+             (local.set $0
+              (i32.load
+               (local.get $3)
+              )
+             )
+             (local.set $1
+              (i32.sub
+               (i32.const 25)
+               (i32.shr_u
+                (local.get $2)
+                (i32.const 1)
+               )
+              )
+             )
+             (local.set $2
+              (i32.shl
+               (local.get $7)
+               (if (result i32)
+                (i32.eq
+                 (local.get $2)
+                 (i32.const 31)
+                )
+                (i32.const 0)
+                (local.get $1)
+               )
+              )
+             )
+             (block $label$273
+              (block $label$274
+               (block $label$275
+                (loop $label$276
+                 (br_if $label$274
+                  (i32.eq
+                   (i32.and
+                    (i32.load offset=4
+                     (local.get $0)
+                    )
+                    (i32.const -8)
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (local.set $3
+                  (i32.shl
+                   (local.get $2)
+                   (i32.const 1)
+                  )
+                 )
+                 (br_if $label$275
+                  (i32.eqz
+                   (local.tee $1
+                    (i32.load
+                     (local.tee $2
+                      (i32.add
+                       (i32.add
+                        (local.get $0)
+                        (i32.const 16)
+                       )
+                       (i32.shl
+                        (i32.shr_u
+                         (local.get $2)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (local.set $2
+                  (local.get $3)
+                 )
+                 (local.set $0
+                  (local.get $1)
+                 )
+                 (br $label$276)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $2)
+                 (i32.load
+                  (i32.const 3668)
+                 )
+                )
+                (call $fimport$10)
+                (block
+                 (i32.store
+                  (local.get $2)
+                  (local.get $6)
+                 )
+                 (i32.store offset=24
+                  (local.get $6)
+                  (local.get $0)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (br $label$217)
+                )
+               )
+               (br $label$273)
+              )
+              (if
+               (i32.and
+                (i32.ge_u
+                 (local.tee $2
+                  (i32.load
+                   (local.tee $3
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (local.tee $1
+                  (i32.load
+                   (i32.const 3668)
+                  )
+                 )
+                )
+                (i32.ge_u
+                 (local.get $0)
+                 (local.get $1)
+                )
+               )
+               (block
+                (i32.store offset=12
+                 (local.get $2)
+                 (local.get $6)
+                )
+                (i32.store
+                 (local.get $3)
+                 (local.get $6)
+                )
+                (i32.store offset=8
+                 (local.get $6)
+                 (local.get $2)
+                )
+                (i32.store offset=12
+                 (local.get $6)
+                 (local.get $0)
+                )
+                (i32.store offset=24
+                 (local.get $6)
+                 (i32.const 0)
+                )
+               )
+               (call $fimport$10)
+              )
+             )
+            )
+           )
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (i32.add
+            (local.get $13)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+       )
+       (loop $label$281
+        (block $label$282
+         (if
+          (i32.le_u
+           (local.tee $2
+            (i32.load
+             (local.get $5)
+            )
+           )
+           (local.get $8)
+          )
+          (br_if $label$282
+           (i32.gt_u
+            (local.tee $13
+             (i32.add
+              (local.get $2)
+              (i32.load offset=4
+               (local.get $5)
+              )
+             )
+            )
+            (local.get $8)
+           )
+          )
+         )
+         (local.set $5
+          (i32.load offset=8
+           (local.get $5)
+          )
+         )
+         (br $label$281)
+        )
+       )
+       (local.set $2
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $5
+           (i32.add
+            (local.tee $7
+             (i32.add
+              (local.get $13)
+              (i32.const -47)
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (local.set $10
+        (i32.add
+         (local.tee $7
+          (if (result i32)
+           (i32.lt_u
+            (local.tee $2
+             (i32.add
+              (local.get $7)
+              (if (result i32)
+               (i32.and
+                (local.get $5)
+                (i32.const 7)
+               )
+               (local.get $2)
+               (i32.const 0)
+              )
+             )
+            )
+            (local.tee $12
+             (i32.add
+              (local.get $8)
+              (i32.const 16)
+             )
+            )
+           )
+           (local.get $8)
+           (local.get $2)
+          )
+         )
+         (i32.const 8)
+        )
+       )
+       (local.set $5
+        (i32.add
+         (local.get $7)
+         (i32.const 24)
+        )
+       )
+       (local.set $9
+        (i32.add
+         (local.get $3)
+         (i32.const -40)
+        )
+       )
+       (local.set $2
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $4
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (i32.store
+        (i32.const 3676)
+        (local.tee $4
+         (i32.add
+          (local.get $1)
+          (if (result i32)
+           (i32.and
+            (local.get $4)
+            (i32.const 7)
+           )
+           (local.get $2)
+           (local.tee $2
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3664)
+        (local.tee $2
+         (i32.sub
+          (local.get $9)
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store offset=4
+        (local.get $4)
+        (i32.or
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (local.get $4)
+         (local.get $2)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 3680)
+        (i32.load
+         (i32.const 4140)
+        )
+       )
+       (i32.store
+        (local.tee $2
+         (i32.add
+          (local.get $7)
+          (i32.const 4)
+         )
+        )
+        (i32.const 27)
+       )
+       (i64.store align=4
+        (local.get $10)
+        (i64.load align=4
+         (i32.const 4100)
+        )
+       )
+       (i64.store offset=8 align=4
+        (local.get $10)
+        (i64.load align=4
+         (i32.const 4108)
+        )
+       )
+       (i32.store
+        (i32.const 4100)
+        (local.get $1)
+       )
+       (i32.store
+        (i32.const 4104)
+        (local.get $3)
+       )
+       (i32.store
+        (i32.const 4112)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 4108)
+        (local.get $10)
+       )
+       (local.set $1
+        (local.get $5)
+       )
+       (loop $label$290
+        (i32.store
+         (local.tee $1
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+         )
+         (i32.const 7)
+        )
+        (br_if $label$290
+         (i32.lt_u
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+          (local.get $13)
+         )
+        )
+       )
+       (if
+        (i32.ne
+         (local.get $7)
+         (local.get $8)
+        )
+        (block
+         (i32.store
+          (local.get $2)
+          (i32.and
+           (i32.load
+            (local.get $2)
+           )
+           (i32.const -2)
+          )
+         )
+         (i32.store offset=4
+          (local.get $8)
+          (i32.or
+           (local.tee $4
+            (i32.sub
+             (local.get $7)
+             (local.get $8)
+            )
+           )
+           (i32.const 1)
+          )
+         )
+         (i32.store
+          (local.get $7)
+          (local.get $4)
+         )
+         (local.set $1
+          (i32.shr_u
+           (local.get $4)
+           (i32.const 3)
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (i32.const 256)
+          )
+          (block
+           (local.set $2
+            (i32.add
+             (i32.shl
+              (i32.shl
+               (local.get $1)
+               (i32.const 1)
+              )
+              (i32.const 2)
+             )
+             (i32.const 3692)
+            )
+           )
+           (if
+            (i32.and
+             (local.tee $3
+              (i32.load
+               (i32.const 3652)
+              )
+             )
+             (local.tee $1
+              (i32.shl
+               (i32.const 1)
+               (local.get $1)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (local.tee $1
+               (i32.load
+                (local.tee $3
+                 (i32.add
+                  (local.get $2)
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.load
+               (i32.const 3668)
+              )
+             )
+             (call $fimport$10)
+             (block
+              (local.set $15
+               (local.get $3)
+              )
+              (local.set $11
+               (local.get $1)
+              )
+             )
+            )
+            (block
+             (i32.store
+              (i32.const 3652)
+              (i32.or
+               (local.get $3)
+               (local.get $1)
+              )
+             )
+             (local.set $15
+              (i32.add
+               (local.get $2)
+               (i32.const 8)
+              )
+             )
+             (local.set $11
+              (local.get $2)
+             )
+            )
+           )
+           (i32.store
+            (local.get $15)
+            (local.get $8)
+           )
+           (i32.store offset=12
+            (local.get $11)
+            (local.get $8)
+           )
+           (i32.store offset=8
+            (local.get $8)
+            (local.get $11)
+           )
+           (i32.store offset=12
+            (local.get $8)
+            (local.get $2)
+           )
+           (br $label$198)
+          )
+         )
+         (local.set $2
+          (i32.add
+           (i32.shl
+            (local.tee $5
+             (if (result i32)
+              (local.tee $1
+               (i32.shr_u
+                (local.get $4)
+                (i32.const 8)
+               )
+              )
+              (if (result i32)
+               (i32.gt_u
+                (local.get $4)
+                (i32.const 16777215)
+               )
+               (i32.const 31)
+               (i32.or
+                (i32.and
+                 (i32.shr_u
+                  (local.get $4)
+                  (i32.add
+                   (local.tee $1
+                    (i32.add
+                     (i32.sub
+                      (i32.const 14)
+                      (i32.or
+                       (i32.or
+                        (local.tee $1
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (local.tee $3
+                             (i32.shl
+                              (local.get $1)
+                              (local.tee $2
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (local.get $1)
+                                  (i32.const 1048320)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 520192)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 4)
+                         )
+                        )
+                        (local.get $2)
+                       )
+                       (local.tee $1
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (local.tee $3
+                            (i32.shl
+                             (local.get $3)
+                             (local.get $1)
+                            )
+                           )
+                           (i32.const 245760)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 2)
+                        )
+                       )
+                      )
+                     )
+                     (i32.shr_u
+                      (i32.shl
+                       (local.get $3)
+                       (local.get $1)
+                      )
+                      (i32.const 15)
+                     )
+                    )
+                   )
+                   (i32.const 7)
+                  )
+                 )
+                 (i32.const 1)
+                )
+                (i32.shl
+                 (local.get $1)
+                 (i32.const 1)
+                )
+               )
+              )
+              (i32.const 0)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 3956)
+          )
+         )
+         (i32.store offset=28
+          (local.get $8)
+          (local.get $5)
+         )
+         (i32.store offset=20
+          (local.get $8)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $12)
+          (i32.const 0)
+         )
+         (if
+          (i32.eqz
+           (i32.and
+            (local.tee $3
+             (i32.load
+              (i32.const 3656)
+             )
+            )
+            (local.tee $1
+             (i32.shl
+              (i32.const 1)
+              (local.get $5)
+             )
+            )
+           )
+          )
+          (block
+           (i32.store
+            (i32.const 3656)
+            (i32.or
+             (local.get $3)
+             (local.get $1)
+            )
+           )
+           (i32.store
+            (local.get $2)
+            (local.get $8)
+           )
+           (i32.store offset=24
+            (local.get $8)
+            (local.get $2)
+           )
+           (i32.store offset=12
+            (local.get $8)
+            (local.get $8)
+           )
+           (i32.store offset=8
+            (local.get $8)
+            (local.get $8)
+           )
+           (br $label$198)
+          )
+         )
+         (local.set $1
+          (i32.load
+           (local.get $2)
+          )
+         )
+         (local.set $3
+          (i32.sub
+           (i32.const 25)
+           (i32.shr_u
+            (local.get $5)
+            (i32.const 1)
+           )
+          )
+         )
+         (local.set $5
+          (i32.shl
+           (local.get $4)
+           (if (result i32)
+            (i32.eq
+             (local.get $5)
+             (i32.const 31)
+            )
+            (i32.const 0)
+            (local.get $3)
+           )
+          )
+         )
+         (block $label$304
+          (block $label$305
+           (block $label$306
+            (loop $label$307
+             (br_if $label$305
+              (i32.eq
+               (i32.and
+                (i32.load offset=4
+                 (local.get $1)
+                )
+                (i32.const -8)
+               )
+               (local.get $4)
+              )
+             )
+             (local.set $2
+              (i32.shl
+               (local.get $5)
+               (i32.const 1)
+              )
+             )
+             (br_if $label$306
+              (i32.eqz
+               (local.tee $3
+                (i32.load
+                 (local.tee $5
+                  (i32.add
+                   (i32.add
+                    (local.get $1)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (local.get $5)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (local.set $5
+              (local.get $2)
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$307)
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $5)
+             (i32.load
+              (i32.const 3668)
+             )
+            )
+            (call $fimport$10)
+            (block
+             (i32.store
+              (local.get $5)
+              (local.get $8)
+             )
+             (i32.store offset=24
+              (local.get $8)
+              (local.get $1)
+             )
+             (i32.store offset=12
+              (local.get $8)
+              (local.get $8)
+             )
+             (i32.store offset=8
+              (local.get $8)
+              (local.get $8)
+             )
+             (br $label$198)
+            )
+           )
+           (br $label$304)
+          )
+          (if
+           (i32.and
+            (i32.ge_u
+             (local.tee $5
+              (i32.load
+               (local.tee $2
+                (i32.add
+                 (local.get $1)
+                 (i32.const 8)
+                )
+               )
+              )
+             )
+             (local.tee $3
+              (i32.load
+               (i32.const 3668)
+              )
+             )
+            )
+            (i32.ge_u
+             (local.get $1)
+             (local.get $3)
+            )
+           )
+           (block
+            (i32.store offset=12
+             (local.get $5)
+             (local.get $8)
+            )
+            (i32.store
+             (local.get $2)
+             (local.get $8)
+            )
+            (i32.store offset=8
+             (local.get $8)
+             (local.get $5)
+            )
+            (i32.store offset=12
+             (local.get $8)
+             (local.get $1)
+            )
+            (i32.store offset=24
+             (local.get $8)
+             (i32.const 0)
+            )
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (i32.or
+         (i32.eqz
+          (local.tee $2
+           (i32.load
+            (i32.const 3668)
+           )
+          )
+         )
+         (i32.lt_u
+          (local.get $1)
+          (local.get $2)
+         )
+        )
+        (i32.store
+         (i32.const 3668)
+         (local.get $1)
+        )
+       )
+       (i32.store
+        (i32.const 4100)
+        (local.get $1)
+       )
+       (i32.store
+        (i32.const 4104)
+        (local.get $3)
+       )
+       (i32.store
+        (i32.const 4112)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 3688)
+        (i32.load
+         (i32.const 4124)
+        )
+       )
+       (i32.store
+        (i32.const 3684)
+        (i32.const -1)
+       )
+       (local.set $2
+        (i32.const 0)
+       )
+       (loop $label$314
+        (i32.store offset=12
+         (local.tee $5
+          (i32.add
+           (i32.shl
+            (i32.shl
+             (local.get $2)
+             (i32.const 1)
+            )
+            (i32.const 2)
+           )
+           (i32.const 3692)
+          )
+         )
+         (local.get $5)
+        )
+        (i32.store offset=8
+         (local.get $5)
+         (local.get $5)
+        )
+        (br_if $label$314
+         (i32.ne
+          (local.tee $2
+           (i32.add
+            (local.get $2)
+            (i32.const 1)
+           )
+          )
+          (i32.const 32)
+         )
+        )
+       )
+       (local.set $5
+        (i32.add
+         (local.get $3)
+         (i32.const -40)
+        )
+       )
+       (local.set $3
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $2
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (i32.store
+        (i32.const 3676)
+        (local.tee $3
+         (i32.add
+          (local.get $1)
+          (local.tee $1
+           (if (result i32)
+            (i32.and
+             (local.get $2)
+             (i32.const 7)
+            )
+            (local.get $3)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3664)
+        (local.tee $1
+         (i32.sub
+          (local.get $5)
+          (local.get $1)
+         )
+        )
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $1)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (local.get $3)
+         (local.get $1)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 3680)
+        (i32.load
+         (i32.const 4140)
+        )
+       )
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (local.tee $1
+       (i32.load
+        (i32.const 3664)
+       )
+      )
+      (local.get $0)
+     )
+     (block
+      (i32.store
+       (i32.const 3664)
+       (local.tee $3
+        (i32.sub
+         (local.get $1)
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 3676)
+       (local.tee $1
+        (i32.add
+         (local.tee $2
+          (i32.load
+           (i32.const 3676)
+          )
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store offset=4
+       (local.get $1)
+       (i32.or
+        (local.get $3)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (local.get $2)
+       (i32.or
+        (local.get $0)
+        (i32.const 3)
+       )
+      )
+      (global.set $global$1
+       (local.get $14)
+      )
+      (return
+       (i32.add
+        (local.get $2)
+        (i32.const 8)
+       )
+      )
+     )
+    )
+   )
+   (i32.store
+    (call $12)
+    (i32.const 12)
+   )
+   (global.set $global$1
+    (local.get $14)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $36 (; 49 ;) (type $2) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (block $label$1
+   (if
+    (i32.eqz
+     (local.get $0)
+    )
+    (return)
+   )
+   (if
+    (i32.lt_u
+     (local.tee $1
+      (i32.add
+       (local.get $0)
+       (i32.const -8)
+      )
+     )
+     (local.tee $11
+      (i32.load
+       (i32.const 3668)
+      )
+     )
+    )
+    (call $fimport$10)
+   )
+   (if
+    (i32.eq
+     (local.tee $8
+      (i32.and
+       (local.tee $0
+        (i32.load
+         (i32.add
+          (local.get $0)
+          (i32.const -4)
+         )
+        )
+       )
+       (i32.const 3)
+      )
+     )
+     (i32.const 1)
+    )
+    (call $fimport$10)
+   )
+   (local.set $6
+    (i32.add
+     (local.get $1)
+     (local.tee $4
+      (i32.and
+       (local.get $0)
+       (i32.const -8)
+      )
+     )
+    )
+   )
+   (block $label$5
+    (if
+     (i32.and
+      (local.get $0)
+      (i32.const 1)
+     )
+     (block
+      (local.set $3
+       (local.get $1)
+      )
+      (local.set $2
+       (local.get $4)
+      )
+     )
+     (block
+      (if
+       (i32.eqz
+        (local.get $8)
+       )
+       (return)
+      )
+      (if
+       (i32.lt_u
+        (local.tee $0
+         (i32.add
+          (local.get $1)
+          (i32.sub
+           (i32.const 0)
+           (local.tee $8
+            (i32.load
+             (local.get $1)
+            )
+           )
+          )
+         )
+        )
+        (local.get $11)
+       )
+       (call $fimport$10)
+      )
+      (local.set $1
+       (i32.add
+        (local.get $8)
+        (local.get $4)
+       )
+      )
+      (if
+       (i32.eq
+        (local.get $0)
+        (i32.load
+         (i32.const 3672)
+        )
+       )
+       (block
+        (if
+         (i32.ne
+          (i32.and
+           (local.tee $3
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (local.get $6)
+               (i32.const 4)
+              )
+             )
+            )
+           )
+           (i32.const 3)
+          )
+          (i32.const 3)
+         )
+         (block
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+          (br $label$5)
+         )
+        )
+        (i32.store
+         (i32.const 3660)
+         (local.get $1)
+        )
+        (i32.store
+         (local.get $2)
+         (i32.and
+          (local.get $3)
+          (i32.const -2)
+         )
+        )
+        (i32.store offset=4
+         (local.get $0)
+         (i32.or
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (i32.store
+         (i32.add
+          (local.get $0)
+          (local.get $1)
+         )
+         (local.get $1)
+        )
+        (return)
+       )
+      )
+      (local.set $10
+       (i32.shr_u
+        (local.get $8)
+        (i32.const 3)
+       )
+      )
+      (if
+       (i32.lt_u
+        (local.get $8)
+        (i32.const 256)
+       )
+       (block
+        (local.set $3
+         (i32.load offset=12
+          (local.get $0)
+         )
+        )
+        (if
+         (i32.ne
+          (local.tee $4
+           (i32.load offset=8
+            (local.get $0)
+           )
+          )
+          (local.tee $2
+           (i32.add
+            (i32.shl
+             (i32.shl
+              (local.get $10)
+              (i32.const 1)
+             )
+             (i32.const 2)
+            )
+            (i32.const 3692)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $4)
+            (local.get $11)
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.ne
+            (i32.load offset=12
+             (local.get $4)
+            )
+            (local.get $0)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $3)
+          (local.get $4)
+         )
+         (block
+          (i32.store
+           (i32.const 3652)
+           (i32.and
+            (i32.load
+             (i32.const 3652)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (local.get $10)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+          (br $label$5)
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $3)
+          (local.get $2)
+         )
+         (local.set $5
+          (i32.add
+           (local.get $3)
+           (i32.const 8)
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $3)
+            (local.get $11)
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (local.get $3)
+               (i32.const 8)
+              )
+             )
+            )
+            (local.get $0)
+           )
+           (local.set $5
+            (local.get $2)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (i32.store offset=12
+         (local.get $4)
+         (local.get $3)
+        )
+        (i32.store
+         (local.get $5)
+         (local.get $4)
+        )
+        (local.set $3
+         (local.get $0)
+        )
+        (local.set $2
+         (local.get $1)
+        )
+        (br $label$5)
+       )
+      )
+      (local.set $12
+       (i32.load offset=24
+        (local.get $0)
+       )
+      )
+      (block $label$22
+       (if
+        (i32.eq
+         (local.tee $4
+          (i32.load offset=12
+           (local.get $0)
+          )
+         )
+         (local.get $0)
+        )
+        (block
+         (if
+          (local.tee $4
+           (i32.load
+            (local.tee $8
+             (i32.add
+              (local.tee $5
+               (i32.add
+                (local.get $0)
+                (i32.const 16)
+               )
+              )
+              (i32.const 4)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (local.get $8)
+          )
+          (if
+           (i32.eqz
+            (local.tee $4
+             (i32.load
+              (local.get $5)
+             )
+            )
+           )
+           (block
+            (local.set $7
+             (i32.const 0)
+            )
+            (br $label$22)
+           )
+          )
+         )
+         (loop $label$27
+          (if
+           (local.tee $10
+            (i32.load
+             (local.tee $8
+              (i32.add
+               (local.get $4)
+               (i32.const 20)
+              )
+             )
+            )
+           )
+           (block
+            (local.set $4
+             (local.get $10)
+            )
+            (local.set $5
+             (local.get $8)
+            )
+            (br $label$27)
+           )
+          )
+          (if
+           (local.tee $10
+            (i32.load
+             (local.tee $8
+              (i32.add
+               (local.get $4)
+               (i32.const 16)
+              )
+             )
+            )
+           )
+           (block
+            (local.set $4
+             (local.get $10)
+            )
+            (local.set $5
+             (local.get $8)
+            )
+            (br $label$27)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $5)
+           (local.get $11)
+          )
+          (call $fimport$10)
+          (block
+           (i32.store
+            (local.get $5)
+            (i32.const 0)
+           )
+           (local.set $7
+            (local.get $4)
+           )
+          )
+         )
+        )
+        (block
+         (if
+          (i32.lt_u
+           (local.tee $5
+            (i32.load offset=8
+             (local.get $0)
+            )
+           )
+           (local.get $11)
+          )
+          (call $fimport$10)
+         )
+         (if
+          (i32.ne
+           (i32.load
+            (local.tee $8
+             (i32.add
+              (local.get $5)
+              (i32.const 12)
+             )
+            )
+           )
+           (local.get $0)
+          )
+          (call $fimport$10)
+         )
+         (if
+          (i32.eq
+           (i32.load
+            (local.tee $10
+             (i32.add
+              (local.get $4)
+              (i32.const 8)
+             )
+            )
+           )
+           (local.get $0)
+          )
+          (block
+           (i32.store
+            (local.get $8)
+            (local.get $4)
+           )
+           (i32.store
+            (local.get $10)
+            (local.get $5)
+           )
+           (local.set $7
+            (local.get $4)
+           )
+          )
+          (call $fimport$10)
+         )
+        )
+       )
+      )
+      (if
+       (local.get $12)
+       (block
+        (if
+         (i32.eq
+          (local.get $0)
+          (i32.load
+           (local.tee $5
+            (i32.add
+             (i32.shl
+              (local.tee $4
+               (i32.load offset=28
+                (local.get $0)
+               )
+              )
+              (i32.const 2)
+             )
+             (i32.const 3956)
+            )
+           )
+          )
+         )
+         (block
+          (i32.store
+           (local.get $5)
+           (local.get $7)
+          )
+          (if
+           (i32.eqz
+            (local.get $7)
+           )
+           (block
+            (i32.store
+             (i32.const 3656)
+             (i32.and
+              (i32.load
+               (i32.const 3656)
+              )
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (local.get $4)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+            (local.set $3
+             (local.get $0)
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$5)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $12)
+            (i32.load
+             (i32.const 3668)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $4
+              (i32.add
+               (local.get $12)
+               (i32.const 16)
+              )
+             )
+            )
+            (local.get $0)
+           )
+           (i32.store
+            (local.get $4)
+            (local.get $7)
+           )
+           (i32.store offset=20
+            (local.get $12)
+            (local.get $7)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.get $7)
+           )
+           (block
+            (local.set $3
+             (local.get $0)
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$5)
+           )
+          )
+         )
+        )
+        (if
+         (i32.lt_u
+          (local.get $7)
+          (local.tee $5
+           (i32.load
+            (i32.const 3668)
+           )
+          )
+         )
+         (call $fimport$10)
+        )
+        (i32.store offset=24
+         (local.get $7)
+         (local.get $12)
+        )
+        (if
+         (local.tee $4
+          (i32.load
+           (local.tee $8
+            (i32.add
+             (local.get $0)
+             (i32.const 16)
+            )
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (local.get $5)
+          )
+          (call $fimport$10)
+          (block
+           (i32.store offset=16
+            (local.get $7)
+            (local.get $4)
+           )
+           (i32.store offset=24
+            (local.get $4)
+            (local.get $7)
+           )
+          )
+         )
+        )
+        (if
+         (local.tee $4
+          (i32.load offset=4
+           (local.get $8)
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (i32.load
+            (i32.const 3668)
+           )
+          )
+          (call $fimport$10)
+          (block
+           (i32.store offset=20
+            (local.get $7)
+            (local.get $4)
+           )
+           (i32.store offset=24
+            (local.get $4)
+            (local.get $7)
+           )
+           (local.set $3
+            (local.get $0)
+           )
+           (local.set $2
+            (local.get $1)
+           )
+          )
+         )
+         (block
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+         )
+        )
+       )
+       (block
+        (local.set $3
+         (local.get $0)
+        )
+        (local.set $2
+         (local.get $1)
+        )
+       )
+      )
+     )
+    )
+   )
+   (if
+    (i32.ge_u
+     (local.get $3)
+     (local.get $6)
+    )
+    (call $fimport$10)
+   )
+   (if
+    (i32.eqz
+     (i32.and
+      (local.tee $0
+       (i32.load
+        (local.tee $1
+         (i32.add
+          (local.get $6)
+          (i32.const 4)
+         )
+        )
+       )
+      )
+      (i32.const 1)
+     )
+    )
+    (call $fimport$10)
+   )
+   (if
+    (i32.and
+     (local.get $0)
+     (i32.const 2)
+    )
+    (block
+     (i32.store
+      (local.get $1)
+      (i32.and
+       (local.get $0)
+       (i32.const -2)
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.or
+       (local.get $2)
+       (i32.const 1)
+      )
+     )
+     (i32.store
+      (i32.add
+       (local.get $3)
+       (local.get $2)
+      )
+      (local.get $2)
+     )
+    )
+    (block
+     (if
+      (i32.eq
+       (local.get $6)
+       (i32.load
+        (i32.const 3676)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3664)
+        (local.tee $0
+         (i32.add
+          (i32.load
+           (i32.const 3664)
+          )
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3676)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $0)
+         (i32.const 1)
+        )
+       )
+       (if
+        (i32.ne
+         (local.get $3)
+         (i32.load
+          (i32.const 3672)
+         )
+        )
+        (return)
+       )
+       (i32.store
+        (i32.const 3672)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 3660)
+        (i32.const 0)
+       )
+       (return)
+      )
+     )
+     (if
+      (i32.eq
+       (local.get $6)
+       (i32.load
+        (i32.const 3672)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3660)
+        (local.tee $0
+         (i32.add
+          (i32.load
+           (i32.const 3660)
+          )
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3672)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $0)
+         (i32.const 1)
+        )
+       )
+       (i32.store
+        (i32.add
+         (local.get $3)
+         (local.get $0)
+        )
+        (local.get $0)
+       )
+       (return)
+      )
+     )
+     (local.set $5
+      (i32.add
+       (i32.and
+        (local.get $0)
+        (i32.const -8)
+       )
+       (local.get $2)
+      )
+     )
+     (local.set $4
+      (i32.shr_u
+       (local.get $0)
+       (i32.const 3)
+      )
+     )
+     (block $label$61
+      (if
+       (i32.lt_u
+        (local.get $0)
+        (i32.const 256)
+       )
+       (block
+        (local.set $2
+         (i32.load offset=12
+          (local.get $6)
+         )
+        )
+        (if
+         (i32.ne
+          (local.tee $1
+           (i32.load offset=8
+            (local.get $6)
+           )
+          )
+          (local.tee $0
+           (i32.add
+            (i32.shl
+             (i32.shl
+              (local.get $4)
+              (i32.const 1)
+             )
+             (i32.const 2)
+            )
+            (i32.const 3692)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $1)
+            (i32.load
+             (i32.const 3668)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.ne
+            (i32.load offset=12
+             (local.get $1)
+            )
+            (local.get $6)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $1)
+         )
+         (block
+          (i32.store
+           (i32.const 3652)
+           (i32.and
+            (i32.load
+             (i32.const 3652)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (local.get $4)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (br $label$61)
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $0)
+         )
+         (local.set $14
+          (i32.add
+           (local.get $2)
+           (i32.const 8)
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $2)
+            (i32.load
+             (i32.const 3668)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $0
+              (i32.add
+               (local.get $2)
+               (i32.const 8)
+              )
+             )
+            )
+            (local.get $6)
+           )
+           (local.set $14
+            (local.get $0)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (i32.store offset=12
+         (local.get $1)
+         (local.get $2)
+        )
+        (i32.store
+         (local.get $14)
+         (local.get $1)
+        )
+       )
+       (block
+        (local.set $7
+         (i32.load offset=24
+          (local.get $6)
+         )
+        )
+        (block $label$73
+         (if
+          (i32.eq
+           (local.tee $0
+            (i32.load offset=12
+             (local.get $6)
+            )
+           )
+           (local.get $6)
+          )
+          (block
+           (if
+            (local.tee $0
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (local.tee $2
+                 (i32.add
+                  (local.get $6)
+                  (i32.const 16)
+                 )
+                )
+                (i32.const 4)
+               )
+              )
+             )
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (if
+             (i32.eqz
+              (local.tee $0
+               (i32.load
+                (local.get $2)
+               )
+              )
+             )
+             (block
+              (local.set $9
+               (i32.const 0)
+              )
+              (br $label$73)
+             )
+            )
+           )
+           (loop $label$78
+            (if
+             (local.tee $4
+              (i32.load
+               (local.tee $1
+                (i32.add
+                 (local.get $0)
+                 (i32.const 20)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (local.get $4)
+              )
+              (local.set $2
+               (local.get $1)
+              )
+              (br $label$78)
+             )
+            )
+            (if
+             (local.tee $4
+              (i32.load
+               (local.tee $1
+                (i32.add
+                 (local.get $0)
+                 (i32.const 16)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (local.get $4)
+              )
+              (local.set $2
+               (local.get $1)
+              )
+              (br $label$78)
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $2)
+             (i32.load
+              (i32.const 3668)
+             )
+            )
+            (call $fimport$10)
+            (block
+             (i32.store
+              (local.get $2)
+              (i32.const 0)
+             )
+             (local.set $9
+              (local.get $0)
+             )
+            )
+           )
+          )
+          (block
+           (if
+            (i32.lt_u
+             (local.tee $2
+              (i32.load offset=8
+               (local.get $6)
+              )
+             )
+             (i32.load
+              (i32.const 3668)
+             )
+            )
+            (call $fimport$10)
+           )
+           (if
+            (i32.ne
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (local.get $2)
+                (i32.const 12)
+               )
+              )
+             )
+             (local.get $6)
+            )
+            (call $fimport$10)
+           )
+           (if
+            (i32.eq
+             (i32.load
+              (local.tee $4
+               (i32.add
+                (local.get $0)
+                (i32.const 8)
+               )
+              )
+             )
+             (local.get $6)
+            )
+            (block
+             (i32.store
+              (local.get $1)
+              (local.get $0)
+             )
+             (i32.store
+              (local.get $4)
+              (local.get $2)
+             )
+             (local.set $9
+              (local.get $0)
+             )
+            )
+            (call $fimport$10)
+           )
+          )
+         )
+        )
+        (if
+         (local.get $7)
+         (block
+          (if
+           (i32.eq
+            (local.get $6)
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (i32.shl
+                (local.tee $0
+                 (i32.load offset=28
+                  (local.get $6)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 3956)
+              )
+             )
+            )
+           )
+           (block
+            (i32.store
+             (local.get $2)
+             (local.get $9)
+            )
+            (if
+             (i32.eqz
+              (local.get $9)
+             )
+             (block
+              (i32.store
+               (i32.const 3656)
+               (i32.and
+                (i32.load
+                 (i32.const 3656)
+                )
+                (i32.xor
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $0)
+                 )
+                 (i32.const -1)
+                )
+               )
+              )
+              (br $label$61)
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $7)
+              (i32.load
+               (i32.const 3668)
+              )
+             )
+             (call $fimport$10)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (local.tee $0
+                (i32.add
+                 (local.get $7)
+                 (i32.const 16)
+                )
+               )
+              )
+              (local.get $6)
+             )
+             (i32.store
+              (local.get $0)
+              (local.get $9)
+             )
+             (i32.store offset=20
+              (local.get $7)
+              (local.get $9)
+             )
+            )
+            (br_if $label$61
+             (i32.eqz
+              (local.get $9)
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $9)
+            (local.tee $2
+             (i32.load
+              (i32.const 3668)
+             )
+            )
+           )
+           (call $fimport$10)
+          )
+          (i32.store offset=24
+           (local.get $9)
+           (local.get $7)
+          )
+          (if
+           (local.tee $0
+            (i32.load
+             (local.tee $1
+              (i32.add
+               (local.get $6)
+               (i32.const 16)
+              )
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $0)
+             (local.get $2)
+            )
+            (call $fimport$10)
+            (block
+             (i32.store offset=16
+              (local.get $9)
+              (local.get $0)
+             )
+             (i32.store offset=24
+              (local.get $0)
+              (local.get $9)
+             )
+            )
+           )
+          )
+          (if
+           (local.tee $0
+            (i32.load offset=4
+             (local.get $1)
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $0)
+             (i32.load
+              (i32.const 3668)
+             )
+            )
+            (call $fimport$10)
+            (block
+             (i32.store offset=20
+              (local.get $9)
+              (local.get $0)
+             )
+             (i32.store offset=24
+              (local.get $0)
+              (local.get $9)
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.or
+       (local.get $5)
+       (i32.const 1)
+      )
+     )
+     (i32.store
+      (i32.add
+       (local.get $3)
+       (local.get $5)
+      )
+      (local.get $5)
+     )
+     (if
+      (i32.eq
+       (local.get $3)
+       (i32.load
+        (i32.const 3672)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3660)
+        (local.get $5)
+       )
+       (return)
+      )
+      (local.set $2
+       (local.get $5)
+      )
+     )
+    )
+   )
+   (local.set $1
+    (i32.shr_u
+     (local.get $2)
+     (i32.const 3)
+    )
+   )
+   (if
+    (i32.lt_u
+     (local.get $2)
+     (i32.const 256)
+    )
+    (block
+     (local.set $0
+      (i32.add
+       (i32.shl
+        (i32.shl
+         (local.get $1)
+         (i32.const 1)
+        )
+        (i32.const 2)
+       )
+       (i32.const 3692)
+      )
+     )
+     (if
+      (i32.and
+       (local.tee $2
+        (i32.load
+         (i32.const 3652)
+        )
+       )
+       (local.tee $1
+        (i32.shl
+         (i32.const 1)
+         (local.get $1)
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (local.tee $1
+         (i32.load
+          (local.tee $2
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (i32.load
+         (i32.const 3668)
+        )
+       )
+       (call $fimport$10)
+       (block
+        (local.set $15
+         (local.get $2)
+        )
+        (local.set $13
+         (local.get $1)
+        )
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3652)
+        (i32.or
+         (local.get $2)
+         (local.get $1)
+        )
+       )
+       (local.set $15
+        (i32.add
+         (local.get $0)
+         (i32.const 8)
+        )
+       )
+       (local.set $13
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (local.get $15)
+      (local.get $3)
+     )
+     (i32.store offset=12
+      (local.get $13)
+      (local.get $3)
+     )
+     (i32.store offset=8
+      (local.get $3)
+      (local.get $13)
+     )
+     (i32.store offset=12
+      (local.get $3)
+      (local.get $0)
+     )
+     (return)
+    )
+   )
+   (local.set $0
+    (i32.add
+     (i32.shl
+      (local.tee $1
+       (if (result i32)
+        (local.tee $0
+         (i32.shr_u
+          (local.get $2)
+          (i32.const 8)
+         )
+        )
+        (if (result i32)
+         (i32.gt_u
+          (local.get $2)
+          (i32.const 16777215)
+         )
+         (i32.const 31)
+         (i32.or
+          (i32.and
+           (i32.shr_u
+            (local.get $2)
+            (i32.add
+             (local.tee $0
+              (i32.add
+               (i32.sub
+                (i32.const 14)
+                (i32.or
+                 (i32.or
+                  (local.tee $4
+                   (i32.and
+                    (i32.shr_u
+                     (i32.add
+                      (local.tee $1
+                       (i32.shl
+                        (local.get $0)
+                        (local.tee $0
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (local.get $0)
+                            (i32.const 1048320)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 8)
+                         )
+                        )
+                       )
+                      )
+                      (i32.const 520192)
+                     )
+                     (i32.const 16)
+                    )
+                    (i32.const 4)
+                   )
+                  )
+                  (local.get $0)
+                 )
+                 (local.tee $1
+                  (i32.and
+                   (i32.shr_u
+                    (i32.add
+                     (local.tee $0
+                      (i32.shl
+                       (local.get $1)
+                       (local.get $4)
+                      )
+                     )
+                     (i32.const 245760)
+                    )
+                    (i32.const 16)
+                   )
+                   (i32.const 2)
+                  )
+                 )
+                )
+               )
+               (i32.shr_u
+                (i32.shl
+                 (local.get $0)
+                 (local.get $1)
+                )
+                (i32.const 15)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.shl
+           (local.get $0)
+           (i32.const 1)
+          )
+         )
+        )
+        (i32.const 0)
+       )
+      )
+      (i32.const 2)
+     )
+     (i32.const 3956)
+    )
+   )
+   (i32.store offset=28
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=20
+    (local.get $3)
+    (i32.const 0)
+   )
+   (i32.store offset=16
+    (local.get $3)
+    (i32.const 0)
+   )
+   (block $label$113
+    (if
+     (i32.and
+      (local.tee $4
+       (i32.load
+        (i32.const 3656)
+       )
+      )
+      (local.tee $5
+       (i32.shl
+        (i32.const 1)
+        (local.get $1)
+       )
+      )
+     )
+     (block
+      (local.set $0
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (local.set $4
+       (i32.sub
+        (i32.const 25)
+        (i32.shr_u
+         (local.get $1)
+         (i32.const 1)
+        )
+       )
+      )
+      (local.set $1
+       (i32.shl
+        (local.get $2)
+        (if (result i32)
+         (i32.eq
+          (local.get $1)
+          (i32.const 31)
+         )
+         (i32.const 0)
+         (local.get $4)
+        )
+       )
+      )
+      (block $label$117
+       (block $label$118
+        (block $label$119
+         (loop $label$120
+          (br_if $label$118
+           (i32.eq
+            (i32.and
+             (i32.load offset=4
+              (local.get $0)
+             )
+             (i32.const -8)
+            )
+            (local.get $2)
+           )
+          )
+          (local.set $4
+           (i32.shl
+            (local.get $1)
+            (i32.const 1)
+           )
+          )
+          (br_if $label$119
+           (i32.eqz
+            (local.tee $5
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (i32.add
+                 (local.get $0)
+                 (i32.const 16)
+                )
+                (i32.shl
+                 (i32.shr_u
+                  (local.get $1)
+                  (i32.const 31)
+                 )
+                 (i32.const 2)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (local.set $1
+           (local.get $4)
+          )
+          (local.set $0
+           (local.get $5)
+          )
+          (br $label$120)
+         )
+        )
+        (if
+         (i32.lt_u
+          (local.get $1)
+          (i32.load
+           (i32.const 3668)
+          )
+         )
+         (call $fimport$10)
+         (block
+          (i32.store
+           (local.get $1)
+           (local.get $3)
+          )
+          (i32.store offset=24
+           (local.get $3)
+           (local.get $0)
+          )
+          (i32.store offset=12
+           (local.get $3)
+           (local.get $3)
+          )
+          (i32.store offset=8
+           (local.get $3)
+           (local.get $3)
+          )
+          (br $label$113)
+         )
+        )
+        (br $label$117)
+       )
+       (if
+        (i32.and
+         (i32.ge_u
+          (local.tee $2
+           (i32.load
+            (local.tee $1
+             (i32.add
+              (local.get $0)
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (local.tee $4
+           (i32.load
+            (i32.const 3668)
+           )
+          )
+         )
+         (i32.ge_u
+          (local.get $0)
+          (local.get $4)
+         )
+        )
+        (block
+         (i32.store offset=12
+          (local.get $2)
+          (local.get $3)
+         )
+         (i32.store
+          (local.get $1)
+          (local.get $3)
+         )
+         (i32.store offset=8
+          (local.get $3)
+          (local.get $2)
+         )
+         (i32.store offset=12
+          (local.get $3)
+          (local.get $0)
+         )
+         (i32.store offset=24
+          (local.get $3)
+          (i32.const 0)
+         )
+        )
+        (call $fimport$10)
+       )
+      )
+     )
+     (block
+      (i32.store
+       (i32.const 3656)
+       (i32.or
+        (local.get $4)
+        (local.get $5)
+       )
+      )
+      (i32.store
+       (local.get $0)
+       (local.get $3)
+      )
+      (i32.store offset=24
+       (local.get $3)
+       (local.get $0)
+      )
+      (i32.store offset=12
+       (local.get $3)
+       (local.get $3)
+      )
+      (i32.store offset=8
+       (local.get $3)
+       (local.get $3)
+      )
+     )
+    )
+   )
+   (i32.store
+    (i32.const 3684)
+    (local.tee $0
+     (i32.add
+      (i32.load
+       (i32.const 3684)
+      )
+      (i32.const -1)
+     )
+    )
+   )
+   (if
+    (local.get $0)
+    (return)
+    (local.set $0
+     (i32.const 4108)
+    )
+   )
+   (loop $label$128
+    (local.set $0
+     (i32.add
+      (local.tee $2
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (i32.const 8)
+     )
+    )
+    (br_if $label$128
+     (local.get $2)
+    )
+   )
+   (i32.store
+    (i32.const 3684)
+    (i32.const -1)
+   )
+  )
+ )
+ (func $37 (; 50 ;) (type $6)
+  (nop)
+ )
+ (func $38 (; 51 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.add
+     (local.tee $2
+      (i32.load
+       (global.get $global$0)
+      )
+     )
+     (local.tee $0
+      (i32.and
+       (i32.add
+        (local.get $0)
+        (i32.const 15)
+       )
+       (i32.const -16)
+      )
+     )
+    )
+   )
+   (if
+    (i32.or
+     (i32.and
+      (i32.gt_s
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.lt_s
+       (local.get $1)
+       (local.get $2)
+      )
+     )
+     (i32.lt_s
+      (local.get $1)
+      (i32.const 0)
+     )
+    )
+    (block
+     (drop
+      (call $fimport$6)
+     )
+     (call $fimport$11
+      (i32.const 12)
+     )
+     (return
+      (i32.const -1)
+     )
+    )
+   )
+   (i32.store
+    (global.get $global$0)
+    (local.get $1)
+   )
+   (if
+    (i32.gt_s
+     (local.get $1)
+     (call $fimport$5)
+    )
+    (if
+     (i32.eqz
+      (call $fimport$4)
+     )
+     (block
+      (call $fimport$11
+       (i32.const 12)
+      )
+      (i32.store
+       (global.get $global$0)
+       (local.get $2)
+      )
+      (return
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (local.get $2)
+  )
+ )
+ (func $39 (; 52 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (i32.add
+     (local.get $0)
+     (local.get $2)
+    )
+   )
+   (if
+    (i32.ge_s
+     (local.get $2)
+     (i32.const 20)
+    )
+    (block
+     (local.set $1
+      (i32.and
+       (local.get $1)
+       (i32.const 255)
+      )
+     )
+     (if
+      (local.tee $3
+       (i32.and
+        (local.get $0)
+        (i32.const 3)
+       )
+      )
+      (block
+       (local.set $3
+        (i32.sub
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+         (local.get $3)
+        )
+       )
+       (loop $label$4
+        (if
+         (i32.lt_s
+          (local.get $0)
+          (local.get $3)
+         )
+         (block
+          (i32.store8
+           (local.get $0)
+           (local.get $1)
+          )
+          (local.set $0
+           (i32.add
+            (local.get $0)
+            (i32.const 1)
+           )
+          )
+          (br $label$4)
+         )
+        )
+       )
+      )
+     )
+     (local.set $3
+      (i32.or
+       (i32.or
+        (i32.or
+         (local.get $1)
+         (i32.shl
+          (local.get $1)
+          (i32.const 8)
+         )
+        )
+        (i32.shl
+         (local.get $1)
+         (i32.const 16)
+        )
+       )
+       (i32.shl
+        (local.get $1)
+        (i32.const 24)
+       )
+      )
+     )
+     (local.set $5
+      (i32.and
+       (local.get $4)
+       (i32.const -4)
+      )
+     )
+     (loop $label$6
+      (if
+       (i32.lt_s
+        (local.get $0)
+        (local.get $5)
+       )
+       (block
+        (i32.store
+         (local.get $0)
+         (local.get $3)
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+        )
+        (br $label$6)
+       )
+      )
+     )
+    )
+   )
+   (loop $label$8
+    (if
+     (i32.lt_s
+      (local.get $0)
+      (local.get $4)
+     )
+     (block
+      (i32.store8
+       (local.get $0)
+       (local.get $1)
+      )
+      (local.set $0
+       (i32.add
+        (local.get $0)
+        (i32.const 1)
+       )
+      )
+      (br $label$8)
+     )
+    )
+   )
+   (i32.sub
+    (local.get $0)
+    (local.get $2)
+   )
+  )
+ )
+ (func $40 (; 53 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (if
+    (i32.ge_s
+     (local.get $2)
+     (i32.const 4096)
+    )
+    (return
+     (call $fimport$12
+      (local.get $0)
+      (local.get $1)
+      (local.get $2)
+     )
+    )
+   )
+   (local.set $3
+    (local.get $0)
+   )
+   (if
+    (i32.eq
+     (i32.and
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.and
+      (local.get $1)
+      (i32.const 3)
+     )
+    )
+    (block
+     (loop $label$4
+      (if
+       (i32.and
+        (local.get $0)
+        (i32.const 3)
+       )
+       (block
+        (if
+         (i32.eqz
+          (local.get $2)
+         )
+         (return
+          (local.get $3)
+         )
+        )
+        (i32.store8
+         (local.get $0)
+         (i32.load8_s
+          (local.get $1)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 1)
+         )
+        )
+        (local.set $1
+         (i32.add
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (local.set $2
+         (i32.sub
+          (local.get $2)
+          (i32.const 1)
+         )
+        )
+        (br $label$4)
+       )
+      )
+     )
+     (loop $label$7
+      (if
+       (i32.ge_s
+        (local.get $2)
+        (i32.const 4)
+       )
+       (block
+        (i32.store
+         (local.get $0)
+         (i32.load
+          (local.get $1)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+        )
+        (local.set $1
+         (i32.add
+          (local.get $1)
+          (i32.const 4)
+         )
+        )
+        (local.set $2
+         (i32.sub
+          (local.get $2)
+          (i32.const 4)
+         )
+        )
+        (br $label$7)
+       )
+      )
+     )
+    )
+   )
+   (loop $label$9
+    (if
+     (i32.gt_s
+      (local.get $2)
+      (i32.const 0)
+     )
+     (block
+      (i32.store8
+       (local.get $0)
+       (i32.load8_s
+        (local.get $1)
+       )
+      )
+      (local.set $0
+       (i32.add
+        (local.get $0)
+        (i32.const 1)
+       )
+      )
+      (local.set $1
+       (i32.add
+        (local.get $1)
+        (i32.const 1)
+       )
+      )
+      (local.set $2
+       (i32.sub
+        (local.get $2)
+        (i32.const 1)
+       )
+      )
+      (br $label$9)
+     )
+    )
+   )
+   (local.get $3)
+  )
+ )
+ (func $41 (; 54 ;) (type $3) (result i32)
+  (i32.const 0)
+ )
+ (func $42 (; 55 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (call_indirect (type $1)
+   (local.get $1)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 1)
+    )
+    (i32.const 0)
+   )
+  )
+ )
+ (func $43 (; 56 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (call_indirect (type $0)
+   (local.get $1)
+   (local.get $2)
+   (local.get $3)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 3)
+    )
+    (i32.const 2)
+   )
+  )
+ )
+ (func $44 (; 57 ;) (type $5) (param $0 i32) (param $1 i32)
+  (call_indirect (type $2)
+   (local.get $1)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 1)
+    )
+    (i32.const 6)
+   )
+  )
+ )
+ (func $45 (; 58 ;) (type $1) (param $0 i32) (result i32)
+  (block $label$1 (result i32)
+   (call $fimport$3
+    (i32.const 0)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $46 (; 59 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (block $label$1 (result i32)
+   (call $fimport$3
+    (i32.const 1)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $47 (; 60 ;) (type $2) (param $0 i32)
+  (call $fimport$3
+   (i32.const 2)
+  )
+ )
+)
+

--- a/wasmtests/embenchen_fasta.wat
+++ b/wasmtests/embenchen_fasta.wat
@@ -1,0 +1,16547 @@
+(module
+ (type $0 (func (param i32 i32 i32) (result i32)))
+ (type $1 (func))
+ (type $2 (func (param i32) (result i32)))
+ (type $3 (func (param i32)))
+ (type $4 (func (result i32)))
+ (type $5 (func (param i32 i32)))
+ (type $6 (func (param i32 i32) (result i32)))
+ (type $7 (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $8 (func (param i32 i32 i32)))
+ (type $9 (func (param i64 i32) (result i32)))
+ (type $10 (func (param i32 i32 i32 i32 i32)))
+ (type $11 (func (param f64 i32) (result f64)))
+ (type $12 (func (param i32 i32 i32 i32) (result i32)))
+ (import "env" "memory" (memory $16 2048 2048))
+ (data (i32.const 1024) "&\02\00\00a\00\00\00q=\8a>\00\00\00\00c\00\00\00\8f\c2\f5=\00\00\00\00g\00\00\00\8f\c2\f5=\00\00\00\00t\00\00\00q=\8a>\00\00\00\00B\00\00\00\n\d7\a3<\00\00\00\00D\00\00\00\n\d7\a3<\00\00\00\00H\00\00\00\n\d7\a3<\00\00\00\00K\00\00\00\n\d7\a3<\00\00\00\00M\00\00\00\n\d7\a3<\00\00\00\00N\00\00\00\n\d7\a3<\00\00\00\00R\00\00\00\n\d7\a3<\00\00\00\00S\00\00\00\n\d7\a3<\00\00\00\00V\00\00\00\n\d7\a3<\00\00\00\00W\00\00\00\n\d7\a3<\00\00\00\00Y\00\00\00\n\d7\a3<")
+ (data (i32.const 1220) "a\00\00\00\e9\1c\9b>\00\00\00\00c\00\00\00r\bdJ>\00\00\00\00g\00\00\00\d7IJ>\00\00\00\00t\00\00\00r_\9a>")
+ (data (i32.const 1280) "\04\05\00\00\05")
+ (data (i32.const 1296) "\01")
+ (data (i32.const 1320) "\01\00\00\00\02\00\00\00L\12\00\00\00\04")
+ (data (i32.const 1344) "\01")
+ (data (i32.const 1359) "\n\ff\ff\ff\ff")
+ (data (i32.const 1396) "*\00\00\00error: %d\n\00GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGATCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACTAAAAATACAAAAATTAGCCGGGCGTGGTGGCGCGCGCCTGTAATCCCAGCTACTCGGGAGGCTGAGGCAGGAGAATCGCTTGAACCCGGGAGGCGGAGGTTGCAGTGAGCCGAGATCGCGCCACTGCACTCCAGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAA\00\11\00\n\00\11\11\11\00\00\00\00\05\00\00\00\00\00\00\t\00\00\00\00\0b")
+ (data (i32.const 1731) "\11\00\0f\n\11\11\11\03\n\07\00\01\13\t\0b\0b\00\00\t\06\0b\00\00\0b\00\06\11\00\00\00\11\11\11")
+ (data (i32.const 1780) "\0b")
+ (data (i32.const 1789) "\11\00\n\n\11\11\11\00\n\00\00\02\00\t\0b\00\00\00\t\00\0b\00\00\0b")
+ (data (i32.const 1838) "\0c")
+ (data (i32.const 1850) "\0c\00\00\00\00\0c\00\00\00\00\t\0c\00\00\00\00\00\0c\00\00\0c")
+ (data (i32.const 1896) "\0e")
+ (data (i32.const 1908) "\0d\00\00\00\04\0d\00\00\00\00\t\0e\00\00\00\00\00\0e\00\00\0e")
+ (data (i32.const 1954) "\10")
+ (data (i32.const 1966) "\0f\00\00\00\00\0f\00\00\00\00\t\10\00\00\00\00\00\10\00\00\10\00\00\12\00\00\00\12\12\12")
+ (data (i32.const 2021) "\12\00\00\00\12\12\12\00\00\00\00\00\00\t")
+ (data (i32.const 2070) "\0b")
+ (data (i32.const 2082) "\n\00\00\00\00\n\00\00\00\00\t\0b\00\00\00\00\00\0b\00\00\0b")
+ (data (i32.const 2128) "\0c")
+ (data (i32.const 2140) "\0c\00\00\00\00\0c\00\00\00\00\t\0c\00\00\00\00\00\0c\00\00\0c\00\000123456789ABCDEF-+   0X0x\00(null)\00-0X+0X 0X-0x+0x 0x\00inf\00INF\00nan\00NAN\00.\00T!\"\19\0d\01\02\03\11K\1c\0c\10\04\0b\1d\12\1e\'hnopqb \05\06\0f\13\14\15\1a\08\16\07($\17\18\t\n\0e\1b\1f%#\83\82}&*+<=>?CGJMXYZ[\\]^_`acdefgijklrstyz{|\00Illegal byte sequence\00Domain error\00Result not representable\00Not a tty\00Permission denied\00Operation not permitted\00No such file or directory\00No such process\00File exists\00Value too large for data type\00No space left on device\00Out of memory\00Resource busy\00Interrupted system call\00Resource temporarily unavailable\00Invalid seek\00Cross-device link\00Read-only file system\00Directory not empty\00Connection reset by peer\00Operation timed out\00Connection refused\00Host is down\00Host is unreachable\00Address in use\00Broken pipe\00I/O error\00No such device or address\00Block device required\00No such device\00Not a directory\00Is a directory\00Text file busy\00Exec format error\00Invalid argument\00Argument list too long\00Symbolic link loop\00Filename too long\00Too many open files in system\00No file descriptors available\00Bad file descriptor\00No child process\00Bad address\00File too large\00Too many links\00No locks available\00Resource deadlock would occur\00State not recoverable\00Previous owner died\00Operation canceled\00Function not implemented\00No message of desired type\00Identifier removed\00Device not a stream\00No data available\00Device timeout\00Out of streams resources\00Link has been severed\00Protocol error\00Bad message\00File descriptor in bad state\00Not a socket\00Destination address required\00Message too large\00Protocol wrong type for socket\00Protocol not available\00Protocol not supported\00Socket type not supported\00Not supported\00Protocol family not supported\00Address family not supported by protocol\00Address not available\00Network is down\00Network unreachable\00Connection reset by network\00Connection aborted\00No buffer space available\00Socket is connected\00Socket not connected\00Cannot send after socket shutdown\00Operation already in progress\00Operation in progress\00Stale file handle\00Remote I/O error\00Quota exceeded\00No medium found\00Wrong medium type\00No error information")
+ (import "env" "table" (table $timport$17 9 9 funcref))
+ (elem (global.get $gimport$19) $53 $9 $54 $14 $10 $15 $55 $16 $56)
+ (import "env" "DYNAMICTOP_PTR" (global $gimport$0 i32))
+ (import "env" "STACKTOP" (global $gimport$1 i32))
+ (import "env" "STACK_MAX" (global $gimport$2 i32))
+ (import "env" "memoryBase" (global $gimport$18 i32))
+ (import "env" "tableBase" (global $gimport$19 i32))
+ (import "env" "abort" (func $fimport$3 (param i32)))
+ (import "env" "enlargeMemory" (func $fimport$4 (result i32)))
+ (import "env" "getTotalMemory" (func $fimport$5 (result i32)))
+ (import "env" "abortOnCannotGrowMemory" (func $fimport$6 (result i32)))
+ (import "env" "_pthread_cleanup_pop" (func $fimport$7 (param i32)))
+ (import "env" "_abort" (func $fimport$8))
+ (import "env" "_pthread_cleanup_push" (func $fimport$9 (param i32 i32)))
+ (import "env" "___syscall6" (func $fimport$10 (param i32 i32) (result i32)))
+ (import "env" "___setErrNo" (func $fimport$11 (param i32)))
+ (import "env" "_emscripten_memcpy_big" (func $fimport$12 (param i32 i32 i32) (result i32)))
+ (import "env" "___syscall54" (func $fimport$13 (param i32 i32) (result i32)))
+ (import "env" "___syscall140" (func $fimport$14 (param i32 i32) (result i32)))
+ (import "env" "___syscall146" (func $fimport$15 (param i32 i32) (result i32)))
+ (global $global$0 (mut i32) (global.get $gimport$0))
+ (global $global$1 (mut i32) (global.get $gimport$1))
+ (global $global$2 (mut i32) (global.get $gimport$2))
+ (global $global$3 (mut i32) (i32.const 0))
+ (global $global$4 (mut i32) (i32.const 0))
+ (global $global$5 (mut i32) (i32.const 0))
+ (export "_sbrk" (func $45))
+ (export "_free" (func $38))
+ (export "_main" (func $7))
+ (export "_pthread_self" (func $48))
+ (export "_memset" (func $46))
+ (export "_malloc" (func $37))
+ (export "_memcpy" (func $47))
+ (export "___errno_location" (func $12))
+ (export "runPostSets" (func $44))
+ (export "stackAlloc" (func $0))
+ (export "stackSave" (func $1))
+ (export "stackRestore" (func $2))
+ (export "establishStackSpace" (func $3))
+ (export "setThrew" (func $4))
+ (export "setTempRet0" (func $5))
+ (export "getTempRet0" (func $6))
+ (export "dynCall_ii" (func $49))
+ (export "dynCall_iiii" (func $50))
+ (export "dynCall_vi" (func $51))
+ (export "dynCall_v" (func $52))
+ (func $0 (; 13 ;) (type $2) (param $0 i32) (result i32)
+  (local $1 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (local.get $0)
+    )
+   )
+   (global.set $global$1
+    (i32.and
+     (i32.add
+      (global.get $global$1)
+      (i32.const 15)
+     )
+     (i32.const -16)
+    )
+   )
+   (local.get $1)
+  )
+ )
+ (func $1 (; 14 ;) (type $4) (result i32)
+  (global.get $global$1)
+ )
+ (func $2 (; 15 ;) (type $3) (param $0 i32)
+  (global.set $global$1
+   (local.get $0)
+  )
+ )
+ (func $3 (; 16 ;) (type $5) (param $0 i32) (param $1 i32)
+  (block $label$1
+   (global.set $global$1
+    (local.get $0)
+   )
+   (global.set $global$2
+    (local.get $1)
+   )
+  )
+ )
+ (func $4 (; 17 ;) (type $5) (param $0 i32) (param $1 i32)
+  (if
+   (i32.eqz
+    (global.get $global$3)
+   )
+   (block
+    (global.set $global$3
+     (local.get $0)
+    )
+    (global.set $global$4
+     (local.get $1)
+    )
+   )
+  )
+ )
+ (func $5 (; 18 ;) (type $3) (param $0 i32)
+  (global.set $global$5
+   (local.get $0)
+  )
+ )
+ (func $6 (; 19 ;) (type $4) (result i32)
+  (global.get $global$5)
+ )
+ (func $7 (; 20 ;) (type $6) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 f32)
+  (local $12 f32)
+  (local $13 f64)
+  (block $label$1 (result i32)
+   (local.set $5
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 4256)
+    )
+   )
+   (local.set $3
+    (local.get $5)
+   )
+   (local.set $6
+    (i32.add
+     (local.get $5)
+     (i32.const 2128)
+    )
+   )
+   (local.set $7
+    (i32.add
+     (local.get $5)
+     (i32.const 8)
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (i32.le_s
+       (local.get $0)
+       (i32.const 1)
+      )
+     )
+     (block $label$4
+      (block $label$5
+       (block $label$6
+        (block $label$7
+         (block $label$8
+          (block $label$9
+           (block $label$10
+            (br_table $label$5 $label$10 $label$8 $label$9 $label$7 $label$6 $label$4
+             (i32.sub
+              (local.tee $0
+               (i32.load8_s
+                (i32.load offset=4
+                 (local.get $1)
+                )
+               )
+              )
+              (i32.const 48)
+             )
+            )
+           )
+           (local.set $4
+            (i32.const 950000)
+           )
+           (br $label$2)
+          )
+          (br $label$3)
+         )
+         (local.set $4
+          (i32.const 9500000)
+         )
+         (br $label$2)
+        )
+        (local.set $4
+         (i32.const 95000000)
+        )
+        (br $label$2)
+       )
+       (local.set $4
+        (i32.const 190000000)
+       )
+       (br $label$2)
+      )
+      (global.set $global$1
+       (local.get $5)
+      )
+      (return
+       (i32.const 0)
+      )
+     )
+     (i32.store
+      (local.get $3)
+      (i32.add
+       (local.get $0)
+       (i32.const -48)
+      )
+     )
+     (drop
+      (call $34
+       (i32.const 1400)
+       (local.get $3)
+      )
+     )
+     (global.set $global$1
+      (local.get $5)
+     )
+     (return
+      (i32.const -1)
+     )
+    )
+    (local.set $4
+     (i32.const 19000000)
+    )
+   )
+   (drop
+    (call $47
+     (local.tee $8
+      (call $40
+       (i32.const 347)
+      )
+     )
+     (i32.const 1411)
+     (i32.const 287)
+    )
+   )
+   (i64.store align=1
+    (local.tee $0
+     (i32.add
+      (local.get $8)
+      (i32.const 287)
+     )
+    )
+    (i64.load align=1
+     (i32.const 1411)
+    )
+   )
+   (i64.store offset=8 align=1
+    (local.get $0)
+    (i64.load align=1
+     (i32.const 1419)
+    )
+   )
+   (i64.store offset=16 align=1
+    (local.get $0)
+    (i64.load align=1
+     (i32.const 1427)
+    )
+   )
+   (i64.store offset=24 align=1
+    (local.get $0)
+    (i64.load align=1
+     (i32.const 1435)
+    )
+   )
+   (i64.store offset=32 align=1
+    (local.get $0)
+    (i64.load align=1
+     (i32.const 1443)
+    )
+   )
+   (i64.store offset=40 align=1
+    (local.get $0)
+    (i64.load align=1
+     (i32.const 1451)
+    )
+   )
+   (i64.store offset=48 align=1
+    (local.get $0)
+    (i64.load align=1
+     (i32.const 1459)
+    )
+   )
+   (i32.store offset=56 align=1
+    (local.get $0)
+    (i32.load align=1
+     (i32.const 1467)
+    )
+   )
+   (local.set $0
+    (i32.shl
+     (local.get $4)
+     (i32.const 1)
+    )
+   )
+   (local.set $1
+    (i32.const 0)
+   )
+   (loop $label$11
+    (drop
+     (call $47
+      (local.tee $2
+       (call $40
+        (i32.add
+         (local.tee $3
+          (if (result i32)
+           (i32.lt_u
+            (local.get $0)
+            (i32.const 60)
+           )
+           (local.get $0)
+           (i32.const 60)
+          )
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (i32.add
+       (local.get $8)
+       (local.get $1)
+      )
+      (local.get $3)
+     )
+    )
+    (i32.store8
+     (i32.add
+      (local.get $2)
+      (local.get $3)
+     )
+     (i32.const 0)
+    )
+    (if
+     (i32.gt_s
+      (local.tee $10
+       (call $31
+        (local.get $2)
+       )
+      )
+      (local.tee $9
+       (i32.load
+        (i32.const 1024)
+       )
+      )
+     )
+     (if
+      (i32.gt_s
+       (local.get $9)
+       (i32.const 0)
+      )
+      (block
+       (i32.store8
+        (i32.add
+         (local.get $2)
+         (local.get $9)
+        )
+        (i32.const 0)
+       )
+       (drop
+        (call $35
+         (local.get $2)
+        )
+       )
+       (i32.store
+        (i32.const 1024)
+        (i32.const 0)
+       )
+      )
+     )
+     (block
+      (drop
+       (call $35
+        (local.get $2)
+       )
+      )
+      (i32.store
+       (i32.const 1024)
+       (i32.sub
+        (i32.load
+         (i32.const 1024)
+        )
+        (local.get $10)
+       )
+      )
+     )
+    )
+    (call $41
+     (local.get $2)
+    )
+    (local.set $1
+     (i32.add
+      (local.tee $2
+       (i32.add
+        (local.get $3)
+        (local.get $1)
+       )
+      )
+      (i32.const -287)
+     )
+    )
+    (if
+     (i32.le_u
+      (local.get $2)
+      (i32.const 287)
+     )
+     (local.set $1
+      (local.get $2)
+     )
+    )
+    (br_if $label$11
+     (local.tee $0
+      (i32.sub
+       (local.get $0)
+       (local.get $3)
+      )
+     )
+    )
+   )
+   (call $42
+    (local.get $8)
+   )
+   (if
+    (i32.load
+     (i32.const 1028)
+    )
+    (block
+     (local.set $0
+      (i32.const 1028)
+     )
+     (local.set $11
+      (f32.const 0)
+     )
+     (loop $label$19
+      (local.set $12
+       (f32.demote_f64
+        (if (result f64)
+         (f64.lt
+          (local.tee $13
+           (f64.promote_f32
+            (local.tee $11
+             (f32.add
+              (local.get $11)
+              (f32.load
+               (local.tee $1
+                (i32.add
+                 (local.get $0)
+                 (i32.const 4)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (f64.const 1)
+         )
+         (local.get $13)
+         (f64.const 1)
+        )
+       )
+      )
+      (f32.store
+       (local.get $1)
+       (local.get $12)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.trunc_f32_s
+        (f32.mul
+         (local.get $12)
+         (f32.const 512)
+        )
+       )
+      )
+      (br_if $label$19
+       (i32.load
+        (local.tee $0
+         (i32.add
+          (local.get $0)
+          (i32.const 12)
+         )
+        )
+       )
+      )
+      (local.set $1
+       (i32.const 0)
+      )
+      (local.set $0
+       (i32.const 1028)
+      )
+     )
+    )
+    (block
+     (local.set $1
+      (i32.const 0)
+     )
+     (local.set $0
+      (i32.const 1028)
+     )
+    )
+   )
+   (loop $label$23
+    (loop $label$24
+     (local.set $3
+      (i32.add
+       (local.get $0)
+       (i32.const 12)
+      )
+     )
+     (if
+      (i32.and
+       (i32.gt_u
+        (local.get $1)
+        (local.tee $2
+         (i32.load offset=8
+          (local.get $0)
+         )
+        )
+       )
+       (i32.ne
+        (local.get $2)
+        (i32.const 0)
+       )
+      )
+      (block
+       (local.set $0
+        (local.get $3)
+       )
+       (br $label$24)
+      )
+     )
+    )
+    (i32.store
+     (i32.add
+      (local.get $6)
+      (i32.shl
+       (local.get $1)
+       (i32.const 2)
+      )
+     )
+     (local.get $0)
+    )
+    (br_if $label$23
+     (i32.ne
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const 1)
+       )
+      )
+      (i32.const 513)
+     )
+    )
+   )
+   (i32.store
+    (i32.add
+     (local.get $6)
+     (i32.const 2116)
+    )
+    (i32.const 0)
+   )
+   (local.set $0
+    (i32.mul
+     (local.get $4)
+     (i32.const 3)
+    )
+   )
+   (loop $label$26
+    (call $8
+     (local.get $6)
+     (local.tee $1
+      (if (result i32)
+       (i32.lt_u
+        (local.get $0)
+        (i32.const 60)
+       )
+       (local.get $0)
+       (i32.const 60)
+      )
+     )
+    )
+    (br_if $label$26
+     (local.tee $0
+      (i32.sub
+       (local.get $0)
+       (local.get $1)
+      )
+     )
+    )
+   )
+   (if
+    (i32.load
+     (i32.const 1220)
+    )
+    (block
+     (local.set $0
+      (i32.const 1220)
+     )
+     (local.set $11
+      (f32.const 0)
+     )
+     (loop $label$30
+      (local.set $12
+       (f32.demote_f64
+        (if (result f64)
+         (f64.lt
+          (local.tee $13
+           (f64.promote_f32
+            (local.tee $11
+             (f32.add
+              (local.get $11)
+              (f32.load
+               (local.tee $1
+                (i32.add
+                 (local.get $0)
+                 (i32.const 4)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (f64.const 1)
+         )
+         (local.get $13)
+         (f64.const 1)
+        )
+       )
+      )
+      (f32.store
+       (local.get $1)
+       (local.get $12)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.trunc_f32_s
+        (f32.mul
+         (local.get $12)
+         (f32.const 512)
+        )
+       )
+      )
+      (br_if $label$30
+       (i32.load
+        (local.tee $0
+         (i32.add
+          (local.get $0)
+          (i32.const 12)
+         )
+        )
+       )
+      )
+      (local.set $1
+       (i32.const 0)
+      )
+      (local.set $0
+       (i32.const 1220)
+      )
+     )
+    )
+    (block
+     (local.set $1
+      (i32.const 0)
+     )
+     (local.set $0
+      (i32.const 1220)
+     )
+    )
+   )
+   (loop $label$34
+    (loop $label$35
+     (local.set $3
+      (i32.add
+       (local.get $0)
+       (i32.const 12)
+      )
+     )
+     (if
+      (i32.and
+       (i32.gt_u
+        (local.get $1)
+        (local.tee $2
+         (i32.load offset=8
+          (local.get $0)
+         )
+        )
+       )
+       (i32.ne
+        (local.get $2)
+        (i32.const 0)
+       )
+      )
+      (block
+       (local.set $0
+        (local.get $3)
+       )
+       (br $label$35)
+      )
+     )
+    )
+    (i32.store
+     (i32.add
+      (local.get $7)
+      (i32.shl
+       (local.get $1)
+       (i32.const 2)
+      )
+     )
+     (local.get $0)
+    )
+    (br_if $label$34
+     (i32.ne
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const 1)
+       )
+      )
+      (i32.const 513)
+     )
+    )
+   )
+   (i32.store
+    (i32.add
+     (local.get $7)
+     (i32.const 2116)
+    )
+    (i32.const 0)
+   )
+   (local.set $0
+    (i32.mul
+     (local.get $4)
+     (i32.const 5)
+    )
+   )
+   (loop $label$37
+    (call $8
+     (local.get $7)
+     (local.tee $1
+      (if (result i32)
+       (i32.lt_u
+        (local.get $0)
+        (i32.const 60)
+       )
+       (local.get $0)
+       (i32.const 60)
+      )
+     )
+    )
+    (br_if $label$37
+     (local.tee $0
+      (i32.sub
+       (local.get $0)
+       (local.get $1)
+      )
+     )
+    )
+    (local.set $0
+     (i32.const 0)
+    )
+   )
+   (global.set $global$1
+    (local.get $5)
+   )
+   (local.get $0)
+  )
+ )
+ (func $8 (; 21 ;) (type $5) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 f32)
+  (block $label$1
+   (if
+    (local.get $1)
+    (block
+     (local.set $3
+      (i32.const 0)
+     )
+     (local.set $2
+      (i32.load
+       (i32.const 1396)
+      )
+     )
+     (loop $label$3
+      (local.set $2
+       (i32.load
+        (i32.add
+         (local.get $0)
+         (i32.shl
+          (i32.trunc_f32_s
+           (f32.mul
+            (local.tee $6
+             (f32.div
+              (f32.convert_i32_u
+               (local.tee $4
+                (i32.rem_u
+                 (i32.add
+                  (i32.mul
+                   (local.get $2)
+                   (i32.const 3877)
+                  )
+                  (i32.const 29573)
+                 )
+                 (i32.const 139968)
+                )
+               )
+              )
+              (f32.const 139968)
+             )
+            )
+            (f32.const 512)
+           )
+          )
+          (i32.const 2)
+         )
+        )
+       )
+      )
+      (loop $label$4
+       (local.set $5
+        (i32.add
+         (local.get $2)
+         (i32.const 12)
+        )
+       )
+       (if
+        (f32.lt
+         (f32.load offset=4
+          (local.get $2)
+         )
+         (local.get $6)
+        )
+        (block
+         (local.set $2
+          (local.get $5)
+         )
+         (br $label$4)
+        )
+       )
+      )
+      (i32.store8
+       (i32.add
+        (i32.add
+         (local.get $0)
+         (i32.const 2052)
+        )
+        (local.get $3)
+       )
+       (i32.load
+        (local.get $2)
+       )
+      )
+      (if
+       (i32.ne
+        (local.tee $3
+         (i32.add
+          (local.get $3)
+          (i32.const 1)
+         )
+        )
+        (local.get $1)
+       )
+       (block
+        (local.set $2
+         (local.get $4)
+        )
+        (br $label$3)
+       )
+      )
+     )
+     (i32.store
+      (i32.const 1396)
+      (local.get $4)
+     )
+    )
+   )
+   (i32.store8
+    (i32.add
+     (i32.add
+      (local.get $0)
+      (i32.const 2052)
+     )
+     (local.get $1)
+    )
+    (i32.const 10)
+   )
+   (i32.store8
+    (i32.add
+     (i32.add
+      (local.get $0)
+      (i32.const 2052)
+     )
+     (local.tee $1
+      (i32.add
+       (local.get $1)
+       (i32.const 1)
+      )
+     )
+    )
+    (i32.const 0)
+   )
+   (i32.store
+    (i32.add
+     (local.get $0)
+     (i32.const 2116)
+    )
+    (local.get $1)
+   )
+   (if
+    (i32.le_s
+     (local.tee $3
+      (call $31
+       (local.tee $1
+        (i32.add
+         (local.get $0)
+         (i32.const 2052)
+        )
+       )
+      )
+     )
+     (local.tee $2
+      (i32.load
+       (i32.const 1024)
+      )
+     )
+    )
+    (block
+     (drop
+      (call $35
+       (local.get $1)
+      )
+     )
+     (i32.store
+      (i32.const 1024)
+      (i32.sub
+       (i32.load
+        (i32.const 1024)
+       )
+       (local.get $3)
+      )
+     )
+     (return)
+    )
+   )
+   (if
+    (i32.le_s
+     (local.get $2)
+     (i32.const 0)
+    )
+    (return)
+   )
+   (i32.store8
+    (i32.add
+     (i32.add
+      (local.get $0)
+      (i32.const 2052)
+     )
+     (local.get $2)
+    )
+    (i32.const 0)
+   )
+   (drop
+    (call $35
+     (local.get $1)
+    )
+   )
+   (i32.store8
+    (i32.add
+     (i32.add
+      (local.get $0)
+      (i32.const 2052)
+     )
+     (i32.load
+      (i32.const 1024)
+     )
+    )
+    (i32.const 122)
+   )
+   (i32.store
+    (i32.const 1024)
+    (i32.const 0)
+   )
+  )
+ )
+ (func $9 (; 22 ;) (type $2) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store
+    (local.tee $2
+     (local.get $1)
+    )
+    (i32.load offset=60
+     (local.get $0)
+    )
+   )
+   (local.set $0
+    (call $11
+     (call $fimport$10
+      (i32.const 6)
+      (local.get $2)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $1)
+   )
+   (local.get $0)
+  )
+ )
+ (func $10 (; 23 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 32)
+    )
+   )
+   (i32.store
+    (local.tee $3
+     (local.get $4)
+    )
+    (i32.load offset=60
+     (local.get $0)
+    )
+   )
+   (i32.store offset=4
+    (local.get $3)
+    (i32.const 0)
+   )
+   (i32.store offset=8
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=12
+    (local.get $3)
+    (local.tee $0
+     (i32.add
+      (local.get $4)
+      (i32.const 20)
+     )
+    )
+   )
+   (i32.store offset=16
+    (local.get $3)
+    (local.get $2)
+   )
+   (local.set $0
+    (if (result i32)
+     (i32.lt_s
+      (call $11
+       (call $fimport$14
+        (i32.const 140)
+        (local.get $3)
+       )
+      )
+      (i32.const 0)
+     )
+     (block (result i32)
+      (i32.store
+       (local.get $0)
+       (i32.const -1)
+      )
+      (i32.const -1)
+     )
+     (i32.load
+      (local.get $0)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $0)
+  )
+ )
+ (func $11 (; 24 ;) (type $2) (param $0 i32) (result i32)
+  (if (result i32)
+   (i32.gt_u
+    (local.get $0)
+    (i32.const -4096)
+   )
+   (block (result i32)
+    (i32.store
+     (call $12)
+     (i32.sub
+      (i32.const 0)
+      (local.get $0)
+     )
+    )
+    (i32.const -1)
+   )
+   (local.get $0)
+  )
+ )
+ (func $12 (; 25 ;) (type $4) (result i32)
+  (i32.const 4172)
+ )
+ (func $13 (; 26 ;) (type $3) (param $0 i32)
+  (nop)
+ )
+ (func $14 (; 27 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 80)
+    )
+   )
+   (local.set $3
+    (local.get $4)
+   )
+   (local.set $5
+    (i32.add
+     (local.get $4)
+     (i32.const 12)
+    )
+   )
+   (i32.store offset=36
+    (local.get $0)
+    (i32.const 3)
+   )
+   (if
+    (i32.eqz
+     (i32.and
+      (i32.load
+       (local.get $0)
+      )
+      (i32.const 64)
+     )
+    )
+    (block
+     (i32.store
+      (local.get $3)
+      (i32.load offset=60
+       (local.get $0)
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.const 21505)
+     )
+     (i32.store offset=8
+      (local.get $3)
+      (local.get $5)
+     )
+     (if
+      (call $fimport$13
+       (i32.const 54)
+       (local.get $3)
+      )
+      (i32.store8 offset=75
+       (local.get $0)
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (local.set $0
+    (call $15
+     (local.get $0)
+     (local.get $1)
+     (local.get $2)
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $0)
+  )
+ )
+ (func $15 (; 28 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (block $label$1 (result i32)
+   (local.set $8
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 48)
+    )
+   )
+   (local.set $9
+    (i32.add
+     (local.get $8)
+     (i32.const 16)
+    )
+   )
+   (local.set $10
+    (local.get $8)
+   )
+   (i32.store
+    (local.tee $3
+     (i32.add
+      (local.get $8)
+      (i32.const 32)
+     )
+    )
+    (local.tee $4
+     (i32.load
+      (local.tee $6
+       (i32.add
+        (local.get $0)
+        (i32.const 28)
+       )
+      )
+     )
+    )
+   )
+   (i32.store offset=4
+    (local.get $3)
+    (local.tee $5
+     (i32.sub
+      (i32.load
+       (local.tee $11
+        (i32.add
+         (local.get $0)
+         (i32.const 20)
+        )
+       )
+      )
+      (local.get $4)
+     )
+    )
+   )
+   (i32.store offset=8
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=12
+    (local.get $3)
+    (local.get $2)
+   )
+   (local.set $13
+    (i32.add
+     (local.get $0)
+     (i32.const 60)
+    )
+   )
+   (local.set $14
+    (i32.add
+     (local.get $0)
+     (i32.const 44)
+    )
+   )
+   (local.set $1
+    (local.get $3)
+   )
+   (local.set $4
+    (i32.const 2)
+   )
+   (local.set $12
+    (i32.add
+     (local.get $5)
+     (local.get $2)
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (loop $label$5
+       (if
+        (i32.load
+         (i32.const 4128)
+        )
+        (block
+         (call $fimport$9
+          (i32.const 1)
+          (local.get $0)
+         )
+         (i32.store
+          (local.get $10)
+          (i32.load
+           (local.get $13)
+          )
+         )
+         (i32.store offset=4
+          (local.get $10)
+          (local.get $1)
+         )
+         (i32.store offset=8
+          (local.get $10)
+          (local.get $4)
+         )
+         (local.set $3
+          (call $11
+           (call $fimport$15
+            (i32.const 146)
+            (local.get $10)
+           )
+          )
+         )
+         (call $fimport$7
+          (i32.const 0)
+         )
+        )
+        (block
+         (i32.store
+          (local.get $9)
+          (i32.load
+           (local.get $13)
+          )
+         )
+         (i32.store offset=4
+          (local.get $9)
+          (local.get $1)
+         )
+         (i32.store offset=8
+          (local.get $9)
+          (local.get $4)
+         )
+         (local.set $3
+          (call $11
+           (call $fimport$15
+            (i32.const 146)
+            (local.get $9)
+           )
+          )
+         )
+        )
+       )
+       (br_if $label$4
+        (i32.eq
+         (local.get $12)
+         (local.get $3)
+        )
+       )
+       (br_if $label$3
+        (i32.lt_s
+         (local.get $3)
+         (i32.const 0)
+        )
+       )
+       (local.set $5
+        (if (result i32)
+         (i32.gt_u
+          (local.get $3)
+          (local.tee $5
+           (i32.load offset=4
+            (local.get $1)
+           )
+          )
+         )
+         (block (result i32)
+          (i32.store
+           (local.get $6)
+           (local.tee $7
+            (i32.load
+             (local.get $14)
+            )
+           )
+          )
+          (i32.store
+           (local.get $11)
+           (local.get $7)
+          )
+          (local.set $7
+           (i32.load offset=12
+            (local.get $1)
+           )
+          )
+          (local.set $1
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+          (local.set $4
+           (i32.add
+            (local.get $4)
+            (i32.const -1)
+           )
+          )
+          (i32.sub
+           (local.get $3)
+           (local.get $5)
+          )
+         )
+         (if (result i32)
+          (i32.eq
+           (local.get $4)
+           (i32.const 2)
+          )
+          (block (result i32)
+           (i32.store
+            (local.get $6)
+            (i32.add
+             (i32.load
+              (local.get $6)
+             )
+             (local.get $3)
+            )
+           )
+           (local.set $7
+            (local.get $5)
+           )
+           (local.set $4
+            (i32.const 2)
+           )
+           (local.get $3)
+          )
+          (block (result i32)
+           (local.set $7
+            (local.get $5)
+           )
+           (local.get $3)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $1)
+        (i32.add
+         (i32.load
+          (local.get $1)
+         )
+         (local.get $5)
+        )
+       )
+       (i32.store offset=4
+        (local.get $1)
+        (i32.sub
+         (local.get $7)
+         (local.get $5)
+        )
+       )
+       (local.set $12
+        (i32.sub
+         (local.get $12)
+         (local.get $3)
+        )
+       )
+       (br $label$5)
+      )
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (i32.add
+       (local.tee $1
+        (i32.load
+         (local.get $14)
+        )
+       )
+       (i32.load offset=48
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (local.get $6)
+      (local.get $1)
+     )
+     (i32.store
+      (local.get $11)
+      (local.get $1)
+     )
+     (br $label$2)
+    )
+    (i32.store offset=16
+     (local.get $0)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $6)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $11)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $0)
+     (i32.or
+      (i32.load
+       (local.get $0)
+      )
+      (i32.const 32)
+     )
+    )
+    (local.set $2
+     (if (result i32)
+      (i32.eq
+       (local.get $4)
+       (i32.const 2)
+      )
+      (i32.const 0)
+      (i32.sub
+       (local.get $2)
+       (i32.load offset=4
+        (local.get $1)
+       )
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $8)
+   )
+   (local.get $2)
+  )
+ )
+ (func $16 (; 29 ;) (type $3) (param $0 i32)
+  (if
+   (i32.eqz
+    (i32.load offset=68
+     (local.get $0)
+    )
+   )
+   (call $13
+    (local.get $0)
+   )
+  )
+ )
+ (func $17 (; 30 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $5
+    (i32.and
+     (local.get $1)
+     (i32.const 255)
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (if
+       (i32.and
+        (local.tee $4
+         (i32.ne
+          (local.get $2)
+          (i32.const 0)
+         )
+        )
+        (i32.ne
+         (i32.and
+          (local.get $0)
+          (i32.const 3)
+         )
+         (i32.const 0)
+        )
+       )
+       (block
+        (local.set $4
+         (i32.and
+          (local.get $1)
+          (i32.const 255)
+         )
+        )
+        (local.set $3
+         (local.get $2)
+        )
+        (local.set $2
+         (local.get $0)
+        )
+        (loop $label$6
+         (if
+          (i32.eq
+           (i32.load8_s
+            (local.get $2)
+           )
+           (i32.shr_s
+            (i32.shl
+             (local.get $4)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+          )
+          (block
+           (local.set $0
+            (local.get $3)
+           )
+           (br $label$3)
+          )
+         )
+         (br_if $label$6
+          (i32.and
+           (local.tee $0
+            (i32.ne
+             (local.tee $3
+              (i32.add
+               (local.get $3)
+               (i32.const -1)
+              )
+             )
+             (i32.const 0)
+            )
+           )
+           (i32.ne
+            (i32.and
+             (local.tee $2
+              (i32.add
+               (local.get $2)
+               (i32.const 1)
+              )
+             )
+             (i32.const 3)
+            )
+            (i32.const 0)
+           )
+          )
+         )
+         (br $label$4)
+        )
+       )
+       (block
+        (local.set $3
+         (local.get $2)
+        )
+        (local.set $2
+         (local.get $0)
+        )
+        (local.set $0
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (if
+      (local.get $0)
+      (block
+       (local.set $0
+        (local.get $3)
+       )
+       (br $label$3)
+      )
+      (local.set $0
+       (i32.const 0)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.ne
+      (i32.load8_s
+       (local.get $2)
+      )
+      (i32.shr_s
+       (i32.shl
+        (local.tee $1
+         (i32.and
+          (local.get $1)
+          (i32.const 255)
+         )
+        )
+        (i32.const 24)
+       )
+       (i32.const 24)
+      )
+     )
+     (block
+      (local.set $3
+       (i32.mul
+        (local.get $5)
+        (i32.const 16843009)
+       )
+      )
+      (block $label$12
+       (block $label$13
+        (br_if $label$13
+         (i32.le_u
+          (local.get $0)
+          (i32.const 3)
+         )
+        )
+        (loop $label$14
+         (if
+          (i32.eqz
+           (i32.and
+            (i32.xor
+             (i32.and
+              (local.tee $4
+               (i32.xor
+                (i32.load
+                 (local.get $2)
+                )
+                (local.get $3)
+               )
+              )
+              (i32.const -2139062144)
+             )
+             (i32.const -2139062144)
+            )
+            (i32.add
+             (local.get $4)
+             (i32.const -16843009)
+            )
+           )
+          )
+          (block
+           (local.set $2
+            (i32.add
+             (local.get $2)
+             (i32.const 4)
+            )
+           )
+           (br_if $label$14
+            (i32.gt_u
+             (local.tee $0
+              (i32.add
+               (local.get $0)
+               (i32.const -4)
+              )
+             )
+             (i32.const 3)
+            )
+           )
+           (br $label$13)
+          )
+         )
+        )
+        (br $label$12)
+       )
+       (if
+        (i32.eqz
+         (local.get $0)
+        )
+        (block
+         (local.set $0
+          (i32.const 0)
+         )
+         (br $label$2)
+        )
+       )
+      )
+      (loop $label$17
+       (br_if $label$2
+        (i32.eq
+         (i32.load8_s
+          (local.get $2)
+         )
+         (i32.shr_s
+          (i32.shl
+           (local.get $1)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (local.set $2
+        (i32.add
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (br_if $label$17
+        (local.tee $0
+         (i32.add
+          (local.get $0)
+          (i32.const -1)
+         )
+        )
+       )
+       (local.set $0
+        (i32.const 0)
+       )
+      )
+     )
+    )
+   )
+   (if (result i32)
+    (local.get $0)
+    (local.get $2)
+    (i32.const 0)
+   )
+  )
+ )
+ (func $18 (; 31 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 224)
+    )
+   )
+   (local.set $5
+    (i32.add
+     (local.get $4)
+     (i32.const 136)
+    )
+   )
+   (i64.store align=4
+    (local.tee $3
+     (i32.add
+      (local.get $4)
+      (i32.const 80)
+     )
+    )
+    (i64.const 0)
+   )
+   (i64.store offset=8 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=16 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=24 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=32 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i32.store
+    (local.tee $6
+     (i32.add
+      (local.get $4)
+      (i32.const 120)
+     )
+    )
+    (i32.load
+     (local.get $2)
+    )
+   )
+   (if
+    (i32.lt_s
+     (call $19
+      (i32.const 0)
+      (local.get $1)
+      (local.get $6)
+      (local.tee $2
+       (local.get $4)
+      )
+      (local.get $3)
+     )
+     (i32.const 0)
+    )
+    (local.set $1
+     (i32.const -1)
+    )
+    (block
+     (local.set $12
+      (if (result i32)
+       (i32.gt_s
+        (i32.load offset=76
+         (local.get $0)
+        )
+        (i32.const -1)
+       )
+       (call $20
+        (local.get $0)
+       )
+       (i32.const 0)
+      )
+     )
+     (local.set $7
+      (i32.load
+       (local.get $0)
+      )
+     )
+     (if
+      (i32.lt_s
+       (i32.load8_s offset=74
+        (local.get $0)
+       )
+       (i32.const 1)
+      )
+      (i32.store
+       (local.get $0)
+       (i32.and
+        (local.get $7)
+        (i32.const -33)
+       )
+      )
+     )
+     (if
+      (i32.load
+       (local.tee $8
+        (i32.add
+         (local.get $0)
+         (i32.const 48)
+        )
+       )
+      )
+      (local.set $1
+       (call $19
+        (local.get $0)
+        (local.get $1)
+        (local.get $6)
+        (local.get $2)
+        (local.get $3)
+       )
+      )
+      (block
+       (local.set $10
+        (i32.load
+         (local.tee $9
+          (i32.add
+           (local.get $0)
+           (i32.const 44)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $9)
+        (local.get $5)
+       )
+       (i32.store
+        (local.tee $13
+         (i32.add
+          (local.get $0)
+          (i32.const 28)
+         )
+        )
+        (local.get $5)
+       )
+       (i32.store
+        (local.tee $11
+         (i32.add
+          (local.get $0)
+          (i32.const 20)
+         )
+        )
+        (local.get $5)
+       )
+       (i32.store
+        (local.get $8)
+        (i32.const 80)
+       )
+       (i32.store
+        (local.tee $14
+         (i32.add
+          (local.get $0)
+          (i32.const 16)
+         )
+        )
+        (i32.add
+         (local.get $5)
+         (i32.const 80)
+        )
+       )
+       (local.set $1
+        (call $19
+         (local.get $0)
+         (local.get $1)
+         (local.get $6)
+         (local.get $2)
+         (local.get $3)
+        )
+       )
+       (if
+        (local.get $10)
+        (block
+         (drop
+          (call_indirect (type $0)
+           (local.get $0)
+           (i32.const 0)
+           (i32.const 0)
+           (i32.add
+            (i32.and
+             (i32.load offset=36
+              (local.get $0)
+             )
+             (i32.const 3)
+            )
+            (i32.const 2)
+           )
+          )
+         )
+         (if
+          (i32.eqz
+           (i32.load
+            (local.get $11)
+           )
+          )
+          (local.set $1
+           (i32.const -1)
+          )
+         )
+         (i32.store
+          (local.get $9)
+          (local.get $10)
+         )
+         (i32.store
+          (local.get $8)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $14)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $13)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $11)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (i32.store
+      (local.get $0)
+      (i32.or
+       (local.tee $2
+        (i32.load
+         (local.get $0)
+        )
+       )
+       (i32.and
+        (local.get $7)
+        (i32.const 32)
+       )
+      )
+     )
+     (if
+      (local.get $12)
+      (call $13
+       (local.get $0)
+      )
+     )
+     (if
+      (i32.and
+       (local.get $2)
+       (i32.const 32)
+      )
+      (local.set $1
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $1)
+  )
+ )
+ (func $19 (; 32 ;) (type $7) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 f64)
+  (local $53 f64)
+  (block $label$1 (result i32)
+   (local.set $23
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 624)
+    )
+   )
+   (local.set $20
+    (i32.add
+     (local.get $23)
+     (i32.const 16)
+    )
+   )
+   (local.set $16
+    (local.get $23)
+   )
+   (local.set $36
+    (i32.add
+     (local.get $23)
+     (i32.const 528)
+    )
+   )
+   (local.set $30
+    (i32.ne
+     (local.get $0)
+     (i32.const 0)
+    )
+   )
+   (local.set $38
+    (local.tee $21
+     (i32.add
+      (local.tee $17
+       (i32.add
+        (local.get $23)
+        (i32.const 536)
+       )
+      )
+      (i32.const 40)
+     )
+    )
+   )
+   (local.set $39
+    (i32.add
+     (local.get $17)
+     (i32.const 39)
+    )
+   )
+   (local.set $42
+    (i32.add
+     (local.tee $37
+      (i32.add
+       (local.get $23)
+       (i32.const 8)
+      )
+     )
+     (i32.const 4)
+    )
+   )
+   (local.set $43
+    (i32.sub
+     (i32.const 0)
+     (local.tee $27
+      (local.tee $19
+       (i32.add
+        (local.get $23)
+        (i32.const 588)
+       )
+      )
+     )
+    )
+   )
+   (local.set $33
+    (i32.add
+     (local.tee $17
+      (i32.add
+       (local.get $23)
+       (i32.const 576)
+      )
+     )
+     (i32.const 12)
+    )
+   )
+   (local.set $40
+    (i32.add
+     (local.get $17)
+     (i32.const 11)
+    )
+   )
+   (local.set $44
+    (i32.sub
+     (local.tee $28
+      (local.get $33)
+     )
+     (local.get $27)
+    )
+   )
+   (local.set $45
+    (i32.sub
+     (i32.const -2)
+     (local.get $27)
+    )
+   )
+   (local.set $46
+    (i32.add
+     (local.get $28)
+     (i32.const 2)
+    )
+   )
+   (local.set $48
+    (i32.add
+     (local.tee $47
+      (i32.add
+       (local.get $23)
+       (i32.const 24)
+      )
+     )
+     (i32.const 288)
+    )
+   )
+   (local.set $41
+    (local.tee $31
+     (i32.add
+      (local.get $19)
+      (i32.const 9)
+     )
+    )
+   )
+   (local.set $34
+    (i32.add
+     (local.get $19)
+     (i32.const 8)
+    )
+   )
+   (local.set $15
+    (i32.const 0)
+   )
+   (local.set $10
+    (i32.const 0)
+   )
+   (local.set $17
+    (i32.const 0)
+   )
+   (block $label$2
+    (block $label$3
+     (loop $label$4
+      (block $label$5
+       (if
+        (i32.gt_s
+         (local.get $15)
+         (i32.const -1)
+        )
+        (local.set $15
+         (if (result i32)
+          (i32.gt_s
+           (local.get $10)
+           (i32.sub
+            (i32.const 2147483647)
+            (local.get $15)
+           )
+          )
+          (block (result i32)
+           (i32.store
+            (call $12)
+            (i32.const 75)
+           )
+           (i32.const -1)
+          )
+          (i32.add
+           (local.get $10)
+           (local.get $15)
+          )
+         )
+        )
+       )
+       (br_if $label$3
+        (i32.eqz
+         (i32.shr_s
+          (i32.shl
+           (local.tee $5
+            (i32.load8_s
+             (local.get $1)
+            )
+           )
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (local.set $11
+        (local.get $1)
+       )
+       (block $label$9
+        (block $label$10
+         (loop $label$11
+          (block $label$12
+           (block $label$13
+            (block $label$14
+             (block $label$15
+              (br_table $label$14 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$15 $label$13
+               (i32.sub
+                (i32.shr_s
+                 (i32.shl
+                  (local.get $5)
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const 0)
+               )
+              )
+             )
+             (local.set $5
+              (local.get $11)
+             )
+             (br $label$10)
+            )
+            (local.set $5
+             (local.get $11)
+            )
+            (br $label$12)
+           )
+           (local.set $5
+            (i32.load8_s
+             (local.tee $11
+              (i32.add
+               (local.get $11)
+               (i32.const 1)
+              )
+             )
+            )
+           )
+           (br $label$11)
+          )
+         )
+         (br $label$9)
+        )
+        (loop $label$16
+         (br_if $label$9
+          (i32.ne
+           (i32.load8_s offset=1
+            (local.get $5)
+           )
+           (i32.const 37)
+          )
+         )
+         (local.set $11
+          (i32.add
+           (local.get $11)
+           (i32.const 1)
+          )
+         )
+         (br_if $label$16
+          (i32.eq
+           (i32.load8_s
+            (local.tee $5
+             (i32.add
+              (local.get $5)
+              (i32.const 2)
+             )
+            )
+           )
+           (i32.const 37)
+          )
+         )
+        )
+       )
+       (local.set $10
+        (i32.sub
+         (local.get $11)
+         (local.get $1)
+        )
+       )
+       (if
+        (local.get $30)
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.load
+            (local.get $0)
+           )
+           (i32.const 32)
+          )
+         )
+         (drop
+          (call $21
+           (local.get $1)
+           (local.get $10)
+           (local.get $0)
+          )
+         )
+        )
+       )
+       (if
+        (local.get $10)
+        (block
+         (local.set $1
+          (local.get $5)
+         )
+         (br $label$4)
+        )
+       )
+       (local.set $10
+        (if (result i32)
+         (i32.lt_u
+          (local.tee $9
+           (i32.add
+            (i32.shr_s
+             (i32.shl
+              (local.tee $10
+               (i32.load8_s
+                (local.tee $11
+                 (i32.add
+                  (local.get $5)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const -48)
+           )
+          )
+          (i32.const 10)
+         )
+         (block (result i32)
+          (local.set $10
+           (i32.add
+            (local.get $5)
+            (i32.const 3)
+           )
+          )
+          (if
+           (local.tee $12
+            (i32.eq
+             (i32.load8_s offset=2
+              (local.get $5)
+             )
+             (i32.const 36)
+            )
+           )
+           (local.set $11
+            (local.get $10)
+           )
+          )
+          (if
+           (local.get $12)
+           (local.set $17
+            (i32.const 1)
+           )
+          )
+          (local.set $5
+           (i32.load8_s
+            (local.get $11)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.get $12)
+           )
+           (local.set $9
+            (i32.const -1)
+           )
+          )
+          (local.get $17)
+         )
+         (block (result i32)
+          (local.set $5
+           (local.get $10)
+          )
+          (local.set $9
+           (i32.const -1)
+          )
+          (local.get $17)
+         )
+        )
+       )
+       (block $label$25
+        (if
+         (i32.lt_u
+          (local.tee $12
+           (i32.add
+            (i32.shr_s
+             (i32.shl
+              (local.get $5)
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const -32)
+           )
+          )
+          (i32.const 32)
+         )
+         (block
+          (local.set $17
+           (i32.const 0)
+          )
+          (loop $label$27
+           (br_if $label$25
+            (i32.eqz
+             (i32.and
+              (i32.shl
+               (i32.const 1)
+               (local.get $12)
+              )
+              (i32.const 75913)
+             )
+            )
+           )
+           (local.set $17
+            (i32.or
+             (i32.shl
+              (i32.const 1)
+              (i32.add
+               (i32.shr_s
+                (i32.shl
+                 (local.get $5)
+                 (i32.const 24)
+                )
+                (i32.const 24)
+               )
+               (i32.const -32)
+              )
+             )
+             (local.get $17)
+            )
+           )
+           (br_if $label$27
+            (i32.lt_u
+             (local.tee $12
+              (i32.add
+               (i32.shr_s
+                (i32.shl
+                 (local.tee $5
+                  (i32.load8_s
+                   (local.tee $11
+                    (i32.add
+                     (local.get $11)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 24)
+                )
+                (i32.const 24)
+               )
+               (i32.const -32)
+              )
+             )
+             (i32.const 32)
+            )
+           )
+          )
+         )
+         (local.set $17
+          (i32.const 0)
+         )
+        )
+       )
+       (block $label$29
+        (if
+         (i32.eq
+          (i32.shr_s
+           (i32.shl
+            (local.get $5)
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+          (i32.const 42)
+         )
+         (block
+          (local.set $11
+           (block $label$31 (result i32)
+            (block $label$32
+             (br_if $label$32
+              (i32.ge_u
+               (local.tee $12
+                (i32.add
+                 (i32.shr_s
+                  (i32.shl
+                   (local.tee $5
+                    (i32.load8_s
+                     (local.tee $7
+                      (i32.add
+                       (local.get $11)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                   )
+                   (i32.const 24)
+                  )
+                  (i32.const 24)
+                 )
+                 (i32.const -48)
+                )
+               )
+               (i32.const 10)
+              )
+             )
+             (br_if $label$32
+              (i32.ne
+               (i32.load8_s offset=2
+                (local.get $11)
+               )
+               (i32.const 36)
+              )
+             )
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $12)
+                (i32.const 2)
+               )
+              )
+              (i32.const 10)
+             )
+             (local.set $8
+              (i32.const 1)
+             )
+             (local.set $10
+              (i32.wrap_i64
+               (i64.load
+                (i32.add
+                 (local.get $3)
+                 (i32.shl
+                  (i32.add
+                   (i32.load8_s
+                    (local.get $7)
+                   )
+                   (i32.const -48)
+                  )
+                  (i32.const 3)
+                 )
+                )
+               )
+              )
+             )
+             (br $label$31
+              (i32.add
+               (local.get $11)
+               (i32.const 3)
+              )
+             )
+            )
+            (if
+             (local.get $10)
+             (block
+              (local.set $15
+               (i32.const -1)
+              )
+              (br $label$5)
+             )
+            )
+            (if
+             (i32.eqz
+              (local.get $30)
+             )
+             (block
+              (local.set $12
+               (local.get $17)
+              )
+              (local.set $17
+               (i32.const 0)
+              )
+              (local.set $11
+               (local.get $7)
+              )
+              (local.set $10
+               (i32.const 0)
+              )
+              (br $label$29)
+             )
+            )
+            (local.set $10
+             (i32.load
+              (local.tee $11
+               (i32.and
+                (i32.add
+                 (i32.load
+                  (local.get $2)
+                 )
+                 (i32.const 3)
+                )
+                (i32.const -4)
+               )
+              )
+             )
+            )
+            (i32.store
+             (local.get $2)
+             (i32.add
+              (local.get $11)
+              (i32.const 4)
+             )
+            )
+            (local.set $8
+             (i32.const 0)
+            )
+            (local.get $7)
+           )
+          )
+          (local.set $12
+           (i32.or
+            (local.get $17)
+            (i32.const 8192)
+           )
+          )
+          (local.set $7
+           (i32.sub
+            (i32.const 0)
+            (local.get $10)
+           )
+          )
+          (local.set $5
+           (i32.load8_s
+            (local.get $11)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.tee $6
+             (i32.lt_s
+              (local.get $10)
+              (i32.const 0)
+             )
+            )
+           )
+           (local.set $12
+            (local.get $17)
+           )
+          )
+          (local.set $17
+           (local.get $8)
+          )
+          (if
+           (local.get $6)
+           (local.set $10
+            (local.get $7)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.tee $12
+            (i32.add
+             (i32.shr_s
+              (i32.shl
+               (local.get $5)
+               (i32.const 24)
+              )
+              (i32.const 24)
+             )
+             (i32.const -48)
+            )
+           )
+           (i32.const 10)
+          )
+          (block
+           (local.set $7
+            (i32.const 0)
+           )
+           (local.set $5
+            (local.get $12)
+           )
+           (loop $label$39
+            (local.set $7
+             (i32.add
+              (i32.mul
+               (local.get $7)
+               (i32.const 10)
+              )
+              (local.get $5)
+             )
+            )
+            (br_if $label$39
+             (i32.lt_u
+              (local.tee $5
+               (i32.add
+                (i32.shr_s
+                 (i32.shl
+                  (local.tee $12
+                   (i32.load8_s
+                    (local.tee $11
+                     (i32.add
+                      (local.get $11)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                  )
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+            )
+           )
+           (if
+            (i32.lt_s
+             (local.get $7)
+             (i32.const 0)
+            )
+            (block
+             (local.set $15
+              (i32.const -1)
+             )
+             (br $label$5)
+            )
+            (block
+             (local.set $5
+              (local.get $12)
+             )
+             (local.set $12
+              (local.get $17)
+             )
+             (local.set $17
+              (local.get $10)
+             )
+             (local.set $10
+              (local.get $7)
+             )
+            )
+           )
+          )
+          (block
+           (local.set $12
+            (local.get $17)
+           )
+           (local.set $17
+            (local.get $10)
+           )
+           (local.set $10
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (block $label$43
+        (if
+         (i32.eq
+          (i32.shr_s
+           (i32.shl
+            (local.get $5)
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+          (i32.const 46)
+         )
+         (block
+          (if
+           (i32.ne
+            (i32.shr_s
+             (i32.shl
+              (local.tee $5
+               (i32.load8_s
+                (local.tee $7
+                 (i32.add
+                  (local.get $11)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const 42)
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.tee $5
+               (i32.add
+                (i32.shr_s
+                 (i32.shl
+                  (local.get $5)
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+             (block
+              (local.set $11
+               (local.get $7)
+              )
+              (local.set $7
+               (i32.const 0)
+              )
+             )
+             (block
+              (local.set $5
+               (i32.const 0)
+              )
+              (local.set $11
+               (local.get $7)
+              )
+              (br $label$43)
+             )
+            )
+            (loop $label$48
+             (local.set $5
+              (i32.add
+               (i32.mul
+                (local.get $7)
+                (i32.const 10)
+               )
+               (local.get $5)
+              )
+             )
+             (br_if $label$43
+              (i32.ge_u
+               (local.tee $8
+                (i32.add
+                 (i32.load8_s
+                  (local.tee $11
+                   (i32.add
+                    (local.get $11)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (i32.const -48)
+                )
+               )
+               (i32.const 10)
+              )
+             )
+             (local.set $7
+              (local.get $5)
+             )
+             (local.set $5
+              (local.get $8)
+             )
+             (br $label$48)
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.tee $5
+             (i32.add
+              (i32.load8_s
+               (local.tee $7
+                (i32.add
+                 (local.get $11)
+                 (i32.const 2)
+                )
+               )
+              )
+              (i32.const -48)
+             )
+            )
+            (i32.const 10)
+           )
+           (if
+            (i32.eq
+             (i32.load8_s offset=3
+              (local.get $11)
+             )
+             (i32.const 36)
+            )
+            (block
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $5)
+                (i32.const 2)
+               )
+              )
+              (i32.const 10)
+             )
+             (local.set $5
+              (i32.wrap_i64
+               (i64.load
+                (i32.add
+                 (local.get $3)
+                 (i32.shl
+                  (i32.add
+                   (i32.load8_s
+                    (local.get $7)
+                   )
+                   (i32.const -48)
+                  )
+                  (i32.const 3)
+                 )
+                )
+               )
+              )
+             )
+             (local.set $11
+              (i32.add
+               (local.get $11)
+               (i32.const 4)
+              )
+             )
+             (br $label$43)
+            )
+           )
+          )
+          (if
+           (local.get $17)
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+          )
+          (local.set $11
+           (if (result i32)
+            (local.get $30)
+            (block (result i32)
+             (local.set $5
+              (i32.load
+               (local.tee $11
+                (i32.and
+                 (i32.add
+                  (i32.load
+                   (local.get $2)
+                  )
+                  (i32.const 3)
+                 )
+                 (i32.const -4)
+                )
+               )
+              )
+             )
+             (i32.store
+              (local.get $2)
+              (i32.add
+               (local.get $11)
+               (i32.const 4)
+              )
+             )
+             (local.get $7)
+            )
+            (block (result i32)
+             (local.set $5
+              (i32.const 0)
+             )
+             (local.get $7)
+            )
+           )
+          )
+         )
+         (local.set $5
+          (i32.const -1)
+         )
+        )
+       )
+       (local.set $7
+        (local.get $11)
+       )
+       (local.set $8
+        (i32.const 0)
+       )
+       (loop $label$55
+        (if
+         (i32.gt_u
+          (local.tee $6
+           (i32.add
+            (i32.load8_s
+             (local.get $7)
+            )
+            (i32.const -65)
+           )
+          )
+          (i32.const 57)
+         )
+         (block
+          (local.set $15
+           (i32.const -1)
+          )
+          (br $label$5)
+         )
+        )
+        (local.set $11
+         (i32.add
+          (local.get $7)
+          (i32.const 1)
+         )
+        )
+        (if
+         (i32.lt_u
+          (i32.add
+           (local.tee $6
+            (i32.and
+             (local.tee $13
+              (i32.load8_s
+               (i32.add
+                (i32.add
+                 (i32.mul
+                  (local.get $8)
+                  (i32.const 58)
+                 )
+                 (i32.const 1699)
+                )
+                (local.get $6)
+               )
+              )
+             )
+             (i32.const 255)
+            )
+           )
+           (i32.const -1)
+          )
+          (i32.const 8)
+         )
+         (block
+          (local.set $7
+           (local.get $11)
+          )
+          (local.set $8
+           (local.get $6)
+          )
+          (br $label$55)
+         )
+        )
+       )
+       (if
+        (i32.eqz
+         (i32.shr_s
+          (i32.shl
+           (local.get $13)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+        (block
+         (local.set $15
+          (i32.const -1)
+         )
+         (br $label$5)
+        )
+       )
+       (local.set $14
+        (i32.gt_s
+         (local.get $9)
+         (i32.const -1)
+        )
+       )
+       (block $label$59
+        (block $label$60
+         (if
+          (i32.eq
+           (i32.shr_s
+            (i32.shl
+             (local.get $13)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+           (i32.const 19)
+          )
+          (if
+           (local.get $14)
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+           (br $label$60)
+          )
+          (block
+           (if
+            (local.get $14)
+            (block
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $9)
+                (i32.const 2)
+               )
+              )
+              (local.get $6)
+             )
+             (i64.store
+              (local.get $16)
+              (i64.load
+               (i32.add
+                (local.get $3)
+                (i32.shl
+                 (local.get $9)
+                 (i32.const 3)
+                )
+               )
+              )
+             )
+             (br $label$60)
+            )
+           )
+           (if
+            (i32.eqz
+             (local.get $30)
+            )
+            (block
+             (local.set $15
+              (i32.const 0)
+             )
+             (br $label$5)
+            )
+           )
+           (call $22
+            (local.get $16)
+            (local.get $6)
+            (local.get $2)
+           )
+          )
+         )
+         (br $label$59)
+        )
+        (if
+         (i32.eqz
+          (local.get $30)
+         )
+         (block
+          (local.set $10
+           (i32.const 0)
+          )
+          (local.set $1
+           (local.get $11)
+          )
+          (br $label$4)
+         )
+        )
+       )
+       (local.set $9
+        (i32.and
+         (local.tee $7
+          (i32.load8_s
+           (local.get $7)
+          )
+         )
+         (i32.const -33)
+        )
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.ne
+           (local.get $8)
+           (i32.const 0)
+          )
+          (i32.eq
+           (i32.and
+            (local.get $7)
+            (i32.const 15)
+           )
+           (i32.const 3)
+          )
+         )
+        )
+        (local.set $9
+         (local.get $7)
+        )
+       )
+       (local.set $7
+        (i32.and
+         (local.get $12)
+         (i32.const -65537)
+        )
+       )
+       (if
+        (i32.and
+         (local.get $12)
+         (i32.const 8192)
+        )
+        (local.set $12
+         (local.get $7)
+        )
+       )
+       (block $label$70
+        (block $label$71
+         (block $label$72
+          (block $label$73
+           (block $label$74
+            (block $label$75
+             (block $label$76
+              (block $label$77
+               (block $label$78
+                (block $label$79
+                 (block $label$80
+                  (block $label$81
+                   (block $label$82
+                    (block $label$83
+                     (block $label$84
+                      (block $label$85
+                       (block $label$86
+                        (block $label$87
+                         (block $label$88
+                          (block $label$89
+                           (br_table $label$78 $label$77 $label$80 $label$77 $label$78 $label$78 $label$78 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$79 $label$77 $label$77 $label$77 $label$77 $label$87 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$78 $label$77 $label$83 $label$85 $label$78 $label$78 $label$78 $label$77 $label$85 $label$77 $label$77 $label$77 $label$82 $label$89 $label$86 $label$88 $label$77 $label$77 $label$81 $label$77 $label$84 $label$77 $label$77 $label$87 $label$77
+                            (i32.sub
+                             (local.get $9)
+                             (i32.const 65)
+                            )
+                           )
+                          )
+                          (block $label$90
+                           (block $label$91
+                            (block $label$92
+                             (block $label$93
+                              (block $label$94
+                               (block $label$95
+                                (block $label$96
+                                 (block $label$97
+                                  (br_table $label$97 $label$96 $label$95 $label$94 $label$93 $label$90 $label$92 $label$91 $label$90
+                                   (i32.sub
+                                    (i32.shr_s
+                                     (i32.shl
+                                      (i32.and
+                                       (local.get $8)
+                                       (i32.const 255)
+                                      )
+                                      (i32.const 24)
+                                     )
+                                     (i32.const 24)
+                                    )
+                                    (i32.const 0)
+                                   )
+                                  )
+                                 )
+                                 (i32.store
+                                  (i32.load
+                                   (local.get $16)
+                                  )
+                                  (local.get $15)
+                                 )
+                                 (local.set $10
+                                  (i32.const 0)
+                                 )
+                                 (local.set $1
+                                  (local.get $11)
+                                 )
+                                 (br $label$4)
+                                )
+                                (i32.store
+                                 (i32.load
+                                  (local.get $16)
+                                 )
+                                 (local.get $15)
+                                )
+                                (local.set $10
+                                 (i32.const 0)
+                                )
+                                (local.set $1
+                                 (local.get $11)
+                                )
+                                (br $label$4)
+                               )
+                               (i64.store
+                                (i32.load
+                                 (local.get $16)
+                                )
+                                (i64.extend_i32_s
+                                 (local.get $15)
+                                )
+                               )
+                               (local.set $10
+                                (i32.const 0)
+                               )
+                               (local.set $1
+                                (local.get $11)
+                               )
+                               (br $label$4)
+                              )
+                              (i32.store16
+                               (i32.load
+                                (local.get $16)
+                               )
+                               (local.get $15)
+                              )
+                              (local.set $10
+                               (i32.const 0)
+                              )
+                              (local.set $1
+                               (local.get $11)
+                              )
+                              (br $label$4)
+                             )
+                             (i32.store8
+                              (i32.load
+                               (local.get $16)
+                              )
+                              (local.get $15)
+                             )
+                             (local.set $10
+                              (i32.const 0)
+                             )
+                             (local.set $1
+                              (local.get $11)
+                             )
+                             (br $label$4)
+                            )
+                            (i32.store
+                             (i32.load
+                              (local.get $16)
+                             )
+                             (local.get $15)
+                            )
+                            (local.set $10
+                             (i32.const 0)
+                            )
+                            (local.set $1
+                             (local.get $11)
+                            )
+                            (br $label$4)
+                           )
+                           (i64.store
+                            (i32.load
+                             (local.get $16)
+                            )
+                            (i64.extend_i32_s
+                             (local.get $15)
+                            )
+                           )
+                           (local.set $10
+                            (i32.const 0)
+                           )
+                           (local.set $1
+                            (local.get $11)
+                           )
+                           (br $label$4)
+                          )
+                          (local.set $10
+                           (i32.const 0)
+                          )
+                          (local.set $1
+                           (local.get $11)
+                          )
+                          (br $label$4)
+                         )
+                         (local.set $12
+                          (i32.or
+                           (local.get $12)
+                           (i32.const 8)
+                          )
+                         )
+                         (if
+                          (i32.le_u
+                           (local.get $5)
+                           (i32.const 8)
+                          )
+                          (local.set $5
+                           (i32.const 8)
+                          )
+                         )
+                         (local.set $9
+                          (i32.const 120)
+                         )
+                         (br $label$76)
+                        )
+                        (br $label$76)
+                       )
+                       (if
+                        (i64.eq
+                         (local.tee $50
+                          (i64.load
+                           (local.get $16)
+                          )
+                         )
+                         (i64.const 0)
+                        )
+                        (local.set $7
+                         (local.get $21)
+                        )
+                        (block
+                         (local.set $1
+                          (local.get $21)
+                         )
+                         (loop $label$101
+                          (i64.store8
+                           (local.tee $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const -1)
+                            )
+                           )
+                           (i64.or
+                            (i64.and
+                             (local.get $50)
+                             (i64.const 7)
+                            )
+                            (i64.const 48)
+                           )
+                          )
+                          (br_if $label$101
+                           (i64.ne
+                            (local.tee $50
+                             (i64.shr_u
+                              (local.get $50)
+                              (i64.const 3)
+                             )
+                            )
+                            (i64.const 0)
+                           )
+                          )
+                          (local.set $7
+                           (local.get $1)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.and
+                         (local.get $12)
+                         (i32.const 8)
+                        )
+                        (block
+                         (local.set $8
+                          (i32.add
+                           (local.tee $1
+                            (i32.sub
+                             (local.get $38)
+                             (local.get $7)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                         )
+                         (if
+                          (i32.le_s
+                           (local.get $5)
+                           (local.get $1)
+                          )
+                          (local.set $5
+                           (local.get $8)
+                          )
+                         )
+                         (local.set $6
+                          (i32.const 0)
+                         )
+                         (local.set $8
+                          (i32.const 2179)
+                         )
+                         (br $label$71)
+                        )
+                        (block
+                         (local.set $6
+                          (i32.const 0)
+                         )
+                         (local.set $8
+                          (i32.const 2179)
+                         )
+                         (br $label$71)
+                        )
+                       )
+                      )
+                      (if
+                       (i64.lt_s
+                        (local.tee $50
+                         (i64.load
+                          (local.get $16)
+                         )
+                        )
+                        (i64.const 0)
+                       )
+                       (block
+                        (i64.store
+                         (local.get $16)
+                         (local.tee $50
+                          (i64.sub
+                           (i64.const 0)
+                           (local.get $50)
+                          )
+                         )
+                        )
+                        (local.set $6
+                         (i32.const 1)
+                        )
+                        (local.set $8
+                         (i32.const 2179)
+                        )
+                        (br $label$75)
+                       )
+                      )
+                      (if
+                       (i32.and
+                        (local.get $12)
+                        (i32.const 2048)
+                       )
+                       (block
+                        (local.set $6
+                         (i32.const 1)
+                        )
+                        (local.set $8
+                         (i32.const 2180)
+                        )
+                        (br $label$75)
+                       )
+                       (block
+                        (local.set $6
+                         (local.tee $1
+                          (i32.and
+                           (local.get $12)
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (local.set $8
+                         (if (result i32)
+                          (local.get $1)
+                          (i32.const 2181)
+                          (i32.const 2179)
+                         )
+                        )
+                        (br $label$75)
+                       )
+                      )
+                     )
+                     (local.set $50
+                      (i64.load
+                       (local.get $16)
+                      )
+                     )
+                     (local.set $6
+                      (i32.const 0)
+                     )
+                     (local.set $8
+                      (i32.const 2179)
+                     )
+                     (br $label$75)
+                    )
+                    (i64.store8
+                     (local.get $39)
+                     (i64.load
+                      (local.get $16)
+                     )
+                    )
+                    (local.set $1
+                     (local.get $39)
+                    )
+                    (local.set $12
+                     (local.get $7)
+                    )
+                    (local.set $7
+                     (i32.const 1)
+                    )
+                    (local.set $6
+                     (i32.const 0)
+                    )
+                    (local.set $8
+                     (i32.const 2179)
+                    )
+                    (local.set $5
+                     (local.get $21)
+                    )
+                    (br $label$70)
+                   )
+                   (local.set $1
+                    (call $24
+                     (i32.load
+                      (call $12)
+                     )
+                    )
+                   )
+                   (br $label$74)
+                  )
+                  (if
+                   (i32.eqz
+                    (local.tee $1
+                     (i32.load
+                      (local.get $16)
+                     )
+                    )
+                   )
+                   (local.set $1
+                    (i32.const 2189)
+                   )
+                  )
+                  (br $label$74)
+                 )
+                 (i64.store32
+                  (local.get $37)
+                  (i64.load
+                   (local.get $16)
+                  )
+                 )
+                 (i32.store
+                  (local.get $42)
+                  (i32.const 0)
+                 )
+                 (i32.store
+                  (local.get $16)
+                  (local.get $37)
+                 )
+                 (local.set $7
+                  (local.get $37)
+                 )
+                 (local.set $6
+                  (i32.const -1)
+                 )
+                 (br $label$73)
+                )
+                (local.set $7
+                 (i32.load
+                  (local.get $16)
+                 )
+                )
+                (if
+                 (local.get $5)
+                 (block
+                  (local.set $6
+                   (local.get $5)
+                  )
+                  (br $label$73)
+                 )
+                 (block
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (i32.const 0)
+                   (local.get $12)
+                  )
+                  (local.set $1
+                   (i32.const 0)
+                  )
+                  (br $label$72)
+                 )
+                )
+               )
+               (local.set $52
+                (f64.load
+                 (local.get $16)
+                )
+               )
+               (i32.store
+                (local.get $20)
+                (i32.const 0)
+               )
+               (local.set $26
+                (if (result i32)
+                 (i64.lt_s
+                  (i64.reinterpret_f64
+                   (local.get $52)
+                  )
+                  (i64.const 0)
+                 )
+                 (block (result i32)
+                  (local.set $24
+                   (i32.const 1)
+                  )
+                  (local.set $52
+                   (f64.neg
+                    (local.get $52)
+                   )
+                  )
+                  (i32.const 2196)
+                 )
+                 (block (result i32)
+                  (local.set $1
+                   (i32.and
+                    (local.get $12)
+                    (i32.const 1)
+                   )
+                  )
+                  (if (result i32)
+                   (i32.and
+                    (local.get $12)
+                    (i32.const 2048)
+                   )
+                   (block (result i32)
+                    (local.set $24
+                     (i32.const 1)
+                    )
+                    (i32.const 2199)
+                   )
+                   (block (result i32)
+                    (local.set $24
+                     (local.get $1)
+                    )
+                    (if (result i32)
+                     (local.get $1)
+                     (i32.const 2202)
+                     (i32.const 2197)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+               (block $label$119
+                (if
+                 (i64.lt_u
+                  (i64.and
+                   (i64.reinterpret_f64
+                    (local.get $52)
+                   )
+                   (i64.const 9218868437227405312)
+                  )
+                  (i64.const 9218868437227405312)
+                 )
+                 (block
+                  (if
+                   (local.tee $1
+                    (f64.ne
+                     (local.tee $52
+                      (f64.mul
+                       (call $27
+                        (local.get $52)
+                        (local.get $20)
+                       )
+                       (f64.const 2)
+                      )
+                     )
+                     (f64.const 0)
+                    )
+                   )
+                   (i32.store
+                    (local.get $20)
+                    (i32.add
+                     (i32.load
+                      (local.get $20)
+                     )
+                     (i32.const -1)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (local.tee $22
+                     (i32.or
+                      (local.get $9)
+                      (i32.const 32)
+                     )
+                    )
+                    (i32.const 97)
+                   )
+                   (block
+                    (local.set $1
+                     (i32.add
+                      (local.get $26)
+                      (i32.const 9)
+                     )
+                    )
+                    (if
+                     (local.tee $6
+                      (i32.and
+                       (local.get $9)
+                       (i32.const 32)
+                      )
+                     )
+                     (local.set $26
+                      (local.get $1)
+                     )
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.or
+                       (i32.gt_u
+                        (local.get $5)
+                        (i32.const 11)
+                       )
+                       (i32.eqz
+                        (local.tee $1
+                         (i32.sub
+                          (i32.const 12)
+                          (local.get $5)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (block
+                      (local.set $53
+                       (f64.const 8)
+                      )
+                      (loop $label$125
+                       (local.set $53
+                        (f64.mul
+                         (local.get $53)
+                         (f64.const 16)
+                        )
+                       )
+                       (br_if $label$125
+                        (local.tee $1
+                         (i32.add
+                          (local.get $1)
+                          (i32.const -1)
+                         )
+                        )
+                       )
+                      )
+                      (local.set $52
+                       (if (result f64)
+                        (i32.eq
+                         (i32.load8_s
+                          (local.get $26)
+                         )
+                         (i32.const 45)
+                        )
+                        (f64.neg
+                         (f64.add
+                          (local.get $53)
+                          (f64.sub
+                           (f64.neg
+                            (local.get $52)
+                           )
+                           (local.get $53)
+                          )
+                         )
+                        )
+                        (f64.sub
+                         (f64.add
+                          (local.get $52)
+                          (local.get $53)
+                         )
+                         (local.get $53)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $1
+                     (i32.sub
+                      (i32.const 0)
+                      (local.tee $7
+                       (i32.load
+                        (local.get $20)
+                       )
+                      )
+                     )
+                    )
+                    (if
+                     (i32.eq
+                      (local.tee $1
+                       (call $23
+                        (i64.extend_i32_s
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.get $7)
+                           (i32.const 0)
+                          )
+                          (local.get $1)
+                          (local.get $7)
+                         )
+                        )
+                        (local.get $33)
+                       )
+                      )
+                      (local.get $33)
+                     )
+                     (block
+                      (i32.store8
+                       (local.get $40)
+                       (i32.const 48)
+                      )
+                      (local.set $1
+                       (local.get $40)
+                      )
+                     )
+                    )
+                    (local.set $13
+                     (i32.or
+                      (local.get $24)
+                      (i32.const 2)
+                     )
+                    )
+                    (i32.store8
+                     (i32.add
+                      (local.get $1)
+                      (i32.const -1)
+                     )
+                     (i32.add
+                      (i32.and
+                       (i32.shr_s
+                        (local.get $7)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 43)
+                     )
+                    )
+                    (i32.store8
+                     (local.tee $8
+                      (i32.add
+                       (local.get $1)
+                       (i32.const -2)
+                      )
+                     )
+                     (i32.add
+                      (local.get $9)
+                      (i32.const 15)
+                     )
+                    )
+                    (local.set $9
+                     (i32.lt_s
+                      (local.get $5)
+                      (i32.const 1)
+                     )
+                    )
+                    (local.set $14
+                     (i32.eqz
+                      (i32.and
+                       (local.get $12)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                    (local.set $1
+                     (local.get $19)
+                    )
+                    (loop $label$131
+                     (i32.store8
+                      (local.get $1)
+                      (i32.or
+                       (i32.load8_u
+                        (i32.add
+                         (local.tee $7
+                          (i32.trunc_f64_s
+                           (local.get $52)
+                          )
+                         )
+                         (i32.const 2163)
+                        )
+                       )
+                       (local.get $6)
+                      )
+                     )
+                     (local.set $52
+                      (f64.mul
+                       (f64.sub
+                        (local.get $52)
+                        (f64.convert_i32_s
+                         (local.get $7)
+                        )
+                       )
+                       (f64.const 16)
+                      )
+                     )
+                     (local.set $1
+                      (block $label$132 (result i32)
+                       (if (result i32)
+                        (i32.eq
+                         (i32.sub
+                          (local.tee $7
+                           (i32.add
+                            (local.get $1)
+                            (i32.const 1)
+                           )
+                          )
+                          (local.get $27)
+                         )
+                         (i32.const 1)
+                        )
+                        (block (result i32)
+                         (drop
+                          (br_if $label$132
+                           (local.get $7)
+                           (i32.and
+                            (local.get $14)
+                            (i32.and
+                             (local.get $9)
+                             (f64.eq
+                              (local.get $52)
+                              (f64.const 0)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.store8
+                          (local.get $7)
+                          (i32.const 46)
+                         )
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 2)
+                         )
+                        )
+                        (local.get $7)
+                       )
+                      )
+                     )
+                     (br_if $label$131
+                      (f64.ne
+                       (local.get $52)
+                       (f64.const 0)
+                      )
+                     )
+                    )
+                    (local.set $6
+                     (i32.sub
+                      (i32.add
+                       (local.get $46)
+                       (local.get $5)
+                      )
+                      (local.tee $7
+                       (local.get $8)
+                      )
+                     )
+                    )
+                    (local.set $9
+                     (i32.add
+                      (i32.sub
+                       (local.get $44)
+                       (local.get $7)
+                      )
+                      (local.get $1)
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 32)
+                     (local.get $10)
+                     (local.tee $5
+                      (i32.add
+                       (if (result i32)
+                        (i32.and
+                         (i32.ne
+                          (local.get $5)
+                          (i32.const 0)
+                         )
+                         (i32.lt_s
+                          (i32.add
+                           (local.get $45)
+                           (local.get $1)
+                          )
+                          (local.get $5)
+                         )
+                        )
+                        (local.get $6)
+                        (local.tee $6
+                         (local.get $9)
+                        )
+                       )
+                       (local.get $13)
+                      )
+                     )
+                     (local.get $12)
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $26)
+                       (local.get $13)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 48)
+                     (local.get $10)
+                     (local.get $5)
+                     (i32.xor
+                      (local.get $12)
+                      (i32.const 65536)
+                     )
+                    )
+                    (local.set $1
+                     (i32.sub
+                      (local.get $1)
+                      (local.get $27)
+                     )
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $19)
+                       (local.get $1)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 48)
+                     (i32.sub
+                      (local.get $6)
+                      (i32.add
+                       (local.get $1)
+                       (local.tee $1
+                        (i32.sub
+                         (local.get $28)
+                         (local.get $7)
+                        )
+                       )
+                      )
+                     )
+                     (i32.const 0)
+                     (i32.const 0)
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $8)
+                       (local.get $1)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 32)
+                     (local.get $10)
+                     (local.get $5)
+                     (i32.xor
+                      (local.get $12)
+                      (i32.const 8192)
+                     )
+                    )
+                    (if
+                     (i32.ge_s
+                      (local.get $5)
+                      (local.get $10)
+                     )
+                     (local.set $10
+                      (local.get $5)
+                     )
+                    )
+                    (br $label$119)
+                   )
+                  )
+                  (if
+                   (local.get $1)
+                   (block
+                    (i32.store
+                     (local.get $20)
+                     (local.tee $6
+                      (i32.add
+                       (i32.load
+                        (local.get $20)
+                       )
+                       (i32.const -28)
+                      )
+                     )
+                    )
+                    (local.set $52
+                     (f64.mul
+                      (local.get $52)
+                      (f64.const 268435456)
+                     )
+                    )
+                   )
+                   (local.set $6
+                    (i32.load
+                     (local.get $20)
+                    )
+                   )
+                  )
+                  (local.set $8
+                   (local.tee $7
+                    (if (result i32)
+                     (i32.lt_s
+                      (local.get $6)
+                      (i32.const 0)
+                     )
+                     (local.get $47)
+                     (local.get $48)
+                    )
+                   )
+                  )
+                  (loop $label$145
+                   (i32.store
+                    (local.get $8)
+                    (local.tee $1
+                     (i32.trunc_f64_s
+                      (local.get $52)
+                     )
+                    )
+                   )
+                   (local.set $8
+                    (i32.add
+                     (local.get $8)
+                     (i32.const 4)
+                    )
+                   )
+                   (br_if $label$145
+                    (f64.ne
+                     (local.tee $52
+                      (f64.mul
+                       (f64.sub
+                        (local.get $52)
+                        (f64.convert_i32_u
+                         (local.get $1)
+                        )
+                       )
+                       (f64.const 1e9)
+                      )
+                     )
+                     (f64.const 0)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.gt_s
+                    (local.get $6)
+                    (i32.const 0)
+                   )
+                   (block
+                    (local.set $1
+                     (local.get $7)
+                    )
+                    (loop $label$147
+                     (local.set $14
+                      (if (result i32)
+                       (i32.gt_s
+                        (local.get $6)
+                        (i32.const 29)
+                       )
+                       (i32.const 29)
+                       (local.get $6)
+                      )
+                     )
+                     (block $label$150
+                      (if
+                       (i32.ge_u
+                        (local.tee $6
+                         (i32.add
+                          (local.get $8)
+                          (i32.const -4)
+                         )
+                        )
+                        (local.get $1)
+                       )
+                       (block
+                        (local.set $50
+                         (i64.extend_i32_u
+                          (local.get $14)
+                         )
+                        )
+                        (local.set $13
+                         (i32.const 0)
+                        )
+                        (loop $label$152
+                         (i64.store32
+                          (local.get $6)
+                          (i64.rem_u
+                           (local.tee $51
+                            (i64.add
+                             (i64.shl
+                              (i64.extend_i32_u
+                               (i32.load
+                                (local.get $6)
+                               )
+                              )
+                              (local.get $50)
+                             )
+                             (i64.extend_i32_u
+                              (local.get $13)
+                             )
+                            )
+                           )
+                           (i64.const 1000000000)
+                          )
+                         )
+                         (local.set $13
+                          (i32.wrap_i64
+                           (i64.div_u
+                            (local.get $51)
+                            (i64.const 1000000000)
+                           )
+                          )
+                         )
+                         (br_if $label$152
+                          (i32.ge_u
+                           (local.tee $6
+                            (i32.add
+                             (local.get $6)
+                             (i32.const -4)
+                            )
+                           )
+                           (local.get $1)
+                          )
+                         )
+                        )
+                        (br_if $label$150
+                         (i32.eqz
+                          (local.get $13)
+                         )
+                        )
+                        (i32.store
+                         (local.tee $1
+                          (i32.add
+                           (local.get $1)
+                           (i32.const -4)
+                          )
+                         )
+                         (local.get $13)
+                        )
+                       )
+                      )
+                     )
+                     (loop $label$153
+                      (if
+                       (i32.gt_u
+                        (local.get $8)
+                        (local.get $1)
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.load
+                          (local.tee $6
+                           (i32.add
+                            (local.get $8)
+                            (i32.const -4)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (local.set $8
+                          (local.get $6)
+                         )
+                         (br $label$153)
+                        )
+                       )
+                      )
+                     )
+                     (i32.store
+                      (local.get $20)
+                      (local.tee $6
+                       (i32.sub
+                        (i32.load
+                         (local.get $20)
+                        )
+                        (local.get $14)
+                       )
+                      )
+                     )
+                     (br_if $label$147
+                      (i32.gt_s
+                       (local.get $6)
+                       (i32.const 0)
+                      )
+                     )
+                    )
+                   )
+                   (local.set $1
+                    (local.get $7)
+                   )
+                  )
+                  (local.set $18
+                   (if (result i32)
+                    (i32.lt_s
+                     (local.get $5)
+                     (i32.const 0)
+                    )
+                    (i32.const 6)
+                    (local.get $5)
+                   )
+                  )
+                  (if
+                   (i32.lt_s
+                    (local.get $6)
+                    (i32.const 0)
+                   )
+                   (block
+                    (local.set $14
+                     (i32.add
+                      (i32.div_s
+                       (i32.add
+                        (local.get $18)
+                        (i32.const 25)
+                       )
+                       (i32.const 9)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                    (local.set $25
+                     (i32.eq
+                      (local.get $22)
+                      (i32.const 102)
+                     )
+                    )
+                    (local.set $5
+                     (local.get $8)
+                    )
+                    (loop $label$160
+                     (if
+                      (i32.gt_s
+                       (local.tee $13
+                        (i32.sub
+                         (i32.const 0)
+                         (local.get $6)
+                        )
+                       )
+                       (i32.const 9)
+                      )
+                      (local.set $13
+                       (i32.const 9)
+                      )
+                     )
+                     (block $label$162
+                      (if
+                       (i32.lt_u
+                        (local.get $1)
+                        (local.get $5)
+                       )
+                       (block
+                        (local.set $29
+                         (i32.add
+                          (i32.shl
+                           (i32.const 1)
+                           (local.get $13)
+                          )
+                          (i32.const -1)
+                         )
+                        )
+                        (local.set $35
+                         (i32.shr_u
+                          (i32.const 1000000000)
+                          (local.get $13)
+                         )
+                        )
+                        (local.set $6
+                         (i32.const 0)
+                        )
+                        (local.set $8
+                         (local.get $1)
+                        )
+                        (loop $label$164
+                         (i32.store
+                          (local.get $8)
+                          (i32.add
+                           (i32.shr_u
+                            (local.tee $32
+                             (i32.load
+                              (local.get $8)
+                             )
+                            )
+                            (local.get $13)
+                           )
+                           (local.get $6)
+                          )
+                         )
+                         (local.set $6
+                          (i32.mul
+                           (i32.and
+                            (local.get $32)
+                            (local.get $29)
+                           )
+                           (local.get $35)
+                          )
+                         )
+                         (br_if $label$164
+                          (i32.lt_u
+                           (local.tee $8
+                            (i32.add
+                             (local.get $8)
+                             (i32.const 4)
+                            )
+                           )
+                           (local.get $5)
+                          )
+                         )
+                        )
+                        (local.set $8
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 4)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (local.set $1
+                          (local.get $8)
+                         )
+                        )
+                        (br_if $label$162
+                         (i32.eqz
+                          (local.get $6)
+                         )
+                        )
+                        (i32.store
+                         (local.get $5)
+                         (local.get $6)
+                        )
+                        (local.set $5
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 4)
+                         )
+                        )
+                       )
+                       (block
+                        (local.set $8
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 4)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (local.set $1
+                          (local.get $8)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (local.set $6
+                      (i32.add
+                       (local.tee $8
+                        (if (result i32)
+                         (local.get $25)
+                         (local.get $7)
+                         (local.get $1)
+                        )
+                       )
+                       (i32.shl
+                        (local.get $14)
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                     (if
+                      (i32.gt_s
+                       (i32.shr_s
+                        (i32.sub
+                         (local.get $5)
+                         (local.get $8)
+                        )
+                        (i32.const 2)
+                       )
+                       (local.get $14)
+                      )
+                      (local.set $5
+                       (local.get $6)
+                      )
+                     )
+                     (i32.store
+                      (local.get $20)
+                      (local.tee $6
+                       (i32.add
+                        (i32.load
+                         (local.get $20)
+                        )
+                        (local.get $13)
+                       )
+                      )
+                     )
+                     (br_if $label$160
+                      (i32.lt_s
+                       (local.get $6)
+                       (i32.const 0)
+                      )
+                     )
+                     (local.set $13
+                      (local.get $5)
+                     )
+                    )
+                   )
+                   (local.set $13
+                    (local.get $8)
+                   )
+                  )
+                  (local.set $25
+                   (local.get $7)
+                  )
+                  (block $label$172
+                   (if
+                    (i32.lt_u
+                     (local.get $1)
+                     (local.get $13)
+                    )
+                    (block
+                     (local.set $5
+                      (i32.mul
+                       (i32.shr_s
+                        (i32.sub
+                         (local.get $25)
+                         (local.get $1)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 9)
+                      )
+                     )
+                     (br_if $label$172
+                      (i32.lt_u
+                       (local.tee $6
+                        (i32.load
+                         (local.get $1)
+                        )
+                       )
+                       (i32.const 10)
+                      )
+                     )
+                     (local.set $8
+                      (i32.const 10)
+                     )
+                     (loop $label$174
+                      (local.set $5
+                       (i32.add
+                        (local.get $5)
+                        (i32.const 1)
+                       )
+                      )
+                      (br_if $label$174
+                       (i32.ge_u
+                        (local.get $6)
+                        (local.tee $8
+                         (i32.mul
+                          (local.get $8)
+                          (i32.const 10)
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $5
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                  (local.set $29
+                   (i32.eq
+                    (local.get $22)
+                    (i32.const 103)
+                   )
+                  )
+                  (local.set $35
+                   (i32.ne
+                    (local.get $18)
+                    (i32.const 0)
+                   )
+                  )
+                  (if
+                   (i32.lt_s
+                    (local.tee $8
+                     (i32.add
+                      (i32.sub
+                       (local.get $18)
+                       (if (result i32)
+                        (i32.ne
+                         (local.get $22)
+                         (i32.const 102)
+                        )
+                        (local.get $5)
+                        (i32.const 0)
+                       )
+                      )
+                      (i32.shr_s
+                       (i32.shl
+                        (i32.and
+                         (local.get $35)
+                         (local.get $29)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                    )
+                    (i32.add
+                     (i32.mul
+                      (i32.shr_s
+                       (i32.sub
+                        (local.get $13)
+                        (local.get $25)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 9)
+                     )
+                     (i32.const -9)
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_s
+                      (local.tee $8
+                       (i32.add
+                        (i32.rem_s
+                         (local.tee $14
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 9216)
+                          )
+                         )
+                         (i32.const 9)
+                        )
+                        (i32.const 1)
+                       )
+                      )
+                      (i32.const 9)
+                     )
+                     (block
+                      (local.set $6
+                       (i32.const 10)
+                      )
+                      (loop $label$180
+                       (local.set $6
+                        (i32.mul
+                         (local.get $6)
+                         (i32.const 10)
+                        )
+                       )
+                       (br_if $label$180
+                        (i32.ne
+                         (local.tee $8
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 1)
+                          )
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                      )
+                     )
+                     (local.set $6
+                      (i32.const 10)
+                     )
+                    )
+                    (local.set $14
+                     (i32.rem_u
+                      (local.tee $22
+                       (i32.load
+                        (local.tee $8
+                         (i32.add
+                          (i32.add
+                           (local.get $7)
+                           (i32.const 4)
+                          )
+                          (i32.shl
+                           (i32.add
+                            (i32.div_s
+                             (local.get $14)
+                             (i32.const 9)
+                            )
+                            (i32.const -1024)
+                           )
+                           (i32.const 2)
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (local.get $6)
+                     )
+                    )
+                    (block $label$182
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (local.tee $32
+                         (i32.eq
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 4)
+                          )
+                          (local.get $13)
+                         )
+                        )
+                        (i32.eqz
+                         (local.get $14)
+                        )
+                       )
+                      )
+                      (block
+                       (local.set $52
+                        (if (result f64)
+                         (i32.lt_u
+                          (local.get $14)
+                          (local.tee $49
+                           (i32.div_s
+                            (local.get $6)
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                         (f64.const 0.5)
+                         (if (result f64)
+                          (i32.and
+                           (local.get $32)
+                           (i32.eq
+                            (local.get $14)
+                            (local.get $49)
+                           )
+                          )
+                          (f64.const 1)
+                          (f64.const 1.5)
+                         )
+                        )
+                       )
+                       (local.set $53
+                        (if (result f64)
+                         (i32.and
+                          (i32.div_u
+                           (local.get $22)
+                           (local.get $6)
+                          )
+                          (i32.const 1)
+                         )
+                         (f64.const 9007199254740994)
+                         (f64.const 9007199254740992)
+                        )
+                       )
+                       (block $label$190
+                        (if
+                         (local.get $24)
+                         (block
+                          (br_if $label$190
+                           (i32.ne
+                            (i32.load8_s
+                             (local.get $26)
+                            )
+                            (i32.const 45)
+                           )
+                          )
+                          (local.set $53
+                           (f64.neg
+                            (local.get $53)
+                           )
+                          )
+                          (local.set $52
+                           (f64.neg
+                            (local.get $52)
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (i32.store
+                        (local.get $8)
+                        (local.tee $14
+                         (i32.sub
+                          (local.get $22)
+                          (local.get $14)
+                         )
+                        )
+                       )
+                       (br_if $label$182
+                        (f64.eq
+                         (f64.add
+                          (local.get $53)
+                          (local.get $52)
+                         )
+                         (local.get $53)
+                        )
+                       )
+                       (i32.store
+                        (local.get $8)
+                        (local.tee $5
+                         (i32.add
+                          (local.get $14)
+                          (local.get $6)
+                         )
+                        )
+                       )
+                       (if
+                        (i32.gt_u
+                         (local.get $5)
+                         (i32.const 999999999)
+                        )
+                        (loop $label$193
+                         (i32.store
+                          (local.get $8)
+                          (i32.const 0)
+                         )
+                         (if
+                          (i32.lt_u
+                           (local.tee $8
+                            (i32.add
+                             (local.get $8)
+                             (i32.const -4)
+                            )
+                           )
+                           (local.get $1)
+                          )
+                          (i32.store
+                           (local.tee $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const -4)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                         )
+                         (i32.store
+                          (local.get $8)
+                          (local.tee $5
+                           (i32.add
+                            (i32.load
+                             (local.get $8)
+                            )
+                            (i32.const 1)
+                           )
+                          )
+                         )
+                         (br_if $label$193
+                          (i32.gt_u
+                           (local.get $5)
+                           (i32.const 999999999)
+                          )
+                         )
+                        )
+                       )
+                       (local.set $5
+                        (i32.mul
+                         (i32.shr_s
+                          (i32.sub
+                           (local.get $25)
+                           (local.get $1)
+                          )
+                          (i32.const 2)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (br_if $label$182
+                        (i32.lt_u
+                         (local.tee $14
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (i32.const 10)
+                        )
+                       )
+                       (local.set $6
+                        (i32.const 10)
+                       )
+                       (loop $label$195
+                        (local.set $5
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 1)
+                         )
+                        )
+                        (br_if $label$195
+                         (i32.ge_u
+                          (local.get $14)
+                          (local.tee $6
+                           (i32.mul
+                            (local.get $6)
+                            (i32.const 10)
+                           )
+                          )
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $14
+                     (local.get $1)
+                    )
+                    (local.set $6
+                     (local.get $5)
+                    )
+                    (if
+                     (i32.le_u
+                      (local.get $13)
+                      (local.tee $8
+                       (i32.add
+                        (local.get $8)
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.set $8
+                      (local.get $13)
+                     )
+                    )
+                   )
+                   (block
+                    (local.set $14
+                     (local.get $1)
+                    )
+                    (local.set $6
+                     (local.get $5)
+                    )
+                    (local.set $8
+                     (local.get $13)
+                    )
+                   )
+                  )
+                  (local.set $32
+                   (i32.sub
+                    (i32.const 0)
+                    (local.get $6)
+                   )
+                  )
+                  (loop $label$198
+                   (block $label$199
+                    (if
+                     (i32.le_u
+                      (local.get $8)
+                      (local.get $14)
+                     )
+                     (block
+                      (local.set $22
+                       (i32.const 0)
+                      )
+                      (br $label$199)
+                     )
+                    )
+                    (if
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $8)
+                        (i32.const -4)
+                       )
+                      )
+                     )
+                     (local.set $22
+                      (i32.const 1)
+                     )
+                     (block
+                      (local.set $8
+                       (local.get $1)
+                      )
+                      (br $label$198)
+                     )
+                    )
+                   )
+                  )
+                  (block $label$203
+                   (if
+                    (local.get $29)
+                    (block
+                     (local.set $1
+                      (if (result i32)
+                       (i32.and
+                        (i32.gt_s
+                         (local.tee $1
+                          (i32.add
+                           (i32.xor
+                            (i32.and
+                             (local.get $35)
+                             (i32.const 1)
+                            )
+                            (i32.const 1)
+                           )
+                           (local.get $18)
+                          )
+                         )
+                         (local.get $6)
+                        )
+                        (i32.gt_s
+                         (local.get $6)
+                         (i32.const -5)
+                        )
+                       )
+                       (block (result i32)
+                        (local.set $5
+                         (i32.add
+                          (local.get $9)
+                          (i32.const -1)
+                         )
+                        )
+                        (i32.sub
+                         (i32.add
+                          (local.get $1)
+                          (i32.const -1)
+                         )
+                         (local.get $6)
+                        )
+                       )
+                       (block (result i32)
+                        (local.set $5
+                         (i32.add
+                          (local.get $9)
+                          (i32.const -2)
+                         )
+                        )
+                        (i32.add
+                         (local.get $1)
+                         (i32.const -1)
+                        )
+                       )
+                      )
+                     )
+                     (br_if $label$203
+                      (local.tee $13
+                       (i32.and
+                        (local.get $12)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (block $label$207
+                      (if
+                       (local.get $22)
+                       (block
+                        (if
+                         (i32.eqz
+                          (local.tee $18
+                           (i32.load
+                            (i32.add
+                             (local.get $8)
+                             (i32.const -4)
+                            )
+                           )
+                          )
+                         )
+                         (block
+                          (local.set $9
+                           (i32.const 9)
+                          )
+                          (br $label$207)
+                         )
+                        )
+                        (if
+                         (i32.rem_u
+                          (local.get $18)
+                          (i32.const 10)
+                         )
+                         (block
+                          (local.set $9
+                           (i32.const 0)
+                          )
+                          (br $label$207)
+                         )
+                         (block
+                          (local.set $13
+                           (i32.const 10)
+                          )
+                          (local.set $9
+                           (i32.const 0)
+                          )
+                         )
+                        )
+                        (loop $label$212
+                         (local.set $9
+                          (i32.add
+                           (local.get $9)
+                           (i32.const 1)
+                          )
+                         )
+                         (br_if $label$212
+                          (i32.eqz
+                           (i32.rem_u
+                            (local.get $18)
+                            (local.tee $13
+                             (i32.mul
+                              (local.get $13)
+                              (i32.const 10)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (local.set $9
+                        (i32.const 9)
+                       )
+                      )
+                     )
+                     (local.set $18
+                      (i32.add
+                       (i32.mul
+                        (i32.shr_s
+                         (i32.sub
+                          (local.get $8)
+                          (local.get $25)
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 9)
+                       )
+                       (i32.const -9)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (i32.or
+                        (local.get $5)
+                        (i32.const 32)
+                       )
+                       (i32.const 102)
+                      )
+                      (block
+                       (local.set $13
+                        (i32.const 0)
+                       )
+                       (if
+                        (i32.ge_s
+                         (local.get $1)
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.tee $9
+                            (i32.sub
+                             (local.get $18)
+                             (local.get $9)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                          (local.tee $9
+                           (i32.const 0)
+                          )
+                          (local.get $9)
+                         )
+                        )
+                        (local.set $1
+                         (local.get $9)
+                        )
+                       )
+                      )
+                      (block
+                       (local.set $13
+                        (i32.const 0)
+                       )
+                       (if
+                        (i32.ge_s
+                         (local.get $1)
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.tee $9
+                            (i32.sub
+                             (i32.add
+                              (local.get $18)
+                              (local.get $6)
+                             )
+                             (local.get $9)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                          (local.tee $9
+                           (i32.const 0)
+                          )
+                          (local.get $9)
+                         )
+                        )
+                        (local.set $1
+                         (local.get $9)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (block
+                     (local.set $13
+                      (i32.and
+                       (local.get $12)
+                       (i32.const 8)
+                      )
+                     )
+                     (local.set $1
+                      (local.get $18)
+                     )
+                     (local.set $5
+                      (local.get $9)
+                     )
+                    )
+                   )
+                  )
+                  (if
+                   (local.tee $25
+                    (i32.eq
+                     (i32.or
+                      (local.get $5)
+                      (i32.const 32)
+                     )
+                     (i32.const 102)
+                    )
+                   )
+                   (block
+                    (local.set $9
+                     (i32.const 0)
+                    )
+                    (if
+                     (i32.le_s
+                      (local.get $6)
+                      (i32.const 0)
+                     )
+                     (local.set $6
+                      (i32.const 0)
+                     )
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_s
+                      (i32.sub
+                       (local.get $28)
+                       (local.tee $9
+                        (call $23
+                         (i64.extend_i32_s
+                          (if (result i32)
+                           (i32.lt_s
+                            (local.get $6)
+                            (i32.const 0)
+                           )
+                           (local.get $32)
+                           (local.get $6)
+                          )
+                         )
+                         (local.get $33)
+                        )
+                       )
+                      )
+                      (i32.const 2)
+                     )
+                     (loop $label$229
+                      (i32.store8
+                       (local.tee $9
+                        (i32.add
+                         (local.get $9)
+                         (i32.const -1)
+                        )
+                       )
+                       (i32.const 48)
+                      )
+                      (br_if $label$229
+                       (i32.lt_s
+                        (i32.sub
+                         (local.get $28)
+                         (local.get $9)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                    (i32.store8
+                     (i32.add
+                      (local.get $9)
+                      (i32.const -1)
+                     )
+                     (i32.add
+                      (i32.and
+                       (i32.shr_s
+                        (local.get $6)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 43)
+                     )
+                    )
+                    (i32.store8
+                     (local.tee $6
+                      (i32.add
+                       (local.get $9)
+                       (i32.const -2)
+                      )
+                     )
+                     (local.get $5)
+                    )
+                    (local.set $9
+                     (local.get $6)
+                    )
+                    (local.set $6
+                     (i32.sub
+                      (local.get $28)
+                      (local.get $6)
+                     )
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.tee $18
+                    (i32.add
+                     (i32.add
+                      (i32.add
+                       (i32.add
+                        (local.get $24)
+                        (i32.const 1)
+                       )
+                       (local.get $1)
+                      )
+                      (i32.ne
+                       (local.tee $29
+                        (i32.or
+                         (local.get $1)
+                         (local.get $13)
+                        )
+                       )
+                       (i32.const 0)
+                      )
+                     )
+                     (local.get $6)
+                    )
+                   )
+                   (local.get $12)
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (i32.load
+                      (local.get $0)
+                     )
+                     (i32.const 32)
+                    )
+                   )
+                   (drop
+                    (call $21
+                     (local.get $26)
+                     (local.get $24)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 48)
+                   (local.get $10)
+                   (local.get $18)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 65536)
+                   )
+                  )
+                  (block $label$231
+                   (if
+                    (local.get $25)
+                    (block
+                     (local.set $6
+                      (local.tee $9
+                       (if (result i32)
+                        (i32.gt_u
+                         (local.get $14)
+                         (local.get $7)
+                        )
+                        (local.get $7)
+                        (local.get $14)
+                       )
+                      )
+                     )
+                     (loop $label$235
+                      (local.set $5
+                       (call $23
+                        (i64.extend_i32_u
+                         (i32.load
+                          (local.get $6)
+                         )
+                        )
+                        (local.get $31)
+                       )
+                      )
+                      (block $label$236
+                       (if
+                        (i32.eq
+                         (local.get $6)
+                         (local.get $9)
+                        )
+                        (block
+                         (br_if $label$236
+                          (i32.ne
+                           (local.get $5)
+                           (local.get $31)
+                          )
+                         )
+                         (i32.store8
+                          (local.get $34)
+                          (i32.const 48)
+                         )
+                         (local.set $5
+                          (local.get $34)
+                         )
+                        )
+                        (block
+                         (br_if $label$236
+                          (i32.le_u
+                           (local.get $5)
+                           (local.get $19)
+                          )
+                         )
+                         (drop
+                          (call $46
+                           (local.get $19)
+                           (i32.const 48)
+                           (i32.sub
+                            (local.get $5)
+                            (local.get $27)
+                           )
+                          )
+                         )
+                         (loop $label$239
+                          (br_if $label$239
+                           (i32.gt_u
+                            (local.tee $5
+                             (i32.add
+                              (local.get $5)
+                              (i32.const -1)
+                             )
+                            )
+                            (local.get $19)
+                           )
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (local.get $0)
+                         )
+                         (i32.const 32)
+                        )
+                       )
+                       (drop
+                        (call $21
+                         (local.get $5)
+                         (i32.sub
+                          (local.get $41)
+                          (local.get $5)
+                         )
+                         (local.get $0)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.le_u
+                        (local.tee $5
+                         (i32.add
+                          (local.get $6)
+                          (i32.const 4)
+                         )
+                        )
+                        (local.get $7)
+                       )
+                       (block
+                        (local.set $6
+                         (local.get $5)
+                        )
+                        (br $label$235)
+                       )
+                      )
+                     )
+                     (block $label$242
+                      (if
+                       (local.get $29)
+                       (block
+                        (br_if $label$242
+                         (i32.and
+                          (i32.load
+                           (local.get $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $21
+                          (i32.const 2231)
+                          (i32.const 1)
+                          (local.get $0)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.and
+                       (i32.gt_s
+                        (local.get $1)
+                        (i32.const 0)
+                       )
+                       (i32.lt_u
+                        (local.get $5)
+                        (local.get $8)
+                       )
+                      )
+                      (loop $label$245
+                       (if
+                        (i32.gt_u
+                         (local.tee $7
+                          (call $23
+                           (i64.extend_i32_u
+                            (i32.load
+                             (local.get $5)
+                            )
+                           )
+                           (local.get $31)
+                          )
+                         )
+                         (local.get $19)
+                        )
+                        (block
+                         (drop
+                          (call $46
+                           (local.get $19)
+                           (i32.const 48)
+                           (i32.sub
+                            (local.get $7)
+                            (local.get $27)
+                           )
+                          )
+                         )
+                         (loop $label$247
+                          (br_if $label$247
+                           (i32.gt_u
+                            (local.tee $7
+                             (i32.add
+                              (local.get $7)
+                              (i32.const -1)
+                             )
+                            )
+                            (local.get $19)
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (i32.load
+                           (local.get $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $21
+                          (local.get $7)
+                          (if (result i32)
+                           (i32.gt_s
+                            (local.get $1)
+                            (i32.const 9)
+                           )
+                           (i32.const 9)
+                           (local.get $1)
+                          )
+                          (local.get $0)
+                         )
+                        )
+                       )
+                       (local.set $7
+                        (i32.add
+                         (local.get $1)
+                         (i32.const -9)
+                        )
+                       )
+                       (if
+                        (i32.and
+                         (i32.gt_s
+                          (local.get $1)
+                          (i32.const 9)
+                         )
+                         (i32.lt_u
+                          (local.tee $5
+                           (i32.add
+                            (local.get $5)
+                            (i32.const 4)
+                           )
+                          )
+                          (local.get $8)
+                         )
+                        )
+                        (block
+                         (local.set $1
+                          (local.get $7)
+                         )
+                         (br $label$245)
+                        )
+                        (local.set $1
+                         (local.get $7)
+                        )
+                       )
+                      )
+                     )
+                     (call $25
+                      (local.get $0)
+                      (i32.const 48)
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 9)
+                      )
+                      (i32.const 9)
+                      (i32.const 0)
+                     )
+                    )
+                    (block
+                     (local.set $5
+                      (i32.add
+                       (local.get $14)
+                       (i32.const 4)
+                      )
+                     )
+                     (if
+                      (i32.eqz
+                       (local.get $22)
+                      )
+                      (local.set $8
+                       (local.get $5)
+                      )
+                     )
+                     (if
+                      (i32.gt_s
+                       (local.get $1)
+                       (i32.const -1)
+                      )
+                      (block
+                       (local.set $13
+                        (i32.eqz
+                         (local.get $13)
+                        )
+                       )
+                       (local.set $7
+                        (local.get $14)
+                       )
+                       (local.set $5
+                        (local.get $1)
+                       )
+                       (loop $label$256
+                        (if
+                         (i32.eq
+                          (local.tee $1
+                           (call $23
+                            (i64.extend_i32_u
+                             (i32.load
+                              (local.get $7)
+                             )
+                            )
+                            (local.get $31)
+                           )
+                          )
+                          (local.get $31)
+                         )
+                         (block
+                          (i32.store8
+                           (local.get $34)
+                           (i32.const 48)
+                          )
+                          (local.set $1
+                           (local.get $34)
+                          )
+                         )
+                        )
+                        (block $label$258
+                         (if
+                          (i32.eq
+                           (local.get $7)
+                           (local.get $14)
+                          )
+                          (block
+                           (if
+                            (i32.eqz
+                             (i32.and
+                              (i32.load
+                               (local.get $0)
+                              )
+                              (i32.const 32)
+                             )
+                            )
+                            (drop
+                             (call $21
+                              (local.get $1)
+                              (i32.const 1)
+                              (local.get $0)
+                             )
+                            )
+                           )
+                           (local.set $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const 1)
+                            )
+                           )
+                           (br_if $label$258
+                            (i32.and
+                             (local.get $13)
+                             (i32.lt_s
+                              (local.get $5)
+                              (i32.const 1)
+                             )
+                            )
+                           )
+                           (br_if $label$258
+                            (i32.and
+                             (i32.load
+                              (local.get $0)
+                             )
+                             (i32.const 32)
+                            )
+                           )
+                           (drop
+                            (call $21
+                             (i32.const 2231)
+                             (i32.const 1)
+                             (local.get $0)
+                            )
+                           )
+                          )
+                          (block
+                           (br_if $label$258
+                            (i32.le_u
+                             (local.get $1)
+                             (local.get $19)
+                            )
+                           )
+                           (drop
+                            (call $46
+                             (local.get $19)
+                             (i32.const 48)
+                             (i32.add
+                              (local.get $1)
+                              (local.get $43)
+                             )
+                            )
+                           )
+                           (loop $label$262
+                            (br_if $label$262
+                             (i32.gt_u
+                              (local.tee $1
+                               (i32.add
+                                (local.get $1)
+                                (i32.const -1)
+                               )
+                              )
+                              (local.get $19)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                        (local.set $6
+                         (i32.sub
+                          (local.get $41)
+                          (local.get $1)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.and
+                           (i32.load
+                            (local.get $0)
+                           )
+                           (i32.const 32)
+                          )
+                         )
+                         (drop
+                          (call $21
+                           (local.get $1)
+                           (if (result i32)
+                            (i32.gt_s
+                             (local.get $5)
+                             (local.get $6)
+                            )
+                            (local.get $6)
+                            (local.get $5)
+                           )
+                           (local.get $0)
+                          )
+                         )
+                        )
+                        (br_if $label$256
+                         (i32.and
+                          (i32.lt_u
+                           (local.tee $7
+                            (i32.add
+                             (local.get $7)
+                             (i32.const 4)
+                            )
+                           )
+                           (local.get $8)
+                          )
+                          (i32.gt_s
+                           (local.tee $5
+                            (i32.sub
+                             (local.get $5)
+                             (local.get $6)
+                            )
+                           )
+                           (i32.const -1)
+                          )
+                         )
+                        )
+                        (local.set $1
+                         (local.get $5)
+                        )
+                       )
+                      )
+                     )
+                     (call $25
+                      (local.get $0)
+                      (i32.const 48)
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 18)
+                      )
+                      (i32.const 18)
+                      (i32.const 0)
+                     )
+                     (br_if $label$231
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $9)
+                       (i32.sub
+                        (local.get $28)
+                        (local.get $9)
+                       )
+                       (local.get $0)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.get $18)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 8192)
+                   )
+                  )
+                  (if
+                   (i32.ge_s
+                    (local.get $18)
+                    (local.get $10)
+                   )
+                   (local.set $10
+                    (local.get $18)
+                   )
+                  )
+                 )
+                 (block
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.tee $8
+                    (i32.add
+                     (if (result i32)
+                      (local.tee $6
+                       (i32.or
+                        (f64.ne
+                         (local.get $52)
+                         (local.get $52)
+                        )
+                        (i32.const 0)
+                       )
+                      )
+                      (local.tee $24
+                       (i32.const 0)
+                      )
+                      (local.get $24)
+                     )
+                     (i32.const 3)
+                    )
+                   )
+                   (local.get $7)
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (local.tee $1
+                      (i32.load
+                       (local.get $0)
+                      )
+                     )
+                     (i32.const 32)
+                    )
+                   )
+                   (block
+                    (drop
+                     (call $21
+                      (local.get $26)
+                      (local.get $24)
+                      (local.get $0)
+                     )
+                    )
+                    (local.set $1
+                     (i32.load
+                      (local.get $0)
+                     )
+                    )
+                   )
+                  )
+                  (local.set $7
+                   (if (result i32)
+                    (local.tee $5
+                     (i32.ne
+                      (i32.and
+                       (local.get $9)
+                       (i32.const 32)
+                      )
+                      (i32.const 0)
+                     )
+                    )
+                    (i32.const 2215)
+                    (i32.const 2219)
+                   )
+                  )
+                  (local.set $5
+                   (if (result i32)
+                    (local.get $5)
+                    (i32.const 2223)
+                    (i32.const 2227)
+                   )
+                  )
+                  (if
+                   (i32.eqz
+                    (local.get $6)
+                   )
+                   (local.set $5
+                    (local.get $7)
+                   )
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (local.get $1)
+                     (i32.const 32)
+                    )
+                   )
+                   (drop
+                    (call $21
+                     (local.get $5)
+                     (i32.const 3)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.get $8)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 8192)
+                   )
+                  )
+                  (if
+                   (i32.ge_s
+                    (local.get $8)
+                    (local.get $10)
+                   )
+                   (local.set $10
+                    (local.get $8)
+                   )
+                  )
+                 )
+                )
+               )
+               (local.set $1
+                (local.get $11)
+               )
+               (br $label$4)
+              )
+              (local.set $7
+               (local.get $5)
+              )
+              (local.set $6
+               (i32.const 0)
+              )
+              (local.set $8
+               (i32.const 2179)
+              )
+              (local.set $5
+               (local.get $21)
+              )
+              (br $label$70)
+             )
+             (local.set $7
+              (i32.and
+               (local.get $9)
+               (i32.const 32)
+              )
+             )
+             (local.set $7
+              (if (result i32)
+               (i64.eq
+                (local.tee $50
+                 (i64.load
+                  (local.get $16)
+                 )
+                )
+                (i64.const 0)
+               )
+               (block (result i32)
+                (local.set $50
+                 (i64.const 0)
+                )
+                (local.get $21)
+               )
+               (block (result i32)
+                (local.set $1
+                 (local.get $21)
+                )
+                (loop $label$280
+                 (i32.store8
+                  (local.tee $1
+                   (i32.add
+                    (local.get $1)
+                    (i32.const -1)
+                   )
+                  )
+                  (i32.or
+                   (i32.load8_u
+                    (i32.add
+                     (i32.and
+                      (i32.wrap_i64
+                       (local.get $50)
+                      )
+                      (i32.const 15)
+                     )
+                     (i32.const 2163)
+                    )
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (br_if $label$280
+                  (i64.ne
+                   (local.tee $50
+                    (i64.shr_u
+                     (local.get $50)
+                     (i64.const 4)
+                    )
+                   )
+                   (i64.const 0)
+                  )
+                 )
+                )
+                (local.set $50
+                 (i64.load
+                  (local.get $16)
+                 )
+                )
+                (local.get $1)
+               )
+              )
+             )
+             (local.set $8
+              (i32.add
+               (i32.shr_s
+                (local.get $9)
+                (i32.const 4)
+               )
+               (i32.const 2179)
+              )
+             )
+             (if
+              (local.tee $1
+               (i32.or
+                (i32.eqz
+                 (i32.and
+                  (local.get $12)
+                  (i32.const 8)
+                 )
+                )
+                (i64.eq
+                 (local.get $50)
+                 (i64.const 0)
+                )
+               )
+              )
+              (local.set $8
+               (i32.const 2179)
+              )
+             )
+             (local.set $6
+              (if (result i32)
+               (local.get $1)
+               (i32.const 0)
+               (i32.const 2)
+              )
+             )
+             (br $label$71)
+            )
+            (local.set $7
+             (call $23
+              (local.get $50)
+              (local.get $21)
+             )
+            )
+            (br $label$71)
+           )
+           (local.set $14
+            (i32.eqz
+             (local.tee $13
+              (call $17
+               (local.get $1)
+               (i32.const 0)
+               (local.get $5)
+              )
+             )
+            )
+           )
+           (local.set $8
+            (i32.sub
+             (local.get $13)
+             (local.get $1)
+            )
+           )
+           (local.set $9
+            (i32.add
+             (local.get $1)
+             (local.get $5)
+            )
+           )
+           (local.set $12
+            (local.get $7)
+           )
+           (local.set $7
+            (if (result i32)
+             (local.get $14)
+             (local.get $5)
+             (local.get $8)
+            )
+           )
+           (local.set $6
+            (i32.const 0)
+           )
+           (local.set $8
+            (i32.const 2179)
+           )
+           (local.set $5
+            (if (result i32)
+             (local.get $14)
+             (local.get $9)
+             (local.get $13)
+            )
+           )
+           (br $label$70)
+          )
+          (local.set $1
+           (i32.const 0)
+          )
+          (local.set $5
+           (i32.const 0)
+          )
+          (local.set $8
+           (local.get $7)
+          )
+          (loop $label$288
+           (block $label$289
+            (br_if $label$289
+             (i32.eqz
+              (local.tee $9
+               (i32.load
+                (local.get $8)
+               )
+              )
+             )
+            )
+            (br_if $label$289
+             (i32.or
+              (i32.lt_s
+               (local.tee $5
+                (call $26
+                 (local.get $36)
+                 (local.get $9)
+                )
+               )
+               (i32.const 0)
+              )
+              (i32.gt_u
+               (local.get $5)
+               (i32.sub
+                (local.get $6)
+                (local.get $1)
+               )
+              )
+             )
+            )
+            (local.set $8
+             (i32.add
+              (local.get $8)
+              (i32.const 4)
+             )
+            )
+            (br_if $label$288
+             (i32.gt_u
+              (local.get $6)
+              (local.tee $1
+               (i32.add
+                (local.get $5)
+                (local.get $1)
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_s
+            (local.get $5)
+            (i32.const 0)
+           )
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+          )
+          (call $25
+           (local.get $0)
+           (i32.const 32)
+           (local.get $10)
+           (local.get $1)
+           (local.get $12)
+          )
+          (if
+           (local.get $1)
+           (block
+            (local.set $5
+             (i32.const 0)
+            )
+            (loop $label$292
+             (br_if $label$72
+              (i32.eqz
+               (local.tee $8
+                (i32.load
+                 (local.get $7)
+                )
+               )
+              )
+             )
+             (br_if $label$72
+              (i32.gt_s
+               (local.tee $5
+                (i32.add
+                 (local.tee $8
+                  (call $26
+                   (local.get $36)
+                   (local.get $8)
+                  )
+                 )
+                 (local.get $5)
+                )
+               )
+               (local.get $1)
+              )
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (i32.load
+                 (local.get $0)
+                )
+                (i32.const 32)
+               )
+              )
+              (drop
+               (call $21
+                (local.get $36)
+                (local.get $8)
+                (local.get $0)
+               )
+              )
+             )
+             (local.set $7
+              (i32.add
+               (local.get $7)
+               (i32.const 4)
+              )
+             )
+             (br_if $label$292
+              (i32.lt_u
+               (local.get $5)
+               (local.get $1)
+              )
+             )
+             (br $label$72)
+            )
+           )
+           (block
+            (local.set $1
+             (i32.const 0)
+            )
+            (br $label$72)
+           )
+          )
+         )
+         (call $25
+          (local.get $0)
+          (i32.const 32)
+          (local.get $10)
+          (local.get $1)
+          (i32.xor
+           (local.get $12)
+           (i32.const 8192)
+          )
+         )
+         (if
+          (i32.le_s
+           (local.get $10)
+           (local.get $1)
+          )
+          (local.set $10
+           (local.get $1)
+          )
+         )
+         (local.set $1
+          (local.get $11)
+         )
+         (br $label$4)
+        )
+        (local.set $1
+         (i32.and
+          (local.get $12)
+          (i32.const -65537)
+         )
+        )
+        (if
+         (i32.gt_s
+          (local.get $5)
+          (i32.const -1)
+         )
+         (local.set $12
+          (local.get $1)
+         )
+        )
+        (local.set $5
+         (if (result i32)
+          (i32.or
+           (local.get $5)
+           (local.tee $9
+            (i64.ne
+             (i64.load
+              (local.get $16)
+             )
+             (i64.const 0)
+            )
+           )
+          )
+          (block (result i32)
+           (local.set $1
+            (local.get $7)
+           )
+           (if
+            (i32.gt_s
+             (local.get $5)
+             (local.tee $7
+              (i32.add
+               (i32.xor
+                (i32.and
+                 (local.get $9)
+                 (i32.const 1)
+                )
+                (i32.const 1)
+               )
+               (i32.sub
+                (local.get $38)
+                (local.get $7)
+               )
+              )
+             )
+            )
+            (local.set $7
+             (local.get $5)
+            )
+           )
+           (local.get $21)
+          )
+          (block (result i32)
+           (local.set $1
+            (local.get $21)
+           )
+           (local.set $7
+            (i32.const 0)
+           )
+           (local.get $21)
+          )
+         )
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 32)
+        (if (result i32)
+         (i32.lt_s
+          (local.get $10)
+          (local.tee $5
+           (i32.add
+            (if (result i32)
+             (i32.lt_s
+              (local.get $7)
+              (local.tee $9
+               (i32.sub
+                (local.get $5)
+                (local.get $1)
+               )
+              )
+             )
+             (local.tee $7
+              (local.get $9)
+             )
+             (local.get $7)
+            )
+            (local.get $6)
+           )
+          )
+         )
+         (local.tee $10
+          (local.get $5)
+         )
+         (local.get $10)
+        )
+        (local.get $5)
+        (local.get $12)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 32)
+         )
+        )
+        (drop
+         (call $21
+          (local.get $8)
+          (local.get $6)
+          (local.get $0)
+         )
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 48)
+        (local.get $10)
+        (local.get $5)
+        (i32.xor
+         (local.get $12)
+         (i32.const 65536)
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 48)
+        (local.get $7)
+        (local.get $9)
+        (i32.const 0)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 32)
+         )
+        )
+        (drop
+         (call $21
+          (local.get $1)
+          (local.get $9)
+          (local.get $0)
+         )
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 32)
+        (local.get $10)
+        (local.get $5)
+        (i32.xor
+         (local.get $12)
+         (i32.const 8192)
+        )
+       )
+       (local.set $1
+        (local.get $11)
+       )
+       (br $label$4)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.eqz
+      (local.get $0)
+     )
+     (if
+      (local.get $17)
+      (block
+       (local.set $0
+        (i32.const 1)
+       )
+       (loop $label$308
+        (if
+         (local.tee $1
+          (i32.load
+           (i32.add
+            (local.get $4)
+            (i32.shl
+             (local.get $0)
+             (i32.const 2)
+            )
+           )
+          )
+         )
+         (block
+          (call $22
+           (i32.add
+            (local.get $3)
+            (i32.shl
+             (local.get $0)
+             (i32.const 3)
+            )
+           )
+           (local.get $1)
+           (local.get $2)
+          )
+          (br_if $label$308
+           (i32.lt_s
+            (local.tee $0
+             (i32.add
+              (local.get $0)
+              (i32.const 1)
+             )
+            )
+            (i32.const 10)
+           )
+          )
+          (local.set $15
+           (i32.const 1)
+          )
+          (br $label$2)
+         )
+        )
+       )
+       (loop $label$310
+        (if
+         (i32.load
+          (i32.add
+           (local.get $4)
+           (i32.shl
+            (local.get $0)
+            (i32.const 2)
+           )
+          )
+         )
+         (block
+          (local.set $15
+           (i32.const -1)
+          )
+          (br $label$2)
+         )
+        )
+        (br_if $label$310
+         (i32.lt_s
+          (local.tee $0
+           (i32.add
+            (local.get $0)
+            (i32.const 1)
+           )
+          )
+          (i32.const 10)
+         )
+        )
+        (local.set $15
+         (i32.const 1)
+        )
+       )
+      )
+      (local.set $15
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $23)
+   )
+   (local.get $15)
+  )
+ )
+ (func $20 (; 33 ;) (type $2) (param $0 i32) (result i32)
+  (i32.const 0)
+ )
+ (func $21 (; 34 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (block $label$1 (result i32)
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (local.tee $3
+       (i32.load
+        (local.tee $4
+         (i32.add
+          (local.get $2)
+          (i32.const 16)
+         )
+        )
+       )
+      )
+     )
+     (if
+      (call $30
+       (local.get $2)
+      )
+      (local.set $3
+       (i32.const 0)
+      )
+      (block
+       (local.set $3
+        (i32.load
+         (local.get $4)
+        )
+       )
+       (br $label$3)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.lt_u
+      (i32.sub
+       (local.get $3)
+       (local.tee $4
+        (i32.load
+         (local.tee $5
+          (i32.add
+           (local.get $2)
+           (i32.const 20)
+          )
+         )
+        )
+       )
+      )
+      (local.get $1)
+     )
+     (block
+      (local.set $3
+       (call_indirect (type $0)
+        (local.get $2)
+        (local.get $0)
+        (local.get $1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (local.get $2)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (br $label$2)
+     )
+    )
+    (local.set $2
+     (block $label$7 (result i32)
+      (if (result i32)
+       (i32.gt_s
+        (i32.load8_s offset=75
+         (local.get $2)
+        )
+        (i32.const -1)
+       )
+       (block (result i32)
+        (local.set $3
+         (local.get $1)
+        )
+        (loop $label$9
+         (drop
+          (br_if $label$7
+           (i32.const 0)
+           (i32.eqz
+            (local.get $3)
+           )
+          )
+         )
+         (if
+          (i32.ne
+           (i32.load8_s
+            (i32.add
+             (local.get $0)
+             (local.tee $6
+              (i32.add
+               (local.get $3)
+               (i32.const -1)
+              )
+             )
+            )
+           )
+           (i32.const 10)
+          )
+          (block
+           (local.set $3
+            (local.get $6)
+           )
+           (br $label$9)
+          )
+         )
+        )
+        (br_if $label$2
+         (i32.lt_u
+          (call_indirect (type $0)
+           (local.get $2)
+           (local.get $0)
+           (local.get $3)
+           (i32.add
+            (i32.and
+             (i32.load offset=36
+              (local.get $2)
+             )
+             (i32.const 3)
+            )
+            (i32.const 2)
+           )
+          )
+          (local.get $3)
+         )
+        )
+        (local.set $4
+         (i32.load
+          (local.get $5)
+         )
+        )
+        (local.set $1
+         (i32.sub
+          (local.get $1)
+          (local.get $3)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (local.get $3)
+         )
+        )
+        (local.get $3)
+       )
+       (i32.const 0)
+      )
+     )
+    )
+    (drop
+     (call $47
+      (local.get $4)
+      (local.get $0)
+      (local.get $1)
+     )
+    )
+    (i32.store
+     (local.get $5)
+     (i32.add
+      (i32.load
+       (local.get $5)
+      )
+      (local.get $1)
+     )
+    )
+    (local.set $3
+     (i32.add
+      (local.get $2)
+      (local.get $1)
+     )
+    )
+   )
+   (local.get $3)
+  )
+ )
+ (func $22 (; 35 ;) (type $8) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i64)
+  (local $5 f64)
+  (block $label$1
+   (if
+    (i32.le_u
+     (local.get $1)
+     (i32.const 20)
+    )
+    (block $label$3
+     (block $label$4
+      (block $label$5
+       (block $label$6
+        (block $label$7
+         (block $label$8
+          (block $label$9
+           (block $label$10
+            (block $label$11
+             (block $label$12
+              (block $label$13
+               (br_table $label$13 $label$12 $label$11 $label$10 $label$9 $label$8 $label$7 $label$6 $label$5 $label$4 $label$3
+                (i32.sub
+                 (local.get $1)
+                 (i32.const 9)
+                )
+               )
+              )
+              (local.set $3
+               (i32.load
+                (local.tee $1
+                 (i32.and
+                  (i32.add
+                   (i32.load
+                    (local.get $2)
+                   )
+                   (i32.const 3)
+                  )
+                  (i32.const -4)
+                 )
+                )
+               )
+              )
+              (i32.store
+               (local.get $2)
+               (i32.add
+                (local.get $1)
+                (i32.const 4)
+               )
+              )
+              (i32.store
+               (local.get $0)
+               (local.get $3)
+              )
+              (br $label$1)
+             )
+             (local.set $3
+              (i32.load
+               (local.tee $1
+                (i32.and
+                 (i32.add
+                  (i32.load
+                   (local.get $2)
+                  )
+                  (i32.const 3)
+                 )
+                 (i32.const -4)
+                )
+               )
+              )
+             )
+             (i32.store
+              (local.get $2)
+              (i32.add
+               (local.get $1)
+               (i32.const 4)
+              )
+             )
+             (i64.store
+              (local.get $0)
+              (i64.extend_i32_s
+               (local.get $3)
+              )
+             )
+             (br $label$1)
+            )
+            (local.set $3
+             (i32.load
+              (local.tee $1
+               (i32.and
+                (i32.add
+                 (i32.load
+                  (local.get $2)
+                 )
+                 (i32.const 3)
+                )
+                (i32.const -4)
+               )
+              )
+             )
+            )
+            (i32.store
+             (local.get $2)
+             (i32.add
+              (local.get $1)
+              (i32.const 4)
+             )
+            )
+            (i64.store
+             (local.get $0)
+             (i64.extend_i32_u
+              (local.get $3)
+             )
+            )
+            (br $label$1)
+           )
+           (local.set $4
+            (i64.load
+             (local.tee $1
+              (i32.and
+               (i32.add
+                (i32.load
+                 (local.get $2)
+                )
+                (i32.const 7)
+               )
+               (i32.const -8)
+              )
+             )
+            )
+           )
+           (i32.store
+            (local.get $2)
+            (i32.add
+             (local.get $1)
+             (i32.const 8)
+            )
+           )
+           (i64.store
+            (local.get $0)
+            (local.get $4)
+           )
+           (br $label$1)
+          )
+          (local.set $3
+           (i32.load
+            (local.tee $1
+             (i32.and
+              (i32.add
+               (i32.load
+                (local.get $2)
+               )
+               (i32.const 3)
+              )
+              (i32.const -4)
+             )
+            )
+           )
+          )
+          (i32.store
+           (local.get $2)
+           (i32.add
+            (local.get $1)
+            (i32.const 4)
+           )
+          )
+          (i64.store
+           (local.get $0)
+           (i64.extend_i32_s
+            (i32.shr_s
+             (i32.shl
+              (i32.and
+               (local.get $3)
+               (i32.const 65535)
+              )
+              (i32.const 16)
+             )
+             (i32.const 16)
+            )
+           )
+          )
+          (br $label$1)
+         )
+         (local.set $3
+          (i32.load
+           (local.tee $1
+            (i32.and
+             (i32.add
+              (i32.load
+               (local.get $2)
+              )
+              (i32.const 3)
+             )
+             (i32.const -4)
+            )
+           )
+          )
+         )
+         (i32.store
+          (local.get $2)
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+         )
+         (i64.store
+          (local.get $0)
+          (i64.extend_i32_u
+           (i32.and
+            (local.get $3)
+            (i32.const 65535)
+           )
+          )
+         )
+         (br $label$1)
+        )
+        (local.set $3
+         (i32.load
+          (local.tee $1
+           (i32.and
+            (i32.add
+             (i32.load
+              (local.get $2)
+             )
+             (i32.const 3)
+            )
+            (i32.const -4)
+           )
+          )
+         )
+        )
+        (i32.store
+         (local.get $2)
+         (i32.add
+          (local.get $1)
+          (i32.const 4)
+         )
+        )
+        (i64.store
+         (local.get $0)
+         (i64.extend_i32_s
+          (i32.shr_s
+           (i32.shl
+            (i32.and
+             (local.get $3)
+             (i32.const 255)
+            )
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+         )
+        )
+        (br $label$1)
+       )
+       (local.set $3
+        (i32.load
+         (local.tee $1
+          (i32.and
+           (i32.add
+            (i32.load
+             (local.get $2)
+            )
+            (i32.const 3)
+           )
+           (i32.const -4)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $2)
+        (i32.add
+         (local.get $1)
+         (i32.const 4)
+        )
+       )
+       (i64.store
+        (local.get $0)
+        (i64.extend_i32_u
+         (i32.and
+          (local.get $3)
+          (i32.const 255)
+         )
+        )
+       )
+       (br $label$1)
+      )
+      (local.set $5
+       (f64.load
+        (local.tee $1
+         (i32.and
+          (i32.add
+           (i32.load
+            (local.get $2)
+           )
+           (i32.const 7)
+          )
+          (i32.const -8)
+         )
+        )
+       )
+      )
+      (i32.store
+       (local.get $2)
+       (i32.add
+        (local.get $1)
+        (i32.const 8)
+       )
+      )
+      (f64.store
+       (local.get $0)
+       (local.get $5)
+      )
+      (br $label$1)
+     )
+     (local.set $5
+      (f64.load
+       (local.tee $1
+        (i32.and
+         (i32.add
+          (i32.load
+           (local.get $2)
+          )
+          (i32.const 7)
+         )
+         (i32.const -8)
+        )
+       )
+      )
+     )
+     (i32.store
+      (local.get $2)
+      (i32.add
+       (local.get $1)
+       (i32.const 8)
+      )
+     )
+     (f64.store
+      (local.get $0)
+      (local.get $5)
+     )
+    )
+   )
+  )
+ )
+ (func $23 (; 36 ;) (type $9) (param $0 i64) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i64)
+  (block $label$1 (result i32)
+   (local.set $2
+    (i32.wrap_i64
+     (local.get $0)
+    )
+   )
+   (if
+    (i64.gt_u
+     (local.get $0)
+     (i64.const 4294967295)
+    )
+    (block
+     (loop $label$3
+      (i64.store8
+       (local.tee $1
+        (i32.add
+         (local.get $1)
+         (i32.const -1)
+        )
+       )
+       (i64.or
+        (i64.rem_u
+         (local.get $0)
+         (i64.const 10)
+        )
+        (i64.const 48)
+       )
+      )
+      (local.set $4
+       (i64.div_u
+        (local.get $0)
+        (i64.const 10)
+       )
+      )
+      (if
+       (i64.gt_u
+        (local.get $0)
+        (i64.const 42949672959)
+       )
+       (block
+        (local.set $0
+         (local.get $4)
+        )
+        (br $label$3)
+       )
+      )
+     )
+     (local.set $2
+      (i32.wrap_i64
+       (local.get $4)
+      )
+     )
+    )
+   )
+   (if
+    (local.get $2)
+    (loop $label$6
+     (i32.store8
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const -1)
+       )
+      )
+      (i32.or
+       (i32.rem_u
+        (local.get $2)
+        (i32.const 10)
+       )
+       (i32.const 48)
+      )
+     )
+     (local.set $3
+      (i32.div_u
+       (local.get $2)
+       (i32.const 10)
+      )
+     )
+     (if
+      (i32.ge_u
+       (local.get $2)
+       (i32.const 10)
+      )
+      (block
+       (local.set $2
+        (local.get $3)
+       )
+       (br $label$6)
+      )
+     )
+    )
+   )
+   (local.get $1)
+  )
+ )
+ (func $24 (; 37 ;) (type $2) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.const 0)
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (loop $label$5
+       (br_if $label$4
+        (i32.eq
+         (i32.load8_u
+          (i32.add
+           (local.get $1)
+           (i32.const 2233)
+          )
+         )
+         (local.get $0)
+        )
+       )
+       (br_if $label$5
+        (i32.ne
+         (local.tee $1
+          (i32.add
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (i32.const 87)
+        )
+       )
+       (local.set $1
+        (i32.const 87)
+       )
+       (local.set $0
+        (i32.const 2321)
+       )
+       (br $label$3)
+      )
+     )
+     (if
+      (local.get $1)
+      (block
+       (local.set $0
+        (i32.const 2321)
+       )
+       (br $label$3)
+      )
+      (local.set $0
+       (i32.const 2321)
+      )
+     )
+     (br $label$2)
+    )
+    (loop $label$8
+     (local.set $2
+      (local.get $0)
+     )
+     (loop $label$9
+      (local.set $0
+       (i32.add
+        (local.get $2)
+        (i32.const 1)
+       )
+      )
+      (if
+       (i32.load8_s
+        (local.get $2)
+       )
+       (block
+        (local.set $2
+         (local.get $0)
+        )
+        (br $label$9)
+       )
+      )
+     )
+     (br_if $label$8
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const -1)
+       )
+      )
+     )
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $25 (; 38 ;) (type $10) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (block $label$1
+   (local.set $7
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 256)
+    )
+   )
+   (local.set $6
+    (local.get $7)
+   )
+   (block $label$2
+    (if
+     (i32.and
+      (i32.gt_s
+       (local.get $2)
+       (local.get $3)
+      )
+      (i32.eqz
+       (i32.and
+        (local.get $4)
+        (i32.const 73728)
+       )
+      )
+     )
+     (block
+      (drop
+       (call $46
+        (local.get $6)
+        (local.get $1)
+        (if (result i32)
+         (i32.gt_u
+          (local.tee $5
+           (i32.sub
+            (local.get $2)
+            (local.get $3)
+           )
+          )
+          (i32.const 256)
+         )
+         (i32.const 256)
+         (local.get $5)
+        )
+       )
+      )
+      (local.set $4
+       (i32.eqz
+        (i32.and
+         (local.tee $1
+          (i32.load
+           (local.get $0)
+          )
+         )
+         (i32.const 32)
+        )
+       )
+      )
+      (if
+       (i32.gt_u
+        (local.get $5)
+        (i32.const 255)
+       )
+       (block
+        (loop $label$7
+         (if
+          (local.get $4)
+          (block
+           (drop
+            (call $21
+             (local.get $6)
+             (i32.const 256)
+             (local.get $0)
+            )
+           )
+           (local.set $1
+            (i32.load
+             (local.get $0)
+            )
+           )
+          )
+         )
+         (local.set $4
+          (i32.eqz
+           (i32.and
+            (local.get $1)
+            (i32.const 32)
+           )
+          )
+         )
+         (br_if $label$7
+          (i32.gt_u
+           (local.tee $5
+            (i32.add
+             (local.get $5)
+             (i32.const -256)
+            )
+           )
+           (i32.const 255)
+          )
+         )
+        )
+        (br_if $label$2
+         (i32.eqz
+          (local.get $4)
+         )
+        )
+        (local.set $5
+         (i32.and
+          (i32.sub
+           (local.get $2)
+           (local.get $3)
+          )
+          (i32.const 255)
+         )
+        )
+       )
+       (br_if $label$2
+        (i32.eqz
+         (local.get $4)
+        )
+       )
+      )
+      (drop
+       (call $21
+        (local.get $6)
+        (local.get $5)
+        (local.get $0)
+       )
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $7)
+   )
+  )
+ )
+ (func $26 (; 39 ;) (type $6) (param $0 i32) (param $1 i32) (result i32)
+  (if (result i32)
+   (local.get $0)
+   (call $29
+    (local.get $0)
+    (local.get $1)
+    (i32.const 0)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $27 (; 40 ;) (type $11) (param $0 f64) (param $1 i32) (result f64)
+  (call $28
+   (local.get $0)
+   (local.get $1)
+  )
+ )
+ (func $28 (; 41 ;) (type $11) (param $0 f64) (param $1 i32) (result f64)
+  (local $2 i64)
+  (local $3 i64)
+  (block $label$1 (result f64)
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (block $label$5
+       (br_table $label$5 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$4 $label$3
+        (i32.sub
+         (i32.shr_s
+          (i32.shl
+           (i32.and
+            (i32.and
+             (i32.wrap_i64
+              (local.tee $3
+               (i64.shr_u
+                (local.tee $2
+                 (i64.reinterpret_f64
+                  (local.get $0)
+                 )
+                )
+                (i64.const 52)
+               )
+              )
+             )
+             (i32.const 65535)
+            )
+            (i32.const 2047)
+           )
+           (i32.const 16)
+          )
+          (i32.const 16)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.store
+       (local.get $1)
+       (if (result i32)
+        (f64.ne
+         (local.get $0)
+         (f64.const 0)
+        )
+        (block (result i32)
+         (local.set $0
+          (call $28
+           (f64.mul
+            (local.get $0)
+            (f64.const 18446744073709551615)
+           )
+           (local.get $1)
+          )
+         )
+         (i32.add
+          (i32.load
+           (local.get $1)
+          )
+          (i32.const -64)
+         )
+        )
+        (i32.const 0)
+       )
+      )
+      (br $label$2)
+     )
+     (br $label$2)
+    )
+    (i32.store
+     (local.get $1)
+     (i32.add
+      (i32.and
+       (i32.wrap_i64
+        (local.get $3)
+       )
+       (i32.const 2047)
+      )
+      (i32.const -1022)
+     )
+    )
+    (local.set $0
+     (f64.reinterpret_i64
+      (i64.or
+       (i64.and
+        (local.get $2)
+        (i64.const -9218868437227405313)
+       )
+       (i64.const 4602678819172646912)
+      )
+     )
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $29 (; 42 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (block $label$1 (result i32)
+   (if (result i32)
+    (local.get $0)
+    (block (result i32)
+     (if
+      (i32.lt_u
+       (local.get $1)
+       (i32.const 128)
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (local.get $1)
+       )
+       (br $label$1
+        (i32.const 1)
+       )
+      )
+     )
+     (if
+      (i32.lt_u
+       (local.get $1)
+       (i32.const 2048)
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 6)
+         )
+         (i32.const 192)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (br $label$1
+        (i32.const 2)
+       )
+      )
+     )
+     (if
+      (i32.or
+       (i32.lt_u
+        (local.get $1)
+        (i32.const 55296)
+       )
+       (i32.eq
+        (i32.and
+         (local.get $1)
+         (i32.const -8192)
+        )
+        (i32.const 57344)
+       )
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 12)
+         )
+         (i32.const 224)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 6)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=2
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (br $label$1
+        (i32.const 3)
+       )
+      )
+     )
+     (if (result i32)
+      (i32.lt_u
+       (i32.add
+        (local.get $1)
+        (i32.const -65536)
+       )
+       (i32.const 1048576)
+      )
+      (block (result i32)
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 18)
+         )
+         (i32.const 240)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 12)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=2
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 6)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=3
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.const 4)
+      )
+      (block (result i32)
+       (i32.store
+        (call $12)
+        (i32.const 84)
+       )
+       (i32.const -1)
+      )
+     )
+    )
+    (i32.const 1)
+   )
+  )
+ )
+ (func $30 (; 43 ;) (type $2) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.load8_s
+     (local.tee $2
+      (i32.add
+       (local.get $0)
+       (i32.const 74)
+      )
+     )
+    )
+   )
+   (i32.store8
+    (local.get $2)
+    (i32.or
+     (i32.add
+      (local.get $1)
+      (i32.const 255)
+     )
+     (local.get $1)
+    )
+   )
+   (local.tee $0
+    (if (result i32)
+     (i32.and
+      (local.tee $1
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (i32.const 8)
+     )
+     (block (result i32)
+      (i32.store
+       (local.get $0)
+       (i32.or
+        (local.get $1)
+        (i32.const 32)
+       )
+      )
+      (i32.const -1)
+     )
+     (block (result i32)
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.store offset=28
+       (local.get $0)
+       (local.tee $1
+        (i32.load offset=44
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store offset=20
+       (local.get $0)
+       (local.get $1)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.add
+        (local.get $1)
+        (i32.load offset=48
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 0)
+     )
+    )
+   )
+  )
+ )
+ (func $31 (; 44 ;) (type $2) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (i32.eqz
+       (i32.and
+        (local.tee $2
+         (local.get $0)
+        )
+        (i32.const 3)
+       )
+      )
+     )
+     (local.set $1
+      (local.get $2)
+     )
+     (loop $label$4
+      (if
+       (i32.eqz
+        (i32.load8_s
+         (local.get $0)
+        )
+       )
+       (block
+        (local.set $0
+         (local.get $1)
+        )
+        (br $label$2)
+       )
+      )
+      (br_if $label$4
+       (i32.and
+        (local.tee $1
+         (local.tee $0
+          (i32.add
+           (local.get $0)
+           (i32.const 1)
+          )
+         )
+        )
+        (i32.const 3)
+       )
+      )
+      (br $label$3)
+     )
+    )
+    (loop $label$6
+     (local.set $1
+      (i32.add
+       (local.get $0)
+       (i32.const 4)
+      )
+     )
+     (if
+      (i32.eqz
+       (i32.and
+        (i32.xor
+         (i32.and
+          (local.tee $3
+           (i32.load
+            (local.get $0)
+           )
+          )
+          (i32.const -2139062144)
+         )
+         (i32.const -2139062144)
+        )
+        (i32.add
+         (local.get $3)
+         (i32.const -16843009)
+        )
+       )
+      )
+      (block
+       (local.set $0
+        (local.get $1)
+       )
+       (br $label$6)
+      )
+     )
+    )
+    (if
+     (i32.shr_s
+      (i32.shl
+       (i32.and
+        (local.get $3)
+        (i32.const 255)
+       )
+       (i32.const 24)
+      )
+      (i32.const 24)
+     )
+     (loop $label$9
+      (br_if $label$9
+       (i32.load8_s
+        (local.tee $0
+         (i32.add
+          (local.get $0)
+          (i32.const 1)
+         )
+        )
+       )
+      )
+     )
+    )
+   )
+   (i32.sub
+    (local.get $0)
+    (local.get $2)
+   )
+  )
+ )
+ (func $32 (; 45 ;) (type $6) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (block $label$1 (result i32)
+   (local.set $3
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store8
+    (local.tee $4
+     (local.get $3)
+    )
+    (local.tee $7
+     (i32.and
+      (local.get $1)
+      (i32.const 255)
+     )
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (local.tee $5
+       (i32.load
+        (local.tee $2
+         (i32.add
+          (local.get $0)
+          (i32.const 16)
+         )
+        )
+       )
+      )
+     )
+     (if
+      (call $30
+       (local.get $0)
+      )
+      (local.set $1
+       (i32.const -1)
+      )
+      (block
+       (local.set $5
+        (i32.load
+         (local.get $2)
+        )
+       )
+       (br $label$3)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.lt_u
+      (local.tee $6
+       (i32.load
+        (local.tee $2
+         (i32.add
+          (local.get $0)
+          (i32.const 20)
+         )
+        )
+       )
+      )
+      (local.get $5)
+     )
+     (if
+      (i32.ne
+       (local.tee $1
+        (i32.and
+         (local.get $1)
+         (i32.const 255)
+        )
+       )
+       (i32.load8_s offset=75
+        (local.get $0)
+       )
+      )
+      (block
+       (i32.store
+        (local.get $2)
+        (i32.add
+         (local.get $6)
+         (i32.const 1)
+        )
+       )
+       (i32.store8
+        (local.get $6)
+        (local.get $7)
+       )
+       (br $label$2)
+      )
+     )
+    )
+    (local.set $1
+     (if (result i32)
+      (i32.eq
+       (call_indirect (type $0)
+        (local.get $0)
+        (local.get $4)
+        (i32.const 1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (local.get $0)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
+       )
+       (i32.const 1)
+      )
+      (i32.load8_u
+       (local.get $4)
+      )
+      (i32.const -1)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $3)
+   )
+   (local.get $1)
+  )
+ )
+ (func $33 (; 46 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (i32.mul
+     (local.get $2)
+     (local.get $1)
+    )
+   )
+   (if
+    (i32.gt_s
+     (i32.load offset=76
+      (local.get $3)
+     )
+     (i32.const -1)
+    )
+    (block
+     (local.set $5
+      (i32.eqz
+       (call $20
+        (local.get $3)
+       )
+      )
+     )
+     (local.set $0
+      (call $21
+       (local.get $0)
+       (local.get $4)
+       (local.get $3)
+      )
+     )
+     (if
+      (i32.eqz
+       (local.get $5)
+      )
+      (call $13
+       (local.get $3)
+      )
+     )
+    )
+    (local.set $0
+     (call $21
+      (local.get $0)
+      (local.get $4)
+      (local.get $3)
+     )
+    )
+   )
+   (if
+    (i32.ne
+     (local.get $0)
+     (local.get $4)
+    )
+    (local.set $2
+     (i32.div_u
+      (local.get $0)
+      (local.get $1)
+     )
+    )
+   )
+   (local.get $2)
+  )
+ )
+ (func $34 (; 47 ;) (type $6) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (local.set $2
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store
+    (local.tee $3
+     (local.get $2)
+    )
+    (local.get $1)
+   )
+   (local.set $0
+    (call $18
+     (i32.load
+      (i32.const 1280)
+     )
+     (local.get $0)
+     (local.get $3)
+    )
+   )
+   (global.set $global$1
+    (local.get $2)
+   )
+   (local.get $0)
+  )
+ )
+ (func $35 (; 48 ;) (type $2) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (local.set $2
+    (if (result i32)
+     (i32.gt_s
+      (i32.load offset=76
+       (local.tee $1
+        (i32.load
+         (i32.const 1280)
+        )
+       )
+      )
+      (i32.const -1)
+     )
+     (call $20
+      (local.get $1)
+     )
+     (i32.const 0)
+    )
+   )
+   (local.set $0
+    (block $label$4 (result i32)
+     (if (result i32)
+      (i32.lt_s
+       (call $36
+        (local.get $0)
+        (local.get $1)
+       )
+       (i32.const 0)
+      )
+      (i32.const 1)
+      (block (result i32)
+       (if
+        (i32.ne
+         (i32.load8_s offset=75
+          (local.get $1)
+         )
+         (i32.const 10)
+        )
+        (if
+         (i32.lt_u
+          (local.tee $0
+           (i32.load
+            (local.tee $3
+             (i32.add
+              (local.get $1)
+              (i32.const 20)
+             )
+            )
+           )
+          )
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (block
+          (i32.store
+           (local.get $3)
+           (i32.add
+            (local.get $0)
+            (i32.const 1)
+           )
+          )
+          (i32.store8
+           (local.get $0)
+           (i32.const 10)
+          )
+          (br $label$4
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (i32.lt_s
+        (call $32
+         (local.get $1)
+         (i32.const 10)
+        )
+        (i32.const 0)
+       )
+      )
+     )
+    )
+   )
+   (if
+    (local.get $2)
+    (call $13
+     (local.get $1)
+    )
+   )
+   (i32.shr_s
+    (i32.shl
+     (local.get $0)
+     (i32.const 31)
+    )
+    (i32.const 31)
+   )
+  )
+ )
+ (func $36 (; 49 ;) (type $6) (param $0 i32) (param $1 i32) (result i32)
+  (i32.add
+   (call $33
+    (local.get $0)
+    (call $31
+     (local.get $0)
+    )
+    (i32.const 1)
+    (local.get $1)
+   )
+   (i32.const -1)
+  )
+ )
+ (func $37 (; 50 ;) (type $2) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (block $label$1 (result i32)
+   (local.set $14
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (local.set $18
+    (local.get $14)
+   )
+   (block $label$2
+    (if
+     (i32.lt_u
+      (local.get $0)
+      (i32.const 245)
+     )
+     (block
+      (local.set $3
+       (i32.and
+        (i32.add
+         (local.get $0)
+         (i32.const 11)
+        )
+        (i32.const -8)
+       )
+      )
+      (if
+       (i32.and
+        (local.tee $0
+         (i32.shr_u
+          (local.tee $8
+           (i32.load
+            (i32.const 4176)
+           )
+          )
+          (local.tee $2
+           (i32.shr_u
+            (if (result i32)
+             (i32.lt_u
+              (local.get $0)
+              (i32.const 11)
+             )
+             (local.tee $3
+              (i32.const 16)
+             )
+             (local.get $3)
+            )
+            (i32.const 3)
+           )
+          )
+         )
+        )
+        (i32.const 3)
+       )
+       (block
+        (local.set $4
+         (i32.load
+          (local.tee $1
+           (i32.add
+            (local.tee $7
+             (i32.load
+              (local.tee $3
+               (i32.add
+                (local.tee $2
+                 (i32.add
+                  (i32.shl
+                   (i32.shl
+                    (local.tee $5
+                     (i32.add
+                      (i32.xor
+                       (i32.and
+                        (local.get $0)
+                        (i32.const 1)
+                       )
+                       (i32.const 1)
+                      )
+                      (local.get $2)
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (i32.const 2)
+                  )
+                  (i32.const 4216)
+                 )
+                )
+                (i32.const 8)
+               )
+              )
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $4)
+         )
+         (i32.store
+          (i32.const 4176)
+          (i32.and
+           (local.get $8)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (local.get $5)
+            )
+            (i32.const -1)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $4)
+            (i32.load
+             (i32.const 4192)
+            )
+           )
+           (call $fimport$8)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $0
+              (i32.add
+               (local.get $4)
+               (i32.const 12)
+              )
+             )
+            )
+            (local.get $7)
+           )
+           (block
+            (i32.store
+             (local.get $0)
+             (local.get $2)
+            )
+            (i32.store
+             (local.get $3)
+             (local.get $4)
+            )
+           )
+           (call $fimport$8)
+          )
+         )
+        )
+        (i32.store offset=4
+         (local.get $7)
+         (i32.or
+          (local.tee $0
+           (i32.shl
+            (local.get $5)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (local.tee $0
+          (i32.add
+           (i32.add
+            (local.get $7)
+            (local.get $0)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 1)
+         )
+        )
+        (global.set $global$1
+         (local.get $14)
+        )
+        (return
+         (local.get $1)
+        )
+       )
+      )
+      (if
+       (i32.gt_u
+        (local.get $3)
+        (local.tee $16
+         (i32.load
+          (i32.const 4184)
+         )
+        )
+       )
+       (block
+        (if
+         (local.get $0)
+         (block
+          (local.set $5
+           (i32.and
+            (i32.shr_u
+             (local.tee $0
+              (i32.add
+               (i32.and
+                (local.tee $0
+                 (i32.and
+                  (i32.shl
+                   (local.get $0)
+                   (local.get $2)
+                  )
+                  (i32.or
+                   (local.tee $0
+                    (i32.shl
+                     (i32.const 2)
+                     (local.get $2)
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (local.get $0)
+                   )
+                  )
+                 )
+                )
+                (i32.sub
+                 (i32.const 0)
+                 (local.get $0)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (local.set $12
+           (i32.load
+            (local.tee $5
+             (i32.add
+              (local.tee $9
+               (i32.load
+                (local.tee $2
+                 (i32.add
+                  (local.tee $4
+                   (i32.add
+                    (i32.shl
+                     (i32.shl
+                      (local.tee $11
+                       (i32.add
+                        (i32.or
+                         (i32.or
+                          (i32.or
+                           (i32.or
+                            (local.tee $0
+                             (i32.and
+                              (i32.shr_u
+                               (local.tee $2
+                                (i32.shr_u
+                                 (local.get $0)
+                                 (local.get $5)
+                                )
+                               )
+                               (i32.const 5)
+                              )
+                              (i32.const 8)
+                             )
+                            )
+                            (local.get $5)
+                           )
+                           (local.tee $0
+                            (i32.and
+                             (i32.shr_u
+                              (local.tee $2
+                               (i32.shr_u
+                                (local.get $2)
+                                (local.get $0)
+                               )
+                              )
+                              (i32.const 2)
+                             )
+                             (i32.const 4)
+                            )
+                           )
+                          )
+                          (local.tee $0
+                           (i32.and
+                            (i32.shr_u
+                             (local.tee $2
+                              (i32.shr_u
+                               (local.get $2)
+                               (local.get $0)
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                         (local.tee $0
+                          (i32.and
+                           (i32.shr_u
+                            (local.tee $2
+                             (i32.shr_u
+                              (local.get $2)
+                              (local.get $0)
+                             )
+                            )
+                            (i32.const 1)
+                           )
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (i32.shr_u
+                         (local.get $2)
+                         (local.get $0)
+                        )
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 2)
+                    )
+                    (i32.const 4216)
+                   )
+                  )
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (if
+           (i32.eq
+            (local.get $4)
+            (local.get $12)
+           )
+           (i32.store
+            (i32.const 4176)
+            (local.tee $7
+             (i32.and
+              (local.get $8)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (local.get $11)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $12)
+              (i32.load
+               (i32.const 4192)
+              )
+             )
+             (call $fimport$8)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (local.tee $0
+                (i32.add
+                 (local.get $12)
+                 (i32.const 12)
+                )
+               )
+              )
+              (local.get $9)
+             )
+             (block
+              (i32.store
+               (local.get $0)
+               (local.get $4)
+              )
+              (i32.store
+               (local.get $2)
+               (local.get $12)
+              )
+              (local.set $7
+               (local.get $8)
+              )
+             )
+             (call $fimport$8)
+            )
+           )
+          )
+          (i32.store offset=4
+           (local.get $9)
+           (i32.or
+            (local.get $3)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (local.tee $4
+            (i32.add
+             (local.get $9)
+             (local.get $3)
+            )
+           )
+           (i32.or
+            (local.tee $11
+             (i32.sub
+              (i32.shl
+               (local.get $11)
+               (i32.const 3)
+              )
+              (local.get $3)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (local.get $4)
+            (local.get $11)
+           )
+           (local.get $11)
+          )
+          (if
+           (local.get $16)
+           (block
+            (local.set $9
+             (i32.load
+              (i32.const 4196)
+             )
+            )
+            (local.set $2
+             (i32.add
+              (i32.shl
+               (i32.shl
+                (local.tee $0
+                 (i32.shr_u
+                  (local.get $16)
+                  (i32.const 3)
+                 )
+                )
+                (i32.const 1)
+               )
+               (i32.const 2)
+              )
+              (i32.const 4216)
+             )
+            )
+            (if
+             (i32.and
+              (local.get $7)
+              (local.tee $0
+               (i32.shl
+                (i32.const 1)
+                (local.get $0)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.tee $0
+                (i32.load
+                 (local.tee $3
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 8)
+                  )
+                 )
+                )
+               )
+               (i32.load
+                (i32.const 4192)
+               )
+              )
+              (call $fimport$8)
+              (block
+               (local.set $6
+                (local.get $3)
+               )
+               (local.set $1
+                (local.get $0)
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 4176)
+               (i32.or
+                (local.get $7)
+                (local.get $0)
+               )
+              )
+              (local.set $6
+               (i32.add
+                (local.get $2)
+                (i32.const 8)
+               )
+              )
+              (local.set $1
+               (local.get $2)
+              )
+             )
+            )
+            (i32.store
+             (local.get $6)
+             (local.get $9)
+            )
+            (i32.store offset=12
+             (local.get $1)
+             (local.get $9)
+            )
+            (i32.store offset=8
+             (local.get $9)
+             (local.get $1)
+            )
+            (i32.store offset=12
+             (local.get $9)
+             (local.get $2)
+            )
+           )
+          )
+          (i32.store
+           (i32.const 4184)
+           (local.get $11)
+          )
+          (i32.store
+           (i32.const 4196)
+           (local.get $4)
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (local.get $5)
+          )
+         )
+        )
+        (if
+         (local.tee $6
+          (i32.load
+           (i32.const 4180)
+          )
+         )
+         (block
+          (local.set $2
+           (i32.and
+            (i32.shr_u
+             (local.tee $0
+              (i32.add
+               (i32.and
+                (local.get $6)
+                (i32.sub
+                 (i32.const 0)
+                 (local.get $6)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (local.set $9
+           (i32.sub
+            (i32.and
+             (i32.load offset=4
+              (local.tee $2
+               (i32.load
+                (i32.add
+                 (i32.shl
+                  (i32.add
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (i32.or
+                       (local.tee $0
+                        (i32.and
+                         (i32.shr_u
+                          (local.tee $1
+                           (i32.shr_u
+                            (local.get $0)
+                            (local.get $2)
+                           )
+                          )
+                          (i32.const 5)
+                         )
+                         (i32.const 8)
+                        )
+                       )
+                       (local.get $2)
+                      )
+                      (local.tee $0
+                       (i32.and
+                        (i32.shr_u
+                         (local.tee $1
+                          (i32.shr_u
+                           (local.get $1)
+                           (local.get $0)
+                          )
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (local.tee $1
+                         (i32.shr_u
+                          (local.get $1)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 1)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (local.tee $1
+                        (i32.shr_u
+                         (local.get $1)
+                         (local.get $0)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.shr_u
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 4480)
+                )
+               )
+              )
+             )
+             (i32.const -8)
+            )
+            (local.get $3)
+           )
+          )
+          (local.set $1
+           (local.get $2)
+          )
+          (loop $label$25
+           (block $label$26
+            (if
+             (i32.eqz
+              (local.tee $0
+               (i32.load offset=16
+                (local.get $1)
+               )
+              )
+             )
+             (br_if $label$26
+              (i32.eqz
+               (local.tee $0
+                (i32.load offset=20
+                 (local.get $1)
+                )
+               )
+              )
+             )
+            )
+            (if
+             (local.tee $7
+              (i32.lt_u
+               (local.tee $1
+                (i32.sub
+                 (i32.and
+                  (i32.load offset=4
+                   (local.get $0)
+                  )
+                  (i32.const -8)
+                 )
+                 (local.get $3)
+                )
+               )
+               (local.get $9)
+              )
+             )
+             (local.set $9
+              (local.get $1)
+             )
+            )
+            (local.set $1
+             (local.get $0)
+            )
+            (if
+             (local.get $7)
+             (local.set $2
+              (local.get $0)
+             )
+            )
+            (br $label$25)
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $2)
+            (local.tee $12
+             (i32.load
+              (i32.const 4192)
+             )
+            )
+           )
+           (call $fimport$8)
+          )
+          (if
+           (i32.ge_u
+            (local.get $2)
+            (local.tee $13
+             (i32.add
+              (local.get $2)
+              (local.get $3)
+             )
+            )
+           )
+           (call $fimport$8)
+          )
+          (local.set $15
+           (i32.load offset=24
+            (local.get $2)
+           )
+          )
+          (block $label$32
+           (if
+            (i32.eq
+             (local.tee $0
+              (i32.load offset=12
+               (local.get $2)
+              )
+             )
+             (local.get $2)
+            )
+            (block
+             (if
+              (i32.eqz
+               (local.tee $0
+                (i32.load
+                 (local.tee $1
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+              )
+              (if
+               (i32.eqz
+                (local.tee $0
+                 (i32.load
+                  (local.tee $1
+                   (i32.add
+                    (local.get $2)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $4
+                 (i32.const 0)
+                )
+                (br $label$32)
+               )
+              )
+             )
+             (loop $label$36
+              (if
+               (local.tee $7
+                (i32.load
+                 (local.tee $11
+                  (i32.add
+                   (local.get $0)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $0
+                 (local.get $7)
+                )
+                (local.set $1
+                 (local.get $11)
+                )
+                (br $label$36)
+               )
+              )
+              (if
+               (local.tee $7
+                (i32.load
+                 (local.tee $11
+                  (i32.add
+                   (local.get $0)
+                   (i32.const 16)
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $0
+                 (local.get $7)
+                )
+                (local.set $1
+                 (local.get $11)
+                )
+                (br $label$36)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $1)
+               (local.get $12)
+              )
+              (call $fimport$8)
+              (block
+               (i32.store
+                (local.get $1)
+                (i32.const 0)
+               )
+               (local.set $4
+                (local.get $0)
+               )
+              )
+             )
+            )
+            (block
+             (if
+              (i32.lt_u
+               (local.tee $11
+                (i32.load offset=8
+                 (local.get $2)
+                )
+               )
+               (local.get $12)
+              )
+              (call $fimport$8)
+             )
+             (if
+              (i32.ne
+               (i32.load
+                (local.tee $7
+                 (i32.add
+                  (local.get $11)
+                  (i32.const 12)
+                 )
+                )
+               )
+               (local.get $2)
+              )
+              (call $fimport$8)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (local.tee $1
+                 (i32.add
+                  (local.get $0)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (local.get $2)
+              )
+              (block
+               (i32.store
+                (local.get $7)
+                (local.get $0)
+               )
+               (i32.store
+                (local.get $1)
+                (local.get $11)
+               )
+               (local.set $4
+                (local.get $0)
+               )
+              )
+              (call $fimport$8)
+             )
+            )
+           )
+          )
+          (block $label$46
+           (if
+            (local.get $15)
+            (block
+             (if
+              (i32.eq
+               (local.get $2)
+               (i32.load
+                (local.tee $0
+                 (i32.add
+                  (i32.shl
+                   (local.tee $1
+                    (i32.load offset=28
+                     (local.get $2)
+                    )
+                   )
+                   (i32.const 2)
+                  )
+                  (i32.const 4480)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (local.get $0)
+                (local.get $4)
+               )
+               (if
+                (i32.eqz
+                 (local.get $4)
+                )
+                (block
+                 (i32.store
+                  (i32.const 4180)
+                  (i32.and
+                   (local.get $6)
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (local.get $1)
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                 )
+                 (br $label$46)
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (local.get $15)
+                 (i32.load
+                  (i32.const 4192)
+                 )
+                )
+                (call $fimport$8)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (local.tee $0
+                   (i32.add
+                    (local.get $15)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                 (local.get $2)
+                )
+                (i32.store
+                 (local.get $0)
+                 (local.get $4)
+                )
+                (i32.store offset=20
+                 (local.get $15)
+                 (local.get $4)
+                )
+               )
+               (br_if $label$46
+                (i32.eqz
+                 (local.get $4)
+                )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $4)
+               (local.tee $0
+                (i32.load
+                 (i32.const 4192)
+                )
+               )
+              )
+              (call $fimport$8)
+             )
+             (i32.store offset=24
+              (local.get $4)
+              (local.get $15)
+             )
+             (if
+              (local.tee $1
+               (i32.load offset=16
+                (local.get $2)
+               )
+              )
+              (if
+               (i32.lt_u
+                (local.get $1)
+                (local.get $0)
+               )
+               (call $fimport$8)
+               (block
+                (i32.store offset=16
+                 (local.get $4)
+                 (local.get $1)
+                )
+                (i32.store offset=24
+                 (local.get $1)
+                 (local.get $4)
+                )
+               )
+              )
+             )
+             (if
+              (local.tee $0
+               (i32.load offset=20
+                (local.get $2)
+               )
+              )
+              (if
+               (i32.lt_u
+                (local.get $0)
+                (i32.load
+                 (i32.const 4192)
+                )
+               )
+               (call $fimport$8)
+               (block
+                (i32.store offset=20
+                 (local.get $4)
+                 (local.get $0)
+                )
+                (i32.store offset=24
+                 (local.get $0)
+                 (local.get $4)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $9)
+            (i32.const 16)
+           )
+           (block
+            (i32.store offset=4
+             (local.get $2)
+             (i32.or
+              (local.tee $0
+               (i32.add
+                (local.get $9)
+                (local.get $3)
+               )
+              )
+              (i32.const 3)
+             )
+            )
+            (i32.store
+             (local.tee $0
+              (i32.add
+               (i32.add
+                (local.get $2)
+                (local.get $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (local.get $0)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block
+            (i32.store offset=4
+             (local.get $2)
+             (i32.or
+              (local.get $3)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (local.get $13)
+             (i32.or
+              (local.get $9)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (local.get $13)
+              (local.get $9)
+             )
+             (local.get $9)
+            )
+            (if
+             (local.get $16)
+             (block
+              (local.set $7
+               (i32.load
+                (i32.const 4196)
+               )
+              )
+              (local.set $3
+               (i32.add
+                (i32.shl
+                 (i32.shl
+                  (local.tee $0
+                   (i32.shr_u
+                    (local.get $16)
+                    (i32.const 3)
+                   )
+                  )
+                  (i32.const 1)
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 4216)
+               )
+              )
+              (if
+               (i32.and
+                (local.get $8)
+                (local.tee $0
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $0)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.tee $0
+                  (i32.load
+                   (local.tee $1
+                    (i32.add
+                     (local.get $3)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (i32.load
+                  (i32.const 4192)
+                 )
+                )
+                (call $fimport$8)
+                (block
+                 (local.set $10
+                  (local.get $1)
+                 )
+                 (local.set $5
+                  (local.get $0)
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (i32.const 4176)
+                 (i32.or
+                  (local.get $8)
+                  (local.get $0)
+                 )
+                )
+                (local.set $10
+                 (i32.add
+                  (local.get $3)
+                  (i32.const 8)
+                 )
+                )
+                (local.set $5
+                 (local.get $3)
+                )
+               )
+              )
+              (i32.store
+               (local.get $10)
+               (local.get $7)
+              )
+              (i32.store offset=12
+               (local.get $5)
+               (local.get $7)
+              )
+              (i32.store offset=8
+               (local.get $7)
+               (local.get $5)
+              )
+              (i32.store offset=12
+               (local.get $7)
+               (local.get $3)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 4184)
+             (local.get $9)
+            )
+            (i32.store
+             (i32.const 4196)
+             (local.get $13)
+            )
+           )
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (i32.add
+            (local.get $2)
+            (i32.const 8)
+           )
+          )
+         )
+         (local.set $0
+          (local.get $3)
+         )
+        )
+       )
+       (local.set $0
+        (local.get $3)
+       )
+      )
+     )
+     (if
+      (i32.gt_u
+       (local.get $0)
+       (i32.const -65)
+      )
+      (local.set $0
+       (i32.const -1)
+      )
+      (block
+       (local.set $7
+        (i32.and
+         (local.tee $0
+          (i32.add
+           (local.get $0)
+           (i32.const 11)
+          )
+         )
+         (i32.const -8)
+        )
+       )
+       (if
+        (local.tee $5
+         (i32.load
+          (i32.const 4180)
+         )
+        )
+        (block
+         (local.set $17
+          (if (result i32)
+           (local.tee $0
+            (i32.shr_u
+             (local.get $0)
+             (i32.const 8)
+            )
+           )
+           (if (result i32)
+            (i32.gt_u
+             (local.get $7)
+             (i32.const 16777215)
+            )
+            (i32.const 31)
+            (i32.or
+             (i32.and
+              (i32.shr_u
+               (local.get $7)
+               (i32.add
+                (local.tee $0
+                 (i32.add
+                  (i32.sub
+                   (i32.const 14)
+                   (i32.or
+                    (i32.or
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (i32.add
+                         (local.tee $1
+                          (i32.shl
+                           (local.get $0)
+                           (local.tee $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 1048320)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 8)
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 520192)
+                        )
+                        (i32.const 16)
+                       )
+                       (i32.const 4)
+                      )
+                     )
+                     (local.get $3)
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (i32.add
+                        (local.tee $1
+                         (i32.shl
+                          (local.get $1)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 245760)
+                       )
+                       (i32.const 16)
+                      )
+                      (i32.const 2)
+                     )
+                    )
+                   )
+                  )
+                  (i32.shr_u
+                   (i32.shl
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                   (i32.const 15)
+                  )
+                 )
+                )
+                (i32.const 7)
+               )
+              )
+              (i32.const 1)
+             )
+             (i32.shl
+              (local.get $0)
+              (i32.const 1)
+             )
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (local.set $3
+          (i32.sub
+           (i32.const 0)
+           (local.get $7)
+          )
+         )
+         (block $label$78
+          (block $label$79
+           (block $label$80
+            (if
+             (local.tee $1
+              (i32.load
+               (i32.add
+                (i32.shl
+                 (local.get $17)
+                 (i32.const 2)
+                )
+                (i32.const 4480)
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (i32.sub
+                (i32.const 25)
+                (i32.shr_u
+                 (local.get $17)
+                 (i32.const 1)
+                )
+               )
+              )
+              (local.set $4
+               (i32.const 0)
+              )
+              (local.set $10
+               (i32.shl
+                (local.get $7)
+                (if (result i32)
+                 (i32.eq
+                  (local.get $17)
+                  (i32.const 31)
+                 )
+                 (i32.const 0)
+                 (local.get $0)
+                )
+               )
+              )
+              (local.set $0
+               (i32.const 0)
+              )
+              (loop $label$84
+               (if
+                (i32.lt_u
+                 (local.tee $6
+                  (i32.sub
+                   (i32.and
+                    (i32.load offset=4
+                     (local.get $1)
+                    )
+                    (i32.const -8)
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (local.get $3)
+                )
+                (if
+                 (local.get $6)
+                 (block
+                  (local.set $3
+                   (local.get $6)
+                  )
+                  (local.set $0
+                   (local.get $1)
+                  )
+                 )
+                 (block
+                  (local.set $3
+                   (i32.const 0)
+                  )
+                  (local.set $0
+                   (local.get $1)
+                  )
+                  (br $label$79)
+                 )
+                )
+               )
+               (local.set $1
+                (if (result i32)
+                 (i32.or
+                  (i32.eqz
+                   (local.tee $19
+                    (i32.load offset=20
+                     (local.get $1)
+                    )
+                   )
+                  )
+                  (i32.eq
+                   (local.get $19)
+                   (local.tee $6
+                    (i32.load
+                     (i32.add
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 16)
+                      )
+                      (i32.shl
+                       (i32.shr_u
+                        (local.get $10)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (local.get $4)
+                 (local.get $19)
+                )
+               )
+               (local.set $10
+                (i32.shl
+                 (local.get $10)
+                 (i32.xor
+                  (i32.and
+                   (local.tee $4
+                    (i32.eqz
+                     (local.get $6)
+                    )
+                   )
+                   (i32.const 1)
+                  )
+                  (i32.const 1)
+                 )
+                )
+               )
+               (if
+                (local.get $4)
+                (block
+                 (local.set $4
+                  (local.get $1)
+                 )
+                 (local.set $1
+                  (local.get $0)
+                 )
+                 (br $label$80)
+                )
+                (block
+                 (local.set $4
+                  (local.get $1)
+                 )
+                 (local.set $1
+                  (local.get $6)
+                 )
+                 (br $label$84)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $4
+               (i32.const 0)
+              )
+              (local.set $1
+               (i32.const 0)
+              )
+             )
+            )
+           )
+           (br_if $label$79
+            (local.tee $0
+             (if (result i32)
+              (i32.and
+               (i32.eqz
+                (local.get $4)
+               )
+               (i32.eqz
+                (local.get $1)
+               )
+              )
+              (block (result i32)
+               (if
+                (i32.eqz
+                 (local.tee $0
+                  (i32.and
+                   (local.get $5)
+                   (i32.or
+                    (local.tee $0
+                     (i32.shl
+                      (i32.const 2)
+                      (local.get $17)
+                     )
+                    )
+                    (i32.sub
+                     (i32.const 0)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                 )
+                )
+                (block
+                 (local.set $0
+                  (local.get $7)
+                 )
+                 (br $label$2)
+                )
+               )
+               (local.set $10
+                (i32.and
+                 (i32.shr_u
+                  (local.tee $0
+                   (i32.add
+                    (i32.and
+                     (local.get $0)
+                     (i32.sub
+                      (i32.const 0)
+                      (local.get $0)
+                     )
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                  (i32.const 12)
+                 )
+                 (i32.const 16)
+                )
+               )
+               (i32.load
+                (i32.add
+                 (i32.shl
+                  (i32.add
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (i32.or
+                       (local.tee $0
+                        (i32.and
+                         (i32.shr_u
+                          (local.tee $4
+                           (i32.shr_u
+                            (local.get $0)
+                            (local.get $10)
+                           )
+                          )
+                          (i32.const 5)
+                         )
+                         (i32.const 8)
+                        )
+                       )
+                       (local.get $10)
+                      )
+                      (local.tee $0
+                       (i32.and
+                        (i32.shr_u
+                         (local.tee $4
+                          (i32.shr_u
+                           (local.get $4)
+                           (local.get $0)
+                          )
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (local.tee $4
+                         (i32.shr_u
+                          (local.get $4)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 1)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (local.tee $4
+                        (i32.shr_u
+                         (local.get $4)
+                         (local.get $0)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.shr_u
+                    (local.get $4)
+                    (local.get $0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 4480)
+                )
+               )
+              )
+              (local.get $4)
+             )
+            )
+           )
+           (local.set $4
+            (local.get $1)
+           )
+           (br $label$78)
+          )
+          (loop $label$96
+           (if
+            (local.tee $10
+             (i32.lt_u
+              (local.tee $4
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (local.get $0)
+                 )
+                 (i32.const -8)
+                )
+                (local.get $7)
+               )
+              )
+              (local.get $3)
+             )
+            )
+            (local.set $3
+             (local.get $4)
+            )
+           )
+           (if
+            (local.get $10)
+            (local.set $1
+             (local.get $0)
+            )
+           )
+           (if
+            (local.tee $4
+             (i32.load offset=16
+              (local.get $0)
+             )
+            )
+            (block
+             (local.set $0
+              (local.get $4)
+             )
+             (br $label$96)
+            )
+           )
+           (br_if $label$96
+            (local.tee $0
+             (i32.load offset=20
+              (local.get $0)
+             )
+            )
+           )
+           (local.set $4
+            (local.get $1)
+           )
+          )
+         )
+         (if
+          (local.get $4)
+          (if
+           (i32.lt_u
+            (local.get $3)
+            (i32.sub
+             (i32.load
+              (i32.const 4184)
+             )
+             (local.get $7)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $4)
+              (local.tee $12
+               (i32.load
+                (i32.const 4192)
+               )
+              )
+             )
+             (call $fimport$8)
+            )
+            (if
+             (i32.ge_u
+              (local.get $4)
+              (local.tee $6
+               (i32.add
+                (local.get $4)
+                (local.get $7)
+               )
+              )
+             )
+             (call $fimport$8)
+            )
+            (local.set $10
+             (i32.load offset=24
+              (local.get $4)
+             )
+            )
+            (block $label$104
+             (if
+              (i32.eq
+               (local.tee $0
+                (i32.load offset=12
+                 (local.get $4)
+                )
+               )
+               (local.get $4)
+              )
+              (block
+               (if
+                (i32.eqz
+                 (local.tee $0
+                  (i32.load
+                   (local.tee $1
+                    (i32.add
+                     (local.get $4)
+                     (i32.const 20)
+                    )
+                   )
+                  )
+                 )
+                )
+                (if
+                 (i32.eqz
+                  (local.tee $0
+                   (i32.load
+                    (local.tee $1
+                     (i32.add
+                      (local.get $4)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $13
+                   (i32.const 0)
+                  )
+                  (br $label$104)
+                 )
+                )
+               )
+               (loop $label$108
+                (if
+                 (local.tee $11
+                  (i32.load
+                   (local.tee $9
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 20)
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $0
+                   (local.get $11)
+                  )
+                  (local.set $1
+                   (local.get $9)
+                  )
+                  (br $label$108)
+                 )
+                )
+                (if
+                 (local.tee $11
+                  (i32.load
+                   (local.tee $9
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $0
+                   (local.get $11)
+                  )
+                  (local.set $1
+                   (local.get $9)
+                  )
+                  (br $label$108)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $1)
+                 (local.get $12)
+                )
+                (call $fimport$8)
+                (block
+                 (i32.store
+                  (local.get $1)
+                  (i32.const 0)
+                 )
+                 (local.set $13
+                  (local.get $0)
+                 )
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (local.tee $9
+                  (i32.load offset=8
+                   (local.get $4)
+                  )
+                 )
+                 (local.get $12)
+                )
+                (call $fimport$8)
+               )
+               (if
+                (i32.ne
+                 (i32.load
+                  (local.tee $11
+                   (i32.add
+                    (local.get $9)
+                    (i32.const 12)
+                   )
+                  )
+                 )
+                 (local.get $4)
+                )
+                (call $fimport$8)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (local.tee $1
+                   (i32.add
+                    (local.get $0)
+                    (i32.const 8)
+                   )
+                  )
+                 )
+                 (local.get $4)
+                )
+                (block
+                 (i32.store
+                  (local.get $11)
+                  (local.get $0)
+                 )
+                 (i32.store
+                  (local.get $1)
+                  (local.get $9)
+                 )
+                 (local.set $13
+                  (local.get $0)
+                 )
+                )
+                (call $fimport$8)
+               )
+              )
+             )
+            )
+            (block $label$118
+             (if
+              (local.get $10)
+              (block
+               (if
+                (i32.eq
+                 (local.get $4)
+                 (i32.load
+                  (local.tee $0
+                   (i32.add
+                    (i32.shl
+                     (local.tee $1
+                      (i32.load offset=28
+                       (local.get $4)
+                      )
+                     )
+                     (i32.const 2)
+                    )
+                    (i32.const 4480)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (local.get $0)
+                  (local.get $13)
+                 )
+                 (if
+                  (i32.eqz
+                   (local.get $13)
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 4180)
+                    (local.tee $2
+                     (i32.and
+                      (local.get $5)
+                      (i32.xor
+                       (i32.shl
+                        (i32.const 1)
+                        (local.get $1)
+                       )
+                       (i32.const -1)
+                      )
+                     )
+                    )
+                   )
+                   (br $label$118)
+                  )
+                 )
+                )
+                (block
+                 (if
+                  (i32.lt_u
+                   (local.get $10)
+                   (i32.load
+                    (i32.const 4192)
+                   )
+                  )
+                  (call $fimport$8)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (local.tee $0
+                     (i32.add
+                      (local.get $10)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                   (local.get $4)
+                  )
+                  (i32.store
+                   (local.get $0)
+                   (local.get $13)
+                  )
+                  (i32.store offset=20
+                   (local.get $10)
+                   (local.get $13)
+                  )
+                 )
+                 (if
+                  (i32.eqz
+                   (local.get $13)
+                  )
+                  (block
+                   (local.set $2
+                    (local.get $5)
+                   )
+                   (br $label$118)
+                  )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $13)
+                 (local.tee $0
+                  (i32.load
+                   (i32.const 4192)
+                  )
+                 )
+                )
+                (call $fimport$8)
+               )
+               (i32.store offset=24
+                (local.get $13)
+                (local.get $10)
+               )
+               (if
+                (local.tee $1
+                 (i32.load offset=16
+                  (local.get $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (local.get $1)
+                  (local.get $0)
+                 )
+                 (call $fimport$8)
+                 (block
+                  (i32.store offset=16
+                   (local.get $13)
+                   (local.get $1)
+                  )
+                  (i32.store offset=24
+                   (local.get $1)
+                   (local.get $13)
+                  )
+                 )
+                )
+               )
+               (if
+                (local.tee $0
+                 (i32.load offset=20
+                  (local.get $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (local.get $0)
+                  (i32.load
+                   (i32.const 4192)
+                  )
+                 )
+                 (call $fimport$8)
+                 (block
+                  (i32.store offset=20
+                   (local.get $13)
+                   (local.get $0)
+                  )
+                  (i32.store offset=24
+                   (local.get $0)
+                   (local.get $13)
+                  )
+                  (local.set $2
+                   (local.get $5)
+                  )
+                 )
+                )
+                (local.set $2
+                 (local.get $5)
+                )
+               )
+              )
+              (local.set $2
+               (local.get $5)
+              )
+             )
+            )
+            (block $label$136
+             (if
+              (i32.lt_u
+               (local.get $3)
+               (i32.const 16)
+              )
+              (block
+               (i32.store offset=4
+                (local.get $4)
+                (i32.or
+                 (local.tee $0
+                  (i32.add
+                   (local.get $3)
+                   (local.get $7)
+                  )
+                 )
+                 (i32.const 3)
+                )
+               )
+               (i32.store
+                (local.tee $0
+                 (i32.add
+                  (i32.add
+                   (local.get $4)
+                   (local.get $0)
+                  )
+                  (i32.const 4)
+                 )
+                )
+                (i32.or
+                 (i32.load
+                  (local.get $0)
+                 )
+                 (i32.const 1)
+                )
+               )
+              )
+              (block
+               (i32.store offset=4
+                (local.get $4)
+                (i32.or
+                 (local.get $7)
+                 (i32.const 3)
+                )
+               )
+               (i32.store offset=4
+                (local.get $6)
+                (i32.or
+                 (local.get $3)
+                 (i32.const 1)
+                )
+               )
+               (i32.store
+                (i32.add
+                 (local.get $6)
+                 (local.get $3)
+                )
+                (local.get $3)
+               )
+               (local.set $0
+                (i32.shr_u
+                 (local.get $3)
+                 (i32.const 3)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $3)
+                 (i32.const 256)
+                )
+                (block
+                 (local.set $3
+                  (i32.add
+                   (i32.shl
+                    (i32.shl
+                     (local.get $0)
+                     (i32.const 1)
+                    )
+                    (i32.const 2)
+                   )
+                   (i32.const 4216)
+                  )
+                 )
+                 (if
+                  (i32.and
+                   (local.tee $1
+                    (i32.load
+                     (i32.const 4176)
+                    )
+                   )
+                   (local.tee $0
+                    (i32.shl
+                     (i32.const 1)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.lt_u
+                    (local.tee $0
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $3)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                    )
+                    (i32.load
+                     (i32.const 4192)
+                    )
+                   )
+                   (call $fimport$8)
+                   (block
+                    (local.set $16
+                     (local.get $1)
+                    )
+                    (local.set $8
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 4176)
+                    (i32.or
+                     (local.get $1)
+                     (local.get $0)
+                    )
+                   )
+                   (local.set $16
+                    (i32.add
+                     (local.get $3)
+                     (i32.const 8)
+                    )
+                   )
+                   (local.set $8
+                    (local.get $3)
+                   )
+                  )
+                 )
+                 (i32.store
+                  (local.get $16)
+                  (local.get $6)
+                 )
+                 (i32.store offset=12
+                  (local.get $8)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $8)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $3)
+                 )
+                 (br $label$136)
+                )
+               )
+               (local.set $1
+                (i32.add
+                 (i32.shl
+                  (local.tee $5
+                   (if (result i32)
+                    (local.tee $0
+                     (i32.shr_u
+                      (local.get $3)
+                      (i32.const 8)
+                     )
+                    )
+                    (if (result i32)
+                     (i32.gt_u
+                      (local.get $3)
+                      (i32.const 16777215)
+                     )
+                     (i32.const 31)
+                     (i32.or
+                      (i32.and
+                       (i32.shr_u
+                        (local.get $3)
+                        (i32.add
+                         (local.tee $0
+                          (i32.add
+                           (i32.sub
+                            (i32.const 14)
+                            (i32.or
+                             (i32.or
+                              (local.tee $0
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (local.tee $1
+                                   (i32.shl
+                                    (local.get $0)
+                                    (local.tee $5
+                                     (i32.and
+                                      (i32.shr_u
+                                       (i32.add
+                                        (local.get $0)
+                                        (i32.const 1048320)
+                                       )
+                                       (i32.const 16)
+                                      )
+                                      (i32.const 8)
+                                     )
+                                    )
+                                   )
+                                  )
+                                  (i32.const 520192)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 4)
+                               )
+                              )
+                              (local.get $5)
+                             )
+                             (local.tee $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (local.tee $1
+                                  (i32.shl
+                                   (local.get $1)
+                                   (local.get $0)
+                                  )
+                                 )
+                                 (i32.const 245760)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 2)
+                              )
+                             )
+                            )
+                           )
+                           (i32.shr_u
+                            (i32.shl
+                             (local.get $1)
+                             (local.get $0)
+                            )
+                            (i32.const 15)
+                           )
+                          )
+                         )
+                         (i32.const 7)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.shl
+                       (local.get $0)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (i32.const 0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 4480)
+                )
+               )
+               (i32.store offset=28
+                (local.get $6)
+                (local.get $5)
+               )
+               (i32.store offset=4
+                (local.tee $0
+                 (i32.add
+                  (local.get $6)
+                  (i32.const 16)
+                 )
+                )
+                (i32.const 0)
+               )
+               (i32.store
+                (local.get $0)
+                (i32.const 0)
+               )
+               (if
+                (i32.eqz
+                 (i32.and
+                  (local.get $2)
+                  (local.tee $0
+                   (i32.shl
+                    (i32.const 1)
+                    (local.get $5)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (i32.const 4180)
+                  (i32.or
+                   (local.get $2)
+                   (local.get $0)
+                  )
+                 )
+                 (i32.store
+                  (local.get $1)
+                  (local.get $6)
+                 )
+                 (i32.store offset=24
+                  (local.get $6)
+                  (local.get $1)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (br $label$136)
+                )
+               )
+               (local.set $0
+                (i32.load
+                 (local.get $1)
+                )
+               )
+               (local.set $1
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (local.get $5)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (local.set $5
+                (i32.shl
+                 (local.get $3)
+                 (if (result i32)
+                  (i32.eq
+                   (local.get $5)
+                   (i32.const 31)
+                  )
+                  (i32.const 0)
+                  (local.get $1)
+                 )
+                )
+               )
+               (block $label$151
+                (block $label$152
+                 (block $label$153
+                  (loop $label$154
+                   (br_if $label$152
+                    (i32.eq
+                     (i32.and
+                      (i32.load offset=4
+                       (local.get $0)
+                      )
+                      (i32.const -8)
+                     )
+                     (local.get $3)
+                    )
+                   )
+                   (local.set $2
+                    (i32.shl
+                     (local.get $5)
+                     (i32.const 1)
+                    )
+                   )
+                   (br_if $label$153
+                    (i32.eqz
+                     (local.tee $1
+                      (i32.load
+                       (local.tee $5
+                        (i32.add
+                         (i32.add
+                          (local.get $0)
+                          (i32.const 16)
+                         )
+                         (i32.shl
+                          (i32.shr_u
+                           (local.get $5)
+                           (i32.const 31)
+                          )
+                          (i32.const 2)
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (local.set $5
+                    (local.get $2)
+                   )
+                   (local.set $0
+                    (local.get $1)
+                   )
+                   (br $label$154)
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (local.get $5)
+                   (i32.load
+                    (i32.const 4192)
+                   )
+                  )
+                  (call $fimport$8)
+                  (block
+                   (i32.store
+                    (local.get $5)
+                    (local.get $6)
+                   )
+                   (i32.store offset=24
+                    (local.get $6)
+                    (local.get $0)
+                   )
+                   (i32.store offset=12
+                    (local.get $6)
+                    (local.get $6)
+                   )
+                   (i32.store offset=8
+                    (local.get $6)
+                    (local.get $6)
+                   )
+                   (br $label$136)
+                  )
+                 )
+                 (br $label$151)
+                )
+                (if
+                 (i32.and
+                  (i32.ge_u
+                   (local.tee $2
+                    (i32.load
+                     (local.tee $3
+                      (i32.add
+                       (local.get $0)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (local.tee $1
+                    (i32.load
+                     (i32.const 4192)
+                    )
+                   )
+                  )
+                  (i32.ge_u
+                   (local.get $0)
+                   (local.get $1)
+                  )
+                 )
+                 (block
+                  (i32.store offset=12
+                   (local.get $2)
+                   (local.get $6)
+                  )
+                  (i32.store
+                   (local.get $3)
+                   (local.get $6)
+                  )
+                  (i32.store offset=8
+                   (local.get $6)
+                   (local.get $2)
+                  )
+                  (i32.store offset=12
+                   (local.get $6)
+                   (local.get $0)
+                  )
+                  (i32.store offset=24
+                   (local.get $6)
+                   (i32.const 0)
+                  )
+                 )
+                 (call $fimport$8)
+                )
+               )
+              )
+             )
+            )
+            (global.set $global$1
+             (local.get $14)
+            )
+            (return
+             (i32.add
+              (local.get $4)
+              (i32.const 8)
+             )
+            )
+           )
+           (local.set $0
+            (local.get $7)
+           )
+          )
+          (local.set $0
+           (local.get $7)
+          )
+         )
+        )
+        (local.set $0
+         (local.get $7)
+        )
+       )
+      )
+     )
+    )
+   )
+   (if
+    (i32.ge_u
+     (local.tee $1
+      (i32.load
+       (i32.const 4184)
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (local.set $2
+      (i32.load
+       (i32.const 4196)
+      )
+     )
+     (if
+      (i32.gt_u
+       (local.tee $3
+        (i32.sub
+         (local.get $1)
+         (local.get $0)
+        )
+       )
+       (i32.const 15)
+      )
+      (block
+       (i32.store
+        (i32.const 4196)
+        (local.tee $1
+         (i32.add
+          (local.get $2)
+          (local.get $0)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 4184)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $1)
+        (i32.or
+         (local.get $3)
+         (i32.const 1)
+        )
+       )
+       (i32.store
+        (i32.add
+         (local.get $1)
+         (local.get $3)
+        )
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $2)
+        (i32.or
+         (local.get $0)
+         (i32.const 3)
+        )
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 4184)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 4196)
+        (i32.const 0)
+       )
+       (i32.store offset=4
+        (local.get $2)
+        (i32.or
+         (local.get $1)
+         (i32.const 3)
+        )
+       )
+       (i32.store
+        (local.tee $0
+         (i32.add
+          (i32.add
+           (local.get $2)
+           (local.get $1)
+          )
+          (i32.const 4)
+         )
+        )
+        (i32.or
+         (i32.load
+          (local.get $0)
+         )
+         (i32.const 1)
+        )
+       )
+      )
+     )
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+     )
+    )
+   )
+   (if
+    (i32.gt_u
+     (local.tee $10
+      (i32.load
+       (i32.const 4188)
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (i32.store
+      (i32.const 4188)
+      (local.tee $3
+       (i32.sub
+        (local.get $10)
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (i32.const 4200)
+      (local.tee $1
+       (i32.add
+        (local.tee $2
+         (i32.load
+          (i32.const 4200)
+         )
+        )
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store offset=4
+      (local.get $1)
+      (i32.or
+       (local.get $3)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=4
+      (local.get $2)
+      (i32.or
+       (local.get $0)
+       (i32.const 3)
+      )
+     )
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+     )
+    )
+   )
+   (if
+    (i32.le_u
+     (local.tee $6
+      (i32.and
+       (local.tee $8
+        (i32.add
+         (local.tee $1
+          (if (result i32)
+           (i32.load
+            (i32.const 4648)
+           )
+           (i32.load
+            (i32.const 4656)
+           )
+           (block (result i32)
+            (i32.store
+             (i32.const 4656)
+             (i32.const 4096)
+            )
+            (i32.store
+             (i32.const 4652)
+             (i32.const 4096)
+            )
+            (i32.store
+             (i32.const 4660)
+             (i32.const -1)
+            )
+            (i32.store
+             (i32.const 4664)
+             (i32.const -1)
+            )
+            (i32.store
+             (i32.const 4668)
+             (i32.const 0)
+            )
+            (i32.store
+             (i32.const 4620)
+             (i32.const 0)
+            )
+            (i32.store
+             (local.get $18)
+             (local.tee $1
+              (i32.xor
+               (i32.and
+                (local.get $18)
+                (i32.const -16)
+               )
+               (i32.const 1431655768)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 4648)
+             (local.get $1)
+            )
+            (i32.const 4096)
+           )
+          )
+         )
+         (local.tee $13
+          (i32.add
+           (local.get $0)
+           (i32.const 47)
+          )
+         )
+        )
+       )
+       (local.tee $4
+        (i32.sub
+         (i32.const 0)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.const 0)
+     )
+    )
+   )
+   (if
+    (local.tee $2
+     (i32.load
+      (i32.const 4616)
+     )
+    )
+    (if
+     (i32.or
+      (i32.le_u
+       (local.tee $1
+        (i32.add
+         (local.tee $3
+          (i32.load
+           (i32.const 4608)
+          )
+         )
+         (local.get $6)
+        )
+       )
+       (local.get $3)
+      )
+      (i32.gt_u
+       (local.get $1)
+       (local.get $2)
+      )
+     )
+     (block
+      (global.set $global$1
+       (local.get $14)
+      )
+      (return
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (local.set $7
+    (i32.add
+     (local.get $0)
+     (i32.const 48)
+    )
+   )
+   (block $label$171
+    (block $label$172
+     (if
+      (i32.eqz
+       (i32.and
+        (i32.load
+         (i32.const 4620)
+        )
+        (i32.const 4)
+       )
+      )
+      (block
+       (block $label$174
+        (block $label$175
+         (block $label$176
+          (br_if $label$176
+           (i32.eqz
+            (local.tee $3
+             (i32.load
+              (i32.const 4200)
+             )
+            )
+           )
+          )
+          (local.set $2
+           (i32.const 4624)
+          )
+          (loop $label$177
+           (block $label$178
+            (if
+             (i32.le_u
+              (local.tee $1
+               (i32.load
+                (local.get $2)
+               )
+              )
+              (local.get $3)
+             )
+             (br_if $label$178
+              (i32.gt_u
+               (i32.add
+                (local.get $1)
+                (i32.load
+                 (local.tee $5
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 4)
+                  )
+                 )
+                )
+               )
+               (local.get $3)
+              )
+             )
+            )
+            (br_if $label$176
+             (i32.eqz
+              (local.tee $1
+               (i32.load offset=8
+                (local.get $2)
+               )
+              )
+             )
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$177)
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.tee $3
+             (i32.and
+              (i32.sub
+               (local.get $8)
+               (local.get $10)
+              )
+              (local.get $4)
+             )
+            )
+            (i32.const 2147483647)
+           )
+           (if
+            (i32.eq
+             (local.tee $1
+              (call $45
+               (local.get $3)
+              )
+             )
+             (i32.add
+              (i32.load
+               (local.get $2)
+              )
+              (i32.load
+               (local.get $5)
+              )
+             )
+            )
+            (br_if $label$172
+             (i32.ne
+              (local.get $1)
+              (i32.const -1)
+             )
+            )
+            (block
+             (local.set $2
+              (local.get $1)
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$175)
+            )
+           )
+          )
+          (br $label$174)
+         )
+         (if
+          (i32.ne
+           (local.tee $1
+            (call $45
+             (i32.const 0)
+            )
+           )
+           (i32.const -1)
+          )
+          (block
+           (local.set $2
+            (i32.sub
+             (i32.and
+              (i32.add
+               (local.tee $5
+                (i32.add
+                 (local.tee $2
+                  (i32.load
+                   (i32.const 4652)
+                  )
+                 )
+                 (i32.const -1)
+                )
+               )
+               (local.tee $3
+                (local.get $1)
+               )
+              )
+              (i32.sub
+               (i32.const 0)
+               (local.get $2)
+              )
+             )
+             (local.get $3)
+            )
+           )
+           (local.set $4
+            (i32.add
+             (local.tee $3
+              (i32.add
+               (if (result i32)
+                (i32.and
+                 (local.get $5)
+                 (local.get $3)
+                )
+                (local.get $2)
+                (i32.const 0)
+               )
+               (local.get $6)
+              )
+             )
+             (local.tee $5
+              (i32.load
+               (i32.const 4608)
+              )
+             )
+            )
+           )
+           (if
+            (i32.and
+             (i32.gt_u
+              (local.get $3)
+              (local.get $0)
+             )
+             (i32.lt_u
+              (local.get $3)
+              (i32.const 2147483647)
+             )
+            )
+            (block
+             (if
+              (local.tee $2
+               (i32.load
+                (i32.const 4616)
+               )
+              )
+              (br_if $label$174
+               (i32.or
+                (i32.le_u
+                 (local.get $4)
+                 (local.get $5)
+                )
+                (i32.gt_u
+                 (local.get $4)
+                 (local.get $2)
+                )
+               )
+              )
+             )
+             (br_if $label$172
+              (i32.eq
+               (local.tee $2
+                (call $45
+                 (local.get $3)
+                )
+               )
+               (local.get $1)
+              )
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$175)
+            )
+           )
+          )
+         )
+         (br $label$174)
+        )
+        (local.set $5
+         (i32.sub
+          (i32.const 0)
+          (local.get $1)
+         )
+        )
+        (if
+         (i32.and
+          (i32.gt_u
+           (local.get $7)
+           (local.get $1)
+          )
+          (i32.and
+           (i32.lt_u
+            (local.get $1)
+            (i32.const 2147483647)
+           )
+           (i32.ne
+            (local.get $2)
+            (i32.const -1)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.tee $3
+            (i32.and
+             (i32.add
+              (i32.sub
+               (local.get $13)
+               (local.get $1)
+              )
+              (local.tee $3
+               (i32.load
+                (i32.const 4656)
+               )
+              )
+             )
+             (i32.sub
+              (i32.const 0)
+              (local.get $3)
+             )
+            )
+           )
+           (i32.const 2147483647)
+          )
+          (if
+           (i32.eq
+            (call $45
+             (local.get $3)
+            )
+            (i32.const -1)
+           )
+           (block
+            (drop
+             (call $45
+              (local.get $5)
+             )
+            )
+            (br $label$174)
+           )
+           (local.set $3
+            (i32.add
+             (local.get $3)
+             (local.get $1)
+            )
+           )
+          )
+          (local.set $3
+           (local.get $1)
+          )
+         )
+         (local.set $3
+          (local.get $1)
+         )
+        )
+        (if
+         (i32.ne
+          (local.get $2)
+          (i32.const -1)
+         )
+         (block
+          (local.set $1
+           (local.get $2)
+          )
+          (br $label$172)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 4620)
+        (i32.or
+         (i32.load
+          (i32.const 4620)
+         )
+         (i32.const 4)
+        )
+       )
+      )
+     )
+     (if
+      (i32.lt_u
+       (local.get $6)
+       (i32.const 2147483647)
+      )
+      (if
+       (i32.and
+        (i32.lt_u
+         (local.tee $1
+          (call $45
+           (local.get $6)
+          )
+         )
+         (local.tee $3
+          (call $45
+           (i32.const 0)
+          )
+         )
+        )
+        (i32.and
+         (i32.ne
+          (local.get $1)
+          (i32.const -1)
+         )
+         (i32.ne
+          (local.get $3)
+          (i32.const -1)
+         )
+        )
+       )
+       (br_if $label$172
+        (i32.gt_u
+         (local.tee $3
+          (i32.sub
+           (local.get $3)
+           (local.get $1)
+          )
+         )
+         (i32.add
+          (local.get $0)
+          (i32.const 40)
+         )
+        )
+       )
+      )
+     )
+     (br $label$171)
+    )
+    (i32.store
+     (i32.const 4608)
+     (local.tee $2
+      (i32.add
+       (i32.load
+        (i32.const 4608)
+       )
+       (local.get $3)
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (local.get $2)
+      (i32.load
+       (i32.const 4612)
+      )
+     )
+     (i32.store
+      (i32.const 4612)
+      (local.get $2)
+     )
+    )
+    (block $label$198
+     (if
+      (local.tee $8
+       (i32.load
+        (i32.const 4200)
+       )
+      )
+      (block
+       (local.set $2
+        (i32.const 4624)
+       )
+       (block $label$200
+        (block $label$201
+         (loop $label$202
+          (br_if $label$201
+           (i32.eq
+            (local.get $1)
+            (i32.add
+             (local.tee $4
+              (i32.load
+               (local.get $2)
+              )
+             )
+             (local.tee $5
+              (i32.load
+               (local.tee $7
+                (i32.add
+                 (local.get $2)
+                 (i32.const 4)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (br_if $label$202
+           (local.tee $2
+            (i32.load offset=8
+             (local.get $2)
+            )
+           )
+          )
+         )
+         (br $label$200)
+        )
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.load offset=12
+            (local.get $2)
+           )
+           (i32.const 8)
+          )
+         )
+         (if
+          (i32.and
+           (i32.lt_u
+            (local.get $8)
+            (local.get $1)
+           )
+           (i32.ge_u
+            (local.get $8)
+            (local.get $4)
+           )
+          )
+          (block
+           (i32.store
+            (local.get $7)
+            (i32.add
+             (local.get $5)
+             (local.get $3)
+            )
+           )
+           (local.set $5
+            (i32.load
+             (i32.const 4188)
+            )
+           )
+           (local.set $1
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (local.tee $2
+               (i32.add
+                (local.get $8)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+           )
+           (i32.store
+            (i32.const 4200)
+            (local.tee $2
+             (i32.add
+              (local.get $8)
+              (if (result i32)
+               (i32.and
+                (local.get $2)
+                (i32.const 7)
+               )
+               (local.get $1)
+               (local.tee $1
+                (i32.const 0)
+               )
+              )
+             )
+            )
+           )
+           (i32.store
+            (i32.const 4188)
+            (local.tee $1
+             (i32.add
+              (i32.sub
+               (local.get $3)
+               (local.get $1)
+              )
+              (local.get $5)
+             )
+            )
+           )
+           (i32.store offset=4
+            (local.get $2)
+            (i32.or
+             (local.get $1)
+             (i32.const 1)
+            )
+           )
+           (i32.store offset=4
+            (i32.add
+             (local.get $2)
+             (local.get $1)
+            )
+            (i32.const 40)
+           )
+           (i32.store
+            (i32.const 4204)
+            (i32.load
+             (i32.const 4664)
+            )
+           )
+           (br $label$198)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (local.get $1)
+         (local.tee $2
+          (i32.load
+           (i32.const 4192)
+          )
+         )
+        )
+        (block
+         (i32.store
+          (i32.const 4192)
+          (local.get $1)
+         )
+         (local.set $2
+          (local.get $1)
+         )
+        )
+       )
+       (local.set $10
+        (i32.add
+         (local.get $1)
+         (local.get $3)
+        )
+       )
+       (local.set $5
+        (i32.const 4624)
+       )
+       (block $label$208
+        (block $label$209
+         (loop $label$210
+          (br_if $label$209
+           (i32.eq
+            (i32.load
+             (local.get $5)
+            )
+            (local.get $10)
+           )
+          )
+          (br_if $label$210
+           (local.tee $5
+            (i32.load offset=8
+             (local.get $5)
+            )
+           )
+          )
+          (local.set $5
+           (i32.const 4624)
+          )
+         )
+         (br $label$208)
+        )
+        (if
+         (i32.and
+          (i32.load offset=12
+           (local.get $5)
+          )
+          (i32.const 8)
+         )
+         (local.set $5
+          (i32.const 4624)
+         )
+         (block
+          (i32.store
+           (local.get $5)
+           (local.get $1)
+          )
+          (i32.store
+           (local.tee $5
+            (i32.add
+             (local.get $5)
+             (i32.const 4)
+            )
+           )
+           (i32.add
+            (i32.load
+             (local.get $5)
+            )
+            (local.get $3)
+           )
+          )
+          (local.set $7
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (local.tee $4
+              (i32.add
+               (local.get $1)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+          )
+          (local.set $3
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (local.tee $5
+              (i32.add
+               (local.get $10)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+          )
+          (local.set $6
+           (i32.add
+            (local.tee $13
+             (i32.add
+              (local.get $1)
+              (if (result i32)
+               (i32.and
+                (local.get $4)
+                (i32.const 7)
+               )
+               (local.get $7)
+               (i32.const 0)
+              )
+             )
+            )
+            (local.get $0)
+           )
+          )
+          (local.set $7
+           (i32.sub
+            (i32.sub
+             (local.tee $4
+              (i32.add
+               (local.get $10)
+               (if (result i32)
+                (i32.and
+                 (local.get $5)
+                 (i32.const 7)
+                )
+                (local.get $3)
+                (i32.const 0)
+               )
+              )
+             )
+             (local.get $13)
+            )
+            (local.get $0)
+           )
+          )
+          (i32.store offset=4
+           (local.get $13)
+           (i32.or
+            (local.get $0)
+            (i32.const 3)
+           )
+          )
+          (block $label$217
+           (if
+            (i32.eq
+             (local.get $4)
+             (local.get $8)
+            )
+            (block
+             (i32.store
+              (i32.const 4188)
+              (local.tee $0
+               (i32.add
+                (i32.load
+                 (i32.const 4188)
+                )
+                (local.get $7)
+               )
+              )
+             )
+             (i32.store
+              (i32.const 4200)
+              (local.get $6)
+             )
+             (i32.store offset=4
+              (local.get $6)
+              (i32.or
+               (local.get $0)
+               (i32.const 1)
+              )
+             )
+            )
+            (block
+             (if
+              (i32.eq
+               (local.get $4)
+               (i32.load
+                (i32.const 4196)
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 4184)
+                (local.tee $0
+                 (i32.add
+                  (i32.load
+                   (i32.const 4184)
+                  )
+                  (local.get $7)
+                 )
+                )
+               )
+               (i32.store
+                (i32.const 4196)
+                (local.get $6)
+               )
+               (i32.store offset=4
+                (local.get $6)
+                (i32.or
+                 (local.get $0)
+                 (i32.const 1)
+                )
+               )
+               (i32.store
+                (i32.add
+                 (local.get $6)
+                 (local.get $0)
+                )
+                (local.get $0)
+               )
+               (br $label$217)
+              )
+             )
+             (i32.store
+              (local.tee $0
+               (i32.add
+                (local.tee $0
+                 (if (result i32)
+                  (i32.eq
+                   (i32.and
+                    (local.tee $0
+                     (i32.load offset=4
+                      (local.get $4)
+                     )
+                    )
+                    (i32.const 3)
+                   )
+                   (i32.const 1)
+                  )
+                  (block (result i32)
+                   (local.set $11
+                    (i32.and
+                     (local.get $0)
+                     (i32.const -8)
+                    )
+                   )
+                   (local.set $1
+                    (i32.shr_u
+                     (local.get $0)
+                     (i32.const 3)
+                    )
+                   )
+                   (block $label$222
+                    (if
+                     (i32.lt_u
+                      (local.get $0)
+                      (i32.const 256)
+                     )
+                     (block
+                      (local.set $5
+                       (i32.load offset=12
+                        (local.get $4)
+                       )
+                      )
+                      (block $label$224
+                       (if
+                        (i32.ne
+                         (local.tee $3
+                          (i32.load offset=8
+                           (local.get $4)
+                          )
+                         )
+                         (local.tee $0
+                          (i32.add
+                           (i32.shl
+                            (i32.shl
+                             (local.get $1)
+                             (i32.const 1)
+                            )
+                            (i32.const 2)
+                           )
+                           (i32.const 4216)
+                          )
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $3)
+                           (local.get $2)
+                          )
+                          (call $fimport$8)
+                         )
+                         (br_if $label$224
+                          (i32.eq
+                           (i32.load offset=12
+                            (local.get $3)
+                           )
+                           (local.get $4)
+                          )
+                         )
+                         (call $fimport$8)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.eq
+                        (local.get $5)
+                        (local.get $3)
+                       )
+                       (block
+                        (i32.store
+                         (i32.const 4176)
+                         (i32.and
+                          (i32.load
+                           (i32.const 4176)
+                          )
+                          (i32.xor
+                           (i32.shl
+                            (i32.const 1)
+                            (local.get $1)
+                           )
+                           (i32.const -1)
+                          )
+                         )
+                        )
+                        (br $label$222)
+                       )
+                      )
+                      (block $label$228
+                       (if
+                        (i32.eq
+                         (local.get $5)
+                         (local.get $0)
+                        )
+                        (local.set $20
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 8)
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $5)
+                           (local.get $2)
+                          )
+                          (call $fimport$8)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $0
+                             (i32.add
+                              (local.get $5)
+                              (i32.const 8)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (block
+                           (local.set $20
+                            (local.get $0)
+                           )
+                           (br $label$228)
+                          )
+                         )
+                         (call $fimport$8)
+                        )
+                       )
+                      )
+                      (i32.store offset=12
+                       (local.get $3)
+                       (local.get $5)
+                      )
+                      (i32.store
+                       (local.get $20)
+                       (local.get $3)
+                      )
+                     )
+                     (block
+                      (local.set $8
+                       (i32.load offset=24
+                        (local.get $4)
+                       )
+                      )
+                      (block $label$234
+                       (if
+                        (i32.eq
+                         (local.tee $0
+                          (i32.load offset=12
+                           (local.get $4)
+                          )
+                         )
+                         (local.get $4)
+                        )
+                        (block
+                         (if
+                          (i32.eqz
+                           (local.tee $0
+                            (i32.load
+                             (local.tee $1
+                              (i32.add
+                               (local.tee $3
+                                (i32.add
+                                 (local.get $4)
+                                 (i32.const 16)
+                                )
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (if
+                           (local.tee $0
+                            (i32.load
+                             (local.get $3)
+                            )
+                           )
+                           (local.set $1
+                            (local.get $3)
+                           )
+                           (block
+                            (local.set $12
+                             (i32.const 0)
+                            )
+                            (br $label$234)
+                           )
+                          )
+                         )
+                         (loop $label$239
+                          (if
+                           (local.tee $3
+                            (i32.load
+                             (local.tee $5
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 20)
+                              )
+                             )
+                            )
+                           )
+                           (block
+                            (local.set $0
+                             (local.get $3)
+                            )
+                            (local.set $1
+                             (local.get $5)
+                            )
+                            (br $label$239)
+                           )
+                          )
+                          (if
+                           (local.tee $3
+                            (i32.load
+                             (local.tee $5
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 16)
+                              )
+                             )
+                            )
+                           )
+                           (block
+                            (local.set $0
+                             (local.get $3)
+                            )
+                            (local.set $1
+                             (local.get $5)
+                            )
+                            (br $label$239)
+                           )
+                          )
+                         )
+                         (if
+                          (i32.lt_u
+                           (local.get $1)
+                           (local.get $2)
+                          )
+                          (call $fimport$8)
+                          (block
+                           (i32.store
+                            (local.get $1)
+                            (i32.const 0)
+                           )
+                           (local.set $12
+                            (local.get $0)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.tee $5
+                            (i32.load offset=8
+                             (local.get $4)
+                            )
+                           )
+                           (local.get $2)
+                          )
+                          (call $fimport$8)
+                         )
+                         (if
+                          (i32.ne
+                           (i32.load
+                            (local.tee $3
+                             (i32.add
+                              (local.get $5)
+                              (i32.const 12)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (call $fimport$8)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $1
+                             (i32.add
+                              (local.get $0)
+                              (i32.const 8)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (block
+                           (i32.store
+                            (local.get $3)
+                            (local.get $0)
+                           )
+                           (i32.store
+                            (local.get $1)
+                            (local.get $5)
+                           )
+                           (local.set $12
+                            (local.get $0)
+                           )
+                          )
+                          (call $fimport$8)
+                         )
+                        )
+                       )
+                      )
+                      (br_if $label$222
+                       (i32.eqz
+                        (local.get $8)
+                       )
+                      )
+                      (block $label$249
+                       (if
+                        (i32.eq
+                         (local.get $4)
+                         (i32.load
+                          (local.tee $0
+                           (i32.add
+                            (i32.shl
+                             (local.tee $1
+                              (i32.load offset=28
+                               (local.get $4)
+                              )
+                             )
+                             (i32.const 2)
+                            )
+                            (i32.const 4480)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (i32.store
+                          (local.get $0)
+                          (local.get $12)
+                         )
+                         (br_if $label$249
+                          (local.get $12)
+                         )
+                         (i32.store
+                          (i32.const 4180)
+                          (i32.and
+                           (i32.load
+                            (i32.const 4180)
+                           )
+                           (i32.xor
+                            (i32.shl
+                             (i32.const 1)
+                             (local.get $1)
+                            )
+                            (i32.const -1)
+                           )
+                          )
+                         )
+                         (br $label$222)
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $8)
+                           (i32.load
+                            (i32.const 4192)
+                           )
+                          )
+                          (call $fimport$8)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $0
+                             (i32.add
+                              (local.get $8)
+                              (i32.const 16)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (i32.store
+                           (local.get $0)
+                           (local.get $12)
+                          )
+                          (i32.store offset=20
+                           (local.get $8)
+                           (local.get $12)
+                          )
+                         )
+                         (br_if $label$222
+                          (i32.eqz
+                           (local.get $12)
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (local.get $12)
+                        (local.tee $1
+                         (i32.load
+                          (i32.const 4192)
+                         )
+                        )
+                       )
+                       (call $fimport$8)
+                      )
+                      (i32.store offset=24
+                       (local.get $12)
+                       (local.get $8)
+                      )
+                      (if
+                       (local.tee $3
+                        (i32.load
+                         (local.tee $0
+                          (i32.add
+                           (local.get $4)
+                           (i32.const 16)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.lt_u
+                         (local.get $3)
+                         (local.get $1)
+                        )
+                        (call $fimport$8)
+                        (block
+                         (i32.store offset=16
+                          (local.get $12)
+                          (local.get $3)
+                         )
+                         (i32.store offset=24
+                          (local.get $3)
+                          (local.get $12)
+                         )
+                        )
+                       )
+                      )
+                      (br_if $label$222
+                       (i32.eqz
+                        (local.tee $0
+                         (i32.load offset=4
+                          (local.get $0)
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (local.get $0)
+                        (i32.load
+                         (i32.const 4192)
+                        )
+                       )
+                       (call $fimport$8)
+                       (block
+                        (i32.store offset=20
+                         (local.get $12)
+                         (local.get $0)
+                        )
+                        (i32.store offset=24
+                         (local.get $0)
+                         (local.get $12)
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (local.set $7
+                    (i32.add
+                     (local.get $11)
+                     (local.get $7)
+                    )
+                   )
+                   (i32.add
+                    (local.get $4)
+                    (local.get $11)
+                   )
+                  )
+                  (local.get $4)
+                 )
+                )
+                (i32.const 4)
+               )
+              )
+              (i32.and
+               (i32.load
+                (local.get $0)
+               )
+               (i32.const -2)
+              )
+             )
+             (i32.store offset=4
+              (local.get $6)
+              (i32.or
+               (local.get $7)
+               (i32.const 1)
+              )
+             )
+             (i32.store
+              (i32.add
+               (local.get $6)
+               (local.get $7)
+              )
+              (local.get $7)
+             )
+             (local.set $0
+              (i32.shr_u
+               (local.get $7)
+               (i32.const 3)
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $7)
+               (i32.const 256)
+              )
+              (block
+               (local.set $3
+                (i32.add
+                 (i32.shl
+                  (i32.shl
+                   (local.get $0)
+                   (i32.const 1)
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 4216)
+                )
+               )
+               (block $label$263
+                (if
+                 (i32.and
+                  (local.tee $1
+                   (i32.load
+                    (i32.const 4176)
+                   )
+                  )
+                  (local.tee $0
+                   (i32.shl
+                    (i32.const 1)
+                    (local.get $0)
+                   )
+                  )
+                 )
+                 (block
+                  (if
+                   (i32.ge_u
+                    (local.tee $0
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $3)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                    )
+                    (i32.load
+                     (i32.const 4192)
+                    )
+                   )
+                   (block
+                    (local.set $21
+                     (local.get $1)
+                    )
+                    (local.set $9
+                     (local.get $0)
+                    )
+                    (br $label$263)
+                   )
+                  )
+                  (call $fimport$8)
+                 )
+                 (block
+                  (i32.store
+                   (i32.const 4176)
+                   (i32.or
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                  )
+                  (local.set $21
+                   (i32.add
+                    (local.get $3)
+                    (i32.const 8)
+                   )
+                  )
+                  (local.set $9
+                   (local.get $3)
+                  )
+                 )
+                )
+               )
+               (i32.store
+                (local.get $21)
+                (local.get $6)
+               )
+               (i32.store offset=12
+                (local.get $9)
+                (local.get $6)
+               )
+               (i32.store offset=8
+                (local.get $6)
+                (local.get $9)
+               )
+               (i32.store offset=12
+                (local.get $6)
+                (local.get $3)
+               )
+               (br $label$217)
+              )
+             )
+             (local.set $3
+              (i32.add
+               (i32.shl
+                (local.tee $2
+                 (block $label$267 (result i32)
+                  (if (result i32)
+                   (local.tee $0
+                    (i32.shr_u
+                     (local.get $7)
+                     (i32.const 8)
+                    )
+                   )
+                   (block (result i32)
+                    (drop
+                     (br_if $label$267
+                      (i32.const 31)
+                      (i32.gt_u
+                       (local.get $7)
+                       (i32.const 16777215)
+                      )
+                     )
+                    )
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (local.get $7)
+                       (i32.add
+                        (local.tee $0
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
+                            (i32.or
+                             (local.tee $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (local.tee $1
+                                  (i32.shl
+                                   (local.get $0)
+                                   (local.tee $3
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (local.get $0)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (i32.const 520192)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                             (local.get $3)
+                            )
+                            (local.tee $0
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (local.tee $1
+                                 (i32.shl
+                                  (local.get $1)
+                                  (local.get $0)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (local.get $1)
+                            (local.get $0)
+                           )
+                           (i32.const 15)
+                          )
+                         )
+                        )
+                        (i32.const 7)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.shl
+                      (local.get $0)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.const 0)
+                  )
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 4480)
+              )
+             )
+             (i32.store offset=28
+              (local.get $6)
+              (local.get $2)
+             )
+             (i32.store offset=4
+              (local.tee $0
+               (i32.add
+                (local.get $6)
+                (i32.const 16)
+               )
+              )
+              (i32.const 0)
+             )
+             (i32.store
+              (local.get $0)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (local.tee $1
+                 (i32.load
+                  (i32.const 4180)
+                 )
+                )
+                (local.tee $0
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $2)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 4180)
+                (i32.or
+                 (local.get $1)
+                 (local.get $0)
+                )
+               )
+               (i32.store
+                (local.get $3)
+                (local.get $6)
+               )
+               (i32.store offset=24
+                (local.get $6)
+                (local.get $3)
+               )
+               (i32.store offset=12
+                (local.get $6)
+                (local.get $6)
+               )
+               (i32.store offset=8
+                (local.get $6)
+                (local.get $6)
+               )
+               (br $label$217)
+              )
+             )
+             (local.set $0
+              (i32.load
+               (local.get $3)
+              )
+             )
+             (local.set $1
+              (i32.sub
+               (i32.const 25)
+               (i32.shr_u
+                (local.get $2)
+                (i32.const 1)
+               )
+              )
+             )
+             (local.set $2
+              (i32.shl
+               (local.get $7)
+               (if (result i32)
+                (i32.eq
+                 (local.get $2)
+                 (i32.const 31)
+                )
+                (i32.const 0)
+                (local.get $1)
+               )
+              )
+             )
+             (block $label$273
+              (block $label$274
+               (block $label$275
+                (loop $label$276
+                 (br_if $label$274
+                  (i32.eq
+                   (i32.and
+                    (i32.load offset=4
+                     (local.get $0)
+                    )
+                    (i32.const -8)
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (local.set $3
+                  (i32.shl
+                   (local.get $2)
+                   (i32.const 1)
+                  )
+                 )
+                 (br_if $label$275
+                  (i32.eqz
+                   (local.tee $1
+                    (i32.load
+                     (local.tee $2
+                      (i32.add
+                       (i32.add
+                        (local.get $0)
+                        (i32.const 16)
+                       )
+                       (i32.shl
+                        (i32.shr_u
+                         (local.get $2)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (local.set $2
+                  (local.get $3)
+                 )
+                 (local.set $0
+                  (local.get $1)
+                 )
+                 (br $label$276)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $2)
+                 (i32.load
+                  (i32.const 4192)
+                 )
+                )
+                (call $fimport$8)
+                (block
+                 (i32.store
+                  (local.get $2)
+                  (local.get $6)
+                 )
+                 (i32.store offset=24
+                  (local.get $6)
+                  (local.get $0)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (br $label$217)
+                )
+               )
+               (br $label$273)
+              )
+              (if
+               (i32.and
+                (i32.ge_u
+                 (local.tee $2
+                  (i32.load
+                   (local.tee $3
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (local.tee $1
+                  (i32.load
+                   (i32.const 4192)
+                  )
+                 )
+                )
+                (i32.ge_u
+                 (local.get $0)
+                 (local.get $1)
+                )
+               )
+               (block
+                (i32.store offset=12
+                 (local.get $2)
+                 (local.get $6)
+                )
+                (i32.store
+                 (local.get $3)
+                 (local.get $6)
+                )
+                (i32.store offset=8
+                 (local.get $6)
+                 (local.get $2)
+                )
+                (i32.store offset=12
+                 (local.get $6)
+                 (local.get $0)
+                )
+                (i32.store offset=24
+                 (local.get $6)
+                 (i32.const 0)
+                )
+               )
+               (call $fimport$8)
+              )
+             )
+            )
+           )
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (i32.add
+            (local.get $13)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+       )
+       (loop $label$281
+        (block $label$282
+         (if
+          (i32.le_u
+           (local.tee $2
+            (i32.load
+             (local.get $5)
+            )
+           )
+           (local.get $8)
+          )
+          (br_if $label$282
+           (i32.gt_u
+            (local.tee $13
+             (i32.add
+              (local.get $2)
+              (i32.load offset=4
+               (local.get $5)
+              )
+             )
+            )
+            (local.get $8)
+           )
+          )
+         )
+         (local.set $5
+          (i32.load offset=8
+           (local.get $5)
+          )
+         )
+         (br $label$281)
+        )
+       )
+       (local.set $2
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $5
+           (i32.add
+            (local.tee $7
+             (i32.add
+              (local.get $13)
+              (i32.const -47)
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (local.set $10
+        (i32.add
+         (local.tee $7
+          (if (result i32)
+           (i32.lt_u
+            (local.tee $2
+             (i32.add
+              (local.get $7)
+              (if (result i32)
+               (i32.and
+                (local.get $5)
+                (i32.const 7)
+               )
+               (local.get $2)
+               (i32.const 0)
+              )
+             )
+            )
+            (local.tee $12
+             (i32.add
+              (local.get $8)
+              (i32.const 16)
+             )
+            )
+           )
+           (local.get $8)
+           (local.get $2)
+          )
+         )
+         (i32.const 8)
+        )
+       )
+       (local.set $5
+        (i32.add
+         (local.get $7)
+         (i32.const 24)
+        )
+       )
+       (local.set $9
+        (i32.add
+         (local.get $3)
+         (i32.const -40)
+        )
+       )
+       (local.set $2
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $4
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (i32.store
+        (i32.const 4200)
+        (local.tee $4
+         (i32.add
+          (local.get $1)
+          (if (result i32)
+           (i32.and
+            (local.get $4)
+            (i32.const 7)
+           )
+           (local.get $2)
+           (local.tee $2
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 4188)
+        (local.tee $2
+         (i32.sub
+          (local.get $9)
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store offset=4
+        (local.get $4)
+        (i32.or
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (local.get $4)
+         (local.get $2)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 4204)
+        (i32.load
+         (i32.const 4664)
+        )
+       )
+       (i32.store
+        (local.tee $2
+         (i32.add
+          (local.get $7)
+          (i32.const 4)
+         )
+        )
+        (i32.const 27)
+       )
+       (i64.store align=4
+        (local.get $10)
+        (i64.load align=4
+         (i32.const 4624)
+        )
+       )
+       (i64.store offset=8 align=4
+        (local.get $10)
+        (i64.load align=4
+         (i32.const 4632)
+        )
+       )
+       (i32.store
+        (i32.const 4624)
+        (local.get $1)
+       )
+       (i32.store
+        (i32.const 4628)
+        (local.get $3)
+       )
+       (i32.store
+        (i32.const 4636)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 4632)
+        (local.get $10)
+       )
+       (local.set $1
+        (local.get $5)
+       )
+       (loop $label$290
+        (i32.store
+         (local.tee $1
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+         )
+         (i32.const 7)
+        )
+        (br_if $label$290
+         (i32.lt_u
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+          (local.get $13)
+         )
+        )
+       )
+       (if
+        (i32.ne
+         (local.get $7)
+         (local.get $8)
+        )
+        (block
+         (i32.store
+          (local.get $2)
+          (i32.and
+           (i32.load
+            (local.get $2)
+           )
+           (i32.const -2)
+          )
+         )
+         (i32.store offset=4
+          (local.get $8)
+          (i32.or
+           (local.tee $4
+            (i32.sub
+             (local.get $7)
+             (local.get $8)
+            )
+           )
+           (i32.const 1)
+          )
+         )
+         (i32.store
+          (local.get $7)
+          (local.get $4)
+         )
+         (local.set $1
+          (i32.shr_u
+           (local.get $4)
+           (i32.const 3)
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (i32.const 256)
+          )
+          (block
+           (local.set $2
+            (i32.add
+             (i32.shl
+              (i32.shl
+               (local.get $1)
+               (i32.const 1)
+              )
+              (i32.const 2)
+             )
+             (i32.const 4216)
+            )
+           )
+           (if
+            (i32.and
+             (local.tee $3
+              (i32.load
+               (i32.const 4176)
+              )
+             )
+             (local.tee $1
+              (i32.shl
+               (i32.const 1)
+               (local.get $1)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (local.tee $1
+               (i32.load
+                (local.tee $3
+                 (i32.add
+                  (local.get $2)
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.load
+               (i32.const 4192)
+              )
+             )
+             (call $fimport$8)
+             (block
+              (local.set $15
+               (local.get $3)
+              )
+              (local.set $11
+               (local.get $1)
+              )
+             )
+            )
+            (block
+             (i32.store
+              (i32.const 4176)
+              (i32.or
+               (local.get $3)
+               (local.get $1)
+              )
+             )
+             (local.set $15
+              (i32.add
+               (local.get $2)
+               (i32.const 8)
+              )
+             )
+             (local.set $11
+              (local.get $2)
+             )
+            )
+           )
+           (i32.store
+            (local.get $15)
+            (local.get $8)
+           )
+           (i32.store offset=12
+            (local.get $11)
+            (local.get $8)
+           )
+           (i32.store offset=8
+            (local.get $8)
+            (local.get $11)
+           )
+           (i32.store offset=12
+            (local.get $8)
+            (local.get $2)
+           )
+           (br $label$198)
+          )
+         )
+         (local.set $2
+          (i32.add
+           (i32.shl
+            (local.tee $5
+             (if (result i32)
+              (local.tee $1
+               (i32.shr_u
+                (local.get $4)
+                (i32.const 8)
+               )
+              )
+              (if (result i32)
+               (i32.gt_u
+                (local.get $4)
+                (i32.const 16777215)
+               )
+               (i32.const 31)
+               (i32.or
+                (i32.and
+                 (i32.shr_u
+                  (local.get $4)
+                  (i32.add
+                   (local.tee $1
+                    (i32.add
+                     (i32.sub
+                      (i32.const 14)
+                      (i32.or
+                       (i32.or
+                        (local.tee $1
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (local.tee $3
+                             (i32.shl
+                              (local.get $1)
+                              (local.tee $2
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (local.get $1)
+                                  (i32.const 1048320)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 520192)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 4)
+                         )
+                        )
+                        (local.get $2)
+                       )
+                       (local.tee $1
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (local.tee $3
+                            (i32.shl
+                             (local.get $3)
+                             (local.get $1)
+                            )
+                           )
+                           (i32.const 245760)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 2)
+                        )
+                       )
+                      )
+                     )
+                     (i32.shr_u
+                      (i32.shl
+                       (local.get $3)
+                       (local.get $1)
+                      )
+                      (i32.const 15)
+                     )
+                    )
+                   )
+                   (i32.const 7)
+                  )
+                 )
+                 (i32.const 1)
+                )
+                (i32.shl
+                 (local.get $1)
+                 (i32.const 1)
+                )
+               )
+              )
+              (i32.const 0)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 4480)
+          )
+         )
+         (i32.store offset=28
+          (local.get $8)
+          (local.get $5)
+         )
+         (i32.store offset=20
+          (local.get $8)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $12)
+          (i32.const 0)
+         )
+         (if
+          (i32.eqz
+           (i32.and
+            (local.tee $3
+             (i32.load
+              (i32.const 4180)
+             )
+            )
+            (local.tee $1
+             (i32.shl
+              (i32.const 1)
+              (local.get $5)
+             )
+            )
+           )
+          )
+          (block
+           (i32.store
+            (i32.const 4180)
+            (i32.or
+             (local.get $3)
+             (local.get $1)
+            )
+           )
+           (i32.store
+            (local.get $2)
+            (local.get $8)
+           )
+           (i32.store offset=24
+            (local.get $8)
+            (local.get $2)
+           )
+           (i32.store offset=12
+            (local.get $8)
+            (local.get $8)
+           )
+           (i32.store offset=8
+            (local.get $8)
+            (local.get $8)
+           )
+           (br $label$198)
+          )
+         )
+         (local.set $1
+          (i32.load
+           (local.get $2)
+          )
+         )
+         (local.set $3
+          (i32.sub
+           (i32.const 25)
+           (i32.shr_u
+            (local.get $5)
+            (i32.const 1)
+           )
+          )
+         )
+         (local.set $5
+          (i32.shl
+           (local.get $4)
+           (if (result i32)
+            (i32.eq
+             (local.get $5)
+             (i32.const 31)
+            )
+            (i32.const 0)
+            (local.get $3)
+           )
+          )
+         )
+         (block $label$304
+          (block $label$305
+           (block $label$306
+            (loop $label$307
+             (br_if $label$305
+              (i32.eq
+               (i32.and
+                (i32.load offset=4
+                 (local.get $1)
+                )
+                (i32.const -8)
+               )
+               (local.get $4)
+              )
+             )
+             (local.set $2
+              (i32.shl
+               (local.get $5)
+               (i32.const 1)
+              )
+             )
+             (br_if $label$306
+              (i32.eqz
+               (local.tee $3
+                (i32.load
+                 (local.tee $5
+                  (i32.add
+                   (i32.add
+                    (local.get $1)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (local.get $5)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (local.set $5
+              (local.get $2)
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$307)
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $5)
+             (i32.load
+              (i32.const 4192)
+             )
+            )
+            (call $fimport$8)
+            (block
+             (i32.store
+              (local.get $5)
+              (local.get $8)
+             )
+             (i32.store offset=24
+              (local.get $8)
+              (local.get $1)
+             )
+             (i32.store offset=12
+              (local.get $8)
+              (local.get $8)
+             )
+             (i32.store offset=8
+              (local.get $8)
+              (local.get $8)
+             )
+             (br $label$198)
+            )
+           )
+           (br $label$304)
+          )
+          (if
+           (i32.and
+            (i32.ge_u
+             (local.tee $5
+              (i32.load
+               (local.tee $2
+                (i32.add
+                 (local.get $1)
+                 (i32.const 8)
+                )
+               )
+              )
+             )
+             (local.tee $3
+              (i32.load
+               (i32.const 4192)
+              )
+             )
+            )
+            (i32.ge_u
+             (local.get $1)
+             (local.get $3)
+            )
+           )
+           (block
+            (i32.store offset=12
+             (local.get $5)
+             (local.get $8)
+            )
+            (i32.store
+             (local.get $2)
+             (local.get $8)
+            )
+            (i32.store offset=8
+             (local.get $8)
+             (local.get $5)
+            )
+            (i32.store offset=12
+             (local.get $8)
+             (local.get $1)
+            )
+            (i32.store offset=24
+             (local.get $8)
+             (i32.const 0)
+            )
+           )
+           (call $fimport$8)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (i32.or
+         (i32.eqz
+          (local.tee $2
+           (i32.load
+            (i32.const 4192)
+           )
+          )
+         )
+         (i32.lt_u
+          (local.get $1)
+          (local.get $2)
+         )
+        )
+        (i32.store
+         (i32.const 4192)
+         (local.get $1)
+        )
+       )
+       (i32.store
+        (i32.const 4624)
+        (local.get $1)
+       )
+       (i32.store
+        (i32.const 4628)
+        (local.get $3)
+       )
+       (i32.store
+        (i32.const 4636)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 4212)
+        (i32.load
+         (i32.const 4648)
+        )
+       )
+       (i32.store
+        (i32.const 4208)
+        (i32.const -1)
+       )
+       (local.set $2
+        (i32.const 0)
+       )
+       (loop $label$314
+        (i32.store offset=12
+         (local.tee $5
+          (i32.add
+           (i32.shl
+            (i32.shl
+             (local.get $2)
+             (i32.const 1)
+            )
+            (i32.const 2)
+           )
+           (i32.const 4216)
+          )
+         )
+         (local.get $5)
+        )
+        (i32.store offset=8
+         (local.get $5)
+         (local.get $5)
+        )
+        (br_if $label$314
+         (i32.ne
+          (local.tee $2
+           (i32.add
+            (local.get $2)
+            (i32.const 1)
+           )
+          )
+          (i32.const 32)
+         )
+        )
+       )
+       (local.set $5
+        (i32.add
+         (local.get $3)
+         (i32.const -40)
+        )
+       )
+       (local.set $3
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $2
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (i32.store
+        (i32.const 4200)
+        (local.tee $3
+         (i32.add
+          (local.get $1)
+          (local.tee $1
+           (if (result i32)
+            (i32.and
+             (local.get $2)
+             (i32.const 7)
+            )
+            (local.get $3)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 4188)
+        (local.tee $1
+         (i32.sub
+          (local.get $5)
+          (local.get $1)
+         )
+        )
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $1)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (local.get $3)
+         (local.get $1)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 4204)
+        (i32.load
+         (i32.const 4664)
+        )
+       )
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (local.tee $1
+       (i32.load
+        (i32.const 4188)
+       )
+      )
+      (local.get $0)
+     )
+     (block
+      (i32.store
+       (i32.const 4188)
+       (local.tee $3
+        (i32.sub
+         (local.get $1)
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 4200)
+       (local.tee $1
+        (i32.add
+         (local.tee $2
+          (i32.load
+           (i32.const 4200)
+          )
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store offset=4
+       (local.get $1)
+       (i32.or
+        (local.get $3)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (local.get $2)
+       (i32.or
+        (local.get $0)
+        (i32.const 3)
+       )
+      )
+      (global.set $global$1
+       (local.get $14)
+      )
+      (return
+       (i32.add
+        (local.get $2)
+        (i32.const 8)
+       )
+      )
+     )
+    )
+   )
+   (i32.store
+    (call $12)
+    (i32.const 12)
+   )
+   (global.set $global$1
+    (local.get $14)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $38 (; 51 ;) (type $3) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (block $label$1
+   (if
+    (i32.eqz
+     (local.get $0)
+    )
+    (return)
+   )
+   (if
+    (i32.lt_u
+     (local.tee $1
+      (i32.add
+       (local.get $0)
+       (i32.const -8)
+      )
+     )
+     (local.tee $11
+      (i32.load
+       (i32.const 4192)
+      )
+     )
+    )
+    (call $fimport$8)
+   )
+   (if
+    (i32.eq
+     (local.tee $8
+      (i32.and
+       (local.tee $0
+        (i32.load
+         (i32.add
+          (local.get $0)
+          (i32.const -4)
+         )
+        )
+       )
+       (i32.const 3)
+      )
+     )
+     (i32.const 1)
+    )
+    (call $fimport$8)
+   )
+   (local.set $6
+    (i32.add
+     (local.get $1)
+     (local.tee $4
+      (i32.and
+       (local.get $0)
+       (i32.const -8)
+      )
+     )
+    )
+   )
+   (block $label$5
+    (if
+     (i32.and
+      (local.get $0)
+      (i32.const 1)
+     )
+     (block
+      (local.set $3
+       (local.get $1)
+      )
+      (local.set $2
+       (local.get $4)
+      )
+     )
+     (block
+      (if
+       (i32.eqz
+        (local.get $8)
+       )
+       (return)
+      )
+      (if
+       (i32.lt_u
+        (local.tee $0
+         (i32.add
+          (local.get $1)
+          (i32.sub
+           (i32.const 0)
+           (local.tee $8
+            (i32.load
+             (local.get $1)
+            )
+           )
+          )
+         )
+        )
+        (local.get $11)
+       )
+       (call $fimport$8)
+      )
+      (local.set $1
+       (i32.add
+        (local.get $8)
+        (local.get $4)
+       )
+      )
+      (if
+       (i32.eq
+        (local.get $0)
+        (i32.load
+         (i32.const 4196)
+        )
+       )
+       (block
+        (if
+         (i32.ne
+          (i32.and
+           (local.tee $3
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (local.get $6)
+               (i32.const 4)
+              )
+             )
+            )
+           )
+           (i32.const 3)
+          )
+          (i32.const 3)
+         )
+         (block
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+          (br $label$5)
+         )
+        )
+        (i32.store
+         (i32.const 4184)
+         (local.get $1)
+        )
+        (i32.store
+         (local.get $2)
+         (i32.and
+          (local.get $3)
+          (i32.const -2)
+         )
+        )
+        (i32.store offset=4
+         (local.get $0)
+         (i32.or
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (i32.store
+         (i32.add
+          (local.get $0)
+          (local.get $1)
+         )
+         (local.get $1)
+        )
+        (return)
+       )
+      )
+      (local.set $10
+       (i32.shr_u
+        (local.get $8)
+        (i32.const 3)
+       )
+      )
+      (if
+       (i32.lt_u
+        (local.get $8)
+        (i32.const 256)
+       )
+       (block
+        (local.set $3
+         (i32.load offset=12
+          (local.get $0)
+         )
+        )
+        (if
+         (i32.ne
+          (local.tee $4
+           (i32.load offset=8
+            (local.get $0)
+           )
+          )
+          (local.tee $2
+           (i32.add
+            (i32.shl
+             (i32.shl
+              (local.get $10)
+              (i32.const 1)
+             )
+             (i32.const 2)
+            )
+            (i32.const 4216)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $4)
+            (local.get $11)
+           )
+           (call $fimport$8)
+          )
+          (if
+           (i32.ne
+            (i32.load offset=12
+             (local.get $4)
+            )
+            (local.get $0)
+           )
+           (call $fimport$8)
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $3)
+          (local.get $4)
+         )
+         (block
+          (i32.store
+           (i32.const 4176)
+           (i32.and
+            (i32.load
+             (i32.const 4176)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (local.get $10)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+          (br $label$5)
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $3)
+          (local.get $2)
+         )
+         (local.set $5
+          (i32.add
+           (local.get $3)
+           (i32.const 8)
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $3)
+            (local.get $11)
+           )
+           (call $fimport$8)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (local.get $3)
+               (i32.const 8)
+              )
+             )
+            )
+            (local.get $0)
+           )
+           (local.set $5
+            (local.get $2)
+           )
+           (call $fimport$8)
+          )
+         )
+        )
+        (i32.store offset=12
+         (local.get $4)
+         (local.get $3)
+        )
+        (i32.store
+         (local.get $5)
+         (local.get $4)
+        )
+        (local.set $3
+         (local.get $0)
+        )
+        (local.set $2
+         (local.get $1)
+        )
+        (br $label$5)
+       )
+      )
+      (local.set $12
+       (i32.load offset=24
+        (local.get $0)
+       )
+      )
+      (block $label$22
+       (if
+        (i32.eq
+         (local.tee $4
+          (i32.load offset=12
+           (local.get $0)
+          )
+         )
+         (local.get $0)
+        )
+        (block
+         (if
+          (local.tee $4
+           (i32.load
+            (local.tee $8
+             (i32.add
+              (local.tee $5
+               (i32.add
+                (local.get $0)
+                (i32.const 16)
+               )
+              )
+              (i32.const 4)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (local.get $8)
+          )
+          (if
+           (i32.eqz
+            (local.tee $4
+             (i32.load
+              (local.get $5)
+             )
+            )
+           )
+           (block
+            (local.set $7
+             (i32.const 0)
+            )
+            (br $label$22)
+           )
+          )
+         )
+         (loop $label$27
+          (if
+           (local.tee $10
+            (i32.load
+             (local.tee $8
+              (i32.add
+               (local.get $4)
+               (i32.const 20)
+              )
+             )
+            )
+           )
+           (block
+            (local.set $4
+             (local.get $10)
+            )
+            (local.set $5
+             (local.get $8)
+            )
+            (br $label$27)
+           )
+          )
+          (if
+           (local.tee $10
+            (i32.load
+             (local.tee $8
+              (i32.add
+               (local.get $4)
+               (i32.const 16)
+              )
+             )
+            )
+           )
+           (block
+            (local.set $4
+             (local.get $10)
+            )
+            (local.set $5
+             (local.get $8)
+            )
+            (br $label$27)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $5)
+           (local.get $11)
+          )
+          (call $fimport$8)
+          (block
+           (i32.store
+            (local.get $5)
+            (i32.const 0)
+           )
+           (local.set $7
+            (local.get $4)
+           )
+          )
+         )
+        )
+        (block
+         (if
+          (i32.lt_u
+           (local.tee $5
+            (i32.load offset=8
+             (local.get $0)
+            )
+           )
+           (local.get $11)
+          )
+          (call $fimport$8)
+         )
+         (if
+          (i32.ne
+           (i32.load
+            (local.tee $8
+             (i32.add
+              (local.get $5)
+              (i32.const 12)
+             )
+            )
+           )
+           (local.get $0)
+          )
+          (call $fimport$8)
+         )
+         (if
+          (i32.eq
+           (i32.load
+            (local.tee $10
+             (i32.add
+              (local.get $4)
+              (i32.const 8)
+             )
+            )
+           )
+           (local.get $0)
+          )
+          (block
+           (i32.store
+            (local.get $8)
+            (local.get $4)
+           )
+           (i32.store
+            (local.get $10)
+            (local.get $5)
+           )
+           (local.set $7
+            (local.get $4)
+           )
+          )
+          (call $fimport$8)
+         )
+        )
+       )
+      )
+      (if
+       (local.get $12)
+       (block
+        (if
+         (i32.eq
+          (local.get $0)
+          (i32.load
+           (local.tee $5
+            (i32.add
+             (i32.shl
+              (local.tee $4
+               (i32.load offset=28
+                (local.get $0)
+               )
+              )
+              (i32.const 2)
+             )
+             (i32.const 4480)
+            )
+           )
+          )
+         )
+         (block
+          (i32.store
+           (local.get $5)
+           (local.get $7)
+          )
+          (if
+           (i32.eqz
+            (local.get $7)
+           )
+           (block
+            (i32.store
+             (i32.const 4180)
+             (i32.and
+              (i32.load
+               (i32.const 4180)
+              )
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (local.get $4)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+            (local.set $3
+             (local.get $0)
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$5)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $12)
+            (i32.load
+             (i32.const 4192)
+            )
+           )
+           (call $fimport$8)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $4
+              (i32.add
+               (local.get $12)
+               (i32.const 16)
+              )
+             )
+            )
+            (local.get $0)
+           )
+           (i32.store
+            (local.get $4)
+            (local.get $7)
+           )
+           (i32.store offset=20
+            (local.get $12)
+            (local.get $7)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.get $7)
+           )
+           (block
+            (local.set $3
+             (local.get $0)
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$5)
+           )
+          )
+         )
+        )
+        (if
+         (i32.lt_u
+          (local.get $7)
+          (local.tee $5
+           (i32.load
+            (i32.const 4192)
+           )
+          )
+         )
+         (call $fimport$8)
+        )
+        (i32.store offset=24
+         (local.get $7)
+         (local.get $12)
+        )
+        (if
+         (local.tee $4
+          (i32.load
+           (local.tee $8
+            (i32.add
+             (local.get $0)
+             (i32.const 16)
+            )
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (local.get $5)
+          )
+          (call $fimport$8)
+          (block
+           (i32.store offset=16
+            (local.get $7)
+            (local.get $4)
+           )
+           (i32.store offset=24
+            (local.get $4)
+            (local.get $7)
+           )
+          )
+         )
+        )
+        (if
+         (local.tee $4
+          (i32.load offset=4
+           (local.get $8)
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (i32.load
+            (i32.const 4192)
+           )
+          )
+          (call $fimport$8)
+          (block
+           (i32.store offset=20
+            (local.get $7)
+            (local.get $4)
+           )
+           (i32.store offset=24
+            (local.get $4)
+            (local.get $7)
+           )
+           (local.set $3
+            (local.get $0)
+           )
+           (local.set $2
+            (local.get $1)
+           )
+          )
+         )
+         (block
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+         )
+        )
+       )
+       (block
+        (local.set $3
+         (local.get $0)
+        )
+        (local.set $2
+         (local.get $1)
+        )
+       )
+      )
+     )
+    )
+   )
+   (if
+    (i32.ge_u
+     (local.get $3)
+     (local.get $6)
+    )
+    (call $fimport$8)
+   )
+   (if
+    (i32.eqz
+     (i32.and
+      (local.tee $0
+       (i32.load
+        (local.tee $1
+         (i32.add
+          (local.get $6)
+          (i32.const 4)
+         )
+        )
+       )
+      )
+      (i32.const 1)
+     )
+    )
+    (call $fimport$8)
+   )
+   (if
+    (i32.and
+     (local.get $0)
+     (i32.const 2)
+    )
+    (block
+     (i32.store
+      (local.get $1)
+      (i32.and
+       (local.get $0)
+       (i32.const -2)
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.or
+       (local.get $2)
+       (i32.const 1)
+      )
+     )
+     (i32.store
+      (i32.add
+       (local.get $3)
+       (local.get $2)
+      )
+      (local.get $2)
+     )
+    )
+    (block
+     (if
+      (i32.eq
+       (local.get $6)
+       (i32.load
+        (i32.const 4200)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 4188)
+        (local.tee $0
+         (i32.add
+          (i32.load
+           (i32.const 4188)
+          )
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 4200)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $0)
+         (i32.const 1)
+        )
+       )
+       (if
+        (i32.ne
+         (local.get $3)
+         (i32.load
+          (i32.const 4196)
+         )
+        )
+        (return)
+       )
+       (i32.store
+        (i32.const 4196)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 4184)
+        (i32.const 0)
+       )
+       (return)
+      )
+     )
+     (if
+      (i32.eq
+       (local.get $6)
+       (i32.load
+        (i32.const 4196)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 4184)
+        (local.tee $0
+         (i32.add
+          (i32.load
+           (i32.const 4184)
+          )
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 4196)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $0)
+         (i32.const 1)
+        )
+       )
+       (i32.store
+        (i32.add
+         (local.get $3)
+         (local.get $0)
+        )
+        (local.get $0)
+       )
+       (return)
+      )
+     )
+     (local.set $5
+      (i32.add
+       (i32.and
+        (local.get $0)
+        (i32.const -8)
+       )
+       (local.get $2)
+      )
+     )
+     (local.set $4
+      (i32.shr_u
+       (local.get $0)
+       (i32.const 3)
+      )
+     )
+     (block $label$61
+      (if
+       (i32.lt_u
+        (local.get $0)
+        (i32.const 256)
+       )
+       (block
+        (local.set $2
+         (i32.load offset=12
+          (local.get $6)
+         )
+        )
+        (if
+         (i32.ne
+          (local.tee $1
+           (i32.load offset=8
+            (local.get $6)
+           )
+          )
+          (local.tee $0
+           (i32.add
+            (i32.shl
+             (i32.shl
+              (local.get $4)
+              (i32.const 1)
+             )
+             (i32.const 2)
+            )
+            (i32.const 4216)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $1)
+            (i32.load
+             (i32.const 4192)
+            )
+           )
+           (call $fimport$8)
+          )
+          (if
+           (i32.ne
+            (i32.load offset=12
+             (local.get $1)
+            )
+            (local.get $6)
+           )
+           (call $fimport$8)
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $1)
+         )
+         (block
+          (i32.store
+           (i32.const 4176)
+           (i32.and
+            (i32.load
+             (i32.const 4176)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (local.get $4)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (br $label$61)
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $0)
+         )
+         (local.set $14
+          (i32.add
+           (local.get $2)
+           (i32.const 8)
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $2)
+            (i32.load
+             (i32.const 4192)
+            )
+           )
+           (call $fimport$8)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $0
+              (i32.add
+               (local.get $2)
+               (i32.const 8)
+              )
+             )
+            )
+            (local.get $6)
+           )
+           (local.set $14
+            (local.get $0)
+           )
+           (call $fimport$8)
+          )
+         )
+        )
+        (i32.store offset=12
+         (local.get $1)
+         (local.get $2)
+        )
+        (i32.store
+         (local.get $14)
+         (local.get $1)
+        )
+       )
+       (block
+        (local.set $7
+         (i32.load offset=24
+          (local.get $6)
+         )
+        )
+        (block $label$73
+         (if
+          (i32.eq
+           (local.tee $0
+            (i32.load offset=12
+             (local.get $6)
+            )
+           )
+           (local.get $6)
+          )
+          (block
+           (if
+            (local.tee $0
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (local.tee $2
+                 (i32.add
+                  (local.get $6)
+                  (i32.const 16)
+                 )
+                )
+                (i32.const 4)
+               )
+              )
+             )
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (if
+             (i32.eqz
+              (local.tee $0
+               (i32.load
+                (local.get $2)
+               )
+              )
+             )
+             (block
+              (local.set $9
+               (i32.const 0)
+              )
+              (br $label$73)
+             )
+            )
+           )
+           (loop $label$78
+            (if
+             (local.tee $4
+              (i32.load
+               (local.tee $1
+                (i32.add
+                 (local.get $0)
+                 (i32.const 20)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (local.get $4)
+              )
+              (local.set $2
+               (local.get $1)
+              )
+              (br $label$78)
+             )
+            )
+            (if
+             (local.tee $4
+              (i32.load
+               (local.tee $1
+                (i32.add
+                 (local.get $0)
+                 (i32.const 16)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (local.get $4)
+              )
+              (local.set $2
+               (local.get $1)
+              )
+              (br $label$78)
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $2)
+             (i32.load
+              (i32.const 4192)
+             )
+            )
+            (call $fimport$8)
+            (block
+             (i32.store
+              (local.get $2)
+              (i32.const 0)
+             )
+             (local.set $9
+              (local.get $0)
+             )
+            )
+           )
+          )
+          (block
+           (if
+            (i32.lt_u
+             (local.tee $2
+              (i32.load offset=8
+               (local.get $6)
+              )
+             )
+             (i32.load
+              (i32.const 4192)
+             )
+            )
+            (call $fimport$8)
+           )
+           (if
+            (i32.ne
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (local.get $2)
+                (i32.const 12)
+               )
+              )
+             )
+             (local.get $6)
+            )
+            (call $fimport$8)
+           )
+           (if
+            (i32.eq
+             (i32.load
+              (local.tee $4
+               (i32.add
+                (local.get $0)
+                (i32.const 8)
+               )
+              )
+             )
+             (local.get $6)
+            )
+            (block
+             (i32.store
+              (local.get $1)
+              (local.get $0)
+             )
+             (i32.store
+              (local.get $4)
+              (local.get $2)
+             )
+             (local.set $9
+              (local.get $0)
+             )
+            )
+            (call $fimport$8)
+           )
+          )
+         )
+        )
+        (if
+         (local.get $7)
+         (block
+          (if
+           (i32.eq
+            (local.get $6)
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (i32.shl
+                (local.tee $0
+                 (i32.load offset=28
+                  (local.get $6)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 4480)
+              )
+             )
+            )
+           )
+           (block
+            (i32.store
+             (local.get $2)
+             (local.get $9)
+            )
+            (if
+             (i32.eqz
+              (local.get $9)
+             )
+             (block
+              (i32.store
+               (i32.const 4180)
+               (i32.and
+                (i32.load
+                 (i32.const 4180)
+                )
+                (i32.xor
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $0)
+                 )
+                 (i32.const -1)
+                )
+               )
+              )
+              (br $label$61)
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $7)
+              (i32.load
+               (i32.const 4192)
+              )
+             )
+             (call $fimport$8)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (local.tee $0
+                (i32.add
+                 (local.get $7)
+                 (i32.const 16)
+                )
+               )
+              )
+              (local.get $6)
+             )
+             (i32.store
+              (local.get $0)
+              (local.get $9)
+             )
+             (i32.store offset=20
+              (local.get $7)
+              (local.get $9)
+             )
+            )
+            (br_if $label$61
+             (i32.eqz
+              (local.get $9)
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $9)
+            (local.tee $2
+             (i32.load
+              (i32.const 4192)
+             )
+            )
+           )
+           (call $fimport$8)
+          )
+          (i32.store offset=24
+           (local.get $9)
+           (local.get $7)
+          )
+          (if
+           (local.tee $0
+            (i32.load
+             (local.tee $1
+              (i32.add
+               (local.get $6)
+               (i32.const 16)
+              )
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $0)
+             (local.get $2)
+            )
+            (call $fimport$8)
+            (block
+             (i32.store offset=16
+              (local.get $9)
+              (local.get $0)
+             )
+             (i32.store offset=24
+              (local.get $0)
+              (local.get $9)
+             )
+            )
+           )
+          )
+          (if
+           (local.tee $0
+            (i32.load offset=4
+             (local.get $1)
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $0)
+             (i32.load
+              (i32.const 4192)
+             )
+            )
+            (call $fimport$8)
+            (block
+             (i32.store offset=20
+              (local.get $9)
+              (local.get $0)
+             )
+             (i32.store offset=24
+              (local.get $0)
+              (local.get $9)
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.or
+       (local.get $5)
+       (i32.const 1)
+      )
+     )
+     (i32.store
+      (i32.add
+       (local.get $3)
+       (local.get $5)
+      )
+      (local.get $5)
+     )
+     (if
+      (i32.eq
+       (local.get $3)
+       (i32.load
+        (i32.const 4196)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 4184)
+        (local.get $5)
+       )
+       (return)
+      )
+      (local.set $2
+       (local.get $5)
+      )
+     )
+    )
+   )
+   (local.set $1
+    (i32.shr_u
+     (local.get $2)
+     (i32.const 3)
+    )
+   )
+   (if
+    (i32.lt_u
+     (local.get $2)
+     (i32.const 256)
+    )
+    (block
+     (local.set $0
+      (i32.add
+       (i32.shl
+        (i32.shl
+         (local.get $1)
+         (i32.const 1)
+        )
+        (i32.const 2)
+       )
+       (i32.const 4216)
+      )
+     )
+     (if
+      (i32.and
+       (local.tee $2
+        (i32.load
+         (i32.const 4176)
+        )
+       )
+       (local.tee $1
+        (i32.shl
+         (i32.const 1)
+         (local.get $1)
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (local.tee $1
+         (i32.load
+          (local.tee $2
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (i32.load
+         (i32.const 4192)
+        )
+       )
+       (call $fimport$8)
+       (block
+        (local.set $15
+         (local.get $2)
+        )
+        (local.set $13
+         (local.get $1)
+        )
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 4176)
+        (i32.or
+         (local.get $2)
+         (local.get $1)
+        )
+       )
+       (local.set $15
+        (i32.add
+         (local.get $0)
+         (i32.const 8)
+        )
+       )
+       (local.set $13
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (local.get $15)
+      (local.get $3)
+     )
+     (i32.store offset=12
+      (local.get $13)
+      (local.get $3)
+     )
+     (i32.store offset=8
+      (local.get $3)
+      (local.get $13)
+     )
+     (i32.store offset=12
+      (local.get $3)
+      (local.get $0)
+     )
+     (return)
+    )
+   )
+   (local.set $0
+    (i32.add
+     (i32.shl
+      (local.tee $1
+       (if (result i32)
+        (local.tee $0
+         (i32.shr_u
+          (local.get $2)
+          (i32.const 8)
+         )
+        )
+        (if (result i32)
+         (i32.gt_u
+          (local.get $2)
+          (i32.const 16777215)
+         )
+         (i32.const 31)
+         (i32.or
+          (i32.and
+           (i32.shr_u
+            (local.get $2)
+            (i32.add
+             (local.tee $0
+              (i32.add
+               (i32.sub
+                (i32.const 14)
+                (i32.or
+                 (i32.or
+                  (local.tee $4
+                   (i32.and
+                    (i32.shr_u
+                     (i32.add
+                      (local.tee $1
+                       (i32.shl
+                        (local.get $0)
+                        (local.tee $0
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (local.get $0)
+                            (i32.const 1048320)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 8)
+                         )
+                        )
+                       )
+                      )
+                      (i32.const 520192)
+                     )
+                     (i32.const 16)
+                    )
+                    (i32.const 4)
+                   )
+                  )
+                  (local.get $0)
+                 )
+                 (local.tee $1
+                  (i32.and
+                   (i32.shr_u
+                    (i32.add
+                     (local.tee $0
+                      (i32.shl
+                       (local.get $1)
+                       (local.get $4)
+                      )
+                     )
+                     (i32.const 245760)
+                    )
+                    (i32.const 16)
+                   )
+                   (i32.const 2)
+                  )
+                 )
+                )
+               )
+               (i32.shr_u
+                (i32.shl
+                 (local.get $0)
+                 (local.get $1)
+                )
+                (i32.const 15)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.shl
+           (local.get $0)
+           (i32.const 1)
+          )
+         )
+        )
+        (i32.const 0)
+       )
+      )
+      (i32.const 2)
+     )
+     (i32.const 4480)
+    )
+   )
+   (i32.store offset=28
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=20
+    (local.get $3)
+    (i32.const 0)
+   )
+   (i32.store offset=16
+    (local.get $3)
+    (i32.const 0)
+   )
+   (block $label$113
+    (if
+     (i32.and
+      (local.tee $4
+       (i32.load
+        (i32.const 4180)
+       )
+      )
+      (local.tee $5
+       (i32.shl
+        (i32.const 1)
+        (local.get $1)
+       )
+      )
+     )
+     (block
+      (local.set $0
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (local.set $4
+       (i32.sub
+        (i32.const 25)
+        (i32.shr_u
+         (local.get $1)
+         (i32.const 1)
+        )
+       )
+      )
+      (local.set $1
+       (i32.shl
+        (local.get $2)
+        (if (result i32)
+         (i32.eq
+          (local.get $1)
+          (i32.const 31)
+         )
+         (i32.const 0)
+         (local.get $4)
+        )
+       )
+      )
+      (block $label$117
+       (block $label$118
+        (block $label$119
+         (loop $label$120
+          (br_if $label$118
+           (i32.eq
+            (i32.and
+             (i32.load offset=4
+              (local.get $0)
+             )
+             (i32.const -8)
+            )
+            (local.get $2)
+           )
+          )
+          (local.set $4
+           (i32.shl
+            (local.get $1)
+            (i32.const 1)
+           )
+          )
+          (br_if $label$119
+           (i32.eqz
+            (local.tee $5
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (i32.add
+                 (local.get $0)
+                 (i32.const 16)
+                )
+                (i32.shl
+                 (i32.shr_u
+                  (local.get $1)
+                  (i32.const 31)
+                 )
+                 (i32.const 2)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (local.set $1
+           (local.get $4)
+          )
+          (local.set $0
+           (local.get $5)
+          )
+          (br $label$120)
+         )
+        )
+        (if
+         (i32.lt_u
+          (local.get $1)
+          (i32.load
+           (i32.const 4192)
+          )
+         )
+         (call $fimport$8)
+         (block
+          (i32.store
+           (local.get $1)
+           (local.get $3)
+          )
+          (i32.store offset=24
+           (local.get $3)
+           (local.get $0)
+          )
+          (i32.store offset=12
+           (local.get $3)
+           (local.get $3)
+          )
+          (i32.store offset=8
+           (local.get $3)
+           (local.get $3)
+          )
+          (br $label$113)
+         )
+        )
+        (br $label$117)
+       )
+       (if
+        (i32.and
+         (i32.ge_u
+          (local.tee $2
+           (i32.load
+            (local.tee $1
+             (i32.add
+              (local.get $0)
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (local.tee $4
+           (i32.load
+            (i32.const 4192)
+           )
+          )
+         )
+         (i32.ge_u
+          (local.get $0)
+          (local.get $4)
+         )
+        )
+        (block
+         (i32.store offset=12
+          (local.get $2)
+          (local.get $3)
+         )
+         (i32.store
+          (local.get $1)
+          (local.get $3)
+         )
+         (i32.store offset=8
+          (local.get $3)
+          (local.get $2)
+         )
+         (i32.store offset=12
+          (local.get $3)
+          (local.get $0)
+         )
+         (i32.store offset=24
+          (local.get $3)
+          (i32.const 0)
+         )
+        )
+        (call $fimport$8)
+       )
+      )
+     )
+     (block
+      (i32.store
+       (i32.const 4180)
+       (i32.or
+        (local.get $4)
+        (local.get $5)
+       )
+      )
+      (i32.store
+       (local.get $0)
+       (local.get $3)
+      )
+      (i32.store offset=24
+       (local.get $3)
+       (local.get $0)
+      )
+      (i32.store offset=12
+       (local.get $3)
+       (local.get $3)
+      )
+      (i32.store offset=8
+       (local.get $3)
+       (local.get $3)
+      )
+     )
+    )
+   )
+   (i32.store
+    (i32.const 4208)
+    (local.tee $0
+     (i32.add
+      (i32.load
+       (i32.const 4208)
+      )
+      (i32.const -1)
+     )
+    )
+   )
+   (if
+    (local.get $0)
+    (return)
+    (local.set $0
+     (i32.const 4632)
+    )
+   )
+   (loop $label$128
+    (local.set $0
+     (i32.add
+      (local.tee $2
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (i32.const 8)
+     )
+    )
+    (br_if $label$128
+     (local.get $2)
+    )
+   )
+   (i32.store
+    (i32.const 4208)
+    (i32.const -1)
+   )
+  )
+ )
+ (func $39 (; 52 ;) (type $2) (param $0 i32) (result i32)
+  (local $1 i32)
+  (block $label$1 (result i32)
+   (if
+    (i32.eqz
+     (local.get $0)
+    )
+    (local.set $0
+     (i32.const 1)
+    )
+   )
+   (loop $label$3
+    (block $label$4
+     (if
+      (local.tee $1
+       (call $37
+        (local.get $0)
+       )
+      )
+      (block
+       (local.set $0
+        (local.get $1)
+       )
+       (br $label$4)
+      )
+     )
+     (if
+      (local.tee $1
+       (call $43)
+      )
+      (block
+       (call_indirect (type $1)
+        (i32.add
+         (i32.and
+          (local.get $1)
+          (i32.const 0)
+         )
+         (i32.const 8)
+        )
+       )
+       (br $label$3)
+      )
+      (local.set $0
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $40 (; 53 ;) (type $2) (param $0 i32) (result i32)
+  (call $39
+   (local.get $0)
+  )
+ )
+ (func $41 (; 54 ;) (type $3) (param $0 i32)
+  (call $38
+   (local.get $0)
+  )
+ )
+ (func $42 (; 55 ;) (type $3) (param $0 i32)
+  (call $41
+   (local.get $0)
+  )
+ )
+ (func $43 (; 56 ;) (type $4) (result i32)
+  (local $0 i32)
+  (block $label$1 (result i32)
+   (i32.store
+    (i32.const 4672)
+    (i32.add
+     (local.tee $0
+      (i32.load
+       (i32.const 4672)
+      )
+     )
+     (i32.const 0)
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $44 (; 57 ;) (type $1)
+  (nop)
+ )
+ (func $45 (; 58 ;) (type $2) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.add
+     (local.tee $2
+      (i32.load
+       (global.get $global$0)
+      )
+     )
+     (local.tee $0
+      (i32.and
+       (i32.add
+        (local.get $0)
+        (i32.const 15)
+       )
+       (i32.const -16)
+      )
+     )
+    )
+   )
+   (if
+    (i32.or
+     (i32.and
+      (i32.gt_s
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.lt_s
+       (local.get $1)
+       (local.get $2)
+      )
+     )
+     (i32.lt_s
+      (local.get $1)
+      (i32.const 0)
+     )
+    )
+    (block
+     (drop
+      (call $fimport$6)
+     )
+     (call $fimport$11
+      (i32.const 12)
+     )
+     (return
+      (i32.const -1)
+     )
+    )
+   )
+   (i32.store
+    (global.get $global$0)
+    (local.get $1)
+   )
+   (if
+    (i32.gt_s
+     (local.get $1)
+     (call $fimport$5)
+    )
+    (if
+     (i32.eqz
+      (call $fimport$4)
+     )
+     (block
+      (call $fimport$11
+       (i32.const 12)
+      )
+      (i32.store
+       (global.get $global$0)
+       (local.get $2)
+      )
+      (return
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (local.get $2)
+  )
+ )
+ (func $46 (; 59 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (i32.add
+     (local.get $0)
+     (local.get $2)
+    )
+   )
+   (if
+    (i32.ge_s
+     (local.get $2)
+     (i32.const 20)
+    )
+    (block
+     (local.set $1
+      (i32.and
+       (local.get $1)
+       (i32.const 255)
+      )
+     )
+     (if
+      (local.tee $3
+       (i32.and
+        (local.get $0)
+        (i32.const 3)
+       )
+      )
+      (block
+       (local.set $3
+        (i32.sub
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+         (local.get $3)
+        )
+       )
+       (loop $label$4
+        (if
+         (i32.lt_s
+          (local.get $0)
+          (local.get $3)
+         )
+         (block
+          (i32.store8
+           (local.get $0)
+           (local.get $1)
+          )
+          (local.set $0
+           (i32.add
+            (local.get $0)
+            (i32.const 1)
+           )
+          )
+          (br $label$4)
+         )
+        )
+       )
+      )
+     )
+     (local.set $3
+      (i32.or
+       (i32.or
+        (i32.or
+         (local.get $1)
+         (i32.shl
+          (local.get $1)
+          (i32.const 8)
+         )
+        )
+        (i32.shl
+         (local.get $1)
+         (i32.const 16)
+        )
+       )
+       (i32.shl
+        (local.get $1)
+        (i32.const 24)
+       )
+      )
+     )
+     (local.set $5
+      (i32.and
+       (local.get $4)
+       (i32.const -4)
+      )
+     )
+     (loop $label$6
+      (if
+       (i32.lt_s
+        (local.get $0)
+        (local.get $5)
+       )
+       (block
+        (i32.store
+         (local.get $0)
+         (local.get $3)
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+        )
+        (br $label$6)
+       )
+      )
+     )
+    )
+   )
+   (loop $label$8
+    (if
+     (i32.lt_s
+      (local.get $0)
+      (local.get $4)
+     )
+     (block
+      (i32.store8
+       (local.get $0)
+       (local.get $1)
+      )
+      (local.set $0
+       (i32.add
+        (local.get $0)
+        (i32.const 1)
+       )
+      )
+      (br $label$8)
+     )
+    )
+   )
+   (i32.sub
+    (local.get $0)
+    (local.get $2)
+   )
+  )
+ )
+ (func $47 (; 60 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (if
+    (i32.ge_s
+     (local.get $2)
+     (i32.const 4096)
+    )
+    (return
+     (call $fimport$12
+      (local.get $0)
+      (local.get $1)
+      (local.get $2)
+     )
+    )
+   )
+   (local.set $3
+    (local.get $0)
+   )
+   (if
+    (i32.eq
+     (i32.and
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.and
+      (local.get $1)
+      (i32.const 3)
+     )
+    )
+    (block
+     (loop $label$4
+      (if
+       (i32.and
+        (local.get $0)
+        (i32.const 3)
+       )
+       (block
+        (if
+         (i32.eqz
+          (local.get $2)
+         )
+         (return
+          (local.get $3)
+         )
+        )
+        (i32.store8
+         (local.get $0)
+         (i32.load8_s
+          (local.get $1)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 1)
+         )
+        )
+        (local.set $1
+         (i32.add
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (local.set $2
+         (i32.sub
+          (local.get $2)
+          (i32.const 1)
+         )
+        )
+        (br $label$4)
+       )
+      )
+     )
+     (loop $label$7
+      (if
+       (i32.ge_s
+        (local.get $2)
+        (i32.const 4)
+       )
+       (block
+        (i32.store
+         (local.get $0)
+         (i32.load
+          (local.get $1)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+        )
+        (local.set $1
+         (i32.add
+          (local.get $1)
+          (i32.const 4)
+         )
+        )
+        (local.set $2
+         (i32.sub
+          (local.get $2)
+          (i32.const 4)
+         )
+        )
+        (br $label$7)
+       )
+      )
+     )
+    )
+   )
+   (loop $label$9
+    (if
+     (i32.gt_s
+      (local.get $2)
+      (i32.const 0)
+     )
+     (block
+      (i32.store8
+       (local.get $0)
+       (i32.load8_s
+        (local.get $1)
+       )
+      )
+      (local.set $0
+       (i32.add
+        (local.get $0)
+        (i32.const 1)
+       )
+      )
+      (local.set $1
+       (i32.add
+        (local.get $1)
+        (i32.const 1)
+       )
+      )
+      (local.set $2
+       (i32.sub
+        (local.get $2)
+        (i32.const 1)
+       )
+      )
+      (br $label$9)
+     )
+    )
+   )
+   (local.get $3)
+  )
+ )
+ (func $48 (; 61 ;) (type $4) (result i32)
+  (i32.const 0)
+ )
+ (func $49 (; 62 ;) (type $6) (param $0 i32) (param $1 i32) (result i32)
+  (call_indirect (type $2)
+   (local.get $1)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 1)
+    )
+    (i32.const 0)
+   )
+  )
+ )
+ (func $50 (; 63 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (call_indirect (type $0)
+   (local.get $1)
+   (local.get $2)
+   (local.get $3)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 3)
+    )
+    (i32.const 2)
+   )
+  )
+ )
+ (func $51 (; 64 ;) (type $5) (param $0 i32) (param $1 i32)
+  (call_indirect (type $3)
+   (local.get $1)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 1)
+    )
+    (i32.const 6)
+   )
+  )
+ )
+ (func $52 (; 65 ;) (type $3) (param $0 i32)
+  (call_indirect (type $1)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 0)
+    )
+    (i32.const 8)
+   )
+  )
+ )
+ (func $53 (; 66 ;) (type $2) (param $0 i32) (result i32)
+  (block $label$1 (result i32)
+   (call $fimport$3
+    (i32.const 0)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $54 (; 67 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (block $label$1 (result i32)
+   (call $fimport$3
+    (i32.const 1)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $55 (; 68 ;) (type $3) (param $0 i32)
+  (call $fimport$3
+   (i32.const 2)
+  )
+ )
+ (func $56 (; 69 ;) (type $1)
+  (call $fimport$3
+   (i32.const 3)
+  )
+ )
+)
+

--- a/wasmtests/embenchen_ifs.wat
+++ b/wasmtests/embenchen_ifs.wat
@@ -1,0 +1,15771 @@
+(module
+ (type $0 (func (param i32 i32 i32) (result i32)))
+ (type $1 (func (param i32) (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (param i32 i32)))
+ (type $6 (func))
+ (type $7 (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $8 (func (param i32 i32 i32)))
+ (type $9 (func (param i64 i32) (result i32)))
+ (type $10 (func (param i32 i32 i32 i32 i32)))
+ (type $11 (func (param f64 i32) (result f64)))
+ (type $12 (func (param i32 i32 i32 i32) (result i32)))
+ (import "env" "memory" (memory $16 2048 2048))
+ (data (i32.const 1024) "\04\04\00\00\05")
+ (data (i32.const 1040) "\01")
+ (data (i32.const 1064) "\01\00\00\00\02\00\00\00,\10\00\00\00\04")
+ (data (i32.const 1088) "\01")
+ (data (i32.const 1103) "\n\ff\ff\ff\ff")
+ (data (i32.const 1140) "error: %d\\n\00ok\00\11\00\n\00\11\11\11\00\00\00\00\05\00\00\00\00\00\00\t\00\00\00\00\0b")
+ (data (i32.const 1187) "\11\00\0f\n\11\11\11\03\n\07\00\01\13\t\0b\0b\00\00\t\06\0b\00\00\0b\00\06\11\00\00\00\11\11\11")
+ (data (i32.const 1236) "\0b")
+ (data (i32.const 1245) "\11\00\n\n\11\11\11\00\n\00\00\02\00\t\0b\00\00\00\t\00\0b\00\00\0b")
+ (data (i32.const 1294) "\0c")
+ (data (i32.const 1306) "\0c\00\00\00\00\0c\00\00\00\00\t\0c\00\00\00\00\00\0c\00\00\0c")
+ (data (i32.const 1352) "\0e")
+ (data (i32.const 1364) "\0d\00\00\00\04\0d\00\00\00\00\t\0e\00\00\00\00\00\0e\00\00\0e")
+ (data (i32.const 1410) "\10")
+ (data (i32.const 1422) "\0f\00\00\00\00\0f\00\00\00\00\t\10\00\00\00\00\00\10\00\00\10\00\00\12\00\00\00\12\12\12")
+ (data (i32.const 1477) "\12\00\00\00\12\12\12\00\00\00\00\00\00\t")
+ (data (i32.const 1526) "\0b")
+ (data (i32.const 1538) "\n\00\00\00\00\n\00\00\00\00\t\0b\00\00\00\00\00\0b\00\00\0b")
+ (data (i32.const 1584) "\0c")
+ (data (i32.const 1596) "\0c\00\00\00\00\0c\00\00\00\00\t\0c\00\00\00\00\00\0c\00\00\0c\00\000123456789ABCDEF-+   0X0x\00(null)\00-0X+0X 0X-0x+0x 0x\00inf\00INF\00nan\00NAN\00.\00T!\"\19\0d\01\02\03\11K\1c\0c\10\04\0b\1d\12\1e\'hnopqb \05\06\0f\13\14\15\1a\08\16\07($\17\18\t\n\0e\1b\1f%#\83\82}&*+<=>?CGJMXYZ[\\]^_`acdefgijklrstyz{|\00Illegal byte sequence\00Domain error\00Result not representable\00Not a tty\00Permission denied\00Operation not permitted\00No such file or directory\00No such process\00File exists\00Value too large for data type\00No space left on device\00Out of memory\00Resource busy\00Interrupted system call\00Resource temporarily unavailable\00Invalid seek\00Cross-device link\00Read-only file system\00Directory not empty\00Connection reset by peer\00Operation timed out\00Connection refused\00Host is down\00Host is unreachable\00Address in use\00Broken pipe\00I/O error\00No such device or address\00Block device required\00No such device\00Not a directory\00Is a directory\00Text file busy\00Exec format error\00Invalid argument\00Argument list too long\00Symbolic link loop\00Filename too long\00Too many open files in system\00No file descriptors available\00Bad file descriptor\00No child process\00Bad address\00File too large\00Too many links\00No locks available\00Resource deadlock would occur\00State not recoverable\00Previous owner died\00Operation canceled\00Function not implemented\00No message of desired type\00Identifier removed\00Device not a stream\00No data available\00Device timeout\00Out of streams resources\00Link has been severed\00Protocol error\00Bad message\00File descriptor in bad state\00Not a socket\00Destination address required\00Message too large\00Protocol wrong type for socket\00Protocol not available\00Protocol not supported\00Socket type not supported\00Not supported\00Protocol family not supported\00Address family not supported by protocol\00Address not available\00Network is down\00Network unreachable\00Connection reset by network\00Connection aborted\00No buffer space available\00Socket is connected\00Socket not connected\00Cannot send after socket shutdown\00Operation already in progress\00Operation in progress\00Stale file handle\00Remote I/O error\00Quota exceeded\00No medium found\00Wrong medium type\00No error information")
+ (import "env" "table" (table $timport$17 8 8 funcref))
+ (elem (global.get $gimport$19) $47 $9 $48 $14 $10 $15 $49 $16)
+ (import "env" "DYNAMICTOP_PTR" (global $gimport$0 i32))
+ (import "env" "STACKTOP" (global $gimport$1 i32))
+ (import "env" "STACK_MAX" (global $gimport$2 i32))
+ (import "env" "memoryBase" (global $gimport$18 i32))
+ (import "env" "tableBase" (global $gimport$19 i32))
+ (import "env" "abort" (func $fimport$3 (param i32)))
+ (import "env" "enlargeMemory" (func $fimport$4 (result i32)))
+ (import "env" "getTotalMemory" (func $fimport$5 (result i32)))
+ (import "env" "abortOnCannotGrowMemory" (func $fimport$6 (result i32)))
+ (import "env" "_pthread_cleanup_pop" (func $fimport$7 (param i32)))
+ (import "env" "___syscall6" (func $fimport$8 (param i32 i32) (result i32)))
+ (import "env" "_pthread_cleanup_push" (func $fimport$9 (param i32 i32)))
+ (import "env" "_abort" (func $fimport$10))
+ (import "env" "___setErrNo" (func $fimport$11 (param i32)))
+ (import "env" "_emscripten_memcpy_big" (func $fimport$12 (param i32 i32 i32) (result i32)))
+ (import "env" "___syscall54" (func $fimport$13 (param i32 i32) (result i32)))
+ (import "env" "___syscall140" (func $fimport$14 (param i32 i32) (result i32)))
+ (import "env" "___syscall146" (func $fimport$15 (param i32 i32) (result i32)))
+ (global $global$0 (mut i32) (global.get $gimport$0))
+ (global $global$1 (mut i32) (global.get $gimport$1))
+ (global $global$2 (mut i32) (global.get $gimport$2))
+ (global $global$3 (mut i32) (i32.const 0))
+ (global $global$4 (mut i32) (i32.const 0))
+ (global $global$5 (mut i32) (i32.const 0))
+ (export "_sbrk" (func $40))
+ (export "_free" (func $38))
+ (export "_main" (func $8))
+ (export "_pthread_self" (func $43))
+ (export "_memset" (func $41))
+ (export "_malloc" (func $37))
+ (export "_memcpy" (func $42))
+ (export "___errno_location" (func $12))
+ (export "runPostSets" (func $39))
+ (export "stackAlloc" (func $0))
+ (export "stackSave" (func $1))
+ (export "stackRestore" (func $2))
+ (export "establishStackSpace" (func $3))
+ (export "setThrew" (func $4))
+ (export "setTempRet0" (func $5))
+ (export "getTempRet0" (func $6))
+ (export "dynCall_ii" (func $44))
+ (export "dynCall_iiii" (func $45))
+ (export "dynCall_vi" (func $46))
+ (func $0 (; 13 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (local.get $0)
+    )
+   )
+   (global.set $global$1
+    (i32.and
+     (i32.add
+      (global.get $global$1)
+      (i32.const 15)
+     )
+     (i32.const -16)
+    )
+   )
+   (local.get $1)
+  )
+ )
+ (func $1 (; 14 ;) (type $3) (result i32)
+  (global.get $global$1)
+ )
+ (func $2 (; 15 ;) (type $2) (param $0 i32)
+  (global.set $global$1
+   (local.get $0)
+  )
+ )
+ (func $3 (; 16 ;) (type $5) (param $0 i32) (param $1 i32)
+  (block $label$1
+   (global.set $global$1
+    (local.get $0)
+   )
+   (global.set $global$2
+    (local.get $1)
+   )
+  )
+ )
+ (func $4 (; 17 ;) (type $5) (param $0 i32) (param $1 i32)
+  (if
+   (i32.eqz
+    (global.get $global$3)
+   )
+   (block
+    (global.set $global$3
+     (local.get $0)
+    )
+    (global.set $global$4
+     (local.get $1)
+    )
+   )
+  )
+ )
+ (func $5 (; 18 ;) (type $2) (param $0 i32)
+  (global.set $global$5
+   (local.get $0)
+  )
+ )
+ (func $6 (; 19 ;) (type $3) (result i32)
+  (global.get $global$5)
+ )
+ (func $7 (; 20 ;) (type $3) (result i32)
+  (local $0 i32)
+  (block $label$1 (result i32)
+   (i32.store
+    (i32.const 3584)
+    (i32.add
+     (local.tee $0
+      (i32.load
+       (i32.const 3584)
+      )
+     )
+     (i32.const 1)
+    )
+   )
+   (i32.and
+    (local.get $0)
+    (i32.const 16384)
+   )
+  )
+ )
+ (func $8 (; 21 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (local.set $2
+    (local.get $4)
+   )
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (i32.le_s
+       (local.get $0)
+       (i32.const 1)
+      )
+     )
+     (block $label$4
+      (block $label$5
+       (block $label$6
+        (block $label$7
+         (block $label$8
+          (block $label$9
+           (block $label$10
+            (br_table $label$5 $label$10 $label$8 $label$9 $label$7 $label$6 $label$4
+             (i32.sub
+              (local.tee $0
+               (i32.load8_s
+                (i32.load offset=4
+                 (local.get $1)
+                )
+               )
+              )
+              (i32.const 48)
+             )
+            )
+           )
+           (local.set $3
+            (i32.const 75)
+           )
+           (br $label$2)
+          )
+          (br $label$3)
+         )
+         (local.set $3
+          (i32.const 625)
+         )
+         (br $label$2)
+        )
+        (local.set $3
+         (i32.const 6250)
+        )
+        (br $label$2)
+       )
+       (local.set $3
+        (i32.const 12500)
+       )
+       (br $label$2)
+      )
+      (global.set $global$1
+       (local.get $4)
+      )
+      (return
+       (i32.const 0)
+      )
+     )
+     (i32.store
+      (local.get $2)
+      (i32.add
+       (local.get $0)
+       (i32.const -48)
+      )
+     )
+     (drop
+      (call $34
+       (i32.const 1140)
+       (local.get $2)
+      )
+     )
+     (global.set $global$1
+      (local.get $4)
+     )
+     (return
+      (i32.const -1)
+     )
+    )
+    (local.set $3
+     (i32.const 1250)
+    )
+   )
+   (local.set $1
+    (i32.const 0)
+   )
+   (local.set $0
+    (i32.const 0)
+   )
+   (loop $label$11
+    (local.set $2
+     (i32.const 0)
+    )
+    (loop $label$12
+     (local.set $0
+      (block $label$13 (result i32)
+       (block $label$14
+        (br_if $label$14
+         (i32.eqz
+          (call $7)
+         )
+        )
+        (br_if $label$14
+         (i32.eqz
+          (call $7)
+         )
+        )
+        (br $label$13
+         (i32.add
+          (local.get $0)
+          (i32.const 17)
+         )
+        )
+       )
+       (i32.add
+        (local.get $0)
+        (i32.const 19)
+       )
+      )
+     )
+     (block $label$15
+      (block $label$16
+       (br_if $label$16
+        (call $7)
+       )
+       (br_if $label$16
+        (call $7)
+       )
+       (br $label$15)
+      )
+      (local.set $0
+       (i32.add
+        (local.get $0)
+        (i32.const 23)
+       )
+      )
+     )
+     (br_if $label$12
+      (i32.lt_s
+       (local.tee $2
+        (i32.add
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (local.get $3)
+      )
+     )
+    )
+    (br_if $label$11
+     (i32.ne
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const 1)
+       )
+      )
+      (i32.const 27000)
+     )
+    )
+   )
+   (drop
+    (call $35
+     (i32.const 1152)
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $0)
+  )
+ )
+ (func $9 (; 22 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store
+    (local.tee $2
+     (local.get $1)
+    )
+    (i32.load offset=60
+     (local.get $0)
+    )
+   )
+   (local.set $0
+    (call $11
+     (call $fimport$8
+      (i32.const 6)
+      (local.get $2)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $1)
+   )
+   (local.get $0)
+  )
+ )
+ (func $10 (; 23 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 32)
+    )
+   )
+   (i32.store
+    (local.tee $3
+     (local.get $4)
+    )
+    (i32.load offset=60
+     (local.get $0)
+    )
+   )
+   (i32.store offset=4
+    (local.get $3)
+    (i32.const 0)
+   )
+   (i32.store offset=8
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=12
+    (local.get $3)
+    (local.tee $0
+     (i32.add
+      (local.get $4)
+      (i32.const 20)
+     )
+    )
+   )
+   (i32.store offset=16
+    (local.get $3)
+    (local.get $2)
+   )
+   (local.set $0
+    (if (result i32)
+     (i32.lt_s
+      (call $11
+       (call $fimport$14
+        (i32.const 140)
+        (local.get $3)
+       )
+      )
+      (i32.const 0)
+     )
+     (block (result i32)
+      (i32.store
+       (local.get $0)
+       (i32.const -1)
+      )
+      (i32.const -1)
+     )
+     (i32.load
+      (local.get $0)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $0)
+  )
+ )
+ (func $11 (; 24 ;) (type $1) (param $0 i32) (result i32)
+  (if (result i32)
+   (i32.gt_u
+    (local.get $0)
+    (i32.const -4096)
+   )
+   (block (result i32)
+    (i32.store
+     (call $12)
+     (i32.sub
+      (i32.const 0)
+      (local.get $0)
+     )
+    )
+    (i32.const -1)
+   )
+   (local.get $0)
+  )
+ )
+ (func $12 (; 25 ;) (type $3) (result i32)
+  (i32.const 3632)
+ )
+ (func $13 (; 26 ;) (type $2) (param $0 i32)
+  (nop)
+ )
+ (func $14 (; 27 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 80)
+    )
+   )
+   (local.set $3
+    (local.get $4)
+   )
+   (local.set $5
+    (i32.add
+     (local.get $4)
+     (i32.const 12)
+    )
+   )
+   (i32.store offset=36
+    (local.get $0)
+    (i32.const 3)
+   )
+   (if
+    (i32.eqz
+     (i32.and
+      (i32.load
+       (local.get $0)
+      )
+      (i32.const 64)
+     )
+    )
+    (block
+     (i32.store
+      (local.get $3)
+      (i32.load offset=60
+       (local.get $0)
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.const 21505)
+     )
+     (i32.store offset=8
+      (local.get $3)
+      (local.get $5)
+     )
+     (if
+      (call $fimport$13
+       (i32.const 54)
+       (local.get $3)
+      )
+      (i32.store8 offset=75
+       (local.get $0)
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (local.set $0
+    (call $15
+     (local.get $0)
+     (local.get $1)
+     (local.get $2)
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $0)
+  )
+ )
+ (func $15 (; 28 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (block $label$1 (result i32)
+   (local.set $8
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 48)
+    )
+   )
+   (local.set $9
+    (i32.add
+     (local.get $8)
+     (i32.const 16)
+    )
+   )
+   (local.set $10
+    (local.get $8)
+   )
+   (i32.store
+    (local.tee $3
+     (i32.add
+      (local.get $8)
+      (i32.const 32)
+     )
+    )
+    (local.tee $4
+     (i32.load
+      (local.tee $6
+       (i32.add
+        (local.get $0)
+        (i32.const 28)
+       )
+      )
+     )
+    )
+   )
+   (i32.store offset=4
+    (local.get $3)
+    (local.tee $5
+     (i32.sub
+      (i32.load
+       (local.tee $11
+        (i32.add
+         (local.get $0)
+         (i32.const 20)
+        )
+       )
+      )
+      (local.get $4)
+     )
+    )
+   )
+   (i32.store offset=8
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=12
+    (local.get $3)
+    (local.get $2)
+   )
+   (local.set $13
+    (i32.add
+     (local.get $0)
+     (i32.const 60)
+    )
+   )
+   (local.set $14
+    (i32.add
+     (local.get $0)
+     (i32.const 44)
+    )
+   )
+   (local.set $1
+    (local.get $3)
+   )
+   (local.set $4
+    (i32.const 2)
+   )
+   (local.set $12
+    (i32.add
+     (local.get $5)
+     (local.get $2)
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (loop $label$5
+       (if
+        (i32.load
+         (i32.const 3588)
+        )
+        (block
+         (call $fimport$9
+          (i32.const 1)
+          (local.get $0)
+         )
+         (i32.store
+          (local.get $10)
+          (i32.load
+           (local.get $13)
+          )
+         )
+         (i32.store offset=4
+          (local.get $10)
+          (local.get $1)
+         )
+         (i32.store offset=8
+          (local.get $10)
+          (local.get $4)
+         )
+         (local.set $3
+          (call $11
+           (call $fimport$15
+            (i32.const 146)
+            (local.get $10)
+           )
+          )
+         )
+         (call $fimport$7
+          (i32.const 0)
+         )
+        )
+        (block
+         (i32.store
+          (local.get $9)
+          (i32.load
+           (local.get $13)
+          )
+         )
+         (i32.store offset=4
+          (local.get $9)
+          (local.get $1)
+         )
+         (i32.store offset=8
+          (local.get $9)
+          (local.get $4)
+         )
+         (local.set $3
+          (call $11
+           (call $fimport$15
+            (i32.const 146)
+            (local.get $9)
+           )
+          )
+         )
+        )
+       )
+       (br_if $label$4
+        (i32.eq
+         (local.get $12)
+         (local.get $3)
+        )
+       )
+       (br_if $label$3
+        (i32.lt_s
+         (local.get $3)
+         (i32.const 0)
+        )
+       )
+       (local.set $5
+        (if (result i32)
+         (i32.gt_u
+          (local.get $3)
+          (local.tee $5
+           (i32.load offset=4
+            (local.get $1)
+           )
+          )
+         )
+         (block (result i32)
+          (i32.store
+           (local.get $6)
+           (local.tee $7
+            (i32.load
+             (local.get $14)
+            )
+           )
+          )
+          (i32.store
+           (local.get $11)
+           (local.get $7)
+          )
+          (local.set $7
+           (i32.load offset=12
+            (local.get $1)
+           )
+          )
+          (local.set $1
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+          (local.set $4
+           (i32.add
+            (local.get $4)
+            (i32.const -1)
+           )
+          )
+          (i32.sub
+           (local.get $3)
+           (local.get $5)
+          )
+         )
+         (if (result i32)
+          (i32.eq
+           (local.get $4)
+           (i32.const 2)
+          )
+          (block (result i32)
+           (i32.store
+            (local.get $6)
+            (i32.add
+             (i32.load
+              (local.get $6)
+             )
+             (local.get $3)
+            )
+           )
+           (local.set $7
+            (local.get $5)
+           )
+           (local.set $4
+            (i32.const 2)
+           )
+           (local.get $3)
+          )
+          (block (result i32)
+           (local.set $7
+            (local.get $5)
+           )
+           (local.get $3)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $1)
+        (i32.add
+         (i32.load
+          (local.get $1)
+         )
+         (local.get $5)
+        )
+       )
+       (i32.store offset=4
+        (local.get $1)
+        (i32.sub
+         (local.get $7)
+         (local.get $5)
+        )
+       )
+       (local.set $12
+        (i32.sub
+         (local.get $12)
+         (local.get $3)
+        )
+       )
+       (br $label$5)
+      )
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (i32.add
+       (local.tee $1
+        (i32.load
+         (local.get $14)
+        )
+       )
+       (i32.load offset=48
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (local.get $6)
+      (local.get $1)
+     )
+     (i32.store
+      (local.get $11)
+      (local.get $1)
+     )
+     (br $label$2)
+    )
+    (i32.store offset=16
+     (local.get $0)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $6)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $11)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $0)
+     (i32.or
+      (i32.load
+       (local.get $0)
+      )
+      (i32.const 32)
+     )
+    )
+    (local.set $2
+     (if (result i32)
+      (i32.eq
+       (local.get $4)
+       (i32.const 2)
+      )
+      (i32.const 0)
+      (i32.sub
+       (local.get $2)
+       (i32.load offset=4
+        (local.get $1)
+       )
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $8)
+   )
+   (local.get $2)
+  )
+ )
+ (func $16 (; 29 ;) (type $2) (param $0 i32)
+  (if
+   (i32.eqz
+    (i32.load offset=68
+     (local.get $0)
+    )
+   )
+   (call $13
+    (local.get $0)
+   )
+  )
+ )
+ (func $17 (; 30 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $5
+    (i32.and
+     (local.get $1)
+     (i32.const 255)
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (if
+       (i32.and
+        (local.tee $4
+         (i32.ne
+          (local.get $2)
+          (i32.const 0)
+         )
+        )
+        (i32.ne
+         (i32.and
+          (local.get $0)
+          (i32.const 3)
+         )
+         (i32.const 0)
+        )
+       )
+       (block
+        (local.set $4
+         (i32.and
+          (local.get $1)
+          (i32.const 255)
+         )
+        )
+        (local.set $3
+         (local.get $2)
+        )
+        (local.set $2
+         (local.get $0)
+        )
+        (loop $label$6
+         (if
+          (i32.eq
+           (i32.load8_s
+            (local.get $2)
+           )
+           (i32.shr_s
+            (i32.shl
+             (local.get $4)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+          )
+          (block
+           (local.set $0
+            (local.get $3)
+           )
+           (br $label$3)
+          )
+         )
+         (br_if $label$6
+          (i32.and
+           (local.tee $0
+            (i32.ne
+             (local.tee $3
+              (i32.add
+               (local.get $3)
+               (i32.const -1)
+              )
+             )
+             (i32.const 0)
+            )
+           )
+           (i32.ne
+            (i32.and
+             (local.tee $2
+              (i32.add
+               (local.get $2)
+               (i32.const 1)
+              )
+             )
+             (i32.const 3)
+            )
+            (i32.const 0)
+           )
+          )
+         )
+         (br $label$4)
+        )
+       )
+       (block
+        (local.set $3
+         (local.get $2)
+        )
+        (local.set $2
+         (local.get $0)
+        )
+        (local.set $0
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (if
+      (local.get $0)
+      (block
+       (local.set $0
+        (local.get $3)
+       )
+       (br $label$3)
+      )
+      (local.set $0
+       (i32.const 0)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.ne
+      (i32.load8_s
+       (local.get $2)
+      )
+      (i32.shr_s
+       (i32.shl
+        (local.tee $1
+         (i32.and
+          (local.get $1)
+          (i32.const 255)
+         )
+        )
+        (i32.const 24)
+       )
+       (i32.const 24)
+      )
+     )
+     (block
+      (local.set $3
+       (i32.mul
+        (local.get $5)
+        (i32.const 16843009)
+       )
+      )
+      (block $label$12
+       (block $label$13
+        (br_if $label$13
+         (i32.le_u
+          (local.get $0)
+          (i32.const 3)
+         )
+        )
+        (loop $label$14
+         (if
+          (i32.eqz
+           (i32.and
+            (i32.xor
+             (i32.and
+              (local.tee $4
+               (i32.xor
+                (i32.load
+                 (local.get $2)
+                )
+                (local.get $3)
+               )
+              )
+              (i32.const -2139062144)
+             )
+             (i32.const -2139062144)
+            )
+            (i32.add
+             (local.get $4)
+             (i32.const -16843009)
+            )
+           )
+          )
+          (block
+           (local.set $2
+            (i32.add
+             (local.get $2)
+             (i32.const 4)
+            )
+           )
+           (br_if $label$14
+            (i32.gt_u
+             (local.tee $0
+              (i32.add
+               (local.get $0)
+               (i32.const -4)
+              )
+             )
+             (i32.const 3)
+            )
+           )
+           (br $label$13)
+          )
+         )
+        )
+        (br $label$12)
+       )
+       (if
+        (i32.eqz
+         (local.get $0)
+        )
+        (block
+         (local.set $0
+          (i32.const 0)
+         )
+         (br $label$2)
+        )
+       )
+      )
+      (loop $label$17
+       (br_if $label$2
+        (i32.eq
+         (i32.load8_s
+          (local.get $2)
+         )
+         (i32.shr_s
+          (i32.shl
+           (local.get $1)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (local.set $2
+        (i32.add
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (br_if $label$17
+        (local.tee $0
+         (i32.add
+          (local.get $0)
+          (i32.const -1)
+         )
+        )
+       )
+       (local.set $0
+        (i32.const 0)
+       )
+      )
+     )
+    )
+   )
+   (if (result i32)
+    (local.get $0)
+    (local.get $2)
+    (i32.const 0)
+   )
+  )
+ )
+ (func $18 (; 31 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 224)
+    )
+   )
+   (local.set $5
+    (i32.add
+     (local.get $4)
+     (i32.const 136)
+    )
+   )
+   (i64.store align=4
+    (local.tee $3
+     (i32.add
+      (local.get $4)
+      (i32.const 80)
+     )
+    )
+    (i64.const 0)
+   )
+   (i64.store offset=8 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=16 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=24 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=32 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i32.store
+    (local.tee $6
+     (i32.add
+      (local.get $4)
+      (i32.const 120)
+     )
+    )
+    (i32.load
+     (local.get $2)
+    )
+   )
+   (if
+    (i32.lt_s
+     (call $19
+      (i32.const 0)
+      (local.get $1)
+      (local.get $6)
+      (local.tee $2
+       (local.get $4)
+      )
+      (local.get $3)
+     )
+     (i32.const 0)
+    )
+    (local.set $1
+     (i32.const -1)
+    )
+    (block
+     (local.set $12
+      (if (result i32)
+       (i32.gt_s
+        (i32.load offset=76
+         (local.get $0)
+        )
+        (i32.const -1)
+       )
+       (call $20
+        (local.get $0)
+       )
+       (i32.const 0)
+      )
+     )
+     (local.set $7
+      (i32.load
+       (local.get $0)
+      )
+     )
+     (if
+      (i32.lt_s
+       (i32.load8_s offset=74
+        (local.get $0)
+       )
+       (i32.const 1)
+      )
+      (i32.store
+       (local.get $0)
+       (i32.and
+        (local.get $7)
+        (i32.const -33)
+       )
+      )
+     )
+     (if
+      (i32.load
+       (local.tee $8
+        (i32.add
+         (local.get $0)
+         (i32.const 48)
+        )
+       )
+      )
+      (local.set $1
+       (call $19
+        (local.get $0)
+        (local.get $1)
+        (local.get $6)
+        (local.get $2)
+        (local.get $3)
+       )
+      )
+      (block
+       (local.set $10
+        (i32.load
+         (local.tee $9
+          (i32.add
+           (local.get $0)
+           (i32.const 44)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $9)
+        (local.get $5)
+       )
+       (i32.store
+        (local.tee $13
+         (i32.add
+          (local.get $0)
+          (i32.const 28)
+         )
+        )
+        (local.get $5)
+       )
+       (i32.store
+        (local.tee $11
+         (i32.add
+          (local.get $0)
+          (i32.const 20)
+         )
+        )
+        (local.get $5)
+       )
+       (i32.store
+        (local.get $8)
+        (i32.const 80)
+       )
+       (i32.store
+        (local.tee $14
+         (i32.add
+          (local.get $0)
+          (i32.const 16)
+         )
+        )
+        (i32.add
+         (local.get $5)
+         (i32.const 80)
+        )
+       )
+       (local.set $1
+        (call $19
+         (local.get $0)
+         (local.get $1)
+         (local.get $6)
+         (local.get $2)
+         (local.get $3)
+        )
+       )
+       (if
+        (local.get $10)
+        (block
+         (drop
+          (call_indirect (type $0)
+           (local.get $0)
+           (i32.const 0)
+           (i32.const 0)
+           (i32.add
+            (i32.and
+             (i32.load offset=36
+              (local.get $0)
+             )
+             (i32.const 3)
+            )
+            (i32.const 2)
+           )
+          )
+         )
+         (if
+          (i32.eqz
+           (i32.load
+            (local.get $11)
+           )
+          )
+          (local.set $1
+           (i32.const -1)
+          )
+         )
+         (i32.store
+          (local.get $9)
+          (local.get $10)
+         )
+         (i32.store
+          (local.get $8)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $14)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $13)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $11)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (i32.store
+      (local.get $0)
+      (i32.or
+       (local.tee $2
+        (i32.load
+         (local.get $0)
+        )
+       )
+       (i32.and
+        (local.get $7)
+        (i32.const 32)
+       )
+      )
+     )
+     (if
+      (local.get $12)
+      (call $13
+       (local.get $0)
+      )
+     )
+     (if
+      (i32.and
+       (local.get $2)
+       (i32.const 32)
+      )
+      (local.set $1
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $1)
+  )
+ )
+ (func $19 (; 32 ;) (type $7) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 f64)
+  (local $53 f64)
+  (block $label$1 (result i32)
+   (local.set $23
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 624)
+    )
+   )
+   (local.set $20
+    (i32.add
+     (local.get $23)
+     (i32.const 16)
+    )
+   )
+   (local.set $16
+    (local.get $23)
+   )
+   (local.set $36
+    (i32.add
+     (local.get $23)
+     (i32.const 528)
+    )
+   )
+   (local.set $30
+    (i32.ne
+     (local.get $0)
+     (i32.const 0)
+    )
+   )
+   (local.set $38
+    (local.tee $21
+     (i32.add
+      (local.tee $17
+       (i32.add
+        (local.get $23)
+        (i32.const 536)
+       )
+      )
+      (i32.const 40)
+     )
+    )
+   )
+   (local.set $39
+    (i32.add
+     (local.get $17)
+     (i32.const 39)
+    )
+   )
+   (local.set $42
+    (i32.add
+     (local.tee $37
+      (i32.add
+       (local.get $23)
+       (i32.const 8)
+      )
+     )
+     (i32.const 4)
+    )
+   )
+   (local.set $43
+    (i32.sub
+     (i32.const 0)
+     (local.tee $27
+      (local.tee $19
+       (i32.add
+        (local.get $23)
+        (i32.const 588)
+       )
+      )
+     )
+    )
+   )
+   (local.set $33
+    (i32.add
+     (local.tee $17
+      (i32.add
+       (local.get $23)
+       (i32.const 576)
+      )
+     )
+     (i32.const 12)
+    )
+   )
+   (local.set $40
+    (i32.add
+     (local.get $17)
+     (i32.const 11)
+    )
+   )
+   (local.set $44
+    (i32.sub
+     (local.tee $28
+      (local.get $33)
+     )
+     (local.get $27)
+    )
+   )
+   (local.set $45
+    (i32.sub
+     (i32.const -2)
+     (local.get $27)
+    )
+   )
+   (local.set $46
+    (i32.add
+     (local.get $28)
+     (i32.const 2)
+    )
+   )
+   (local.set $48
+    (i32.add
+     (local.tee $47
+      (i32.add
+       (local.get $23)
+       (i32.const 24)
+      )
+     )
+     (i32.const 288)
+    )
+   )
+   (local.set $41
+    (local.tee $31
+     (i32.add
+      (local.get $19)
+      (i32.const 9)
+     )
+    )
+   )
+   (local.set $34
+    (i32.add
+     (local.get $19)
+     (i32.const 8)
+    )
+   )
+   (local.set $15
+    (i32.const 0)
+   )
+   (local.set $10
+    (i32.const 0)
+   )
+   (local.set $17
+    (i32.const 0)
+   )
+   (block $label$2
+    (block $label$3
+     (loop $label$4
+      (block $label$5
+       (if
+        (i32.gt_s
+         (local.get $15)
+         (i32.const -1)
+        )
+        (local.set $15
+         (if (result i32)
+          (i32.gt_s
+           (local.get $10)
+           (i32.sub
+            (i32.const 2147483647)
+            (local.get $15)
+           )
+          )
+          (block (result i32)
+           (i32.store
+            (call $12)
+            (i32.const 75)
+           )
+           (i32.const -1)
+          )
+          (i32.add
+           (local.get $10)
+           (local.get $15)
+          )
+         )
+        )
+       )
+       (br_if $label$3
+        (i32.eqz
+         (i32.shr_s
+          (i32.shl
+           (local.tee $5
+            (i32.load8_s
+             (local.get $1)
+            )
+           )
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (local.set $11
+        (local.get $1)
+       )
+       (block $label$9
+        (block $label$10
+         (loop $label$11
+          (block $label$12
+           (block $label$13
+            (block $label$14
+             (block $label$15
+              (br_table $label$14 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$15 $label$13
+               (i32.sub
+                (i32.shr_s
+                 (i32.shl
+                  (local.get $5)
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const 0)
+               )
+              )
+             )
+             (local.set $5
+              (local.get $11)
+             )
+             (br $label$10)
+            )
+            (local.set $5
+             (local.get $11)
+            )
+            (br $label$12)
+           )
+           (local.set $5
+            (i32.load8_s
+             (local.tee $11
+              (i32.add
+               (local.get $11)
+               (i32.const 1)
+              )
+             )
+            )
+           )
+           (br $label$11)
+          )
+         )
+         (br $label$9)
+        )
+        (loop $label$16
+         (br_if $label$9
+          (i32.ne
+           (i32.load8_s offset=1
+            (local.get $5)
+           )
+           (i32.const 37)
+          )
+         )
+         (local.set $11
+          (i32.add
+           (local.get $11)
+           (i32.const 1)
+          )
+         )
+         (br_if $label$16
+          (i32.eq
+           (i32.load8_s
+            (local.tee $5
+             (i32.add
+              (local.get $5)
+              (i32.const 2)
+             )
+            )
+           )
+           (i32.const 37)
+          )
+         )
+        )
+       )
+       (local.set $10
+        (i32.sub
+         (local.get $11)
+         (local.get $1)
+        )
+       )
+       (if
+        (local.get $30)
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.load
+            (local.get $0)
+           )
+           (i32.const 32)
+          )
+         )
+         (drop
+          (call $21
+           (local.get $1)
+           (local.get $10)
+           (local.get $0)
+          )
+         )
+        )
+       )
+       (if
+        (local.get $10)
+        (block
+         (local.set $1
+          (local.get $5)
+         )
+         (br $label$4)
+        )
+       )
+       (local.set $10
+        (if (result i32)
+         (i32.lt_u
+          (local.tee $9
+           (i32.add
+            (i32.shr_s
+             (i32.shl
+              (local.tee $10
+               (i32.load8_s
+                (local.tee $11
+                 (i32.add
+                  (local.get $5)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const -48)
+           )
+          )
+          (i32.const 10)
+         )
+         (block (result i32)
+          (local.set $10
+           (i32.add
+            (local.get $5)
+            (i32.const 3)
+           )
+          )
+          (if
+           (local.tee $12
+            (i32.eq
+             (i32.load8_s offset=2
+              (local.get $5)
+             )
+             (i32.const 36)
+            )
+           )
+           (local.set $11
+            (local.get $10)
+           )
+          )
+          (if
+           (local.get $12)
+           (local.set $17
+            (i32.const 1)
+           )
+          )
+          (local.set $5
+           (i32.load8_s
+            (local.get $11)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.get $12)
+           )
+           (local.set $9
+            (i32.const -1)
+           )
+          )
+          (local.get $17)
+         )
+         (block (result i32)
+          (local.set $5
+           (local.get $10)
+          )
+          (local.set $9
+           (i32.const -1)
+          )
+          (local.get $17)
+         )
+        )
+       )
+       (block $label$25
+        (if
+         (i32.lt_u
+          (local.tee $12
+           (i32.add
+            (i32.shr_s
+             (i32.shl
+              (local.get $5)
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const -32)
+           )
+          )
+          (i32.const 32)
+         )
+         (block
+          (local.set $17
+           (i32.const 0)
+          )
+          (loop $label$27
+           (br_if $label$25
+            (i32.eqz
+             (i32.and
+              (i32.shl
+               (i32.const 1)
+               (local.get $12)
+              )
+              (i32.const 75913)
+             )
+            )
+           )
+           (local.set $17
+            (i32.or
+             (i32.shl
+              (i32.const 1)
+              (i32.add
+               (i32.shr_s
+                (i32.shl
+                 (local.get $5)
+                 (i32.const 24)
+                )
+                (i32.const 24)
+               )
+               (i32.const -32)
+              )
+             )
+             (local.get $17)
+            )
+           )
+           (br_if $label$27
+            (i32.lt_u
+             (local.tee $12
+              (i32.add
+               (i32.shr_s
+                (i32.shl
+                 (local.tee $5
+                  (i32.load8_s
+                   (local.tee $11
+                    (i32.add
+                     (local.get $11)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 24)
+                )
+                (i32.const 24)
+               )
+               (i32.const -32)
+              )
+             )
+             (i32.const 32)
+            )
+           )
+          )
+         )
+         (local.set $17
+          (i32.const 0)
+         )
+        )
+       )
+       (block $label$29
+        (if
+         (i32.eq
+          (i32.shr_s
+           (i32.shl
+            (local.get $5)
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+          (i32.const 42)
+         )
+         (block
+          (local.set $11
+           (block $label$31 (result i32)
+            (block $label$32
+             (br_if $label$32
+              (i32.ge_u
+               (local.tee $12
+                (i32.add
+                 (i32.shr_s
+                  (i32.shl
+                   (local.tee $5
+                    (i32.load8_s
+                     (local.tee $7
+                      (i32.add
+                       (local.get $11)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                   )
+                   (i32.const 24)
+                  )
+                  (i32.const 24)
+                 )
+                 (i32.const -48)
+                )
+               )
+               (i32.const 10)
+              )
+             )
+             (br_if $label$32
+              (i32.ne
+               (i32.load8_s offset=2
+                (local.get $11)
+               )
+               (i32.const 36)
+              )
+             )
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $12)
+                (i32.const 2)
+               )
+              )
+              (i32.const 10)
+             )
+             (local.set $8
+              (i32.const 1)
+             )
+             (local.set $10
+              (i32.wrap_i64
+               (i64.load
+                (i32.add
+                 (local.get $3)
+                 (i32.shl
+                  (i32.add
+                   (i32.load8_s
+                    (local.get $7)
+                   )
+                   (i32.const -48)
+                  )
+                  (i32.const 3)
+                 )
+                )
+               )
+              )
+             )
+             (br $label$31
+              (i32.add
+               (local.get $11)
+               (i32.const 3)
+              )
+             )
+            )
+            (if
+             (local.get $10)
+             (block
+              (local.set $15
+               (i32.const -1)
+              )
+              (br $label$5)
+             )
+            )
+            (if
+             (i32.eqz
+              (local.get $30)
+             )
+             (block
+              (local.set $12
+               (local.get $17)
+              )
+              (local.set $17
+               (i32.const 0)
+              )
+              (local.set $11
+               (local.get $7)
+              )
+              (local.set $10
+               (i32.const 0)
+              )
+              (br $label$29)
+             )
+            )
+            (local.set $10
+             (i32.load
+              (local.tee $11
+               (i32.and
+                (i32.add
+                 (i32.load
+                  (local.get $2)
+                 )
+                 (i32.const 3)
+                )
+                (i32.const -4)
+               )
+              )
+             )
+            )
+            (i32.store
+             (local.get $2)
+             (i32.add
+              (local.get $11)
+              (i32.const 4)
+             )
+            )
+            (local.set $8
+             (i32.const 0)
+            )
+            (local.get $7)
+           )
+          )
+          (local.set $12
+           (i32.or
+            (local.get $17)
+            (i32.const 8192)
+           )
+          )
+          (local.set $7
+           (i32.sub
+            (i32.const 0)
+            (local.get $10)
+           )
+          )
+          (local.set $5
+           (i32.load8_s
+            (local.get $11)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.tee $6
+             (i32.lt_s
+              (local.get $10)
+              (i32.const 0)
+             )
+            )
+           )
+           (local.set $12
+            (local.get $17)
+           )
+          )
+          (local.set $17
+           (local.get $8)
+          )
+          (if
+           (local.get $6)
+           (local.set $10
+            (local.get $7)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.tee $12
+            (i32.add
+             (i32.shr_s
+              (i32.shl
+               (local.get $5)
+               (i32.const 24)
+              )
+              (i32.const 24)
+             )
+             (i32.const -48)
+            )
+           )
+           (i32.const 10)
+          )
+          (block
+           (local.set $7
+            (i32.const 0)
+           )
+           (local.set $5
+            (local.get $12)
+           )
+           (loop $label$39
+            (local.set $7
+             (i32.add
+              (i32.mul
+               (local.get $7)
+               (i32.const 10)
+              )
+              (local.get $5)
+             )
+            )
+            (br_if $label$39
+             (i32.lt_u
+              (local.tee $5
+               (i32.add
+                (i32.shr_s
+                 (i32.shl
+                  (local.tee $12
+                   (i32.load8_s
+                    (local.tee $11
+                     (i32.add
+                      (local.get $11)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                  )
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+            )
+           )
+           (if
+            (i32.lt_s
+             (local.get $7)
+             (i32.const 0)
+            )
+            (block
+             (local.set $15
+              (i32.const -1)
+             )
+             (br $label$5)
+            )
+            (block
+             (local.set $5
+              (local.get $12)
+             )
+             (local.set $12
+              (local.get $17)
+             )
+             (local.set $17
+              (local.get $10)
+             )
+             (local.set $10
+              (local.get $7)
+             )
+            )
+           )
+          )
+          (block
+           (local.set $12
+            (local.get $17)
+           )
+           (local.set $17
+            (local.get $10)
+           )
+           (local.set $10
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (block $label$43
+        (if
+         (i32.eq
+          (i32.shr_s
+           (i32.shl
+            (local.get $5)
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+          (i32.const 46)
+         )
+         (block
+          (if
+           (i32.ne
+            (i32.shr_s
+             (i32.shl
+              (local.tee $5
+               (i32.load8_s
+                (local.tee $7
+                 (i32.add
+                  (local.get $11)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const 42)
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.tee $5
+               (i32.add
+                (i32.shr_s
+                 (i32.shl
+                  (local.get $5)
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+             (block
+              (local.set $11
+               (local.get $7)
+              )
+              (local.set $7
+               (i32.const 0)
+              )
+             )
+             (block
+              (local.set $5
+               (i32.const 0)
+              )
+              (local.set $11
+               (local.get $7)
+              )
+              (br $label$43)
+             )
+            )
+            (loop $label$48
+             (local.set $5
+              (i32.add
+               (i32.mul
+                (local.get $7)
+                (i32.const 10)
+               )
+               (local.get $5)
+              )
+             )
+             (br_if $label$43
+              (i32.ge_u
+               (local.tee $8
+                (i32.add
+                 (i32.load8_s
+                  (local.tee $11
+                   (i32.add
+                    (local.get $11)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (i32.const -48)
+                )
+               )
+               (i32.const 10)
+              )
+             )
+             (local.set $7
+              (local.get $5)
+             )
+             (local.set $5
+              (local.get $8)
+             )
+             (br $label$48)
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.tee $5
+             (i32.add
+              (i32.load8_s
+               (local.tee $7
+                (i32.add
+                 (local.get $11)
+                 (i32.const 2)
+                )
+               )
+              )
+              (i32.const -48)
+             )
+            )
+            (i32.const 10)
+           )
+           (if
+            (i32.eq
+             (i32.load8_s offset=3
+              (local.get $11)
+             )
+             (i32.const 36)
+            )
+            (block
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $5)
+                (i32.const 2)
+               )
+              )
+              (i32.const 10)
+             )
+             (local.set $5
+              (i32.wrap_i64
+               (i64.load
+                (i32.add
+                 (local.get $3)
+                 (i32.shl
+                  (i32.add
+                   (i32.load8_s
+                    (local.get $7)
+                   )
+                   (i32.const -48)
+                  )
+                  (i32.const 3)
+                 )
+                )
+               )
+              )
+             )
+             (local.set $11
+              (i32.add
+               (local.get $11)
+               (i32.const 4)
+              )
+             )
+             (br $label$43)
+            )
+           )
+          )
+          (if
+           (local.get $17)
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+          )
+          (local.set $11
+           (if (result i32)
+            (local.get $30)
+            (block (result i32)
+             (local.set $5
+              (i32.load
+               (local.tee $11
+                (i32.and
+                 (i32.add
+                  (i32.load
+                   (local.get $2)
+                  )
+                  (i32.const 3)
+                 )
+                 (i32.const -4)
+                )
+               )
+              )
+             )
+             (i32.store
+              (local.get $2)
+              (i32.add
+               (local.get $11)
+               (i32.const 4)
+              )
+             )
+             (local.get $7)
+            )
+            (block (result i32)
+             (local.set $5
+              (i32.const 0)
+             )
+             (local.get $7)
+            )
+           )
+          )
+         )
+         (local.set $5
+          (i32.const -1)
+         )
+        )
+       )
+       (local.set $7
+        (local.get $11)
+       )
+       (local.set $8
+        (i32.const 0)
+       )
+       (loop $label$55
+        (if
+         (i32.gt_u
+          (local.tee $6
+           (i32.add
+            (i32.load8_s
+             (local.get $7)
+            )
+            (i32.const -65)
+           )
+          )
+          (i32.const 57)
+         )
+         (block
+          (local.set $15
+           (i32.const -1)
+          )
+          (br $label$5)
+         )
+        )
+        (local.set $11
+         (i32.add
+          (local.get $7)
+          (i32.const 1)
+         )
+        )
+        (if
+         (i32.lt_u
+          (i32.add
+           (local.tee $6
+            (i32.and
+             (local.tee $13
+              (i32.load8_s
+               (i32.add
+                (i32.add
+                 (i32.mul
+                  (local.get $8)
+                  (i32.const 58)
+                 )
+                 (i32.const 1155)
+                )
+                (local.get $6)
+               )
+              )
+             )
+             (i32.const 255)
+            )
+           )
+           (i32.const -1)
+          )
+          (i32.const 8)
+         )
+         (block
+          (local.set $7
+           (local.get $11)
+          )
+          (local.set $8
+           (local.get $6)
+          )
+          (br $label$55)
+         )
+        )
+       )
+       (if
+        (i32.eqz
+         (i32.shr_s
+          (i32.shl
+           (local.get $13)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+        (block
+         (local.set $15
+          (i32.const -1)
+         )
+         (br $label$5)
+        )
+       )
+       (local.set $14
+        (i32.gt_s
+         (local.get $9)
+         (i32.const -1)
+        )
+       )
+       (block $label$59
+        (block $label$60
+         (if
+          (i32.eq
+           (i32.shr_s
+            (i32.shl
+             (local.get $13)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+           (i32.const 19)
+          )
+          (if
+           (local.get $14)
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+           (br $label$60)
+          )
+          (block
+           (if
+            (local.get $14)
+            (block
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $9)
+                (i32.const 2)
+               )
+              )
+              (local.get $6)
+             )
+             (i64.store
+              (local.get $16)
+              (i64.load
+               (i32.add
+                (local.get $3)
+                (i32.shl
+                 (local.get $9)
+                 (i32.const 3)
+                )
+               )
+              )
+             )
+             (br $label$60)
+            )
+           )
+           (if
+            (i32.eqz
+             (local.get $30)
+            )
+            (block
+             (local.set $15
+              (i32.const 0)
+             )
+             (br $label$5)
+            )
+           )
+           (call $22
+            (local.get $16)
+            (local.get $6)
+            (local.get $2)
+           )
+          )
+         )
+         (br $label$59)
+        )
+        (if
+         (i32.eqz
+          (local.get $30)
+         )
+         (block
+          (local.set $10
+           (i32.const 0)
+          )
+          (local.set $1
+           (local.get $11)
+          )
+          (br $label$4)
+         )
+        )
+       )
+       (local.set $9
+        (i32.and
+         (local.tee $7
+          (i32.load8_s
+           (local.get $7)
+          )
+         )
+         (i32.const -33)
+        )
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.ne
+           (local.get $8)
+           (i32.const 0)
+          )
+          (i32.eq
+           (i32.and
+            (local.get $7)
+            (i32.const 15)
+           )
+           (i32.const 3)
+          )
+         )
+        )
+        (local.set $9
+         (local.get $7)
+        )
+       )
+       (local.set $7
+        (i32.and
+         (local.get $12)
+         (i32.const -65537)
+        )
+       )
+       (if
+        (i32.and
+         (local.get $12)
+         (i32.const 8192)
+        )
+        (local.set $12
+         (local.get $7)
+        )
+       )
+       (block $label$70
+        (block $label$71
+         (block $label$72
+          (block $label$73
+           (block $label$74
+            (block $label$75
+             (block $label$76
+              (block $label$77
+               (block $label$78
+                (block $label$79
+                 (block $label$80
+                  (block $label$81
+                   (block $label$82
+                    (block $label$83
+                     (block $label$84
+                      (block $label$85
+                       (block $label$86
+                        (block $label$87
+                         (block $label$88
+                          (block $label$89
+                           (br_table $label$78 $label$77 $label$80 $label$77 $label$78 $label$78 $label$78 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$79 $label$77 $label$77 $label$77 $label$77 $label$87 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$78 $label$77 $label$83 $label$85 $label$78 $label$78 $label$78 $label$77 $label$85 $label$77 $label$77 $label$77 $label$82 $label$89 $label$86 $label$88 $label$77 $label$77 $label$81 $label$77 $label$84 $label$77 $label$77 $label$87 $label$77
+                            (i32.sub
+                             (local.get $9)
+                             (i32.const 65)
+                            )
+                           )
+                          )
+                          (block $label$90
+                           (block $label$91
+                            (block $label$92
+                             (block $label$93
+                              (block $label$94
+                               (block $label$95
+                                (block $label$96
+                                 (block $label$97
+                                  (br_table $label$97 $label$96 $label$95 $label$94 $label$93 $label$90 $label$92 $label$91 $label$90
+                                   (i32.sub
+                                    (i32.shr_s
+                                     (i32.shl
+                                      (i32.and
+                                       (local.get $8)
+                                       (i32.const 255)
+                                      )
+                                      (i32.const 24)
+                                     )
+                                     (i32.const 24)
+                                    )
+                                    (i32.const 0)
+                                   )
+                                  )
+                                 )
+                                 (i32.store
+                                  (i32.load
+                                   (local.get $16)
+                                  )
+                                  (local.get $15)
+                                 )
+                                 (local.set $10
+                                  (i32.const 0)
+                                 )
+                                 (local.set $1
+                                  (local.get $11)
+                                 )
+                                 (br $label$4)
+                                )
+                                (i32.store
+                                 (i32.load
+                                  (local.get $16)
+                                 )
+                                 (local.get $15)
+                                )
+                                (local.set $10
+                                 (i32.const 0)
+                                )
+                                (local.set $1
+                                 (local.get $11)
+                                )
+                                (br $label$4)
+                               )
+                               (i64.store
+                                (i32.load
+                                 (local.get $16)
+                                )
+                                (i64.extend_i32_s
+                                 (local.get $15)
+                                )
+                               )
+                               (local.set $10
+                                (i32.const 0)
+                               )
+                               (local.set $1
+                                (local.get $11)
+                               )
+                               (br $label$4)
+                              )
+                              (i32.store16
+                               (i32.load
+                                (local.get $16)
+                               )
+                               (local.get $15)
+                              )
+                              (local.set $10
+                               (i32.const 0)
+                              )
+                              (local.set $1
+                               (local.get $11)
+                              )
+                              (br $label$4)
+                             )
+                             (i32.store8
+                              (i32.load
+                               (local.get $16)
+                              )
+                              (local.get $15)
+                             )
+                             (local.set $10
+                              (i32.const 0)
+                             )
+                             (local.set $1
+                              (local.get $11)
+                             )
+                             (br $label$4)
+                            )
+                            (i32.store
+                             (i32.load
+                              (local.get $16)
+                             )
+                             (local.get $15)
+                            )
+                            (local.set $10
+                             (i32.const 0)
+                            )
+                            (local.set $1
+                             (local.get $11)
+                            )
+                            (br $label$4)
+                           )
+                           (i64.store
+                            (i32.load
+                             (local.get $16)
+                            )
+                            (i64.extend_i32_s
+                             (local.get $15)
+                            )
+                           )
+                           (local.set $10
+                            (i32.const 0)
+                           )
+                           (local.set $1
+                            (local.get $11)
+                           )
+                           (br $label$4)
+                          )
+                          (local.set $10
+                           (i32.const 0)
+                          )
+                          (local.set $1
+                           (local.get $11)
+                          )
+                          (br $label$4)
+                         )
+                         (local.set $12
+                          (i32.or
+                           (local.get $12)
+                           (i32.const 8)
+                          )
+                         )
+                         (if
+                          (i32.le_u
+                           (local.get $5)
+                           (i32.const 8)
+                          )
+                          (local.set $5
+                           (i32.const 8)
+                          )
+                         )
+                         (local.set $9
+                          (i32.const 120)
+                         )
+                         (br $label$76)
+                        )
+                        (br $label$76)
+                       )
+                       (if
+                        (i64.eq
+                         (local.tee $50
+                          (i64.load
+                           (local.get $16)
+                          )
+                         )
+                         (i64.const 0)
+                        )
+                        (local.set $7
+                         (local.get $21)
+                        )
+                        (block
+                         (local.set $1
+                          (local.get $21)
+                         )
+                         (loop $label$101
+                          (i64.store8
+                           (local.tee $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const -1)
+                            )
+                           )
+                           (i64.or
+                            (i64.and
+                             (local.get $50)
+                             (i64.const 7)
+                            )
+                            (i64.const 48)
+                           )
+                          )
+                          (br_if $label$101
+                           (i64.ne
+                            (local.tee $50
+                             (i64.shr_u
+                              (local.get $50)
+                              (i64.const 3)
+                             )
+                            )
+                            (i64.const 0)
+                           )
+                          )
+                          (local.set $7
+                           (local.get $1)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.and
+                         (local.get $12)
+                         (i32.const 8)
+                        )
+                        (block
+                         (local.set $8
+                          (i32.add
+                           (local.tee $1
+                            (i32.sub
+                             (local.get $38)
+                             (local.get $7)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                         )
+                         (if
+                          (i32.le_s
+                           (local.get $5)
+                           (local.get $1)
+                          )
+                          (local.set $5
+                           (local.get $8)
+                          )
+                         )
+                         (local.set $6
+                          (i32.const 0)
+                         )
+                         (local.set $8
+                          (i32.const 1635)
+                         )
+                         (br $label$71)
+                        )
+                        (block
+                         (local.set $6
+                          (i32.const 0)
+                         )
+                         (local.set $8
+                          (i32.const 1635)
+                         )
+                         (br $label$71)
+                        )
+                       )
+                      )
+                      (if
+                       (i64.lt_s
+                        (local.tee $50
+                         (i64.load
+                          (local.get $16)
+                         )
+                        )
+                        (i64.const 0)
+                       )
+                       (block
+                        (i64.store
+                         (local.get $16)
+                         (local.tee $50
+                          (i64.sub
+                           (i64.const 0)
+                           (local.get $50)
+                          )
+                         )
+                        )
+                        (local.set $6
+                         (i32.const 1)
+                        )
+                        (local.set $8
+                         (i32.const 1635)
+                        )
+                        (br $label$75)
+                       )
+                      )
+                      (if
+                       (i32.and
+                        (local.get $12)
+                        (i32.const 2048)
+                       )
+                       (block
+                        (local.set $6
+                         (i32.const 1)
+                        )
+                        (local.set $8
+                         (i32.const 1636)
+                        )
+                        (br $label$75)
+                       )
+                       (block
+                        (local.set $6
+                         (local.tee $1
+                          (i32.and
+                           (local.get $12)
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (local.set $8
+                         (if (result i32)
+                          (local.get $1)
+                          (i32.const 1637)
+                          (i32.const 1635)
+                         )
+                        )
+                        (br $label$75)
+                       )
+                      )
+                     )
+                     (local.set $50
+                      (i64.load
+                       (local.get $16)
+                      )
+                     )
+                     (local.set $6
+                      (i32.const 0)
+                     )
+                     (local.set $8
+                      (i32.const 1635)
+                     )
+                     (br $label$75)
+                    )
+                    (i64.store8
+                     (local.get $39)
+                     (i64.load
+                      (local.get $16)
+                     )
+                    )
+                    (local.set $1
+                     (local.get $39)
+                    )
+                    (local.set $12
+                     (local.get $7)
+                    )
+                    (local.set $7
+                     (i32.const 1)
+                    )
+                    (local.set $6
+                     (i32.const 0)
+                    )
+                    (local.set $8
+                     (i32.const 1635)
+                    )
+                    (local.set $5
+                     (local.get $21)
+                    )
+                    (br $label$70)
+                   )
+                   (local.set $1
+                    (call $24
+                     (i32.load
+                      (call $12)
+                     )
+                    )
+                   )
+                   (br $label$74)
+                  )
+                  (if
+                   (i32.eqz
+                    (local.tee $1
+                     (i32.load
+                      (local.get $16)
+                     )
+                    )
+                   )
+                   (local.set $1
+                    (i32.const 1645)
+                   )
+                  )
+                  (br $label$74)
+                 )
+                 (i64.store32
+                  (local.get $37)
+                  (i64.load
+                   (local.get $16)
+                  )
+                 )
+                 (i32.store
+                  (local.get $42)
+                  (i32.const 0)
+                 )
+                 (i32.store
+                  (local.get $16)
+                  (local.get $37)
+                 )
+                 (local.set $7
+                  (local.get $37)
+                 )
+                 (local.set $6
+                  (i32.const -1)
+                 )
+                 (br $label$73)
+                )
+                (local.set $7
+                 (i32.load
+                  (local.get $16)
+                 )
+                )
+                (if
+                 (local.get $5)
+                 (block
+                  (local.set $6
+                   (local.get $5)
+                  )
+                  (br $label$73)
+                 )
+                 (block
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (i32.const 0)
+                   (local.get $12)
+                  )
+                  (local.set $1
+                   (i32.const 0)
+                  )
+                  (br $label$72)
+                 )
+                )
+               )
+               (local.set $52
+                (f64.load
+                 (local.get $16)
+                )
+               )
+               (i32.store
+                (local.get $20)
+                (i32.const 0)
+               )
+               (local.set $26
+                (if (result i32)
+                 (i64.lt_s
+                  (i64.reinterpret_f64
+                   (local.get $52)
+                  )
+                  (i64.const 0)
+                 )
+                 (block (result i32)
+                  (local.set $24
+                   (i32.const 1)
+                  )
+                  (local.set $52
+                   (f64.neg
+                    (local.get $52)
+                   )
+                  )
+                  (i32.const 1652)
+                 )
+                 (block (result i32)
+                  (local.set $1
+                   (i32.and
+                    (local.get $12)
+                    (i32.const 1)
+                   )
+                  )
+                  (if (result i32)
+                   (i32.and
+                    (local.get $12)
+                    (i32.const 2048)
+                   )
+                   (block (result i32)
+                    (local.set $24
+                     (i32.const 1)
+                    )
+                    (i32.const 1655)
+                   )
+                   (block (result i32)
+                    (local.set $24
+                     (local.get $1)
+                    )
+                    (if (result i32)
+                     (local.get $1)
+                     (i32.const 1658)
+                     (i32.const 1653)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+               (block $label$119
+                (if
+                 (i64.lt_u
+                  (i64.and
+                   (i64.reinterpret_f64
+                    (local.get $52)
+                   )
+                   (i64.const 9218868437227405312)
+                  )
+                  (i64.const 9218868437227405312)
+                 )
+                 (block
+                  (if
+                   (local.tee $1
+                    (f64.ne
+                     (local.tee $52
+                      (f64.mul
+                       (call $27
+                        (local.get $52)
+                        (local.get $20)
+                       )
+                       (f64.const 2)
+                      )
+                     )
+                     (f64.const 0)
+                    )
+                   )
+                   (i32.store
+                    (local.get $20)
+                    (i32.add
+                     (i32.load
+                      (local.get $20)
+                     )
+                     (i32.const -1)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (local.tee $22
+                     (i32.or
+                      (local.get $9)
+                      (i32.const 32)
+                     )
+                    )
+                    (i32.const 97)
+                   )
+                   (block
+                    (local.set $1
+                     (i32.add
+                      (local.get $26)
+                      (i32.const 9)
+                     )
+                    )
+                    (if
+                     (local.tee $6
+                      (i32.and
+                       (local.get $9)
+                       (i32.const 32)
+                      )
+                     )
+                     (local.set $26
+                      (local.get $1)
+                     )
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.or
+                       (i32.gt_u
+                        (local.get $5)
+                        (i32.const 11)
+                       )
+                       (i32.eqz
+                        (local.tee $1
+                         (i32.sub
+                          (i32.const 12)
+                          (local.get $5)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (block
+                      (local.set $53
+                       (f64.const 8)
+                      )
+                      (loop $label$125
+                       (local.set $53
+                        (f64.mul
+                         (local.get $53)
+                         (f64.const 16)
+                        )
+                       )
+                       (br_if $label$125
+                        (local.tee $1
+                         (i32.add
+                          (local.get $1)
+                          (i32.const -1)
+                         )
+                        )
+                       )
+                      )
+                      (local.set $52
+                       (if (result f64)
+                        (i32.eq
+                         (i32.load8_s
+                          (local.get $26)
+                         )
+                         (i32.const 45)
+                        )
+                        (f64.neg
+                         (f64.add
+                          (local.get $53)
+                          (f64.sub
+                           (f64.neg
+                            (local.get $52)
+                           )
+                           (local.get $53)
+                          )
+                         )
+                        )
+                        (f64.sub
+                         (f64.add
+                          (local.get $52)
+                          (local.get $53)
+                         )
+                         (local.get $53)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $1
+                     (i32.sub
+                      (i32.const 0)
+                      (local.tee $7
+                       (i32.load
+                        (local.get $20)
+                       )
+                      )
+                     )
+                    )
+                    (if
+                     (i32.eq
+                      (local.tee $1
+                       (call $23
+                        (i64.extend_i32_s
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.get $7)
+                           (i32.const 0)
+                          )
+                          (local.get $1)
+                          (local.get $7)
+                         )
+                        )
+                        (local.get $33)
+                       )
+                      )
+                      (local.get $33)
+                     )
+                     (block
+                      (i32.store8
+                       (local.get $40)
+                       (i32.const 48)
+                      )
+                      (local.set $1
+                       (local.get $40)
+                      )
+                     )
+                    )
+                    (local.set $13
+                     (i32.or
+                      (local.get $24)
+                      (i32.const 2)
+                     )
+                    )
+                    (i32.store8
+                     (i32.add
+                      (local.get $1)
+                      (i32.const -1)
+                     )
+                     (i32.add
+                      (i32.and
+                       (i32.shr_s
+                        (local.get $7)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 43)
+                     )
+                    )
+                    (i32.store8
+                     (local.tee $8
+                      (i32.add
+                       (local.get $1)
+                       (i32.const -2)
+                      )
+                     )
+                     (i32.add
+                      (local.get $9)
+                      (i32.const 15)
+                     )
+                    )
+                    (local.set $9
+                     (i32.lt_s
+                      (local.get $5)
+                      (i32.const 1)
+                     )
+                    )
+                    (local.set $14
+                     (i32.eqz
+                      (i32.and
+                       (local.get $12)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                    (local.set $1
+                     (local.get $19)
+                    )
+                    (loop $label$131
+                     (i32.store8
+                      (local.get $1)
+                      (i32.or
+                       (i32.load8_u
+                        (i32.add
+                         (local.tee $7
+                          (i32.trunc_f64_s
+                           (local.get $52)
+                          )
+                         )
+                         (i32.const 1619)
+                        )
+                       )
+                       (local.get $6)
+                      )
+                     )
+                     (local.set $52
+                      (f64.mul
+                       (f64.sub
+                        (local.get $52)
+                        (f64.convert_i32_s
+                         (local.get $7)
+                        )
+                       )
+                       (f64.const 16)
+                      )
+                     )
+                     (local.set $1
+                      (block $label$132 (result i32)
+                       (if (result i32)
+                        (i32.eq
+                         (i32.sub
+                          (local.tee $7
+                           (i32.add
+                            (local.get $1)
+                            (i32.const 1)
+                           )
+                          )
+                          (local.get $27)
+                         )
+                         (i32.const 1)
+                        )
+                        (block (result i32)
+                         (drop
+                          (br_if $label$132
+                           (local.get $7)
+                           (i32.and
+                            (local.get $14)
+                            (i32.and
+                             (local.get $9)
+                             (f64.eq
+                              (local.get $52)
+                              (f64.const 0)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.store8
+                          (local.get $7)
+                          (i32.const 46)
+                         )
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 2)
+                         )
+                        )
+                        (local.get $7)
+                       )
+                      )
+                     )
+                     (br_if $label$131
+                      (f64.ne
+                       (local.get $52)
+                       (f64.const 0)
+                      )
+                     )
+                    )
+                    (local.set $6
+                     (i32.sub
+                      (i32.add
+                       (local.get $46)
+                       (local.get $5)
+                      )
+                      (local.tee $7
+                       (local.get $8)
+                      )
+                     )
+                    )
+                    (local.set $9
+                     (i32.add
+                      (i32.sub
+                       (local.get $44)
+                       (local.get $7)
+                      )
+                      (local.get $1)
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 32)
+                     (local.get $10)
+                     (local.tee $5
+                      (i32.add
+                       (if (result i32)
+                        (i32.and
+                         (i32.ne
+                          (local.get $5)
+                          (i32.const 0)
+                         )
+                         (i32.lt_s
+                          (i32.add
+                           (local.get $45)
+                           (local.get $1)
+                          )
+                          (local.get $5)
+                         )
+                        )
+                        (local.get $6)
+                        (local.tee $6
+                         (local.get $9)
+                        )
+                       )
+                       (local.get $13)
+                      )
+                     )
+                     (local.get $12)
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $26)
+                       (local.get $13)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 48)
+                     (local.get $10)
+                     (local.get $5)
+                     (i32.xor
+                      (local.get $12)
+                      (i32.const 65536)
+                     )
+                    )
+                    (local.set $1
+                     (i32.sub
+                      (local.get $1)
+                      (local.get $27)
+                     )
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $19)
+                       (local.get $1)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 48)
+                     (i32.sub
+                      (local.get $6)
+                      (i32.add
+                       (local.get $1)
+                       (local.tee $1
+                        (i32.sub
+                         (local.get $28)
+                         (local.get $7)
+                        )
+                       )
+                      )
+                     )
+                     (i32.const 0)
+                     (i32.const 0)
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $8)
+                       (local.get $1)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $25
+                     (local.get $0)
+                     (i32.const 32)
+                     (local.get $10)
+                     (local.get $5)
+                     (i32.xor
+                      (local.get $12)
+                      (i32.const 8192)
+                     )
+                    )
+                    (if
+                     (i32.ge_s
+                      (local.get $5)
+                      (local.get $10)
+                     )
+                     (local.set $10
+                      (local.get $5)
+                     )
+                    )
+                    (br $label$119)
+                   )
+                  )
+                  (if
+                   (local.get $1)
+                   (block
+                    (i32.store
+                     (local.get $20)
+                     (local.tee $6
+                      (i32.add
+                       (i32.load
+                        (local.get $20)
+                       )
+                       (i32.const -28)
+                      )
+                     )
+                    )
+                    (local.set $52
+                     (f64.mul
+                      (local.get $52)
+                      (f64.const 268435456)
+                     )
+                    )
+                   )
+                   (local.set $6
+                    (i32.load
+                     (local.get $20)
+                    )
+                   )
+                  )
+                  (local.set $8
+                   (local.tee $7
+                    (if (result i32)
+                     (i32.lt_s
+                      (local.get $6)
+                      (i32.const 0)
+                     )
+                     (local.get $47)
+                     (local.get $48)
+                    )
+                   )
+                  )
+                  (loop $label$145
+                   (i32.store
+                    (local.get $8)
+                    (local.tee $1
+                     (i32.trunc_f64_s
+                      (local.get $52)
+                     )
+                    )
+                   )
+                   (local.set $8
+                    (i32.add
+                     (local.get $8)
+                     (i32.const 4)
+                    )
+                   )
+                   (br_if $label$145
+                    (f64.ne
+                     (local.tee $52
+                      (f64.mul
+                       (f64.sub
+                        (local.get $52)
+                        (f64.convert_i32_u
+                         (local.get $1)
+                        )
+                       )
+                       (f64.const 1e9)
+                      )
+                     )
+                     (f64.const 0)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.gt_s
+                    (local.get $6)
+                    (i32.const 0)
+                   )
+                   (block
+                    (local.set $1
+                     (local.get $7)
+                    )
+                    (loop $label$147
+                     (local.set $14
+                      (if (result i32)
+                       (i32.gt_s
+                        (local.get $6)
+                        (i32.const 29)
+                       )
+                       (i32.const 29)
+                       (local.get $6)
+                      )
+                     )
+                     (block $label$150
+                      (if
+                       (i32.ge_u
+                        (local.tee $6
+                         (i32.add
+                          (local.get $8)
+                          (i32.const -4)
+                         )
+                        )
+                        (local.get $1)
+                       )
+                       (block
+                        (local.set $50
+                         (i64.extend_i32_u
+                          (local.get $14)
+                         )
+                        )
+                        (local.set $13
+                         (i32.const 0)
+                        )
+                        (loop $label$152
+                         (i64.store32
+                          (local.get $6)
+                          (i64.rem_u
+                           (local.tee $51
+                            (i64.add
+                             (i64.shl
+                              (i64.extend_i32_u
+                               (i32.load
+                                (local.get $6)
+                               )
+                              )
+                              (local.get $50)
+                             )
+                             (i64.extend_i32_u
+                              (local.get $13)
+                             )
+                            )
+                           )
+                           (i64.const 1000000000)
+                          )
+                         )
+                         (local.set $13
+                          (i32.wrap_i64
+                           (i64.div_u
+                            (local.get $51)
+                            (i64.const 1000000000)
+                           )
+                          )
+                         )
+                         (br_if $label$152
+                          (i32.ge_u
+                           (local.tee $6
+                            (i32.add
+                             (local.get $6)
+                             (i32.const -4)
+                            )
+                           )
+                           (local.get $1)
+                          )
+                         )
+                        )
+                        (br_if $label$150
+                         (i32.eqz
+                          (local.get $13)
+                         )
+                        )
+                        (i32.store
+                         (local.tee $1
+                          (i32.add
+                           (local.get $1)
+                           (i32.const -4)
+                          )
+                         )
+                         (local.get $13)
+                        )
+                       )
+                      )
+                     )
+                     (loop $label$153
+                      (if
+                       (i32.gt_u
+                        (local.get $8)
+                        (local.get $1)
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.load
+                          (local.tee $6
+                           (i32.add
+                            (local.get $8)
+                            (i32.const -4)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (local.set $8
+                          (local.get $6)
+                         )
+                         (br $label$153)
+                        )
+                       )
+                      )
+                     )
+                     (i32.store
+                      (local.get $20)
+                      (local.tee $6
+                       (i32.sub
+                        (i32.load
+                         (local.get $20)
+                        )
+                        (local.get $14)
+                       )
+                      )
+                     )
+                     (br_if $label$147
+                      (i32.gt_s
+                       (local.get $6)
+                       (i32.const 0)
+                      )
+                     )
+                    )
+                   )
+                   (local.set $1
+                    (local.get $7)
+                   )
+                  )
+                  (local.set $18
+                   (if (result i32)
+                    (i32.lt_s
+                     (local.get $5)
+                     (i32.const 0)
+                    )
+                    (i32.const 6)
+                    (local.get $5)
+                   )
+                  )
+                  (if
+                   (i32.lt_s
+                    (local.get $6)
+                    (i32.const 0)
+                   )
+                   (block
+                    (local.set $14
+                     (i32.add
+                      (i32.div_s
+                       (i32.add
+                        (local.get $18)
+                        (i32.const 25)
+                       )
+                       (i32.const 9)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                    (local.set $25
+                     (i32.eq
+                      (local.get $22)
+                      (i32.const 102)
+                     )
+                    )
+                    (local.set $5
+                     (local.get $8)
+                    )
+                    (loop $label$160
+                     (if
+                      (i32.gt_s
+                       (local.tee $13
+                        (i32.sub
+                         (i32.const 0)
+                         (local.get $6)
+                        )
+                       )
+                       (i32.const 9)
+                      )
+                      (local.set $13
+                       (i32.const 9)
+                      )
+                     )
+                     (block $label$162
+                      (if
+                       (i32.lt_u
+                        (local.get $1)
+                        (local.get $5)
+                       )
+                       (block
+                        (local.set $29
+                         (i32.add
+                          (i32.shl
+                           (i32.const 1)
+                           (local.get $13)
+                          )
+                          (i32.const -1)
+                         )
+                        )
+                        (local.set $35
+                         (i32.shr_u
+                          (i32.const 1000000000)
+                          (local.get $13)
+                         )
+                        )
+                        (local.set $6
+                         (i32.const 0)
+                        )
+                        (local.set $8
+                         (local.get $1)
+                        )
+                        (loop $label$164
+                         (i32.store
+                          (local.get $8)
+                          (i32.add
+                           (i32.shr_u
+                            (local.tee $32
+                             (i32.load
+                              (local.get $8)
+                             )
+                            )
+                            (local.get $13)
+                           )
+                           (local.get $6)
+                          )
+                         )
+                         (local.set $6
+                          (i32.mul
+                           (i32.and
+                            (local.get $32)
+                            (local.get $29)
+                           )
+                           (local.get $35)
+                          )
+                         )
+                         (br_if $label$164
+                          (i32.lt_u
+                           (local.tee $8
+                            (i32.add
+                             (local.get $8)
+                             (i32.const 4)
+                            )
+                           )
+                           (local.get $5)
+                          )
+                         )
+                        )
+                        (local.set $8
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 4)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (local.set $1
+                          (local.get $8)
+                         )
+                        )
+                        (br_if $label$162
+                         (i32.eqz
+                          (local.get $6)
+                         )
+                        )
+                        (i32.store
+                         (local.get $5)
+                         (local.get $6)
+                        )
+                        (local.set $5
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 4)
+                         )
+                        )
+                       )
+                       (block
+                        (local.set $8
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 4)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (local.set $1
+                          (local.get $8)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (local.set $6
+                      (i32.add
+                       (local.tee $8
+                        (if (result i32)
+                         (local.get $25)
+                         (local.get $7)
+                         (local.get $1)
+                        )
+                       )
+                       (i32.shl
+                        (local.get $14)
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                     (if
+                      (i32.gt_s
+                       (i32.shr_s
+                        (i32.sub
+                         (local.get $5)
+                         (local.get $8)
+                        )
+                        (i32.const 2)
+                       )
+                       (local.get $14)
+                      )
+                      (local.set $5
+                       (local.get $6)
+                      )
+                     )
+                     (i32.store
+                      (local.get $20)
+                      (local.tee $6
+                       (i32.add
+                        (i32.load
+                         (local.get $20)
+                        )
+                        (local.get $13)
+                       )
+                      )
+                     )
+                     (br_if $label$160
+                      (i32.lt_s
+                       (local.get $6)
+                       (i32.const 0)
+                      )
+                     )
+                     (local.set $13
+                      (local.get $5)
+                     )
+                    )
+                   )
+                   (local.set $13
+                    (local.get $8)
+                   )
+                  )
+                  (local.set $25
+                   (local.get $7)
+                  )
+                  (block $label$172
+                   (if
+                    (i32.lt_u
+                     (local.get $1)
+                     (local.get $13)
+                    )
+                    (block
+                     (local.set $5
+                      (i32.mul
+                       (i32.shr_s
+                        (i32.sub
+                         (local.get $25)
+                         (local.get $1)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 9)
+                      )
+                     )
+                     (br_if $label$172
+                      (i32.lt_u
+                       (local.tee $6
+                        (i32.load
+                         (local.get $1)
+                        )
+                       )
+                       (i32.const 10)
+                      )
+                     )
+                     (local.set $8
+                      (i32.const 10)
+                     )
+                     (loop $label$174
+                      (local.set $5
+                       (i32.add
+                        (local.get $5)
+                        (i32.const 1)
+                       )
+                      )
+                      (br_if $label$174
+                       (i32.ge_u
+                        (local.get $6)
+                        (local.tee $8
+                         (i32.mul
+                          (local.get $8)
+                          (i32.const 10)
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $5
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                  (local.set $29
+                   (i32.eq
+                    (local.get $22)
+                    (i32.const 103)
+                   )
+                  )
+                  (local.set $35
+                   (i32.ne
+                    (local.get $18)
+                    (i32.const 0)
+                   )
+                  )
+                  (if
+                   (i32.lt_s
+                    (local.tee $8
+                     (i32.add
+                      (i32.sub
+                       (local.get $18)
+                       (if (result i32)
+                        (i32.ne
+                         (local.get $22)
+                         (i32.const 102)
+                        )
+                        (local.get $5)
+                        (i32.const 0)
+                       )
+                      )
+                      (i32.shr_s
+                       (i32.shl
+                        (i32.and
+                         (local.get $35)
+                         (local.get $29)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                    )
+                    (i32.add
+                     (i32.mul
+                      (i32.shr_s
+                       (i32.sub
+                        (local.get $13)
+                        (local.get $25)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 9)
+                     )
+                     (i32.const -9)
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_s
+                      (local.tee $8
+                       (i32.add
+                        (i32.rem_s
+                         (local.tee $14
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 9216)
+                          )
+                         )
+                         (i32.const 9)
+                        )
+                        (i32.const 1)
+                       )
+                      )
+                      (i32.const 9)
+                     )
+                     (block
+                      (local.set $6
+                       (i32.const 10)
+                      )
+                      (loop $label$180
+                       (local.set $6
+                        (i32.mul
+                         (local.get $6)
+                         (i32.const 10)
+                        )
+                       )
+                       (br_if $label$180
+                        (i32.ne
+                         (local.tee $8
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 1)
+                          )
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                      )
+                     )
+                     (local.set $6
+                      (i32.const 10)
+                     )
+                    )
+                    (local.set $14
+                     (i32.rem_u
+                      (local.tee $22
+                       (i32.load
+                        (local.tee $8
+                         (i32.add
+                          (i32.add
+                           (local.get $7)
+                           (i32.const 4)
+                          )
+                          (i32.shl
+                           (i32.add
+                            (i32.div_s
+                             (local.get $14)
+                             (i32.const 9)
+                            )
+                            (i32.const -1024)
+                           )
+                           (i32.const 2)
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (local.get $6)
+                     )
+                    )
+                    (block $label$182
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (local.tee $32
+                         (i32.eq
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 4)
+                          )
+                          (local.get $13)
+                         )
+                        )
+                        (i32.eqz
+                         (local.get $14)
+                        )
+                       )
+                      )
+                      (block
+                       (local.set $52
+                        (if (result f64)
+                         (i32.lt_u
+                          (local.get $14)
+                          (local.tee $49
+                           (i32.div_s
+                            (local.get $6)
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                         (f64.const 0.5)
+                         (if (result f64)
+                          (i32.and
+                           (local.get $32)
+                           (i32.eq
+                            (local.get $14)
+                            (local.get $49)
+                           )
+                          )
+                          (f64.const 1)
+                          (f64.const 1.5)
+                         )
+                        )
+                       )
+                       (local.set $53
+                        (if (result f64)
+                         (i32.and
+                          (i32.div_u
+                           (local.get $22)
+                           (local.get $6)
+                          )
+                          (i32.const 1)
+                         )
+                         (f64.const 9007199254740994)
+                         (f64.const 9007199254740992)
+                        )
+                       )
+                       (block $label$190
+                        (if
+                         (local.get $24)
+                         (block
+                          (br_if $label$190
+                           (i32.ne
+                            (i32.load8_s
+                             (local.get $26)
+                            )
+                            (i32.const 45)
+                           )
+                          )
+                          (local.set $53
+                           (f64.neg
+                            (local.get $53)
+                           )
+                          )
+                          (local.set $52
+                           (f64.neg
+                            (local.get $52)
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (i32.store
+                        (local.get $8)
+                        (local.tee $14
+                         (i32.sub
+                          (local.get $22)
+                          (local.get $14)
+                         )
+                        )
+                       )
+                       (br_if $label$182
+                        (f64.eq
+                         (f64.add
+                          (local.get $53)
+                          (local.get $52)
+                         )
+                         (local.get $53)
+                        )
+                       )
+                       (i32.store
+                        (local.get $8)
+                        (local.tee $5
+                         (i32.add
+                          (local.get $14)
+                          (local.get $6)
+                         )
+                        )
+                       )
+                       (if
+                        (i32.gt_u
+                         (local.get $5)
+                         (i32.const 999999999)
+                        )
+                        (loop $label$193
+                         (i32.store
+                          (local.get $8)
+                          (i32.const 0)
+                         )
+                         (if
+                          (i32.lt_u
+                           (local.tee $8
+                            (i32.add
+                             (local.get $8)
+                             (i32.const -4)
+                            )
+                           )
+                           (local.get $1)
+                          )
+                          (i32.store
+                           (local.tee $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const -4)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                         )
+                         (i32.store
+                          (local.get $8)
+                          (local.tee $5
+                           (i32.add
+                            (i32.load
+                             (local.get $8)
+                            )
+                            (i32.const 1)
+                           )
+                          )
+                         )
+                         (br_if $label$193
+                          (i32.gt_u
+                           (local.get $5)
+                           (i32.const 999999999)
+                          )
+                         )
+                        )
+                       )
+                       (local.set $5
+                        (i32.mul
+                         (i32.shr_s
+                          (i32.sub
+                           (local.get $25)
+                           (local.get $1)
+                          )
+                          (i32.const 2)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (br_if $label$182
+                        (i32.lt_u
+                         (local.tee $14
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (i32.const 10)
+                        )
+                       )
+                       (local.set $6
+                        (i32.const 10)
+                       )
+                       (loop $label$195
+                        (local.set $5
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 1)
+                         )
+                        )
+                        (br_if $label$195
+                         (i32.ge_u
+                          (local.get $14)
+                          (local.tee $6
+                           (i32.mul
+                            (local.get $6)
+                            (i32.const 10)
+                           )
+                          )
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $14
+                     (local.get $1)
+                    )
+                    (local.set $6
+                     (local.get $5)
+                    )
+                    (if
+                     (i32.le_u
+                      (local.get $13)
+                      (local.tee $8
+                       (i32.add
+                        (local.get $8)
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.set $8
+                      (local.get $13)
+                     )
+                    )
+                   )
+                   (block
+                    (local.set $14
+                     (local.get $1)
+                    )
+                    (local.set $6
+                     (local.get $5)
+                    )
+                    (local.set $8
+                     (local.get $13)
+                    )
+                   )
+                  )
+                  (local.set $32
+                   (i32.sub
+                    (i32.const 0)
+                    (local.get $6)
+                   )
+                  )
+                  (loop $label$198
+                   (block $label$199
+                    (if
+                     (i32.le_u
+                      (local.get $8)
+                      (local.get $14)
+                     )
+                     (block
+                      (local.set $22
+                       (i32.const 0)
+                      )
+                      (br $label$199)
+                     )
+                    )
+                    (if
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $8)
+                        (i32.const -4)
+                       )
+                      )
+                     )
+                     (local.set $22
+                      (i32.const 1)
+                     )
+                     (block
+                      (local.set $8
+                       (local.get $1)
+                      )
+                      (br $label$198)
+                     )
+                    )
+                   )
+                  )
+                  (block $label$203
+                   (if
+                    (local.get $29)
+                    (block
+                     (local.set $1
+                      (if (result i32)
+                       (i32.and
+                        (i32.gt_s
+                         (local.tee $1
+                          (i32.add
+                           (i32.xor
+                            (i32.and
+                             (local.get $35)
+                             (i32.const 1)
+                            )
+                            (i32.const 1)
+                           )
+                           (local.get $18)
+                          )
+                         )
+                         (local.get $6)
+                        )
+                        (i32.gt_s
+                         (local.get $6)
+                         (i32.const -5)
+                        )
+                       )
+                       (block (result i32)
+                        (local.set $5
+                         (i32.add
+                          (local.get $9)
+                          (i32.const -1)
+                         )
+                        )
+                        (i32.sub
+                         (i32.add
+                          (local.get $1)
+                          (i32.const -1)
+                         )
+                         (local.get $6)
+                        )
+                       )
+                       (block (result i32)
+                        (local.set $5
+                         (i32.add
+                          (local.get $9)
+                          (i32.const -2)
+                         )
+                        )
+                        (i32.add
+                         (local.get $1)
+                         (i32.const -1)
+                        )
+                       )
+                      )
+                     )
+                     (br_if $label$203
+                      (local.tee $13
+                       (i32.and
+                        (local.get $12)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (block $label$207
+                      (if
+                       (local.get $22)
+                       (block
+                        (if
+                         (i32.eqz
+                          (local.tee $18
+                           (i32.load
+                            (i32.add
+                             (local.get $8)
+                             (i32.const -4)
+                            )
+                           )
+                          )
+                         )
+                         (block
+                          (local.set $9
+                           (i32.const 9)
+                          )
+                          (br $label$207)
+                         )
+                        )
+                        (if
+                         (i32.rem_u
+                          (local.get $18)
+                          (i32.const 10)
+                         )
+                         (block
+                          (local.set $9
+                           (i32.const 0)
+                          )
+                          (br $label$207)
+                         )
+                         (block
+                          (local.set $13
+                           (i32.const 10)
+                          )
+                          (local.set $9
+                           (i32.const 0)
+                          )
+                         )
+                        )
+                        (loop $label$212
+                         (local.set $9
+                          (i32.add
+                           (local.get $9)
+                           (i32.const 1)
+                          )
+                         )
+                         (br_if $label$212
+                          (i32.eqz
+                           (i32.rem_u
+                            (local.get $18)
+                            (local.tee $13
+                             (i32.mul
+                              (local.get $13)
+                              (i32.const 10)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (local.set $9
+                        (i32.const 9)
+                       )
+                      )
+                     )
+                     (local.set $18
+                      (i32.add
+                       (i32.mul
+                        (i32.shr_s
+                         (i32.sub
+                          (local.get $8)
+                          (local.get $25)
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 9)
+                       )
+                       (i32.const -9)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (i32.or
+                        (local.get $5)
+                        (i32.const 32)
+                       )
+                       (i32.const 102)
+                      )
+                      (block
+                       (local.set $13
+                        (i32.const 0)
+                       )
+                       (if
+                        (i32.ge_s
+                         (local.get $1)
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.tee $9
+                            (i32.sub
+                             (local.get $18)
+                             (local.get $9)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                          (local.tee $9
+                           (i32.const 0)
+                          )
+                          (local.get $9)
+                         )
+                        )
+                        (local.set $1
+                         (local.get $9)
+                        )
+                       )
+                      )
+                      (block
+                       (local.set $13
+                        (i32.const 0)
+                       )
+                       (if
+                        (i32.ge_s
+                         (local.get $1)
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.tee $9
+                            (i32.sub
+                             (i32.add
+                              (local.get $18)
+                              (local.get $6)
+                             )
+                             (local.get $9)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                          (local.tee $9
+                           (i32.const 0)
+                          )
+                          (local.get $9)
+                         )
+                        )
+                        (local.set $1
+                         (local.get $9)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (block
+                     (local.set $13
+                      (i32.and
+                       (local.get $12)
+                       (i32.const 8)
+                      )
+                     )
+                     (local.set $1
+                      (local.get $18)
+                     )
+                     (local.set $5
+                      (local.get $9)
+                     )
+                    )
+                   )
+                  )
+                  (if
+                   (local.tee $25
+                    (i32.eq
+                     (i32.or
+                      (local.get $5)
+                      (i32.const 32)
+                     )
+                     (i32.const 102)
+                    )
+                   )
+                   (block
+                    (local.set $9
+                     (i32.const 0)
+                    )
+                    (if
+                     (i32.le_s
+                      (local.get $6)
+                      (i32.const 0)
+                     )
+                     (local.set $6
+                      (i32.const 0)
+                     )
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_s
+                      (i32.sub
+                       (local.get $28)
+                       (local.tee $9
+                        (call $23
+                         (i64.extend_i32_s
+                          (if (result i32)
+                           (i32.lt_s
+                            (local.get $6)
+                            (i32.const 0)
+                           )
+                           (local.get $32)
+                           (local.get $6)
+                          )
+                         )
+                         (local.get $33)
+                        )
+                       )
+                      )
+                      (i32.const 2)
+                     )
+                     (loop $label$229
+                      (i32.store8
+                       (local.tee $9
+                        (i32.add
+                         (local.get $9)
+                         (i32.const -1)
+                        )
+                       )
+                       (i32.const 48)
+                      )
+                      (br_if $label$229
+                       (i32.lt_s
+                        (i32.sub
+                         (local.get $28)
+                         (local.get $9)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                    (i32.store8
+                     (i32.add
+                      (local.get $9)
+                      (i32.const -1)
+                     )
+                     (i32.add
+                      (i32.and
+                       (i32.shr_s
+                        (local.get $6)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 43)
+                     )
+                    )
+                    (i32.store8
+                     (local.tee $6
+                      (i32.add
+                       (local.get $9)
+                       (i32.const -2)
+                      )
+                     )
+                     (local.get $5)
+                    )
+                    (local.set $9
+                     (local.get $6)
+                    )
+                    (local.set $6
+                     (i32.sub
+                      (local.get $28)
+                      (local.get $6)
+                     )
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.tee $18
+                    (i32.add
+                     (i32.add
+                      (i32.add
+                       (i32.add
+                        (local.get $24)
+                        (i32.const 1)
+                       )
+                       (local.get $1)
+                      )
+                      (i32.ne
+                       (local.tee $29
+                        (i32.or
+                         (local.get $1)
+                         (local.get $13)
+                        )
+                       )
+                       (i32.const 0)
+                      )
+                     )
+                     (local.get $6)
+                    )
+                   )
+                   (local.get $12)
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (i32.load
+                      (local.get $0)
+                     )
+                     (i32.const 32)
+                    )
+                   )
+                   (drop
+                    (call $21
+                     (local.get $26)
+                     (local.get $24)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 48)
+                   (local.get $10)
+                   (local.get $18)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 65536)
+                   )
+                  )
+                  (block $label$231
+                   (if
+                    (local.get $25)
+                    (block
+                     (local.set $6
+                      (local.tee $9
+                       (if (result i32)
+                        (i32.gt_u
+                         (local.get $14)
+                         (local.get $7)
+                        )
+                        (local.get $7)
+                        (local.get $14)
+                       )
+                      )
+                     )
+                     (loop $label$235
+                      (local.set $5
+                       (call $23
+                        (i64.extend_i32_u
+                         (i32.load
+                          (local.get $6)
+                         )
+                        )
+                        (local.get $31)
+                       )
+                      )
+                      (block $label$236
+                       (if
+                        (i32.eq
+                         (local.get $6)
+                         (local.get $9)
+                        )
+                        (block
+                         (br_if $label$236
+                          (i32.ne
+                           (local.get $5)
+                           (local.get $31)
+                          )
+                         )
+                         (i32.store8
+                          (local.get $34)
+                          (i32.const 48)
+                         )
+                         (local.set $5
+                          (local.get $34)
+                         )
+                        )
+                        (block
+                         (br_if $label$236
+                          (i32.le_u
+                           (local.get $5)
+                           (local.get $19)
+                          )
+                         )
+                         (drop
+                          (call $41
+                           (local.get $19)
+                           (i32.const 48)
+                           (i32.sub
+                            (local.get $5)
+                            (local.get $27)
+                           )
+                          )
+                         )
+                         (loop $label$239
+                          (br_if $label$239
+                           (i32.gt_u
+                            (local.tee $5
+                             (i32.add
+                              (local.get $5)
+                              (i32.const -1)
+                             )
+                            )
+                            (local.get $19)
+                           )
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (local.get $0)
+                         )
+                         (i32.const 32)
+                        )
+                       )
+                       (drop
+                        (call $21
+                         (local.get $5)
+                         (i32.sub
+                          (local.get $41)
+                          (local.get $5)
+                         )
+                         (local.get $0)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.le_u
+                        (local.tee $5
+                         (i32.add
+                          (local.get $6)
+                          (i32.const 4)
+                         )
+                        )
+                        (local.get $7)
+                       )
+                       (block
+                        (local.set $6
+                         (local.get $5)
+                        )
+                        (br $label$235)
+                       )
+                      )
+                     )
+                     (block $label$242
+                      (if
+                       (local.get $29)
+                       (block
+                        (br_if $label$242
+                         (i32.and
+                          (i32.load
+                           (local.get $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $21
+                          (i32.const 1687)
+                          (i32.const 1)
+                          (local.get $0)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.and
+                       (i32.gt_s
+                        (local.get $1)
+                        (i32.const 0)
+                       )
+                       (i32.lt_u
+                        (local.get $5)
+                        (local.get $8)
+                       )
+                      )
+                      (loop $label$245
+                       (if
+                        (i32.gt_u
+                         (local.tee $7
+                          (call $23
+                           (i64.extend_i32_u
+                            (i32.load
+                             (local.get $5)
+                            )
+                           )
+                           (local.get $31)
+                          )
+                         )
+                         (local.get $19)
+                        )
+                        (block
+                         (drop
+                          (call $41
+                           (local.get $19)
+                           (i32.const 48)
+                           (i32.sub
+                            (local.get $7)
+                            (local.get $27)
+                           )
+                          )
+                         )
+                         (loop $label$247
+                          (br_if $label$247
+                           (i32.gt_u
+                            (local.tee $7
+                             (i32.add
+                              (local.get $7)
+                              (i32.const -1)
+                             )
+                            )
+                            (local.get $19)
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (i32.load
+                           (local.get $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $21
+                          (local.get $7)
+                          (if (result i32)
+                           (i32.gt_s
+                            (local.get $1)
+                            (i32.const 9)
+                           )
+                           (i32.const 9)
+                           (local.get $1)
+                          )
+                          (local.get $0)
+                         )
+                        )
+                       )
+                       (local.set $7
+                        (i32.add
+                         (local.get $1)
+                         (i32.const -9)
+                        )
+                       )
+                       (if
+                        (i32.and
+                         (i32.gt_s
+                          (local.get $1)
+                          (i32.const 9)
+                         )
+                         (i32.lt_u
+                          (local.tee $5
+                           (i32.add
+                            (local.get $5)
+                            (i32.const 4)
+                           )
+                          )
+                          (local.get $8)
+                         )
+                        )
+                        (block
+                         (local.set $1
+                          (local.get $7)
+                         )
+                         (br $label$245)
+                        )
+                        (local.set $1
+                         (local.get $7)
+                        )
+                       )
+                      )
+                     )
+                     (call $25
+                      (local.get $0)
+                      (i32.const 48)
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 9)
+                      )
+                      (i32.const 9)
+                      (i32.const 0)
+                     )
+                    )
+                    (block
+                     (local.set $5
+                      (i32.add
+                       (local.get $14)
+                       (i32.const 4)
+                      )
+                     )
+                     (if
+                      (i32.eqz
+                       (local.get $22)
+                      )
+                      (local.set $8
+                       (local.get $5)
+                      )
+                     )
+                     (if
+                      (i32.gt_s
+                       (local.get $1)
+                       (i32.const -1)
+                      )
+                      (block
+                       (local.set $13
+                        (i32.eqz
+                         (local.get $13)
+                        )
+                       )
+                       (local.set $7
+                        (local.get $14)
+                       )
+                       (local.set $5
+                        (local.get $1)
+                       )
+                       (loop $label$256
+                        (if
+                         (i32.eq
+                          (local.tee $1
+                           (call $23
+                            (i64.extend_i32_u
+                             (i32.load
+                              (local.get $7)
+                             )
+                            )
+                            (local.get $31)
+                           )
+                          )
+                          (local.get $31)
+                         )
+                         (block
+                          (i32.store8
+                           (local.get $34)
+                           (i32.const 48)
+                          )
+                          (local.set $1
+                           (local.get $34)
+                          )
+                         )
+                        )
+                        (block $label$258
+                         (if
+                          (i32.eq
+                           (local.get $7)
+                           (local.get $14)
+                          )
+                          (block
+                           (if
+                            (i32.eqz
+                             (i32.and
+                              (i32.load
+                               (local.get $0)
+                              )
+                              (i32.const 32)
+                             )
+                            )
+                            (drop
+                             (call $21
+                              (local.get $1)
+                              (i32.const 1)
+                              (local.get $0)
+                             )
+                            )
+                           )
+                           (local.set $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const 1)
+                            )
+                           )
+                           (br_if $label$258
+                            (i32.and
+                             (local.get $13)
+                             (i32.lt_s
+                              (local.get $5)
+                              (i32.const 1)
+                             )
+                            )
+                           )
+                           (br_if $label$258
+                            (i32.and
+                             (i32.load
+                              (local.get $0)
+                             )
+                             (i32.const 32)
+                            )
+                           )
+                           (drop
+                            (call $21
+                             (i32.const 1687)
+                             (i32.const 1)
+                             (local.get $0)
+                            )
+                           )
+                          )
+                          (block
+                           (br_if $label$258
+                            (i32.le_u
+                             (local.get $1)
+                             (local.get $19)
+                            )
+                           )
+                           (drop
+                            (call $41
+                             (local.get $19)
+                             (i32.const 48)
+                             (i32.add
+                              (local.get $1)
+                              (local.get $43)
+                             )
+                            )
+                           )
+                           (loop $label$262
+                            (br_if $label$262
+                             (i32.gt_u
+                              (local.tee $1
+                               (i32.add
+                                (local.get $1)
+                                (i32.const -1)
+                               )
+                              )
+                              (local.get $19)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                        (local.set $6
+                         (i32.sub
+                          (local.get $41)
+                          (local.get $1)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.and
+                           (i32.load
+                            (local.get $0)
+                           )
+                           (i32.const 32)
+                          )
+                         )
+                         (drop
+                          (call $21
+                           (local.get $1)
+                           (if (result i32)
+                            (i32.gt_s
+                             (local.get $5)
+                             (local.get $6)
+                            )
+                            (local.get $6)
+                            (local.get $5)
+                           )
+                           (local.get $0)
+                          )
+                         )
+                        )
+                        (br_if $label$256
+                         (i32.and
+                          (i32.lt_u
+                           (local.tee $7
+                            (i32.add
+                             (local.get $7)
+                             (i32.const 4)
+                            )
+                           )
+                           (local.get $8)
+                          )
+                          (i32.gt_s
+                           (local.tee $5
+                            (i32.sub
+                             (local.get $5)
+                             (local.get $6)
+                            )
+                           )
+                           (i32.const -1)
+                          )
+                         )
+                        )
+                        (local.set $1
+                         (local.get $5)
+                        )
+                       )
+                      )
+                     )
+                     (call $25
+                      (local.get $0)
+                      (i32.const 48)
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 18)
+                      )
+                      (i32.const 18)
+                      (i32.const 0)
+                     )
+                     (br_if $label$231
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $21
+                       (local.get $9)
+                       (i32.sub
+                        (local.get $28)
+                        (local.get $9)
+                       )
+                       (local.get $0)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.get $18)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 8192)
+                   )
+                  )
+                  (if
+                   (i32.ge_s
+                    (local.get $18)
+                    (local.get $10)
+                   )
+                   (local.set $10
+                    (local.get $18)
+                   )
+                  )
+                 )
+                 (block
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.tee $8
+                    (i32.add
+                     (if (result i32)
+                      (local.tee $6
+                       (i32.or
+                        (f64.ne
+                         (local.get $52)
+                         (local.get $52)
+                        )
+                        (i32.const 0)
+                       )
+                      )
+                      (local.tee $24
+                       (i32.const 0)
+                      )
+                      (local.get $24)
+                     )
+                     (i32.const 3)
+                    )
+                   )
+                   (local.get $7)
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (local.tee $1
+                      (i32.load
+                       (local.get $0)
+                      )
+                     )
+                     (i32.const 32)
+                    )
+                   )
+                   (block
+                    (drop
+                     (call $21
+                      (local.get $26)
+                      (local.get $24)
+                      (local.get $0)
+                     )
+                    )
+                    (local.set $1
+                     (i32.load
+                      (local.get $0)
+                     )
+                    )
+                   )
+                  )
+                  (local.set $7
+                   (if (result i32)
+                    (local.tee $5
+                     (i32.ne
+                      (i32.and
+                       (local.get $9)
+                       (i32.const 32)
+                      )
+                      (i32.const 0)
+                     )
+                    )
+                    (i32.const 1671)
+                    (i32.const 1675)
+                   )
+                  )
+                  (local.set $5
+                   (if (result i32)
+                    (local.get $5)
+                    (i32.const 1679)
+                    (i32.const 1683)
+                   )
+                  )
+                  (if
+                   (i32.eqz
+                    (local.get $6)
+                   )
+                   (local.set $5
+                    (local.get $7)
+                   )
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (local.get $1)
+                     (i32.const 32)
+                    )
+                   )
+                   (drop
+                    (call $21
+                     (local.get $5)
+                     (i32.const 3)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (call $25
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.get $8)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 8192)
+                   )
+                  )
+                  (if
+                   (i32.ge_s
+                    (local.get $8)
+                    (local.get $10)
+                   )
+                   (local.set $10
+                    (local.get $8)
+                   )
+                  )
+                 )
+                )
+               )
+               (local.set $1
+                (local.get $11)
+               )
+               (br $label$4)
+              )
+              (local.set $7
+               (local.get $5)
+              )
+              (local.set $6
+               (i32.const 0)
+              )
+              (local.set $8
+               (i32.const 1635)
+              )
+              (local.set $5
+               (local.get $21)
+              )
+              (br $label$70)
+             )
+             (local.set $7
+              (i32.and
+               (local.get $9)
+               (i32.const 32)
+              )
+             )
+             (local.set $7
+              (if (result i32)
+               (i64.eq
+                (local.tee $50
+                 (i64.load
+                  (local.get $16)
+                 )
+                )
+                (i64.const 0)
+               )
+               (block (result i32)
+                (local.set $50
+                 (i64.const 0)
+                )
+                (local.get $21)
+               )
+               (block (result i32)
+                (local.set $1
+                 (local.get $21)
+                )
+                (loop $label$280
+                 (i32.store8
+                  (local.tee $1
+                   (i32.add
+                    (local.get $1)
+                    (i32.const -1)
+                   )
+                  )
+                  (i32.or
+                   (i32.load8_u
+                    (i32.add
+                     (i32.and
+                      (i32.wrap_i64
+                       (local.get $50)
+                      )
+                      (i32.const 15)
+                     )
+                     (i32.const 1619)
+                    )
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (br_if $label$280
+                  (i64.ne
+                   (local.tee $50
+                    (i64.shr_u
+                     (local.get $50)
+                     (i64.const 4)
+                    )
+                   )
+                   (i64.const 0)
+                  )
+                 )
+                )
+                (local.set $50
+                 (i64.load
+                  (local.get $16)
+                 )
+                )
+                (local.get $1)
+               )
+              )
+             )
+             (local.set $8
+              (i32.add
+               (i32.shr_s
+                (local.get $9)
+                (i32.const 4)
+               )
+               (i32.const 1635)
+              )
+             )
+             (if
+              (local.tee $1
+               (i32.or
+                (i32.eqz
+                 (i32.and
+                  (local.get $12)
+                  (i32.const 8)
+                 )
+                )
+                (i64.eq
+                 (local.get $50)
+                 (i64.const 0)
+                )
+               )
+              )
+              (local.set $8
+               (i32.const 1635)
+              )
+             )
+             (local.set $6
+              (if (result i32)
+               (local.get $1)
+               (i32.const 0)
+               (i32.const 2)
+              )
+             )
+             (br $label$71)
+            )
+            (local.set $7
+             (call $23
+              (local.get $50)
+              (local.get $21)
+             )
+            )
+            (br $label$71)
+           )
+           (local.set $14
+            (i32.eqz
+             (local.tee $13
+              (call $17
+               (local.get $1)
+               (i32.const 0)
+               (local.get $5)
+              )
+             )
+            )
+           )
+           (local.set $8
+            (i32.sub
+             (local.get $13)
+             (local.get $1)
+            )
+           )
+           (local.set $9
+            (i32.add
+             (local.get $1)
+             (local.get $5)
+            )
+           )
+           (local.set $12
+            (local.get $7)
+           )
+           (local.set $7
+            (if (result i32)
+             (local.get $14)
+             (local.get $5)
+             (local.get $8)
+            )
+           )
+           (local.set $6
+            (i32.const 0)
+           )
+           (local.set $8
+            (i32.const 1635)
+           )
+           (local.set $5
+            (if (result i32)
+             (local.get $14)
+             (local.get $9)
+             (local.get $13)
+            )
+           )
+           (br $label$70)
+          )
+          (local.set $1
+           (i32.const 0)
+          )
+          (local.set $5
+           (i32.const 0)
+          )
+          (local.set $8
+           (local.get $7)
+          )
+          (loop $label$288
+           (block $label$289
+            (br_if $label$289
+             (i32.eqz
+              (local.tee $9
+               (i32.load
+                (local.get $8)
+               )
+              )
+             )
+            )
+            (br_if $label$289
+             (i32.or
+              (i32.lt_s
+               (local.tee $5
+                (call $26
+                 (local.get $36)
+                 (local.get $9)
+                )
+               )
+               (i32.const 0)
+              )
+              (i32.gt_u
+               (local.get $5)
+               (i32.sub
+                (local.get $6)
+                (local.get $1)
+               )
+              )
+             )
+            )
+            (local.set $8
+             (i32.add
+              (local.get $8)
+              (i32.const 4)
+             )
+            )
+            (br_if $label$288
+             (i32.gt_u
+              (local.get $6)
+              (local.tee $1
+               (i32.add
+                (local.get $5)
+                (local.get $1)
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_s
+            (local.get $5)
+            (i32.const 0)
+           )
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+          )
+          (call $25
+           (local.get $0)
+           (i32.const 32)
+           (local.get $10)
+           (local.get $1)
+           (local.get $12)
+          )
+          (if
+           (local.get $1)
+           (block
+            (local.set $5
+             (i32.const 0)
+            )
+            (loop $label$292
+             (br_if $label$72
+              (i32.eqz
+               (local.tee $8
+                (i32.load
+                 (local.get $7)
+                )
+               )
+              )
+             )
+             (br_if $label$72
+              (i32.gt_s
+               (local.tee $5
+                (i32.add
+                 (local.tee $8
+                  (call $26
+                   (local.get $36)
+                   (local.get $8)
+                  )
+                 )
+                 (local.get $5)
+                )
+               )
+               (local.get $1)
+              )
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (i32.load
+                 (local.get $0)
+                )
+                (i32.const 32)
+               )
+              )
+              (drop
+               (call $21
+                (local.get $36)
+                (local.get $8)
+                (local.get $0)
+               )
+              )
+             )
+             (local.set $7
+              (i32.add
+               (local.get $7)
+               (i32.const 4)
+              )
+             )
+             (br_if $label$292
+              (i32.lt_u
+               (local.get $5)
+               (local.get $1)
+              )
+             )
+             (br $label$72)
+            )
+           )
+           (block
+            (local.set $1
+             (i32.const 0)
+            )
+            (br $label$72)
+           )
+          )
+         )
+         (call $25
+          (local.get $0)
+          (i32.const 32)
+          (local.get $10)
+          (local.get $1)
+          (i32.xor
+           (local.get $12)
+           (i32.const 8192)
+          )
+         )
+         (if
+          (i32.le_s
+           (local.get $10)
+           (local.get $1)
+          )
+          (local.set $10
+           (local.get $1)
+          )
+         )
+         (local.set $1
+          (local.get $11)
+         )
+         (br $label$4)
+        )
+        (local.set $1
+         (i32.and
+          (local.get $12)
+          (i32.const -65537)
+         )
+        )
+        (if
+         (i32.gt_s
+          (local.get $5)
+          (i32.const -1)
+         )
+         (local.set $12
+          (local.get $1)
+         )
+        )
+        (local.set $5
+         (if (result i32)
+          (i32.or
+           (local.get $5)
+           (local.tee $9
+            (i64.ne
+             (i64.load
+              (local.get $16)
+             )
+             (i64.const 0)
+            )
+           )
+          )
+          (block (result i32)
+           (local.set $1
+            (local.get $7)
+           )
+           (if
+            (i32.gt_s
+             (local.get $5)
+             (local.tee $7
+              (i32.add
+               (i32.xor
+                (i32.and
+                 (local.get $9)
+                 (i32.const 1)
+                )
+                (i32.const 1)
+               )
+               (i32.sub
+                (local.get $38)
+                (local.get $7)
+               )
+              )
+             )
+            )
+            (local.set $7
+             (local.get $5)
+            )
+           )
+           (local.get $21)
+          )
+          (block (result i32)
+           (local.set $1
+            (local.get $21)
+           )
+           (local.set $7
+            (i32.const 0)
+           )
+           (local.get $21)
+          )
+         )
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 32)
+        (if (result i32)
+         (i32.lt_s
+          (local.get $10)
+          (local.tee $5
+           (i32.add
+            (if (result i32)
+             (i32.lt_s
+              (local.get $7)
+              (local.tee $9
+               (i32.sub
+                (local.get $5)
+                (local.get $1)
+               )
+              )
+             )
+             (local.tee $7
+              (local.get $9)
+             )
+             (local.get $7)
+            )
+            (local.get $6)
+           )
+          )
+         )
+         (local.tee $10
+          (local.get $5)
+         )
+         (local.get $10)
+        )
+        (local.get $5)
+        (local.get $12)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 32)
+         )
+        )
+        (drop
+         (call $21
+          (local.get $8)
+          (local.get $6)
+          (local.get $0)
+         )
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 48)
+        (local.get $10)
+        (local.get $5)
+        (i32.xor
+         (local.get $12)
+         (i32.const 65536)
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 48)
+        (local.get $7)
+        (local.get $9)
+        (i32.const 0)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 32)
+         )
+        )
+        (drop
+         (call $21
+          (local.get $1)
+          (local.get $9)
+          (local.get $0)
+         )
+        )
+       )
+       (call $25
+        (local.get $0)
+        (i32.const 32)
+        (local.get $10)
+        (local.get $5)
+        (i32.xor
+         (local.get $12)
+         (i32.const 8192)
+        )
+       )
+       (local.set $1
+        (local.get $11)
+       )
+       (br $label$4)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.eqz
+      (local.get $0)
+     )
+     (if
+      (local.get $17)
+      (block
+       (local.set $0
+        (i32.const 1)
+       )
+       (loop $label$308
+        (if
+         (local.tee $1
+          (i32.load
+           (i32.add
+            (local.get $4)
+            (i32.shl
+             (local.get $0)
+             (i32.const 2)
+            )
+           )
+          )
+         )
+         (block
+          (call $22
+           (i32.add
+            (local.get $3)
+            (i32.shl
+             (local.get $0)
+             (i32.const 3)
+            )
+           )
+           (local.get $1)
+           (local.get $2)
+          )
+          (br_if $label$308
+           (i32.lt_s
+            (local.tee $0
+             (i32.add
+              (local.get $0)
+              (i32.const 1)
+             )
+            )
+            (i32.const 10)
+           )
+          )
+          (local.set $15
+           (i32.const 1)
+          )
+          (br $label$2)
+         )
+        )
+       )
+       (loop $label$310
+        (if
+         (i32.load
+          (i32.add
+           (local.get $4)
+           (i32.shl
+            (local.get $0)
+            (i32.const 2)
+           )
+          )
+         )
+         (block
+          (local.set $15
+           (i32.const -1)
+          )
+          (br $label$2)
+         )
+        )
+        (br_if $label$310
+         (i32.lt_s
+          (local.tee $0
+           (i32.add
+            (local.get $0)
+            (i32.const 1)
+           )
+          )
+          (i32.const 10)
+         )
+        )
+        (local.set $15
+         (i32.const 1)
+        )
+       )
+      )
+      (local.set $15
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $23)
+   )
+   (local.get $15)
+  )
+ )
+ (func $20 (; 33 ;) (type $1) (param $0 i32) (result i32)
+  (i32.const 0)
+ )
+ (func $21 (; 34 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (block $label$1 (result i32)
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (local.tee $3
+       (i32.load
+        (local.tee $4
+         (i32.add
+          (local.get $2)
+          (i32.const 16)
+         )
+        )
+       )
+      )
+     )
+     (if
+      (call $30
+       (local.get $2)
+      )
+      (local.set $3
+       (i32.const 0)
+      )
+      (block
+       (local.set $3
+        (i32.load
+         (local.get $4)
+        )
+       )
+       (br $label$3)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.lt_u
+      (i32.sub
+       (local.get $3)
+       (local.tee $4
+        (i32.load
+         (local.tee $5
+          (i32.add
+           (local.get $2)
+           (i32.const 20)
+          )
+         )
+        )
+       )
+      )
+      (local.get $1)
+     )
+     (block
+      (local.set $3
+       (call_indirect (type $0)
+        (local.get $2)
+        (local.get $0)
+        (local.get $1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (local.get $2)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (br $label$2)
+     )
+    )
+    (local.set $2
+     (block $label$7 (result i32)
+      (if (result i32)
+       (i32.gt_s
+        (i32.load8_s offset=75
+         (local.get $2)
+        )
+        (i32.const -1)
+       )
+       (block (result i32)
+        (local.set $3
+         (local.get $1)
+        )
+        (loop $label$9
+         (drop
+          (br_if $label$7
+           (i32.const 0)
+           (i32.eqz
+            (local.get $3)
+           )
+          )
+         )
+         (if
+          (i32.ne
+           (i32.load8_s
+            (i32.add
+             (local.get $0)
+             (local.tee $6
+              (i32.add
+               (local.get $3)
+               (i32.const -1)
+              )
+             )
+            )
+           )
+           (i32.const 10)
+          )
+          (block
+           (local.set $3
+            (local.get $6)
+           )
+           (br $label$9)
+          )
+         )
+        )
+        (br_if $label$2
+         (i32.lt_u
+          (call_indirect (type $0)
+           (local.get $2)
+           (local.get $0)
+           (local.get $3)
+           (i32.add
+            (i32.and
+             (i32.load offset=36
+              (local.get $2)
+             )
+             (i32.const 3)
+            )
+            (i32.const 2)
+           )
+          )
+          (local.get $3)
+         )
+        )
+        (local.set $4
+         (i32.load
+          (local.get $5)
+         )
+        )
+        (local.set $1
+         (i32.sub
+          (local.get $1)
+          (local.get $3)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (local.get $3)
+         )
+        )
+        (local.get $3)
+       )
+       (i32.const 0)
+      )
+     )
+    )
+    (drop
+     (call $42
+      (local.get $4)
+      (local.get $0)
+      (local.get $1)
+     )
+    )
+    (i32.store
+     (local.get $5)
+     (i32.add
+      (i32.load
+       (local.get $5)
+      )
+      (local.get $1)
+     )
+    )
+    (local.set $3
+     (i32.add
+      (local.get $2)
+      (local.get $1)
+     )
+    )
+   )
+   (local.get $3)
+  )
+ )
+ (func $22 (; 35 ;) (type $8) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i64)
+  (local $5 f64)
+  (block $label$1
+   (if
+    (i32.le_u
+     (local.get $1)
+     (i32.const 20)
+    )
+    (block $label$3
+     (block $label$4
+      (block $label$5
+       (block $label$6
+        (block $label$7
+         (block $label$8
+          (block $label$9
+           (block $label$10
+            (block $label$11
+             (block $label$12
+              (block $label$13
+               (br_table $label$13 $label$12 $label$11 $label$10 $label$9 $label$8 $label$7 $label$6 $label$5 $label$4 $label$3
+                (i32.sub
+                 (local.get $1)
+                 (i32.const 9)
+                )
+               )
+              )
+              (local.set $3
+               (i32.load
+                (local.tee $1
+                 (i32.and
+                  (i32.add
+                   (i32.load
+                    (local.get $2)
+                   )
+                   (i32.const 3)
+                  )
+                  (i32.const -4)
+                 )
+                )
+               )
+              )
+              (i32.store
+               (local.get $2)
+               (i32.add
+                (local.get $1)
+                (i32.const 4)
+               )
+              )
+              (i32.store
+               (local.get $0)
+               (local.get $3)
+              )
+              (br $label$1)
+             )
+             (local.set $3
+              (i32.load
+               (local.tee $1
+                (i32.and
+                 (i32.add
+                  (i32.load
+                   (local.get $2)
+                  )
+                  (i32.const 3)
+                 )
+                 (i32.const -4)
+                )
+               )
+              )
+             )
+             (i32.store
+              (local.get $2)
+              (i32.add
+               (local.get $1)
+               (i32.const 4)
+              )
+             )
+             (i64.store
+              (local.get $0)
+              (i64.extend_i32_s
+               (local.get $3)
+              )
+             )
+             (br $label$1)
+            )
+            (local.set $3
+             (i32.load
+              (local.tee $1
+               (i32.and
+                (i32.add
+                 (i32.load
+                  (local.get $2)
+                 )
+                 (i32.const 3)
+                )
+                (i32.const -4)
+               )
+              )
+             )
+            )
+            (i32.store
+             (local.get $2)
+             (i32.add
+              (local.get $1)
+              (i32.const 4)
+             )
+            )
+            (i64.store
+             (local.get $0)
+             (i64.extend_i32_u
+              (local.get $3)
+             )
+            )
+            (br $label$1)
+           )
+           (local.set $4
+            (i64.load
+             (local.tee $1
+              (i32.and
+               (i32.add
+                (i32.load
+                 (local.get $2)
+                )
+                (i32.const 7)
+               )
+               (i32.const -8)
+              )
+             )
+            )
+           )
+           (i32.store
+            (local.get $2)
+            (i32.add
+             (local.get $1)
+             (i32.const 8)
+            )
+           )
+           (i64.store
+            (local.get $0)
+            (local.get $4)
+           )
+           (br $label$1)
+          )
+          (local.set $3
+           (i32.load
+            (local.tee $1
+             (i32.and
+              (i32.add
+               (i32.load
+                (local.get $2)
+               )
+               (i32.const 3)
+              )
+              (i32.const -4)
+             )
+            )
+           )
+          )
+          (i32.store
+           (local.get $2)
+           (i32.add
+            (local.get $1)
+            (i32.const 4)
+           )
+          )
+          (i64.store
+           (local.get $0)
+           (i64.extend_i32_s
+            (i32.shr_s
+             (i32.shl
+              (i32.and
+               (local.get $3)
+               (i32.const 65535)
+              )
+              (i32.const 16)
+             )
+             (i32.const 16)
+            )
+           )
+          )
+          (br $label$1)
+         )
+         (local.set $3
+          (i32.load
+           (local.tee $1
+            (i32.and
+             (i32.add
+              (i32.load
+               (local.get $2)
+              )
+              (i32.const 3)
+             )
+             (i32.const -4)
+            )
+           )
+          )
+         )
+         (i32.store
+          (local.get $2)
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+         )
+         (i64.store
+          (local.get $0)
+          (i64.extend_i32_u
+           (i32.and
+            (local.get $3)
+            (i32.const 65535)
+           )
+          )
+         )
+         (br $label$1)
+        )
+        (local.set $3
+         (i32.load
+          (local.tee $1
+           (i32.and
+            (i32.add
+             (i32.load
+              (local.get $2)
+             )
+             (i32.const 3)
+            )
+            (i32.const -4)
+           )
+          )
+         )
+        )
+        (i32.store
+         (local.get $2)
+         (i32.add
+          (local.get $1)
+          (i32.const 4)
+         )
+        )
+        (i64.store
+         (local.get $0)
+         (i64.extend_i32_s
+          (i32.shr_s
+           (i32.shl
+            (i32.and
+             (local.get $3)
+             (i32.const 255)
+            )
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+         )
+        )
+        (br $label$1)
+       )
+       (local.set $3
+        (i32.load
+         (local.tee $1
+          (i32.and
+           (i32.add
+            (i32.load
+             (local.get $2)
+            )
+            (i32.const 3)
+           )
+           (i32.const -4)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $2)
+        (i32.add
+         (local.get $1)
+         (i32.const 4)
+        )
+       )
+       (i64.store
+        (local.get $0)
+        (i64.extend_i32_u
+         (i32.and
+          (local.get $3)
+          (i32.const 255)
+         )
+        )
+       )
+       (br $label$1)
+      )
+      (local.set $5
+       (f64.load
+        (local.tee $1
+         (i32.and
+          (i32.add
+           (i32.load
+            (local.get $2)
+           )
+           (i32.const 7)
+          )
+          (i32.const -8)
+         )
+        )
+       )
+      )
+      (i32.store
+       (local.get $2)
+       (i32.add
+        (local.get $1)
+        (i32.const 8)
+       )
+      )
+      (f64.store
+       (local.get $0)
+       (local.get $5)
+      )
+      (br $label$1)
+     )
+     (local.set $5
+      (f64.load
+       (local.tee $1
+        (i32.and
+         (i32.add
+          (i32.load
+           (local.get $2)
+          )
+          (i32.const 7)
+         )
+         (i32.const -8)
+        )
+       )
+      )
+     )
+     (i32.store
+      (local.get $2)
+      (i32.add
+       (local.get $1)
+       (i32.const 8)
+      )
+     )
+     (f64.store
+      (local.get $0)
+      (local.get $5)
+     )
+    )
+   )
+  )
+ )
+ (func $23 (; 36 ;) (type $9) (param $0 i64) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i64)
+  (block $label$1 (result i32)
+   (local.set $2
+    (i32.wrap_i64
+     (local.get $0)
+    )
+   )
+   (if
+    (i64.gt_u
+     (local.get $0)
+     (i64.const 4294967295)
+    )
+    (block
+     (loop $label$3
+      (i64.store8
+       (local.tee $1
+        (i32.add
+         (local.get $1)
+         (i32.const -1)
+        )
+       )
+       (i64.or
+        (i64.rem_u
+         (local.get $0)
+         (i64.const 10)
+        )
+        (i64.const 48)
+       )
+      )
+      (local.set $4
+       (i64.div_u
+        (local.get $0)
+        (i64.const 10)
+       )
+      )
+      (if
+       (i64.gt_u
+        (local.get $0)
+        (i64.const 42949672959)
+       )
+       (block
+        (local.set $0
+         (local.get $4)
+        )
+        (br $label$3)
+       )
+      )
+     )
+     (local.set $2
+      (i32.wrap_i64
+       (local.get $4)
+      )
+     )
+    )
+   )
+   (if
+    (local.get $2)
+    (loop $label$6
+     (i32.store8
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const -1)
+       )
+      )
+      (i32.or
+       (i32.rem_u
+        (local.get $2)
+        (i32.const 10)
+       )
+       (i32.const 48)
+      )
+     )
+     (local.set $3
+      (i32.div_u
+       (local.get $2)
+       (i32.const 10)
+      )
+     )
+     (if
+      (i32.ge_u
+       (local.get $2)
+       (i32.const 10)
+      )
+      (block
+       (local.set $2
+        (local.get $3)
+       )
+       (br $label$6)
+      )
+     )
+    )
+   )
+   (local.get $1)
+  )
+ )
+ (func $24 (; 37 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.const 0)
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (loop $label$5
+       (br_if $label$4
+        (i32.eq
+         (i32.load8_u
+          (i32.add
+           (local.get $1)
+           (i32.const 1689)
+          )
+         )
+         (local.get $0)
+        )
+       )
+       (br_if $label$5
+        (i32.ne
+         (local.tee $1
+          (i32.add
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (i32.const 87)
+        )
+       )
+       (local.set $1
+        (i32.const 87)
+       )
+       (local.set $0
+        (i32.const 1777)
+       )
+       (br $label$3)
+      )
+     )
+     (if
+      (local.get $1)
+      (block
+       (local.set $0
+        (i32.const 1777)
+       )
+       (br $label$3)
+      )
+      (local.set $0
+       (i32.const 1777)
+      )
+     )
+     (br $label$2)
+    )
+    (loop $label$8
+     (local.set $2
+      (local.get $0)
+     )
+     (loop $label$9
+      (local.set $0
+       (i32.add
+        (local.get $2)
+        (i32.const 1)
+       )
+      )
+      (if
+       (i32.load8_s
+        (local.get $2)
+       )
+       (block
+        (local.set $2
+         (local.get $0)
+        )
+        (br $label$9)
+       )
+      )
+     )
+     (br_if $label$8
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const -1)
+       )
+      )
+     )
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $25 (; 38 ;) (type $10) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (block $label$1
+   (local.set $7
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 256)
+    )
+   )
+   (local.set $6
+    (local.get $7)
+   )
+   (block $label$2
+    (if
+     (i32.and
+      (i32.gt_s
+       (local.get $2)
+       (local.get $3)
+      )
+      (i32.eqz
+       (i32.and
+        (local.get $4)
+        (i32.const 73728)
+       )
+      )
+     )
+     (block
+      (drop
+       (call $41
+        (local.get $6)
+        (local.get $1)
+        (if (result i32)
+         (i32.gt_u
+          (local.tee $5
+           (i32.sub
+            (local.get $2)
+            (local.get $3)
+           )
+          )
+          (i32.const 256)
+         )
+         (i32.const 256)
+         (local.get $5)
+        )
+       )
+      )
+      (local.set $4
+       (i32.eqz
+        (i32.and
+         (local.tee $1
+          (i32.load
+           (local.get $0)
+          )
+         )
+         (i32.const 32)
+        )
+       )
+      )
+      (if
+       (i32.gt_u
+        (local.get $5)
+        (i32.const 255)
+       )
+       (block
+        (loop $label$7
+         (if
+          (local.get $4)
+          (block
+           (drop
+            (call $21
+             (local.get $6)
+             (i32.const 256)
+             (local.get $0)
+            )
+           )
+           (local.set $1
+            (i32.load
+             (local.get $0)
+            )
+           )
+          )
+         )
+         (local.set $4
+          (i32.eqz
+           (i32.and
+            (local.get $1)
+            (i32.const 32)
+           )
+          )
+         )
+         (br_if $label$7
+          (i32.gt_u
+           (local.tee $5
+            (i32.add
+             (local.get $5)
+             (i32.const -256)
+            )
+           )
+           (i32.const 255)
+          )
+         )
+        )
+        (br_if $label$2
+         (i32.eqz
+          (local.get $4)
+         )
+        )
+        (local.set $5
+         (i32.and
+          (i32.sub
+           (local.get $2)
+           (local.get $3)
+          )
+          (i32.const 255)
+         )
+        )
+       )
+       (br_if $label$2
+        (i32.eqz
+         (local.get $4)
+        )
+       )
+      )
+      (drop
+       (call $21
+        (local.get $6)
+        (local.get $5)
+        (local.get $0)
+       )
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $7)
+   )
+  )
+ )
+ (func $26 (; 39 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (if (result i32)
+   (local.get $0)
+   (call $29
+    (local.get $0)
+    (local.get $1)
+    (i32.const 0)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $27 (; 40 ;) (type $11) (param $0 f64) (param $1 i32) (result f64)
+  (call $28
+   (local.get $0)
+   (local.get $1)
+  )
+ )
+ (func $28 (; 41 ;) (type $11) (param $0 f64) (param $1 i32) (result f64)
+  (local $2 i64)
+  (local $3 i64)
+  (block $label$1 (result f64)
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (block $label$5
+       (br_table $label$5 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$4 $label$3
+        (i32.sub
+         (i32.shr_s
+          (i32.shl
+           (i32.and
+            (i32.and
+             (i32.wrap_i64
+              (local.tee $3
+               (i64.shr_u
+                (local.tee $2
+                 (i64.reinterpret_f64
+                  (local.get $0)
+                 )
+                )
+                (i64.const 52)
+               )
+              )
+             )
+             (i32.const 65535)
+            )
+            (i32.const 2047)
+           )
+           (i32.const 16)
+          )
+          (i32.const 16)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.store
+       (local.get $1)
+       (if (result i32)
+        (f64.ne
+         (local.get $0)
+         (f64.const 0)
+        )
+        (block (result i32)
+         (local.set $0
+          (call $28
+           (f64.mul
+            (local.get $0)
+            (f64.const 18446744073709551615)
+           )
+           (local.get $1)
+          )
+         )
+         (i32.add
+          (i32.load
+           (local.get $1)
+          )
+          (i32.const -64)
+         )
+        )
+        (i32.const 0)
+       )
+      )
+      (br $label$2)
+     )
+     (br $label$2)
+    )
+    (i32.store
+     (local.get $1)
+     (i32.add
+      (i32.and
+       (i32.wrap_i64
+        (local.get $3)
+       )
+       (i32.const 2047)
+      )
+      (i32.const -1022)
+     )
+    )
+    (local.set $0
+     (f64.reinterpret_i64
+      (i64.or
+       (i64.and
+        (local.get $2)
+        (i64.const -9218868437227405313)
+       )
+       (i64.const 4602678819172646912)
+      )
+     )
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $29 (; 42 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (block $label$1 (result i32)
+   (if (result i32)
+    (local.get $0)
+    (block (result i32)
+     (if
+      (i32.lt_u
+       (local.get $1)
+       (i32.const 128)
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (local.get $1)
+       )
+       (br $label$1
+        (i32.const 1)
+       )
+      )
+     )
+     (if
+      (i32.lt_u
+       (local.get $1)
+       (i32.const 2048)
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 6)
+         )
+         (i32.const 192)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (br $label$1
+        (i32.const 2)
+       )
+      )
+     )
+     (if
+      (i32.or
+       (i32.lt_u
+        (local.get $1)
+        (i32.const 55296)
+       )
+       (i32.eq
+        (i32.and
+         (local.get $1)
+         (i32.const -8192)
+        )
+        (i32.const 57344)
+       )
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 12)
+         )
+         (i32.const 224)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 6)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=2
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (br $label$1
+        (i32.const 3)
+       )
+      )
+     )
+     (if (result i32)
+      (i32.lt_u
+       (i32.add
+        (local.get $1)
+        (i32.const -65536)
+       )
+       (i32.const 1048576)
+      )
+      (block (result i32)
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 18)
+         )
+         (i32.const 240)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 12)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=2
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 6)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=3
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.const 4)
+      )
+      (block (result i32)
+       (i32.store
+        (call $12)
+        (i32.const 84)
+       )
+       (i32.const -1)
+      )
+     )
+    )
+    (i32.const 1)
+   )
+  )
+ )
+ (func $30 (; 43 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.load8_s
+     (local.tee $2
+      (i32.add
+       (local.get $0)
+       (i32.const 74)
+      )
+     )
+    )
+   )
+   (i32.store8
+    (local.get $2)
+    (i32.or
+     (i32.add
+      (local.get $1)
+      (i32.const 255)
+     )
+     (local.get $1)
+    )
+   )
+   (local.tee $0
+    (if (result i32)
+     (i32.and
+      (local.tee $1
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (i32.const 8)
+     )
+     (block (result i32)
+      (i32.store
+       (local.get $0)
+       (i32.or
+        (local.get $1)
+        (i32.const 32)
+       )
+      )
+      (i32.const -1)
+     )
+     (block (result i32)
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.store offset=28
+       (local.get $0)
+       (local.tee $1
+        (i32.load offset=44
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store offset=20
+       (local.get $0)
+       (local.get $1)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.add
+        (local.get $1)
+        (i32.load offset=48
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 0)
+     )
+    )
+   )
+  )
+ )
+ (func $31 (; 44 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (i32.eqz
+       (i32.and
+        (local.tee $2
+         (local.get $0)
+        )
+        (i32.const 3)
+       )
+      )
+     )
+     (local.set $1
+      (local.get $2)
+     )
+     (loop $label$4
+      (if
+       (i32.eqz
+        (i32.load8_s
+         (local.get $0)
+        )
+       )
+       (block
+        (local.set $0
+         (local.get $1)
+        )
+        (br $label$2)
+       )
+      )
+      (br_if $label$4
+       (i32.and
+        (local.tee $1
+         (local.tee $0
+          (i32.add
+           (local.get $0)
+           (i32.const 1)
+          )
+         )
+        )
+        (i32.const 3)
+       )
+      )
+      (br $label$3)
+     )
+    )
+    (loop $label$6
+     (local.set $1
+      (i32.add
+       (local.get $0)
+       (i32.const 4)
+      )
+     )
+     (if
+      (i32.eqz
+       (i32.and
+        (i32.xor
+         (i32.and
+          (local.tee $3
+           (i32.load
+            (local.get $0)
+           )
+          )
+          (i32.const -2139062144)
+         )
+         (i32.const -2139062144)
+        )
+        (i32.add
+         (local.get $3)
+         (i32.const -16843009)
+        )
+       )
+      )
+      (block
+       (local.set $0
+        (local.get $1)
+       )
+       (br $label$6)
+      )
+     )
+    )
+    (if
+     (i32.shr_s
+      (i32.shl
+       (i32.and
+        (local.get $3)
+        (i32.const 255)
+       )
+       (i32.const 24)
+      )
+      (i32.const 24)
+     )
+     (loop $label$9
+      (br_if $label$9
+       (i32.load8_s
+        (local.tee $0
+         (i32.add
+          (local.get $0)
+          (i32.const 1)
+         )
+        )
+       )
+      )
+     )
+    )
+   )
+   (i32.sub
+    (local.get $0)
+    (local.get $2)
+   )
+  )
+ )
+ (func $32 (; 45 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (block $label$1 (result i32)
+   (local.set $3
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store8
+    (local.tee $4
+     (local.get $3)
+    )
+    (local.tee $7
+     (i32.and
+      (local.get $1)
+      (i32.const 255)
+     )
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (local.tee $5
+       (i32.load
+        (local.tee $2
+         (i32.add
+          (local.get $0)
+          (i32.const 16)
+         )
+        )
+       )
+      )
+     )
+     (if
+      (call $30
+       (local.get $0)
+      )
+      (local.set $1
+       (i32.const -1)
+      )
+      (block
+       (local.set $5
+        (i32.load
+         (local.get $2)
+        )
+       )
+       (br $label$3)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.lt_u
+      (local.tee $6
+       (i32.load
+        (local.tee $2
+         (i32.add
+          (local.get $0)
+          (i32.const 20)
+         )
+        )
+       )
+      )
+      (local.get $5)
+     )
+     (if
+      (i32.ne
+       (local.tee $1
+        (i32.and
+         (local.get $1)
+         (i32.const 255)
+        )
+       )
+       (i32.load8_s offset=75
+        (local.get $0)
+       )
+      )
+      (block
+       (i32.store
+        (local.get $2)
+        (i32.add
+         (local.get $6)
+         (i32.const 1)
+        )
+       )
+       (i32.store8
+        (local.get $6)
+        (local.get $7)
+       )
+       (br $label$2)
+      )
+     )
+    )
+    (local.set $1
+     (if (result i32)
+      (i32.eq
+       (call_indirect (type $0)
+        (local.get $0)
+        (local.get $4)
+        (i32.const 1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (local.get $0)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
+       )
+       (i32.const 1)
+      )
+      (i32.load8_u
+       (local.get $4)
+      )
+      (i32.const -1)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $3)
+   )
+   (local.get $1)
+  )
+ )
+ (func $33 (; 46 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (i32.mul
+     (local.get $2)
+     (local.get $1)
+    )
+   )
+   (if
+    (i32.gt_s
+     (i32.load offset=76
+      (local.get $3)
+     )
+     (i32.const -1)
+    )
+    (block
+     (local.set $5
+      (i32.eqz
+       (call $20
+        (local.get $3)
+       )
+      )
+     )
+     (local.set $0
+      (call $21
+       (local.get $0)
+       (local.get $4)
+       (local.get $3)
+      )
+     )
+     (if
+      (i32.eqz
+       (local.get $5)
+      )
+      (call $13
+       (local.get $3)
+      )
+     )
+    )
+    (local.set $0
+     (call $21
+      (local.get $0)
+      (local.get $4)
+      (local.get $3)
+     )
+    )
+   )
+   (if
+    (i32.ne
+     (local.get $0)
+     (local.get $4)
+    )
+    (local.set $2
+     (i32.div_u
+      (local.get $0)
+      (local.get $1)
+     )
+    )
+   )
+   (local.get $2)
+  )
+ )
+ (func $34 (; 47 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (local.set $2
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store
+    (local.tee $3
+     (local.get $2)
+    )
+    (local.get $1)
+   )
+   (local.set $0
+    (call $18
+     (i32.load
+      (i32.const 1024)
+     )
+     (local.get $0)
+     (local.get $3)
+    )
+   )
+   (global.set $global$1
+    (local.get $2)
+   )
+   (local.get $0)
+  )
+ )
+ (func $35 (; 48 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (local.set $2
+    (if (result i32)
+     (i32.gt_s
+      (i32.load offset=76
+       (local.tee $1
+        (i32.load
+         (i32.const 1024)
+        )
+       )
+      )
+      (i32.const -1)
+     )
+     (call $20
+      (local.get $1)
+     )
+     (i32.const 0)
+    )
+   )
+   (local.set $0
+    (block $label$4 (result i32)
+     (if (result i32)
+      (i32.lt_s
+       (call $36
+        (local.get $0)
+        (local.get $1)
+       )
+       (i32.const 0)
+      )
+      (i32.const 1)
+      (block (result i32)
+       (if
+        (i32.ne
+         (i32.load8_s offset=75
+          (local.get $1)
+         )
+         (i32.const 10)
+        )
+        (if
+         (i32.lt_u
+          (local.tee $0
+           (i32.load
+            (local.tee $3
+             (i32.add
+              (local.get $1)
+              (i32.const 20)
+             )
+            )
+           )
+          )
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (block
+          (i32.store
+           (local.get $3)
+           (i32.add
+            (local.get $0)
+            (i32.const 1)
+           )
+          )
+          (i32.store8
+           (local.get $0)
+           (i32.const 10)
+          )
+          (br $label$4
+           (i32.const 0)
+          )
+         )
+        )
+       )
+       (i32.lt_s
+        (call $32
+         (local.get $1)
+         (i32.const 10)
+        )
+        (i32.const 0)
+       )
+      )
+     )
+    )
+   )
+   (if
+    (local.get $2)
+    (call $13
+     (local.get $1)
+    )
+   )
+   (i32.shr_s
+    (i32.shl
+     (local.get $0)
+     (i32.const 31)
+    )
+    (i32.const 31)
+   )
+  )
+ )
+ (func $36 (; 49 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (i32.add
+   (call $33
+    (local.get $0)
+    (call $31
+     (local.get $0)
+    )
+    (i32.const 1)
+    (local.get $1)
+   )
+   (i32.const -1)
+  )
+ )
+ (func $37 (; 50 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (block $label$1 (result i32)
+   (local.set $14
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (local.set $18
+    (local.get $14)
+   )
+   (block $label$2
+    (if
+     (i32.lt_u
+      (local.get $0)
+      (i32.const 245)
+     )
+     (block
+      (local.set $3
+       (i32.and
+        (i32.add
+         (local.get $0)
+         (i32.const 11)
+        )
+        (i32.const -8)
+       )
+      )
+      (if
+       (i32.and
+        (local.tee $0
+         (i32.shr_u
+          (local.tee $8
+           (i32.load
+            (i32.const 3636)
+           )
+          )
+          (local.tee $2
+           (i32.shr_u
+            (if (result i32)
+             (i32.lt_u
+              (local.get $0)
+              (i32.const 11)
+             )
+             (local.tee $3
+              (i32.const 16)
+             )
+             (local.get $3)
+            )
+            (i32.const 3)
+           )
+          )
+         )
+        )
+        (i32.const 3)
+       )
+       (block
+        (local.set $4
+         (i32.load
+          (local.tee $1
+           (i32.add
+            (local.tee $7
+             (i32.load
+              (local.tee $3
+               (i32.add
+                (local.tee $2
+                 (i32.add
+                  (i32.shl
+                   (i32.shl
+                    (local.tee $5
+                     (i32.add
+                      (i32.xor
+                       (i32.and
+                        (local.get $0)
+                        (i32.const 1)
+                       )
+                       (i32.const 1)
+                      )
+                      (local.get $2)
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (i32.const 2)
+                  )
+                  (i32.const 3676)
+                 )
+                )
+                (i32.const 8)
+               )
+              )
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $4)
+         )
+         (i32.store
+          (i32.const 3636)
+          (i32.and
+           (local.get $8)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (local.get $5)
+            )
+            (i32.const -1)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $4)
+            (i32.load
+             (i32.const 3652)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $0
+              (i32.add
+               (local.get $4)
+               (i32.const 12)
+              )
+             )
+            )
+            (local.get $7)
+           )
+           (block
+            (i32.store
+             (local.get $0)
+             (local.get $2)
+            )
+            (i32.store
+             (local.get $3)
+             (local.get $4)
+            )
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (i32.store offset=4
+         (local.get $7)
+         (i32.or
+          (local.tee $0
+           (i32.shl
+            (local.get $5)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (local.tee $0
+          (i32.add
+           (i32.add
+            (local.get $7)
+            (local.get $0)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 1)
+         )
+        )
+        (global.set $global$1
+         (local.get $14)
+        )
+        (return
+         (local.get $1)
+        )
+       )
+      )
+      (if
+       (i32.gt_u
+        (local.get $3)
+        (local.tee $16
+         (i32.load
+          (i32.const 3644)
+         )
+        )
+       )
+       (block
+        (if
+         (local.get $0)
+         (block
+          (local.set $5
+           (i32.and
+            (i32.shr_u
+             (local.tee $0
+              (i32.add
+               (i32.and
+                (local.tee $0
+                 (i32.and
+                  (i32.shl
+                   (local.get $0)
+                   (local.get $2)
+                  )
+                  (i32.or
+                   (local.tee $0
+                    (i32.shl
+                     (i32.const 2)
+                     (local.get $2)
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (local.get $0)
+                   )
+                  )
+                 )
+                )
+                (i32.sub
+                 (i32.const 0)
+                 (local.get $0)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (local.set $12
+           (i32.load
+            (local.tee $5
+             (i32.add
+              (local.tee $9
+               (i32.load
+                (local.tee $2
+                 (i32.add
+                  (local.tee $4
+                   (i32.add
+                    (i32.shl
+                     (i32.shl
+                      (local.tee $11
+                       (i32.add
+                        (i32.or
+                         (i32.or
+                          (i32.or
+                           (i32.or
+                            (local.tee $0
+                             (i32.and
+                              (i32.shr_u
+                               (local.tee $2
+                                (i32.shr_u
+                                 (local.get $0)
+                                 (local.get $5)
+                                )
+                               )
+                               (i32.const 5)
+                              )
+                              (i32.const 8)
+                             )
+                            )
+                            (local.get $5)
+                           )
+                           (local.tee $0
+                            (i32.and
+                             (i32.shr_u
+                              (local.tee $2
+                               (i32.shr_u
+                                (local.get $2)
+                                (local.get $0)
+                               )
+                              )
+                              (i32.const 2)
+                             )
+                             (i32.const 4)
+                            )
+                           )
+                          )
+                          (local.tee $0
+                           (i32.and
+                            (i32.shr_u
+                             (local.tee $2
+                              (i32.shr_u
+                               (local.get $2)
+                               (local.get $0)
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                         (local.tee $0
+                          (i32.and
+                           (i32.shr_u
+                            (local.tee $2
+                             (i32.shr_u
+                              (local.get $2)
+                              (local.get $0)
+                             )
+                            )
+                            (i32.const 1)
+                           )
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (i32.shr_u
+                         (local.get $2)
+                         (local.get $0)
+                        )
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 2)
+                    )
+                    (i32.const 3676)
+                   )
+                  )
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (if
+           (i32.eq
+            (local.get $4)
+            (local.get $12)
+           )
+           (i32.store
+            (i32.const 3636)
+            (local.tee $7
+             (i32.and
+              (local.get $8)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (local.get $11)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $12)
+              (i32.load
+               (i32.const 3652)
+              )
+             )
+             (call $fimport$10)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (local.tee $0
+                (i32.add
+                 (local.get $12)
+                 (i32.const 12)
+                )
+               )
+              )
+              (local.get $9)
+             )
+             (block
+              (i32.store
+               (local.get $0)
+               (local.get $4)
+              )
+              (i32.store
+               (local.get $2)
+               (local.get $12)
+              )
+              (local.set $7
+               (local.get $8)
+              )
+             )
+             (call $fimport$10)
+            )
+           )
+          )
+          (i32.store offset=4
+           (local.get $9)
+           (i32.or
+            (local.get $3)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (local.tee $4
+            (i32.add
+             (local.get $9)
+             (local.get $3)
+            )
+           )
+           (i32.or
+            (local.tee $11
+             (i32.sub
+              (i32.shl
+               (local.get $11)
+               (i32.const 3)
+              )
+              (local.get $3)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (local.get $4)
+            (local.get $11)
+           )
+           (local.get $11)
+          )
+          (if
+           (local.get $16)
+           (block
+            (local.set $9
+             (i32.load
+              (i32.const 3656)
+             )
+            )
+            (local.set $2
+             (i32.add
+              (i32.shl
+               (i32.shl
+                (local.tee $0
+                 (i32.shr_u
+                  (local.get $16)
+                  (i32.const 3)
+                 )
+                )
+                (i32.const 1)
+               )
+               (i32.const 2)
+              )
+              (i32.const 3676)
+             )
+            )
+            (if
+             (i32.and
+              (local.get $7)
+              (local.tee $0
+               (i32.shl
+                (i32.const 1)
+                (local.get $0)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.tee $0
+                (i32.load
+                 (local.tee $3
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 8)
+                  )
+                 )
+                )
+               )
+               (i32.load
+                (i32.const 3652)
+               )
+              )
+              (call $fimport$10)
+              (block
+               (local.set $6
+                (local.get $3)
+               )
+               (local.set $1
+                (local.get $0)
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 3636)
+               (i32.or
+                (local.get $7)
+                (local.get $0)
+               )
+              )
+              (local.set $6
+               (i32.add
+                (local.get $2)
+                (i32.const 8)
+               )
+              )
+              (local.set $1
+               (local.get $2)
+              )
+             )
+            )
+            (i32.store
+             (local.get $6)
+             (local.get $9)
+            )
+            (i32.store offset=12
+             (local.get $1)
+             (local.get $9)
+            )
+            (i32.store offset=8
+             (local.get $9)
+             (local.get $1)
+            )
+            (i32.store offset=12
+             (local.get $9)
+             (local.get $2)
+            )
+           )
+          )
+          (i32.store
+           (i32.const 3644)
+           (local.get $11)
+          )
+          (i32.store
+           (i32.const 3656)
+           (local.get $4)
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (local.get $5)
+          )
+         )
+        )
+        (if
+         (local.tee $6
+          (i32.load
+           (i32.const 3640)
+          )
+         )
+         (block
+          (local.set $2
+           (i32.and
+            (i32.shr_u
+             (local.tee $0
+              (i32.add
+               (i32.and
+                (local.get $6)
+                (i32.sub
+                 (i32.const 0)
+                 (local.get $6)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (local.set $9
+           (i32.sub
+            (i32.and
+             (i32.load offset=4
+              (local.tee $2
+               (i32.load
+                (i32.add
+                 (i32.shl
+                  (i32.add
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (i32.or
+                       (local.tee $0
+                        (i32.and
+                         (i32.shr_u
+                          (local.tee $1
+                           (i32.shr_u
+                            (local.get $0)
+                            (local.get $2)
+                           )
+                          )
+                          (i32.const 5)
+                         )
+                         (i32.const 8)
+                        )
+                       )
+                       (local.get $2)
+                      )
+                      (local.tee $0
+                       (i32.and
+                        (i32.shr_u
+                         (local.tee $1
+                          (i32.shr_u
+                           (local.get $1)
+                           (local.get $0)
+                          )
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (local.tee $1
+                         (i32.shr_u
+                          (local.get $1)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 1)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (local.tee $1
+                        (i32.shr_u
+                         (local.get $1)
+                         (local.get $0)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.shr_u
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3940)
+                )
+               )
+              )
+             )
+             (i32.const -8)
+            )
+            (local.get $3)
+           )
+          )
+          (local.set $1
+           (local.get $2)
+          )
+          (loop $label$25
+           (block $label$26
+            (if
+             (i32.eqz
+              (local.tee $0
+               (i32.load offset=16
+                (local.get $1)
+               )
+              )
+             )
+             (br_if $label$26
+              (i32.eqz
+               (local.tee $0
+                (i32.load offset=20
+                 (local.get $1)
+                )
+               )
+              )
+             )
+            )
+            (if
+             (local.tee $7
+              (i32.lt_u
+               (local.tee $1
+                (i32.sub
+                 (i32.and
+                  (i32.load offset=4
+                   (local.get $0)
+                  )
+                  (i32.const -8)
+                 )
+                 (local.get $3)
+                )
+               )
+               (local.get $9)
+              )
+             )
+             (local.set $9
+              (local.get $1)
+             )
+            )
+            (local.set $1
+             (local.get $0)
+            )
+            (if
+             (local.get $7)
+             (local.set $2
+              (local.get $0)
+             )
+            )
+            (br $label$25)
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $2)
+            (local.tee $12
+             (i32.load
+              (i32.const 3652)
+             )
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.ge_u
+            (local.get $2)
+            (local.tee $13
+             (i32.add
+              (local.get $2)
+              (local.get $3)
+             )
+            )
+           )
+           (call $fimport$10)
+          )
+          (local.set $15
+           (i32.load offset=24
+            (local.get $2)
+           )
+          )
+          (block $label$32
+           (if
+            (i32.eq
+             (local.tee $0
+              (i32.load offset=12
+               (local.get $2)
+              )
+             )
+             (local.get $2)
+            )
+            (block
+             (if
+              (i32.eqz
+               (local.tee $0
+                (i32.load
+                 (local.tee $1
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+              )
+              (if
+               (i32.eqz
+                (local.tee $0
+                 (i32.load
+                  (local.tee $1
+                   (i32.add
+                    (local.get $2)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $4
+                 (i32.const 0)
+                )
+                (br $label$32)
+               )
+              )
+             )
+             (loop $label$36
+              (if
+               (local.tee $7
+                (i32.load
+                 (local.tee $11
+                  (i32.add
+                   (local.get $0)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $0
+                 (local.get $7)
+                )
+                (local.set $1
+                 (local.get $11)
+                )
+                (br $label$36)
+               )
+              )
+              (if
+               (local.tee $7
+                (i32.load
+                 (local.tee $11
+                  (i32.add
+                   (local.get $0)
+                   (i32.const 16)
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $0
+                 (local.get $7)
+                )
+                (local.set $1
+                 (local.get $11)
+                )
+                (br $label$36)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $1)
+               (local.get $12)
+              )
+              (call $fimport$10)
+              (block
+               (i32.store
+                (local.get $1)
+                (i32.const 0)
+               )
+               (local.set $4
+                (local.get $0)
+               )
+              )
+             )
+            )
+            (block
+             (if
+              (i32.lt_u
+               (local.tee $11
+                (i32.load offset=8
+                 (local.get $2)
+                )
+               )
+               (local.get $12)
+              )
+              (call $fimport$10)
+             )
+             (if
+              (i32.ne
+               (i32.load
+                (local.tee $7
+                 (i32.add
+                  (local.get $11)
+                  (i32.const 12)
+                 )
+                )
+               )
+               (local.get $2)
+              )
+              (call $fimport$10)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (local.tee $1
+                 (i32.add
+                  (local.get $0)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (local.get $2)
+              )
+              (block
+               (i32.store
+                (local.get $7)
+                (local.get $0)
+               )
+               (i32.store
+                (local.get $1)
+                (local.get $11)
+               )
+               (local.set $4
+                (local.get $0)
+               )
+              )
+              (call $fimport$10)
+             )
+            )
+           )
+          )
+          (block $label$46
+           (if
+            (local.get $15)
+            (block
+             (if
+              (i32.eq
+               (local.get $2)
+               (i32.load
+                (local.tee $0
+                 (i32.add
+                  (i32.shl
+                   (local.tee $1
+                    (i32.load offset=28
+                     (local.get $2)
+                    )
+                   )
+                   (i32.const 2)
+                  )
+                  (i32.const 3940)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (local.get $0)
+                (local.get $4)
+               )
+               (if
+                (i32.eqz
+                 (local.get $4)
+                )
+                (block
+                 (i32.store
+                  (i32.const 3640)
+                  (i32.and
+                   (local.get $6)
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (local.get $1)
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                 )
+                 (br $label$46)
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (local.get $15)
+                 (i32.load
+                  (i32.const 3652)
+                 )
+                )
+                (call $fimport$10)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (local.tee $0
+                   (i32.add
+                    (local.get $15)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                 (local.get $2)
+                )
+                (i32.store
+                 (local.get $0)
+                 (local.get $4)
+                )
+                (i32.store offset=20
+                 (local.get $15)
+                 (local.get $4)
+                )
+               )
+               (br_if $label$46
+                (i32.eqz
+                 (local.get $4)
+                )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $4)
+               (local.tee $0
+                (i32.load
+                 (i32.const 3652)
+                )
+               )
+              )
+              (call $fimport$10)
+             )
+             (i32.store offset=24
+              (local.get $4)
+              (local.get $15)
+             )
+             (if
+              (local.tee $1
+               (i32.load offset=16
+                (local.get $2)
+               )
+              )
+              (if
+               (i32.lt_u
+                (local.get $1)
+                (local.get $0)
+               )
+               (call $fimport$10)
+               (block
+                (i32.store offset=16
+                 (local.get $4)
+                 (local.get $1)
+                )
+                (i32.store offset=24
+                 (local.get $1)
+                 (local.get $4)
+                )
+               )
+              )
+             )
+             (if
+              (local.tee $0
+               (i32.load offset=20
+                (local.get $2)
+               )
+              )
+              (if
+               (i32.lt_u
+                (local.get $0)
+                (i32.load
+                 (i32.const 3652)
+                )
+               )
+               (call $fimport$10)
+               (block
+                (i32.store offset=20
+                 (local.get $4)
+                 (local.get $0)
+                )
+                (i32.store offset=24
+                 (local.get $0)
+                 (local.get $4)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $9)
+            (i32.const 16)
+           )
+           (block
+            (i32.store offset=4
+             (local.get $2)
+             (i32.or
+              (local.tee $0
+               (i32.add
+                (local.get $9)
+                (local.get $3)
+               )
+              )
+              (i32.const 3)
+             )
+            )
+            (i32.store
+             (local.tee $0
+              (i32.add
+               (i32.add
+                (local.get $2)
+                (local.get $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (local.get $0)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block
+            (i32.store offset=4
+             (local.get $2)
+             (i32.or
+              (local.get $3)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (local.get $13)
+             (i32.or
+              (local.get $9)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (local.get $13)
+              (local.get $9)
+             )
+             (local.get $9)
+            )
+            (if
+             (local.get $16)
+             (block
+              (local.set $7
+               (i32.load
+                (i32.const 3656)
+               )
+              )
+              (local.set $3
+               (i32.add
+                (i32.shl
+                 (i32.shl
+                  (local.tee $0
+                   (i32.shr_u
+                    (local.get $16)
+                    (i32.const 3)
+                   )
+                  )
+                  (i32.const 1)
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 3676)
+               )
+              )
+              (if
+               (i32.and
+                (local.get $8)
+                (local.tee $0
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $0)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.tee $0
+                  (i32.load
+                   (local.tee $1
+                    (i32.add
+                     (local.get $3)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (i32.load
+                  (i32.const 3652)
+                 )
+                )
+                (call $fimport$10)
+                (block
+                 (local.set $10
+                  (local.get $1)
+                 )
+                 (local.set $5
+                  (local.get $0)
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (i32.const 3636)
+                 (i32.or
+                  (local.get $8)
+                  (local.get $0)
+                 )
+                )
+                (local.set $10
+                 (i32.add
+                  (local.get $3)
+                  (i32.const 8)
+                 )
+                )
+                (local.set $5
+                 (local.get $3)
+                )
+               )
+              )
+              (i32.store
+               (local.get $10)
+               (local.get $7)
+              )
+              (i32.store offset=12
+               (local.get $5)
+               (local.get $7)
+              )
+              (i32.store offset=8
+               (local.get $7)
+               (local.get $5)
+              )
+              (i32.store offset=12
+               (local.get $7)
+               (local.get $3)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 3644)
+             (local.get $9)
+            )
+            (i32.store
+             (i32.const 3656)
+             (local.get $13)
+            )
+           )
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (i32.add
+            (local.get $2)
+            (i32.const 8)
+           )
+          )
+         )
+         (local.set $0
+          (local.get $3)
+         )
+        )
+       )
+       (local.set $0
+        (local.get $3)
+       )
+      )
+     )
+     (if
+      (i32.gt_u
+       (local.get $0)
+       (i32.const -65)
+      )
+      (local.set $0
+       (i32.const -1)
+      )
+      (block
+       (local.set $7
+        (i32.and
+         (local.tee $0
+          (i32.add
+           (local.get $0)
+           (i32.const 11)
+          )
+         )
+         (i32.const -8)
+        )
+       )
+       (if
+        (local.tee $5
+         (i32.load
+          (i32.const 3640)
+         )
+        )
+        (block
+         (local.set $17
+          (if (result i32)
+           (local.tee $0
+            (i32.shr_u
+             (local.get $0)
+             (i32.const 8)
+            )
+           )
+           (if (result i32)
+            (i32.gt_u
+             (local.get $7)
+             (i32.const 16777215)
+            )
+            (i32.const 31)
+            (i32.or
+             (i32.and
+              (i32.shr_u
+               (local.get $7)
+               (i32.add
+                (local.tee $0
+                 (i32.add
+                  (i32.sub
+                   (i32.const 14)
+                   (i32.or
+                    (i32.or
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (i32.add
+                         (local.tee $1
+                          (i32.shl
+                           (local.get $0)
+                           (local.tee $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 1048320)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 8)
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 520192)
+                        )
+                        (i32.const 16)
+                       )
+                       (i32.const 4)
+                      )
+                     )
+                     (local.get $3)
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (i32.add
+                        (local.tee $1
+                         (i32.shl
+                          (local.get $1)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 245760)
+                       )
+                       (i32.const 16)
+                      )
+                      (i32.const 2)
+                     )
+                    )
+                   )
+                  )
+                  (i32.shr_u
+                   (i32.shl
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                   (i32.const 15)
+                  )
+                 )
+                )
+                (i32.const 7)
+               )
+              )
+              (i32.const 1)
+             )
+             (i32.shl
+              (local.get $0)
+              (i32.const 1)
+             )
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (local.set $3
+          (i32.sub
+           (i32.const 0)
+           (local.get $7)
+          )
+         )
+         (block $label$78
+          (block $label$79
+           (block $label$80
+            (if
+             (local.tee $1
+              (i32.load
+               (i32.add
+                (i32.shl
+                 (local.get $17)
+                 (i32.const 2)
+                )
+                (i32.const 3940)
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (i32.sub
+                (i32.const 25)
+                (i32.shr_u
+                 (local.get $17)
+                 (i32.const 1)
+                )
+               )
+              )
+              (local.set $4
+               (i32.const 0)
+              )
+              (local.set $10
+               (i32.shl
+                (local.get $7)
+                (if (result i32)
+                 (i32.eq
+                  (local.get $17)
+                  (i32.const 31)
+                 )
+                 (i32.const 0)
+                 (local.get $0)
+                )
+               )
+              )
+              (local.set $0
+               (i32.const 0)
+              )
+              (loop $label$84
+               (if
+                (i32.lt_u
+                 (local.tee $6
+                  (i32.sub
+                   (i32.and
+                    (i32.load offset=4
+                     (local.get $1)
+                    )
+                    (i32.const -8)
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (local.get $3)
+                )
+                (if
+                 (local.get $6)
+                 (block
+                  (local.set $3
+                   (local.get $6)
+                  )
+                  (local.set $0
+                   (local.get $1)
+                  )
+                 )
+                 (block
+                  (local.set $3
+                   (i32.const 0)
+                  )
+                  (local.set $0
+                   (local.get $1)
+                  )
+                  (br $label$79)
+                 )
+                )
+               )
+               (local.set $1
+                (if (result i32)
+                 (i32.or
+                  (i32.eqz
+                   (local.tee $19
+                    (i32.load offset=20
+                     (local.get $1)
+                    )
+                   )
+                  )
+                  (i32.eq
+                   (local.get $19)
+                   (local.tee $6
+                    (i32.load
+                     (i32.add
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 16)
+                      )
+                      (i32.shl
+                       (i32.shr_u
+                        (local.get $10)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (local.get $4)
+                 (local.get $19)
+                )
+               )
+               (local.set $10
+                (i32.shl
+                 (local.get $10)
+                 (i32.xor
+                  (i32.and
+                   (local.tee $4
+                    (i32.eqz
+                     (local.get $6)
+                    )
+                   )
+                   (i32.const 1)
+                  )
+                  (i32.const 1)
+                 )
+                )
+               )
+               (if
+                (local.get $4)
+                (block
+                 (local.set $4
+                  (local.get $1)
+                 )
+                 (local.set $1
+                  (local.get $0)
+                 )
+                 (br $label$80)
+                )
+                (block
+                 (local.set $4
+                  (local.get $1)
+                 )
+                 (local.set $1
+                  (local.get $6)
+                 )
+                 (br $label$84)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $4
+               (i32.const 0)
+              )
+              (local.set $1
+               (i32.const 0)
+              )
+             )
+            )
+           )
+           (br_if $label$79
+            (local.tee $0
+             (if (result i32)
+              (i32.and
+               (i32.eqz
+                (local.get $4)
+               )
+               (i32.eqz
+                (local.get $1)
+               )
+              )
+              (block (result i32)
+               (if
+                (i32.eqz
+                 (local.tee $0
+                  (i32.and
+                   (local.get $5)
+                   (i32.or
+                    (local.tee $0
+                     (i32.shl
+                      (i32.const 2)
+                      (local.get $17)
+                     )
+                    )
+                    (i32.sub
+                     (i32.const 0)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                 )
+                )
+                (block
+                 (local.set $0
+                  (local.get $7)
+                 )
+                 (br $label$2)
+                )
+               )
+               (local.set $10
+                (i32.and
+                 (i32.shr_u
+                  (local.tee $0
+                   (i32.add
+                    (i32.and
+                     (local.get $0)
+                     (i32.sub
+                      (i32.const 0)
+                      (local.get $0)
+                     )
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                  (i32.const 12)
+                 )
+                 (i32.const 16)
+                )
+               )
+               (i32.load
+                (i32.add
+                 (i32.shl
+                  (i32.add
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (i32.or
+                       (local.tee $0
+                        (i32.and
+                         (i32.shr_u
+                          (local.tee $4
+                           (i32.shr_u
+                            (local.get $0)
+                            (local.get $10)
+                           )
+                          )
+                          (i32.const 5)
+                         )
+                         (i32.const 8)
+                        )
+                       )
+                       (local.get $10)
+                      )
+                      (local.tee $0
+                       (i32.and
+                        (i32.shr_u
+                         (local.tee $4
+                          (i32.shr_u
+                           (local.get $4)
+                           (local.get $0)
+                          )
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (local.tee $4
+                         (i32.shr_u
+                          (local.get $4)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 1)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (local.tee $4
+                        (i32.shr_u
+                         (local.get $4)
+                         (local.get $0)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.shr_u
+                    (local.get $4)
+                    (local.get $0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3940)
+                )
+               )
+              )
+              (local.get $4)
+             )
+            )
+           )
+           (local.set $4
+            (local.get $1)
+           )
+           (br $label$78)
+          )
+          (loop $label$96
+           (if
+            (local.tee $10
+             (i32.lt_u
+              (local.tee $4
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (local.get $0)
+                 )
+                 (i32.const -8)
+                )
+                (local.get $7)
+               )
+              )
+              (local.get $3)
+             )
+            )
+            (local.set $3
+             (local.get $4)
+            )
+           )
+           (if
+            (local.get $10)
+            (local.set $1
+             (local.get $0)
+            )
+           )
+           (if
+            (local.tee $4
+             (i32.load offset=16
+              (local.get $0)
+             )
+            )
+            (block
+             (local.set $0
+              (local.get $4)
+             )
+             (br $label$96)
+            )
+           )
+           (br_if $label$96
+            (local.tee $0
+             (i32.load offset=20
+              (local.get $0)
+             )
+            )
+           )
+           (local.set $4
+            (local.get $1)
+           )
+          )
+         )
+         (if
+          (local.get $4)
+          (if
+           (i32.lt_u
+            (local.get $3)
+            (i32.sub
+             (i32.load
+              (i32.const 3644)
+             )
+             (local.get $7)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $4)
+              (local.tee $12
+               (i32.load
+                (i32.const 3652)
+               )
+              )
+             )
+             (call $fimport$10)
+            )
+            (if
+             (i32.ge_u
+              (local.get $4)
+              (local.tee $6
+               (i32.add
+                (local.get $4)
+                (local.get $7)
+               )
+              )
+             )
+             (call $fimport$10)
+            )
+            (local.set $10
+             (i32.load offset=24
+              (local.get $4)
+             )
+            )
+            (block $label$104
+             (if
+              (i32.eq
+               (local.tee $0
+                (i32.load offset=12
+                 (local.get $4)
+                )
+               )
+               (local.get $4)
+              )
+              (block
+               (if
+                (i32.eqz
+                 (local.tee $0
+                  (i32.load
+                   (local.tee $1
+                    (i32.add
+                     (local.get $4)
+                     (i32.const 20)
+                    )
+                   )
+                  )
+                 )
+                )
+                (if
+                 (i32.eqz
+                  (local.tee $0
+                   (i32.load
+                    (local.tee $1
+                     (i32.add
+                      (local.get $4)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $13
+                   (i32.const 0)
+                  )
+                  (br $label$104)
+                 )
+                )
+               )
+               (loop $label$108
+                (if
+                 (local.tee $11
+                  (i32.load
+                   (local.tee $9
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 20)
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $0
+                   (local.get $11)
+                  )
+                  (local.set $1
+                   (local.get $9)
+                  )
+                  (br $label$108)
+                 )
+                )
+                (if
+                 (local.tee $11
+                  (i32.load
+                   (local.tee $9
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $0
+                   (local.get $11)
+                  )
+                  (local.set $1
+                   (local.get $9)
+                  )
+                  (br $label$108)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $1)
+                 (local.get $12)
+                )
+                (call $fimport$10)
+                (block
+                 (i32.store
+                  (local.get $1)
+                  (i32.const 0)
+                 )
+                 (local.set $13
+                  (local.get $0)
+                 )
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (local.tee $9
+                  (i32.load offset=8
+                   (local.get $4)
+                  )
+                 )
+                 (local.get $12)
+                )
+                (call $fimport$10)
+               )
+               (if
+                (i32.ne
+                 (i32.load
+                  (local.tee $11
+                   (i32.add
+                    (local.get $9)
+                    (i32.const 12)
+                   )
+                  )
+                 )
+                 (local.get $4)
+                )
+                (call $fimport$10)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (local.tee $1
+                   (i32.add
+                    (local.get $0)
+                    (i32.const 8)
+                   )
+                  )
+                 )
+                 (local.get $4)
+                )
+                (block
+                 (i32.store
+                  (local.get $11)
+                  (local.get $0)
+                 )
+                 (i32.store
+                  (local.get $1)
+                  (local.get $9)
+                 )
+                 (local.set $13
+                  (local.get $0)
+                 )
+                )
+                (call $fimport$10)
+               )
+              )
+             )
+            )
+            (block $label$118
+             (if
+              (local.get $10)
+              (block
+               (if
+                (i32.eq
+                 (local.get $4)
+                 (i32.load
+                  (local.tee $0
+                   (i32.add
+                    (i32.shl
+                     (local.tee $1
+                      (i32.load offset=28
+                       (local.get $4)
+                      )
+                     )
+                     (i32.const 2)
+                    )
+                    (i32.const 3940)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (local.get $0)
+                  (local.get $13)
+                 )
+                 (if
+                  (i32.eqz
+                   (local.get $13)
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 3640)
+                    (local.tee $2
+                     (i32.and
+                      (local.get $5)
+                      (i32.xor
+                       (i32.shl
+                        (i32.const 1)
+                        (local.get $1)
+                       )
+                       (i32.const -1)
+                      )
+                     )
+                    )
+                   )
+                   (br $label$118)
+                  )
+                 )
+                )
+                (block
+                 (if
+                  (i32.lt_u
+                   (local.get $10)
+                   (i32.load
+                    (i32.const 3652)
+                   )
+                  )
+                  (call $fimport$10)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (local.tee $0
+                     (i32.add
+                      (local.get $10)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                   (local.get $4)
+                  )
+                  (i32.store
+                   (local.get $0)
+                   (local.get $13)
+                  )
+                  (i32.store offset=20
+                   (local.get $10)
+                   (local.get $13)
+                  )
+                 )
+                 (if
+                  (i32.eqz
+                   (local.get $13)
+                  )
+                  (block
+                   (local.set $2
+                    (local.get $5)
+                   )
+                   (br $label$118)
+                  )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $13)
+                 (local.tee $0
+                  (i32.load
+                   (i32.const 3652)
+                  )
+                 )
+                )
+                (call $fimport$10)
+               )
+               (i32.store offset=24
+                (local.get $13)
+                (local.get $10)
+               )
+               (if
+                (local.tee $1
+                 (i32.load offset=16
+                  (local.get $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (local.get $1)
+                  (local.get $0)
+                 )
+                 (call $fimport$10)
+                 (block
+                  (i32.store offset=16
+                   (local.get $13)
+                   (local.get $1)
+                  )
+                  (i32.store offset=24
+                   (local.get $1)
+                   (local.get $13)
+                  )
+                 )
+                )
+               )
+               (if
+                (local.tee $0
+                 (i32.load offset=20
+                  (local.get $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (local.get $0)
+                  (i32.load
+                   (i32.const 3652)
+                  )
+                 )
+                 (call $fimport$10)
+                 (block
+                  (i32.store offset=20
+                   (local.get $13)
+                   (local.get $0)
+                  )
+                  (i32.store offset=24
+                   (local.get $0)
+                   (local.get $13)
+                  )
+                  (local.set $2
+                   (local.get $5)
+                  )
+                 )
+                )
+                (local.set $2
+                 (local.get $5)
+                )
+               )
+              )
+              (local.set $2
+               (local.get $5)
+              )
+             )
+            )
+            (block $label$136
+             (if
+              (i32.lt_u
+               (local.get $3)
+               (i32.const 16)
+              )
+              (block
+               (i32.store offset=4
+                (local.get $4)
+                (i32.or
+                 (local.tee $0
+                  (i32.add
+                   (local.get $3)
+                   (local.get $7)
+                  )
+                 )
+                 (i32.const 3)
+                )
+               )
+               (i32.store
+                (local.tee $0
+                 (i32.add
+                  (i32.add
+                   (local.get $4)
+                   (local.get $0)
+                  )
+                  (i32.const 4)
+                 )
+                )
+                (i32.or
+                 (i32.load
+                  (local.get $0)
+                 )
+                 (i32.const 1)
+                )
+               )
+              )
+              (block
+               (i32.store offset=4
+                (local.get $4)
+                (i32.or
+                 (local.get $7)
+                 (i32.const 3)
+                )
+               )
+               (i32.store offset=4
+                (local.get $6)
+                (i32.or
+                 (local.get $3)
+                 (i32.const 1)
+                )
+               )
+               (i32.store
+                (i32.add
+                 (local.get $6)
+                 (local.get $3)
+                )
+                (local.get $3)
+               )
+               (local.set $0
+                (i32.shr_u
+                 (local.get $3)
+                 (i32.const 3)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $3)
+                 (i32.const 256)
+                )
+                (block
+                 (local.set $3
+                  (i32.add
+                   (i32.shl
+                    (i32.shl
+                     (local.get $0)
+                     (i32.const 1)
+                    )
+                    (i32.const 2)
+                   )
+                   (i32.const 3676)
+                  )
+                 )
+                 (if
+                  (i32.and
+                   (local.tee $1
+                    (i32.load
+                     (i32.const 3636)
+                    )
+                   )
+                   (local.tee $0
+                    (i32.shl
+                     (i32.const 1)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.lt_u
+                    (local.tee $0
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $3)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                    )
+                    (i32.load
+                     (i32.const 3652)
+                    )
+                   )
+                   (call $fimport$10)
+                   (block
+                    (local.set $16
+                     (local.get $1)
+                    )
+                    (local.set $8
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 3636)
+                    (i32.or
+                     (local.get $1)
+                     (local.get $0)
+                    )
+                   )
+                   (local.set $16
+                    (i32.add
+                     (local.get $3)
+                     (i32.const 8)
+                    )
+                   )
+                   (local.set $8
+                    (local.get $3)
+                   )
+                  )
+                 )
+                 (i32.store
+                  (local.get $16)
+                  (local.get $6)
+                 )
+                 (i32.store offset=12
+                  (local.get $8)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $8)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $3)
+                 )
+                 (br $label$136)
+                )
+               )
+               (local.set $1
+                (i32.add
+                 (i32.shl
+                  (local.tee $5
+                   (if (result i32)
+                    (local.tee $0
+                     (i32.shr_u
+                      (local.get $3)
+                      (i32.const 8)
+                     )
+                    )
+                    (if (result i32)
+                     (i32.gt_u
+                      (local.get $3)
+                      (i32.const 16777215)
+                     )
+                     (i32.const 31)
+                     (i32.or
+                      (i32.and
+                       (i32.shr_u
+                        (local.get $3)
+                        (i32.add
+                         (local.tee $0
+                          (i32.add
+                           (i32.sub
+                            (i32.const 14)
+                            (i32.or
+                             (i32.or
+                              (local.tee $0
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (local.tee $1
+                                   (i32.shl
+                                    (local.get $0)
+                                    (local.tee $5
+                                     (i32.and
+                                      (i32.shr_u
+                                       (i32.add
+                                        (local.get $0)
+                                        (i32.const 1048320)
+                                       )
+                                       (i32.const 16)
+                                      )
+                                      (i32.const 8)
+                                     )
+                                    )
+                                   )
+                                  )
+                                  (i32.const 520192)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 4)
+                               )
+                              )
+                              (local.get $5)
+                             )
+                             (local.tee $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (local.tee $1
+                                  (i32.shl
+                                   (local.get $1)
+                                   (local.get $0)
+                                  )
+                                 )
+                                 (i32.const 245760)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 2)
+                              )
+                             )
+                            )
+                           )
+                           (i32.shr_u
+                            (i32.shl
+                             (local.get $1)
+                             (local.get $0)
+                            )
+                            (i32.const 15)
+                           )
+                          )
+                         )
+                         (i32.const 7)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.shl
+                       (local.get $0)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (i32.const 0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3940)
+                )
+               )
+               (i32.store offset=28
+                (local.get $6)
+                (local.get $5)
+               )
+               (i32.store offset=4
+                (local.tee $0
+                 (i32.add
+                  (local.get $6)
+                  (i32.const 16)
+                 )
+                )
+                (i32.const 0)
+               )
+               (i32.store
+                (local.get $0)
+                (i32.const 0)
+               )
+               (if
+                (i32.eqz
+                 (i32.and
+                  (local.get $2)
+                  (local.tee $0
+                   (i32.shl
+                    (i32.const 1)
+                    (local.get $5)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (i32.const 3640)
+                  (i32.or
+                   (local.get $2)
+                   (local.get $0)
+                  )
+                 )
+                 (i32.store
+                  (local.get $1)
+                  (local.get $6)
+                 )
+                 (i32.store offset=24
+                  (local.get $6)
+                  (local.get $1)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (br $label$136)
+                )
+               )
+               (local.set $0
+                (i32.load
+                 (local.get $1)
+                )
+               )
+               (local.set $1
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (local.get $5)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (local.set $5
+                (i32.shl
+                 (local.get $3)
+                 (if (result i32)
+                  (i32.eq
+                   (local.get $5)
+                   (i32.const 31)
+                  )
+                  (i32.const 0)
+                  (local.get $1)
+                 )
+                )
+               )
+               (block $label$151
+                (block $label$152
+                 (block $label$153
+                  (loop $label$154
+                   (br_if $label$152
+                    (i32.eq
+                     (i32.and
+                      (i32.load offset=4
+                       (local.get $0)
+                      )
+                      (i32.const -8)
+                     )
+                     (local.get $3)
+                    )
+                   )
+                   (local.set $2
+                    (i32.shl
+                     (local.get $5)
+                     (i32.const 1)
+                    )
+                   )
+                   (br_if $label$153
+                    (i32.eqz
+                     (local.tee $1
+                      (i32.load
+                       (local.tee $5
+                        (i32.add
+                         (i32.add
+                          (local.get $0)
+                          (i32.const 16)
+                         )
+                         (i32.shl
+                          (i32.shr_u
+                           (local.get $5)
+                           (i32.const 31)
+                          )
+                          (i32.const 2)
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (local.set $5
+                    (local.get $2)
+                   )
+                   (local.set $0
+                    (local.get $1)
+                   )
+                   (br $label$154)
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (local.get $5)
+                   (i32.load
+                    (i32.const 3652)
+                   )
+                  )
+                  (call $fimport$10)
+                  (block
+                   (i32.store
+                    (local.get $5)
+                    (local.get $6)
+                   )
+                   (i32.store offset=24
+                    (local.get $6)
+                    (local.get $0)
+                   )
+                   (i32.store offset=12
+                    (local.get $6)
+                    (local.get $6)
+                   )
+                   (i32.store offset=8
+                    (local.get $6)
+                    (local.get $6)
+                   )
+                   (br $label$136)
+                  )
+                 )
+                 (br $label$151)
+                )
+                (if
+                 (i32.and
+                  (i32.ge_u
+                   (local.tee $2
+                    (i32.load
+                     (local.tee $3
+                      (i32.add
+                       (local.get $0)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (local.tee $1
+                    (i32.load
+                     (i32.const 3652)
+                    )
+                   )
+                  )
+                  (i32.ge_u
+                   (local.get $0)
+                   (local.get $1)
+                  )
+                 )
+                 (block
+                  (i32.store offset=12
+                   (local.get $2)
+                   (local.get $6)
+                  )
+                  (i32.store
+                   (local.get $3)
+                   (local.get $6)
+                  )
+                  (i32.store offset=8
+                   (local.get $6)
+                   (local.get $2)
+                  )
+                  (i32.store offset=12
+                   (local.get $6)
+                   (local.get $0)
+                  )
+                  (i32.store offset=24
+                   (local.get $6)
+                   (i32.const 0)
+                  )
+                 )
+                 (call $fimport$10)
+                )
+               )
+              )
+             )
+            )
+            (global.set $global$1
+             (local.get $14)
+            )
+            (return
+             (i32.add
+              (local.get $4)
+              (i32.const 8)
+             )
+            )
+           )
+           (local.set $0
+            (local.get $7)
+           )
+          )
+          (local.set $0
+           (local.get $7)
+          )
+         )
+        )
+        (local.set $0
+         (local.get $7)
+        )
+       )
+      )
+     )
+    )
+   )
+   (if
+    (i32.ge_u
+     (local.tee $1
+      (i32.load
+       (i32.const 3644)
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (local.set $2
+      (i32.load
+       (i32.const 3656)
+      )
+     )
+     (if
+      (i32.gt_u
+       (local.tee $3
+        (i32.sub
+         (local.get $1)
+         (local.get $0)
+        )
+       )
+       (i32.const 15)
+      )
+      (block
+       (i32.store
+        (i32.const 3656)
+        (local.tee $1
+         (i32.add
+          (local.get $2)
+          (local.get $0)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3644)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $1)
+        (i32.or
+         (local.get $3)
+         (i32.const 1)
+        )
+       )
+       (i32.store
+        (i32.add
+         (local.get $1)
+         (local.get $3)
+        )
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $2)
+        (i32.or
+         (local.get $0)
+         (i32.const 3)
+        )
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3644)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 3656)
+        (i32.const 0)
+       )
+       (i32.store offset=4
+        (local.get $2)
+        (i32.or
+         (local.get $1)
+         (i32.const 3)
+        )
+       )
+       (i32.store
+        (local.tee $0
+         (i32.add
+          (i32.add
+           (local.get $2)
+           (local.get $1)
+          )
+          (i32.const 4)
+         )
+        )
+        (i32.or
+         (i32.load
+          (local.get $0)
+         )
+         (i32.const 1)
+        )
+       )
+      )
+     )
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+     )
+    )
+   )
+   (if
+    (i32.gt_u
+     (local.tee $10
+      (i32.load
+       (i32.const 3648)
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (i32.store
+      (i32.const 3648)
+      (local.tee $3
+       (i32.sub
+        (local.get $10)
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (i32.const 3660)
+      (local.tee $1
+       (i32.add
+        (local.tee $2
+         (i32.load
+          (i32.const 3660)
+         )
+        )
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store offset=4
+      (local.get $1)
+      (i32.or
+       (local.get $3)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=4
+      (local.get $2)
+      (i32.or
+       (local.get $0)
+       (i32.const 3)
+      )
+     )
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+     )
+    )
+   )
+   (if
+    (i32.le_u
+     (local.tee $6
+      (i32.and
+       (local.tee $8
+        (i32.add
+         (local.tee $1
+          (if (result i32)
+           (i32.load
+            (i32.const 4108)
+           )
+           (i32.load
+            (i32.const 4116)
+           )
+           (block (result i32)
+            (i32.store
+             (i32.const 4116)
+             (i32.const 4096)
+            )
+            (i32.store
+             (i32.const 4112)
+             (i32.const 4096)
+            )
+            (i32.store
+             (i32.const 4120)
+             (i32.const -1)
+            )
+            (i32.store
+             (i32.const 4124)
+             (i32.const -1)
+            )
+            (i32.store
+             (i32.const 4128)
+             (i32.const 0)
+            )
+            (i32.store
+             (i32.const 4080)
+             (i32.const 0)
+            )
+            (i32.store
+             (local.get $18)
+             (local.tee $1
+              (i32.xor
+               (i32.and
+                (local.get $18)
+                (i32.const -16)
+               )
+               (i32.const 1431655768)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 4108)
+             (local.get $1)
+            )
+            (i32.const 4096)
+           )
+          )
+         )
+         (local.tee $13
+          (i32.add
+           (local.get $0)
+           (i32.const 47)
+          )
+         )
+        )
+       )
+       (local.tee $4
+        (i32.sub
+         (i32.const 0)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.const 0)
+     )
+    )
+   )
+   (if
+    (local.tee $2
+     (i32.load
+      (i32.const 4076)
+     )
+    )
+    (if
+     (i32.or
+      (i32.le_u
+       (local.tee $1
+        (i32.add
+         (local.tee $3
+          (i32.load
+           (i32.const 4068)
+          )
+         )
+         (local.get $6)
+        )
+       )
+       (local.get $3)
+      )
+      (i32.gt_u
+       (local.get $1)
+       (local.get $2)
+      )
+     )
+     (block
+      (global.set $global$1
+       (local.get $14)
+      )
+      (return
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (local.set $7
+    (i32.add
+     (local.get $0)
+     (i32.const 48)
+    )
+   )
+   (block $label$171
+    (block $label$172
+     (if
+      (i32.eqz
+       (i32.and
+        (i32.load
+         (i32.const 4080)
+        )
+        (i32.const 4)
+       )
+      )
+      (block
+       (block $label$174
+        (block $label$175
+         (block $label$176
+          (br_if $label$176
+           (i32.eqz
+            (local.tee $3
+             (i32.load
+              (i32.const 3660)
+             )
+            )
+           )
+          )
+          (local.set $2
+           (i32.const 4084)
+          )
+          (loop $label$177
+           (block $label$178
+            (if
+             (i32.le_u
+              (local.tee $1
+               (i32.load
+                (local.get $2)
+               )
+              )
+              (local.get $3)
+             )
+             (br_if $label$178
+              (i32.gt_u
+               (i32.add
+                (local.get $1)
+                (i32.load
+                 (local.tee $5
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 4)
+                  )
+                 )
+                )
+               )
+               (local.get $3)
+              )
+             )
+            )
+            (br_if $label$176
+             (i32.eqz
+              (local.tee $1
+               (i32.load offset=8
+                (local.get $2)
+               )
+              )
+             )
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$177)
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.tee $3
+             (i32.and
+              (i32.sub
+               (local.get $8)
+               (local.get $10)
+              )
+              (local.get $4)
+             )
+            )
+            (i32.const 2147483647)
+           )
+           (if
+            (i32.eq
+             (local.tee $1
+              (call $40
+               (local.get $3)
+              )
+             )
+             (i32.add
+              (i32.load
+               (local.get $2)
+              )
+              (i32.load
+               (local.get $5)
+              )
+             )
+            )
+            (br_if $label$172
+             (i32.ne
+              (local.get $1)
+              (i32.const -1)
+             )
+            )
+            (block
+             (local.set $2
+              (local.get $1)
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$175)
+            )
+           )
+          )
+          (br $label$174)
+         )
+         (if
+          (i32.ne
+           (local.tee $1
+            (call $40
+             (i32.const 0)
+            )
+           )
+           (i32.const -1)
+          )
+          (block
+           (local.set $2
+            (i32.sub
+             (i32.and
+              (i32.add
+               (local.tee $5
+                (i32.add
+                 (local.tee $2
+                  (i32.load
+                   (i32.const 4112)
+                  )
+                 )
+                 (i32.const -1)
+                )
+               )
+               (local.tee $3
+                (local.get $1)
+               )
+              )
+              (i32.sub
+               (i32.const 0)
+               (local.get $2)
+              )
+             )
+             (local.get $3)
+            )
+           )
+           (local.set $4
+            (i32.add
+             (local.tee $3
+              (i32.add
+               (if (result i32)
+                (i32.and
+                 (local.get $5)
+                 (local.get $3)
+                )
+                (local.get $2)
+                (i32.const 0)
+               )
+               (local.get $6)
+              )
+             )
+             (local.tee $5
+              (i32.load
+               (i32.const 4068)
+              )
+             )
+            )
+           )
+           (if
+            (i32.and
+             (i32.gt_u
+              (local.get $3)
+              (local.get $0)
+             )
+             (i32.lt_u
+              (local.get $3)
+              (i32.const 2147483647)
+             )
+            )
+            (block
+             (if
+              (local.tee $2
+               (i32.load
+                (i32.const 4076)
+               )
+              )
+              (br_if $label$174
+               (i32.or
+                (i32.le_u
+                 (local.get $4)
+                 (local.get $5)
+                )
+                (i32.gt_u
+                 (local.get $4)
+                 (local.get $2)
+                )
+               )
+              )
+             )
+             (br_if $label$172
+              (i32.eq
+               (local.tee $2
+                (call $40
+                 (local.get $3)
+                )
+               )
+               (local.get $1)
+              )
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$175)
+            )
+           )
+          )
+         )
+         (br $label$174)
+        )
+        (local.set $5
+         (i32.sub
+          (i32.const 0)
+          (local.get $1)
+         )
+        )
+        (if
+         (i32.and
+          (i32.gt_u
+           (local.get $7)
+           (local.get $1)
+          )
+          (i32.and
+           (i32.lt_u
+            (local.get $1)
+            (i32.const 2147483647)
+           )
+           (i32.ne
+            (local.get $2)
+            (i32.const -1)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.tee $3
+            (i32.and
+             (i32.add
+              (i32.sub
+               (local.get $13)
+               (local.get $1)
+              )
+              (local.tee $3
+               (i32.load
+                (i32.const 4116)
+               )
+              )
+             )
+             (i32.sub
+              (i32.const 0)
+              (local.get $3)
+             )
+            )
+           )
+           (i32.const 2147483647)
+          )
+          (if
+           (i32.eq
+            (call $40
+             (local.get $3)
+            )
+            (i32.const -1)
+           )
+           (block
+            (drop
+             (call $40
+              (local.get $5)
+             )
+            )
+            (br $label$174)
+           )
+           (local.set $3
+            (i32.add
+             (local.get $3)
+             (local.get $1)
+            )
+           )
+          )
+          (local.set $3
+           (local.get $1)
+          )
+         )
+         (local.set $3
+          (local.get $1)
+         )
+        )
+        (if
+         (i32.ne
+          (local.get $2)
+          (i32.const -1)
+         )
+         (block
+          (local.set $1
+           (local.get $2)
+          )
+          (br $label$172)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 4080)
+        (i32.or
+         (i32.load
+          (i32.const 4080)
+         )
+         (i32.const 4)
+        )
+       )
+      )
+     )
+     (if
+      (i32.lt_u
+       (local.get $6)
+       (i32.const 2147483647)
+      )
+      (if
+       (i32.and
+        (i32.lt_u
+         (local.tee $1
+          (call $40
+           (local.get $6)
+          )
+         )
+         (local.tee $3
+          (call $40
+           (i32.const 0)
+          )
+         )
+        )
+        (i32.and
+         (i32.ne
+          (local.get $1)
+          (i32.const -1)
+         )
+         (i32.ne
+          (local.get $3)
+          (i32.const -1)
+         )
+        )
+       )
+       (br_if $label$172
+        (i32.gt_u
+         (local.tee $3
+          (i32.sub
+           (local.get $3)
+           (local.get $1)
+          )
+         )
+         (i32.add
+          (local.get $0)
+          (i32.const 40)
+         )
+        )
+       )
+      )
+     )
+     (br $label$171)
+    )
+    (i32.store
+     (i32.const 4068)
+     (local.tee $2
+      (i32.add
+       (i32.load
+        (i32.const 4068)
+       )
+       (local.get $3)
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (local.get $2)
+      (i32.load
+       (i32.const 4072)
+      )
+     )
+     (i32.store
+      (i32.const 4072)
+      (local.get $2)
+     )
+    )
+    (block $label$198
+     (if
+      (local.tee $8
+       (i32.load
+        (i32.const 3660)
+       )
+      )
+      (block
+       (local.set $2
+        (i32.const 4084)
+       )
+       (block $label$200
+        (block $label$201
+         (loop $label$202
+          (br_if $label$201
+           (i32.eq
+            (local.get $1)
+            (i32.add
+             (local.tee $4
+              (i32.load
+               (local.get $2)
+              )
+             )
+             (local.tee $5
+              (i32.load
+               (local.tee $7
+                (i32.add
+                 (local.get $2)
+                 (i32.const 4)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (br_if $label$202
+           (local.tee $2
+            (i32.load offset=8
+             (local.get $2)
+            )
+           )
+          )
+         )
+         (br $label$200)
+        )
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.load offset=12
+            (local.get $2)
+           )
+           (i32.const 8)
+          )
+         )
+         (if
+          (i32.and
+           (i32.lt_u
+            (local.get $8)
+            (local.get $1)
+           )
+           (i32.ge_u
+            (local.get $8)
+            (local.get $4)
+           )
+          )
+          (block
+           (i32.store
+            (local.get $7)
+            (i32.add
+             (local.get $5)
+             (local.get $3)
+            )
+           )
+           (local.set $5
+            (i32.load
+             (i32.const 3648)
+            )
+           )
+           (local.set $1
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (local.tee $2
+               (i32.add
+                (local.get $8)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+           )
+           (i32.store
+            (i32.const 3660)
+            (local.tee $2
+             (i32.add
+              (local.get $8)
+              (if (result i32)
+               (i32.and
+                (local.get $2)
+                (i32.const 7)
+               )
+               (local.get $1)
+               (local.tee $1
+                (i32.const 0)
+               )
+              )
+             )
+            )
+           )
+           (i32.store
+            (i32.const 3648)
+            (local.tee $1
+             (i32.add
+              (i32.sub
+               (local.get $3)
+               (local.get $1)
+              )
+              (local.get $5)
+             )
+            )
+           )
+           (i32.store offset=4
+            (local.get $2)
+            (i32.or
+             (local.get $1)
+             (i32.const 1)
+            )
+           )
+           (i32.store offset=4
+            (i32.add
+             (local.get $2)
+             (local.get $1)
+            )
+            (i32.const 40)
+           )
+           (i32.store
+            (i32.const 3664)
+            (i32.load
+             (i32.const 4124)
+            )
+           )
+           (br $label$198)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (local.get $1)
+         (local.tee $2
+          (i32.load
+           (i32.const 3652)
+          )
+         )
+        )
+        (block
+         (i32.store
+          (i32.const 3652)
+          (local.get $1)
+         )
+         (local.set $2
+          (local.get $1)
+         )
+        )
+       )
+       (local.set $10
+        (i32.add
+         (local.get $1)
+         (local.get $3)
+        )
+       )
+       (local.set $5
+        (i32.const 4084)
+       )
+       (block $label$208
+        (block $label$209
+         (loop $label$210
+          (br_if $label$209
+           (i32.eq
+            (i32.load
+             (local.get $5)
+            )
+            (local.get $10)
+           )
+          )
+          (br_if $label$210
+           (local.tee $5
+            (i32.load offset=8
+             (local.get $5)
+            )
+           )
+          )
+          (local.set $5
+           (i32.const 4084)
+          )
+         )
+         (br $label$208)
+        )
+        (if
+         (i32.and
+          (i32.load offset=12
+           (local.get $5)
+          )
+          (i32.const 8)
+         )
+         (local.set $5
+          (i32.const 4084)
+         )
+         (block
+          (i32.store
+           (local.get $5)
+           (local.get $1)
+          )
+          (i32.store
+           (local.tee $5
+            (i32.add
+             (local.get $5)
+             (i32.const 4)
+            )
+           )
+           (i32.add
+            (i32.load
+             (local.get $5)
+            )
+            (local.get $3)
+           )
+          )
+          (local.set $7
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (local.tee $4
+              (i32.add
+               (local.get $1)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+          )
+          (local.set $3
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (local.tee $5
+              (i32.add
+               (local.get $10)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+          )
+          (local.set $6
+           (i32.add
+            (local.tee $13
+             (i32.add
+              (local.get $1)
+              (if (result i32)
+               (i32.and
+                (local.get $4)
+                (i32.const 7)
+               )
+               (local.get $7)
+               (i32.const 0)
+              )
+             )
+            )
+            (local.get $0)
+           )
+          )
+          (local.set $7
+           (i32.sub
+            (i32.sub
+             (local.tee $4
+              (i32.add
+               (local.get $10)
+               (if (result i32)
+                (i32.and
+                 (local.get $5)
+                 (i32.const 7)
+                )
+                (local.get $3)
+                (i32.const 0)
+               )
+              )
+             )
+             (local.get $13)
+            )
+            (local.get $0)
+           )
+          )
+          (i32.store offset=4
+           (local.get $13)
+           (i32.or
+            (local.get $0)
+            (i32.const 3)
+           )
+          )
+          (block $label$217
+           (if
+            (i32.eq
+             (local.get $4)
+             (local.get $8)
+            )
+            (block
+             (i32.store
+              (i32.const 3648)
+              (local.tee $0
+               (i32.add
+                (i32.load
+                 (i32.const 3648)
+                )
+                (local.get $7)
+               )
+              )
+             )
+             (i32.store
+              (i32.const 3660)
+              (local.get $6)
+             )
+             (i32.store offset=4
+              (local.get $6)
+              (i32.or
+               (local.get $0)
+               (i32.const 1)
+              )
+             )
+            )
+            (block
+             (if
+              (i32.eq
+               (local.get $4)
+               (i32.load
+                (i32.const 3656)
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 3644)
+                (local.tee $0
+                 (i32.add
+                  (i32.load
+                   (i32.const 3644)
+                  )
+                  (local.get $7)
+                 )
+                )
+               )
+               (i32.store
+                (i32.const 3656)
+                (local.get $6)
+               )
+               (i32.store offset=4
+                (local.get $6)
+                (i32.or
+                 (local.get $0)
+                 (i32.const 1)
+                )
+               )
+               (i32.store
+                (i32.add
+                 (local.get $6)
+                 (local.get $0)
+                )
+                (local.get $0)
+               )
+               (br $label$217)
+              )
+             )
+             (i32.store
+              (local.tee $0
+               (i32.add
+                (local.tee $0
+                 (if (result i32)
+                  (i32.eq
+                   (i32.and
+                    (local.tee $0
+                     (i32.load offset=4
+                      (local.get $4)
+                     )
+                    )
+                    (i32.const 3)
+                   )
+                   (i32.const 1)
+                  )
+                  (block (result i32)
+                   (local.set $11
+                    (i32.and
+                     (local.get $0)
+                     (i32.const -8)
+                    )
+                   )
+                   (local.set $1
+                    (i32.shr_u
+                     (local.get $0)
+                     (i32.const 3)
+                    )
+                   )
+                   (block $label$222
+                    (if
+                     (i32.lt_u
+                      (local.get $0)
+                      (i32.const 256)
+                     )
+                     (block
+                      (local.set $5
+                       (i32.load offset=12
+                        (local.get $4)
+                       )
+                      )
+                      (block $label$224
+                       (if
+                        (i32.ne
+                         (local.tee $3
+                          (i32.load offset=8
+                           (local.get $4)
+                          )
+                         )
+                         (local.tee $0
+                          (i32.add
+                           (i32.shl
+                            (i32.shl
+                             (local.get $1)
+                             (i32.const 1)
+                            )
+                            (i32.const 2)
+                           )
+                           (i32.const 3676)
+                          )
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $3)
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                         )
+                         (br_if $label$224
+                          (i32.eq
+                           (i32.load offset=12
+                            (local.get $3)
+                           )
+                           (local.get $4)
+                          )
+                         )
+                         (call $fimport$10)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.eq
+                        (local.get $5)
+                        (local.get $3)
+                       )
+                       (block
+                        (i32.store
+                         (i32.const 3636)
+                         (i32.and
+                          (i32.load
+                           (i32.const 3636)
+                          )
+                          (i32.xor
+                           (i32.shl
+                            (i32.const 1)
+                            (local.get $1)
+                           )
+                           (i32.const -1)
+                          )
+                         )
+                        )
+                        (br $label$222)
+                       )
+                      )
+                      (block $label$228
+                       (if
+                        (i32.eq
+                         (local.get $5)
+                         (local.get $0)
+                        )
+                        (local.set $20
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 8)
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $5)
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $0
+                             (i32.add
+                              (local.get $5)
+                              (i32.const 8)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (block
+                           (local.set $20
+                            (local.get $0)
+                           )
+                           (br $label$228)
+                          )
+                         )
+                         (call $fimport$10)
+                        )
+                       )
+                      )
+                      (i32.store offset=12
+                       (local.get $3)
+                       (local.get $5)
+                      )
+                      (i32.store
+                       (local.get $20)
+                       (local.get $3)
+                      )
+                     )
+                     (block
+                      (local.set $8
+                       (i32.load offset=24
+                        (local.get $4)
+                       )
+                      )
+                      (block $label$234
+                       (if
+                        (i32.eq
+                         (local.tee $0
+                          (i32.load offset=12
+                           (local.get $4)
+                          )
+                         )
+                         (local.get $4)
+                        )
+                        (block
+                         (if
+                          (i32.eqz
+                           (local.tee $0
+                            (i32.load
+                             (local.tee $1
+                              (i32.add
+                               (local.tee $3
+                                (i32.add
+                                 (local.get $4)
+                                 (i32.const 16)
+                                )
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (if
+                           (local.tee $0
+                            (i32.load
+                             (local.get $3)
+                            )
+                           )
+                           (local.set $1
+                            (local.get $3)
+                           )
+                           (block
+                            (local.set $12
+                             (i32.const 0)
+                            )
+                            (br $label$234)
+                           )
+                          )
+                         )
+                         (loop $label$239
+                          (if
+                           (local.tee $3
+                            (i32.load
+                             (local.tee $5
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 20)
+                              )
+                             )
+                            )
+                           )
+                           (block
+                            (local.set $0
+                             (local.get $3)
+                            )
+                            (local.set $1
+                             (local.get $5)
+                            )
+                            (br $label$239)
+                           )
+                          )
+                          (if
+                           (local.tee $3
+                            (i32.load
+                             (local.tee $5
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 16)
+                              )
+                             )
+                            )
+                           )
+                           (block
+                            (local.set $0
+                             (local.get $3)
+                            )
+                            (local.set $1
+                             (local.get $5)
+                            )
+                            (br $label$239)
+                           )
+                          )
+                         )
+                         (if
+                          (i32.lt_u
+                           (local.get $1)
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                          (block
+                           (i32.store
+                            (local.get $1)
+                            (i32.const 0)
+                           )
+                           (local.set $12
+                            (local.get $0)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.tee $5
+                            (i32.load offset=8
+                             (local.get $4)
+                            )
+                           )
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.ne
+                           (i32.load
+                            (local.tee $3
+                             (i32.add
+                              (local.get $5)
+                              (i32.const 12)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $1
+                             (i32.add
+                              (local.get $0)
+                              (i32.const 8)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (block
+                           (i32.store
+                            (local.get $3)
+                            (local.get $0)
+                           )
+                           (i32.store
+                            (local.get $1)
+                            (local.get $5)
+                           )
+                           (local.set $12
+                            (local.get $0)
+                           )
+                          )
+                          (call $fimport$10)
+                         )
+                        )
+                       )
+                      )
+                      (br_if $label$222
+                       (i32.eqz
+                        (local.get $8)
+                       )
+                      )
+                      (block $label$249
+                       (if
+                        (i32.eq
+                         (local.get $4)
+                         (i32.load
+                          (local.tee $0
+                           (i32.add
+                            (i32.shl
+                             (local.tee $1
+                              (i32.load offset=28
+                               (local.get $4)
+                              )
+                             )
+                             (i32.const 2)
+                            )
+                            (i32.const 3940)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (i32.store
+                          (local.get $0)
+                          (local.get $12)
+                         )
+                         (br_if $label$249
+                          (local.get $12)
+                         )
+                         (i32.store
+                          (i32.const 3640)
+                          (i32.and
+                           (i32.load
+                            (i32.const 3640)
+                           )
+                           (i32.xor
+                            (i32.shl
+                             (i32.const 1)
+                             (local.get $1)
+                            )
+                            (i32.const -1)
+                           )
+                          )
+                         )
+                         (br $label$222)
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $8)
+                           (i32.load
+                            (i32.const 3652)
+                           )
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $0
+                             (i32.add
+                              (local.get $8)
+                              (i32.const 16)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (i32.store
+                           (local.get $0)
+                           (local.get $12)
+                          )
+                          (i32.store offset=20
+                           (local.get $8)
+                           (local.get $12)
+                          )
+                         )
+                         (br_if $label$222
+                          (i32.eqz
+                           (local.get $12)
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (local.get $12)
+                        (local.tee $1
+                         (i32.load
+                          (i32.const 3652)
+                         )
+                        )
+                       )
+                       (call $fimport$10)
+                      )
+                      (i32.store offset=24
+                       (local.get $12)
+                       (local.get $8)
+                      )
+                      (if
+                       (local.tee $3
+                        (i32.load
+                         (local.tee $0
+                          (i32.add
+                           (local.get $4)
+                           (i32.const 16)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.lt_u
+                         (local.get $3)
+                         (local.get $1)
+                        )
+                        (call $fimport$10)
+                        (block
+                         (i32.store offset=16
+                          (local.get $12)
+                          (local.get $3)
+                         )
+                         (i32.store offset=24
+                          (local.get $3)
+                          (local.get $12)
+                         )
+                        )
+                       )
+                      )
+                      (br_if $label$222
+                       (i32.eqz
+                        (local.tee $0
+                         (i32.load offset=4
+                          (local.get $0)
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (local.get $0)
+                        (i32.load
+                         (i32.const 3652)
+                        )
+                       )
+                       (call $fimport$10)
+                       (block
+                        (i32.store offset=20
+                         (local.get $12)
+                         (local.get $0)
+                        )
+                        (i32.store offset=24
+                         (local.get $0)
+                         (local.get $12)
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (local.set $7
+                    (i32.add
+                     (local.get $11)
+                     (local.get $7)
+                    )
+                   )
+                   (i32.add
+                    (local.get $4)
+                    (local.get $11)
+                   )
+                  )
+                  (local.get $4)
+                 )
+                )
+                (i32.const 4)
+               )
+              )
+              (i32.and
+               (i32.load
+                (local.get $0)
+               )
+               (i32.const -2)
+              )
+             )
+             (i32.store offset=4
+              (local.get $6)
+              (i32.or
+               (local.get $7)
+               (i32.const 1)
+              )
+             )
+             (i32.store
+              (i32.add
+               (local.get $6)
+               (local.get $7)
+              )
+              (local.get $7)
+             )
+             (local.set $0
+              (i32.shr_u
+               (local.get $7)
+               (i32.const 3)
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $7)
+               (i32.const 256)
+              )
+              (block
+               (local.set $3
+                (i32.add
+                 (i32.shl
+                  (i32.shl
+                   (local.get $0)
+                   (i32.const 1)
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3676)
+                )
+               )
+               (block $label$263
+                (if
+                 (i32.and
+                  (local.tee $1
+                   (i32.load
+                    (i32.const 3636)
+                   )
+                  )
+                  (local.tee $0
+                   (i32.shl
+                    (i32.const 1)
+                    (local.get $0)
+                   )
+                  )
+                 )
+                 (block
+                  (if
+                   (i32.ge_u
+                    (local.tee $0
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $3)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                    )
+                    (i32.load
+                     (i32.const 3652)
+                    )
+                   )
+                   (block
+                    (local.set $21
+                     (local.get $1)
+                    )
+                    (local.set $9
+                     (local.get $0)
+                    )
+                    (br $label$263)
+                   )
+                  )
+                  (call $fimport$10)
+                 )
+                 (block
+                  (i32.store
+                   (i32.const 3636)
+                   (i32.or
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                  )
+                  (local.set $21
+                   (i32.add
+                    (local.get $3)
+                    (i32.const 8)
+                   )
+                  )
+                  (local.set $9
+                   (local.get $3)
+                  )
+                 )
+                )
+               )
+               (i32.store
+                (local.get $21)
+                (local.get $6)
+               )
+               (i32.store offset=12
+                (local.get $9)
+                (local.get $6)
+               )
+               (i32.store offset=8
+                (local.get $6)
+                (local.get $9)
+               )
+               (i32.store offset=12
+                (local.get $6)
+                (local.get $3)
+               )
+               (br $label$217)
+              )
+             )
+             (local.set $3
+              (i32.add
+               (i32.shl
+                (local.tee $2
+                 (block $label$267 (result i32)
+                  (if (result i32)
+                   (local.tee $0
+                    (i32.shr_u
+                     (local.get $7)
+                     (i32.const 8)
+                    )
+                   )
+                   (block (result i32)
+                    (drop
+                     (br_if $label$267
+                      (i32.const 31)
+                      (i32.gt_u
+                       (local.get $7)
+                       (i32.const 16777215)
+                      )
+                     )
+                    )
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (local.get $7)
+                       (i32.add
+                        (local.tee $0
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
+                            (i32.or
+                             (local.tee $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (local.tee $1
+                                  (i32.shl
+                                   (local.get $0)
+                                   (local.tee $3
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (local.get $0)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (i32.const 520192)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                             (local.get $3)
+                            )
+                            (local.tee $0
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (local.tee $1
+                                 (i32.shl
+                                  (local.get $1)
+                                  (local.get $0)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (local.get $1)
+                            (local.get $0)
+                           )
+                           (i32.const 15)
+                          )
+                         )
+                        )
+                        (i32.const 7)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.shl
+                      (local.get $0)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.const 0)
+                  )
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 3940)
+              )
+             )
+             (i32.store offset=28
+              (local.get $6)
+              (local.get $2)
+             )
+             (i32.store offset=4
+              (local.tee $0
+               (i32.add
+                (local.get $6)
+                (i32.const 16)
+               )
+              )
+              (i32.const 0)
+             )
+             (i32.store
+              (local.get $0)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (local.tee $1
+                 (i32.load
+                  (i32.const 3640)
+                 )
+                )
+                (local.tee $0
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $2)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 3640)
+                (i32.or
+                 (local.get $1)
+                 (local.get $0)
+                )
+               )
+               (i32.store
+                (local.get $3)
+                (local.get $6)
+               )
+               (i32.store offset=24
+                (local.get $6)
+                (local.get $3)
+               )
+               (i32.store offset=12
+                (local.get $6)
+                (local.get $6)
+               )
+               (i32.store offset=8
+                (local.get $6)
+                (local.get $6)
+               )
+               (br $label$217)
+              )
+             )
+             (local.set $0
+              (i32.load
+               (local.get $3)
+              )
+             )
+             (local.set $1
+              (i32.sub
+               (i32.const 25)
+               (i32.shr_u
+                (local.get $2)
+                (i32.const 1)
+               )
+              )
+             )
+             (local.set $2
+              (i32.shl
+               (local.get $7)
+               (if (result i32)
+                (i32.eq
+                 (local.get $2)
+                 (i32.const 31)
+                )
+                (i32.const 0)
+                (local.get $1)
+               )
+              )
+             )
+             (block $label$273
+              (block $label$274
+               (block $label$275
+                (loop $label$276
+                 (br_if $label$274
+                  (i32.eq
+                   (i32.and
+                    (i32.load offset=4
+                     (local.get $0)
+                    )
+                    (i32.const -8)
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (local.set $3
+                  (i32.shl
+                   (local.get $2)
+                   (i32.const 1)
+                  )
+                 )
+                 (br_if $label$275
+                  (i32.eqz
+                   (local.tee $1
+                    (i32.load
+                     (local.tee $2
+                      (i32.add
+                       (i32.add
+                        (local.get $0)
+                        (i32.const 16)
+                       )
+                       (i32.shl
+                        (i32.shr_u
+                         (local.get $2)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (local.set $2
+                  (local.get $3)
+                 )
+                 (local.set $0
+                  (local.get $1)
+                 )
+                 (br $label$276)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $2)
+                 (i32.load
+                  (i32.const 3652)
+                 )
+                )
+                (call $fimport$10)
+                (block
+                 (i32.store
+                  (local.get $2)
+                  (local.get $6)
+                 )
+                 (i32.store offset=24
+                  (local.get $6)
+                  (local.get $0)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (br $label$217)
+                )
+               )
+               (br $label$273)
+              )
+              (if
+               (i32.and
+                (i32.ge_u
+                 (local.tee $2
+                  (i32.load
+                   (local.tee $3
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (local.tee $1
+                  (i32.load
+                   (i32.const 3652)
+                  )
+                 )
+                )
+                (i32.ge_u
+                 (local.get $0)
+                 (local.get $1)
+                )
+               )
+               (block
+                (i32.store offset=12
+                 (local.get $2)
+                 (local.get $6)
+                )
+                (i32.store
+                 (local.get $3)
+                 (local.get $6)
+                )
+                (i32.store offset=8
+                 (local.get $6)
+                 (local.get $2)
+                )
+                (i32.store offset=12
+                 (local.get $6)
+                 (local.get $0)
+                )
+                (i32.store offset=24
+                 (local.get $6)
+                 (i32.const 0)
+                )
+               )
+               (call $fimport$10)
+              )
+             )
+            )
+           )
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (i32.add
+            (local.get $13)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+       )
+       (loop $label$281
+        (block $label$282
+         (if
+          (i32.le_u
+           (local.tee $2
+            (i32.load
+             (local.get $5)
+            )
+           )
+           (local.get $8)
+          )
+          (br_if $label$282
+           (i32.gt_u
+            (local.tee $13
+             (i32.add
+              (local.get $2)
+              (i32.load offset=4
+               (local.get $5)
+              )
+             )
+            )
+            (local.get $8)
+           )
+          )
+         )
+         (local.set $5
+          (i32.load offset=8
+           (local.get $5)
+          )
+         )
+         (br $label$281)
+        )
+       )
+       (local.set $2
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $5
+           (i32.add
+            (local.tee $7
+             (i32.add
+              (local.get $13)
+              (i32.const -47)
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (local.set $10
+        (i32.add
+         (local.tee $7
+          (if (result i32)
+           (i32.lt_u
+            (local.tee $2
+             (i32.add
+              (local.get $7)
+              (if (result i32)
+               (i32.and
+                (local.get $5)
+                (i32.const 7)
+               )
+               (local.get $2)
+               (i32.const 0)
+              )
+             )
+            )
+            (local.tee $12
+             (i32.add
+              (local.get $8)
+              (i32.const 16)
+             )
+            )
+           )
+           (local.get $8)
+           (local.get $2)
+          )
+         )
+         (i32.const 8)
+        )
+       )
+       (local.set $5
+        (i32.add
+         (local.get $7)
+         (i32.const 24)
+        )
+       )
+       (local.set $9
+        (i32.add
+         (local.get $3)
+         (i32.const -40)
+        )
+       )
+       (local.set $2
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $4
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (i32.store
+        (i32.const 3660)
+        (local.tee $4
+         (i32.add
+          (local.get $1)
+          (if (result i32)
+           (i32.and
+            (local.get $4)
+            (i32.const 7)
+           )
+           (local.get $2)
+           (local.tee $2
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3648)
+        (local.tee $2
+         (i32.sub
+          (local.get $9)
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store offset=4
+        (local.get $4)
+        (i32.or
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (local.get $4)
+         (local.get $2)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 3664)
+        (i32.load
+         (i32.const 4124)
+        )
+       )
+       (i32.store
+        (local.tee $2
+         (i32.add
+          (local.get $7)
+          (i32.const 4)
+         )
+        )
+        (i32.const 27)
+       )
+       (i64.store align=4
+        (local.get $10)
+        (i64.load align=4
+         (i32.const 4084)
+        )
+       )
+       (i64.store offset=8 align=4
+        (local.get $10)
+        (i64.load align=4
+         (i32.const 4092)
+        )
+       )
+       (i32.store
+        (i32.const 4084)
+        (local.get $1)
+       )
+       (i32.store
+        (i32.const 4088)
+        (local.get $3)
+       )
+       (i32.store
+        (i32.const 4096)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 4092)
+        (local.get $10)
+       )
+       (local.set $1
+        (local.get $5)
+       )
+       (loop $label$290
+        (i32.store
+         (local.tee $1
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+         )
+         (i32.const 7)
+        )
+        (br_if $label$290
+         (i32.lt_u
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+          (local.get $13)
+         )
+        )
+       )
+       (if
+        (i32.ne
+         (local.get $7)
+         (local.get $8)
+        )
+        (block
+         (i32.store
+          (local.get $2)
+          (i32.and
+           (i32.load
+            (local.get $2)
+           )
+           (i32.const -2)
+          )
+         )
+         (i32.store offset=4
+          (local.get $8)
+          (i32.or
+           (local.tee $4
+            (i32.sub
+             (local.get $7)
+             (local.get $8)
+            )
+           )
+           (i32.const 1)
+          )
+         )
+         (i32.store
+          (local.get $7)
+          (local.get $4)
+         )
+         (local.set $1
+          (i32.shr_u
+           (local.get $4)
+           (i32.const 3)
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (i32.const 256)
+          )
+          (block
+           (local.set $2
+            (i32.add
+             (i32.shl
+              (i32.shl
+               (local.get $1)
+               (i32.const 1)
+              )
+              (i32.const 2)
+             )
+             (i32.const 3676)
+            )
+           )
+           (if
+            (i32.and
+             (local.tee $3
+              (i32.load
+               (i32.const 3636)
+              )
+             )
+             (local.tee $1
+              (i32.shl
+               (i32.const 1)
+               (local.get $1)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (local.tee $1
+               (i32.load
+                (local.tee $3
+                 (i32.add
+                  (local.get $2)
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.load
+               (i32.const 3652)
+              )
+             )
+             (call $fimport$10)
+             (block
+              (local.set $15
+               (local.get $3)
+              )
+              (local.set $11
+               (local.get $1)
+              )
+             )
+            )
+            (block
+             (i32.store
+              (i32.const 3636)
+              (i32.or
+               (local.get $3)
+               (local.get $1)
+              )
+             )
+             (local.set $15
+              (i32.add
+               (local.get $2)
+               (i32.const 8)
+              )
+             )
+             (local.set $11
+              (local.get $2)
+             )
+            )
+           )
+           (i32.store
+            (local.get $15)
+            (local.get $8)
+           )
+           (i32.store offset=12
+            (local.get $11)
+            (local.get $8)
+           )
+           (i32.store offset=8
+            (local.get $8)
+            (local.get $11)
+           )
+           (i32.store offset=12
+            (local.get $8)
+            (local.get $2)
+           )
+           (br $label$198)
+          )
+         )
+         (local.set $2
+          (i32.add
+           (i32.shl
+            (local.tee $5
+             (if (result i32)
+              (local.tee $1
+               (i32.shr_u
+                (local.get $4)
+                (i32.const 8)
+               )
+              )
+              (if (result i32)
+               (i32.gt_u
+                (local.get $4)
+                (i32.const 16777215)
+               )
+               (i32.const 31)
+               (i32.or
+                (i32.and
+                 (i32.shr_u
+                  (local.get $4)
+                  (i32.add
+                   (local.tee $1
+                    (i32.add
+                     (i32.sub
+                      (i32.const 14)
+                      (i32.or
+                       (i32.or
+                        (local.tee $1
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (local.tee $3
+                             (i32.shl
+                              (local.get $1)
+                              (local.tee $2
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (local.get $1)
+                                  (i32.const 1048320)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 520192)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 4)
+                         )
+                        )
+                        (local.get $2)
+                       )
+                       (local.tee $1
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (local.tee $3
+                            (i32.shl
+                             (local.get $3)
+                             (local.get $1)
+                            )
+                           )
+                           (i32.const 245760)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 2)
+                        )
+                       )
+                      )
+                     )
+                     (i32.shr_u
+                      (i32.shl
+                       (local.get $3)
+                       (local.get $1)
+                      )
+                      (i32.const 15)
+                     )
+                    )
+                   )
+                   (i32.const 7)
+                  )
+                 )
+                 (i32.const 1)
+                )
+                (i32.shl
+                 (local.get $1)
+                 (i32.const 1)
+                )
+               )
+              )
+              (i32.const 0)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 3940)
+          )
+         )
+         (i32.store offset=28
+          (local.get $8)
+          (local.get $5)
+         )
+         (i32.store offset=20
+          (local.get $8)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $12)
+          (i32.const 0)
+         )
+         (if
+          (i32.eqz
+           (i32.and
+            (local.tee $3
+             (i32.load
+              (i32.const 3640)
+             )
+            )
+            (local.tee $1
+             (i32.shl
+              (i32.const 1)
+              (local.get $5)
+             )
+            )
+           )
+          )
+          (block
+           (i32.store
+            (i32.const 3640)
+            (i32.or
+             (local.get $3)
+             (local.get $1)
+            )
+           )
+           (i32.store
+            (local.get $2)
+            (local.get $8)
+           )
+           (i32.store offset=24
+            (local.get $8)
+            (local.get $2)
+           )
+           (i32.store offset=12
+            (local.get $8)
+            (local.get $8)
+           )
+           (i32.store offset=8
+            (local.get $8)
+            (local.get $8)
+           )
+           (br $label$198)
+          )
+         )
+         (local.set $1
+          (i32.load
+           (local.get $2)
+          )
+         )
+         (local.set $3
+          (i32.sub
+           (i32.const 25)
+           (i32.shr_u
+            (local.get $5)
+            (i32.const 1)
+           )
+          )
+         )
+         (local.set $5
+          (i32.shl
+           (local.get $4)
+           (if (result i32)
+            (i32.eq
+             (local.get $5)
+             (i32.const 31)
+            )
+            (i32.const 0)
+            (local.get $3)
+           )
+          )
+         )
+         (block $label$304
+          (block $label$305
+           (block $label$306
+            (loop $label$307
+             (br_if $label$305
+              (i32.eq
+               (i32.and
+                (i32.load offset=4
+                 (local.get $1)
+                )
+                (i32.const -8)
+               )
+               (local.get $4)
+              )
+             )
+             (local.set $2
+              (i32.shl
+               (local.get $5)
+               (i32.const 1)
+              )
+             )
+             (br_if $label$306
+              (i32.eqz
+               (local.tee $3
+                (i32.load
+                 (local.tee $5
+                  (i32.add
+                   (i32.add
+                    (local.get $1)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (local.get $5)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (local.set $5
+              (local.get $2)
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$307)
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $5)
+             (i32.load
+              (i32.const 3652)
+             )
+            )
+            (call $fimport$10)
+            (block
+             (i32.store
+              (local.get $5)
+              (local.get $8)
+             )
+             (i32.store offset=24
+              (local.get $8)
+              (local.get $1)
+             )
+             (i32.store offset=12
+              (local.get $8)
+              (local.get $8)
+             )
+             (i32.store offset=8
+              (local.get $8)
+              (local.get $8)
+             )
+             (br $label$198)
+            )
+           )
+           (br $label$304)
+          )
+          (if
+           (i32.and
+            (i32.ge_u
+             (local.tee $5
+              (i32.load
+               (local.tee $2
+                (i32.add
+                 (local.get $1)
+                 (i32.const 8)
+                )
+               )
+              )
+             )
+             (local.tee $3
+              (i32.load
+               (i32.const 3652)
+              )
+             )
+            )
+            (i32.ge_u
+             (local.get $1)
+             (local.get $3)
+            )
+           )
+           (block
+            (i32.store offset=12
+             (local.get $5)
+             (local.get $8)
+            )
+            (i32.store
+             (local.get $2)
+             (local.get $8)
+            )
+            (i32.store offset=8
+             (local.get $8)
+             (local.get $5)
+            )
+            (i32.store offset=12
+             (local.get $8)
+             (local.get $1)
+            )
+            (i32.store offset=24
+             (local.get $8)
+             (i32.const 0)
+            )
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (i32.or
+         (i32.eqz
+          (local.tee $2
+           (i32.load
+            (i32.const 3652)
+           )
+          )
+         )
+         (i32.lt_u
+          (local.get $1)
+          (local.get $2)
+         )
+        )
+        (i32.store
+         (i32.const 3652)
+         (local.get $1)
+        )
+       )
+       (i32.store
+        (i32.const 4084)
+        (local.get $1)
+       )
+       (i32.store
+        (i32.const 4088)
+        (local.get $3)
+       )
+       (i32.store
+        (i32.const 4096)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 3672)
+        (i32.load
+         (i32.const 4108)
+        )
+       )
+       (i32.store
+        (i32.const 3668)
+        (i32.const -1)
+       )
+       (local.set $2
+        (i32.const 0)
+       )
+       (loop $label$314
+        (i32.store offset=12
+         (local.tee $5
+          (i32.add
+           (i32.shl
+            (i32.shl
+             (local.get $2)
+             (i32.const 1)
+            )
+            (i32.const 2)
+           )
+           (i32.const 3676)
+          )
+         )
+         (local.get $5)
+        )
+        (i32.store offset=8
+         (local.get $5)
+         (local.get $5)
+        )
+        (br_if $label$314
+         (i32.ne
+          (local.tee $2
+           (i32.add
+            (local.get $2)
+            (i32.const 1)
+           )
+          )
+          (i32.const 32)
+         )
+        )
+       )
+       (local.set $5
+        (i32.add
+         (local.get $3)
+         (i32.const -40)
+        )
+       )
+       (local.set $3
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $2
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (i32.store
+        (i32.const 3660)
+        (local.tee $3
+         (i32.add
+          (local.get $1)
+          (local.tee $1
+           (if (result i32)
+            (i32.and
+             (local.get $2)
+             (i32.const 7)
+            )
+            (local.get $3)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3648)
+        (local.tee $1
+         (i32.sub
+          (local.get $5)
+          (local.get $1)
+         )
+        )
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $1)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (local.get $3)
+         (local.get $1)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 3664)
+        (i32.load
+         (i32.const 4124)
+        )
+       )
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (local.tee $1
+       (i32.load
+        (i32.const 3648)
+       )
+      )
+      (local.get $0)
+     )
+     (block
+      (i32.store
+       (i32.const 3648)
+       (local.tee $3
+        (i32.sub
+         (local.get $1)
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 3660)
+       (local.tee $1
+        (i32.add
+         (local.tee $2
+          (i32.load
+           (i32.const 3660)
+          )
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store offset=4
+       (local.get $1)
+       (i32.or
+        (local.get $3)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (local.get $2)
+       (i32.or
+        (local.get $0)
+        (i32.const 3)
+       )
+      )
+      (global.set $global$1
+       (local.get $14)
+      )
+      (return
+       (i32.add
+        (local.get $2)
+        (i32.const 8)
+       )
+      )
+     )
+    )
+   )
+   (i32.store
+    (call $12)
+    (i32.const 12)
+   )
+   (global.set $global$1
+    (local.get $14)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $38 (; 51 ;) (type $2) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (block $label$1
+   (if
+    (i32.eqz
+     (local.get $0)
+    )
+    (return)
+   )
+   (if
+    (i32.lt_u
+     (local.tee $1
+      (i32.add
+       (local.get $0)
+       (i32.const -8)
+      )
+     )
+     (local.tee $11
+      (i32.load
+       (i32.const 3652)
+      )
+     )
+    )
+    (call $fimport$10)
+   )
+   (if
+    (i32.eq
+     (local.tee $8
+      (i32.and
+       (local.tee $0
+        (i32.load
+         (i32.add
+          (local.get $0)
+          (i32.const -4)
+         )
+        )
+       )
+       (i32.const 3)
+      )
+     )
+     (i32.const 1)
+    )
+    (call $fimport$10)
+   )
+   (local.set $6
+    (i32.add
+     (local.get $1)
+     (local.tee $4
+      (i32.and
+       (local.get $0)
+       (i32.const -8)
+      )
+     )
+    )
+   )
+   (block $label$5
+    (if
+     (i32.and
+      (local.get $0)
+      (i32.const 1)
+     )
+     (block
+      (local.set $3
+       (local.get $1)
+      )
+      (local.set $2
+       (local.get $4)
+      )
+     )
+     (block
+      (if
+       (i32.eqz
+        (local.get $8)
+       )
+       (return)
+      )
+      (if
+       (i32.lt_u
+        (local.tee $0
+         (i32.add
+          (local.get $1)
+          (i32.sub
+           (i32.const 0)
+           (local.tee $8
+            (i32.load
+             (local.get $1)
+            )
+           )
+          )
+         )
+        )
+        (local.get $11)
+       )
+       (call $fimport$10)
+      )
+      (local.set $1
+       (i32.add
+        (local.get $8)
+        (local.get $4)
+       )
+      )
+      (if
+       (i32.eq
+        (local.get $0)
+        (i32.load
+         (i32.const 3656)
+        )
+       )
+       (block
+        (if
+         (i32.ne
+          (i32.and
+           (local.tee $3
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (local.get $6)
+               (i32.const 4)
+              )
+             )
+            )
+           )
+           (i32.const 3)
+          )
+          (i32.const 3)
+         )
+         (block
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+          (br $label$5)
+         )
+        )
+        (i32.store
+         (i32.const 3644)
+         (local.get $1)
+        )
+        (i32.store
+         (local.get $2)
+         (i32.and
+          (local.get $3)
+          (i32.const -2)
+         )
+        )
+        (i32.store offset=4
+         (local.get $0)
+         (i32.or
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (i32.store
+         (i32.add
+          (local.get $0)
+          (local.get $1)
+         )
+         (local.get $1)
+        )
+        (return)
+       )
+      )
+      (local.set $10
+       (i32.shr_u
+        (local.get $8)
+        (i32.const 3)
+       )
+      )
+      (if
+       (i32.lt_u
+        (local.get $8)
+        (i32.const 256)
+       )
+       (block
+        (local.set $3
+         (i32.load offset=12
+          (local.get $0)
+         )
+        )
+        (if
+         (i32.ne
+          (local.tee $4
+           (i32.load offset=8
+            (local.get $0)
+           )
+          )
+          (local.tee $2
+           (i32.add
+            (i32.shl
+             (i32.shl
+              (local.get $10)
+              (i32.const 1)
+             )
+             (i32.const 2)
+            )
+            (i32.const 3676)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $4)
+            (local.get $11)
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.ne
+            (i32.load offset=12
+             (local.get $4)
+            )
+            (local.get $0)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $3)
+          (local.get $4)
+         )
+         (block
+          (i32.store
+           (i32.const 3636)
+           (i32.and
+            (i32.load
+             (i32.const 3636)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (local.get $10)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+          (br $label$5)
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $3)
+          (local.get $2)
+         )
+         (local.set $5
+          (i32.add
+           (local.get $3)
+           (i32.const 8)
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $3)
+            (local.get $11)
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (local.get $3)
+               (i32.const 8)
+              )
+             )
+            )
+            (local.get $0)
+           )
+           (local.set $5
+            (local.get $2)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (i32.store offset=12
+         (local.get $4)
+         (local.get $3)
+        )
+        (i32.store
+         (local.get $5)
+         (local.get $4)
+        )
+        (local.set $3
+         (local.get $0)
+        )
+        (local.set $2
+         (local.get $1)
+        )
+        (br $label$5)
+       )
+      )
+      (local.set $12
+       (i32.load offset=24
+        (local.get $0)
+       )
+      )
+      (block $label$22
+       (if
+        (i32.eq
+         (local.tee $4
+          (i32.load offset=12
+           (local.get $0)
+          )
+         )
+         (local.get $0)
+        )
+        (block
+         (if
+          (local.tee $4
+           (i32.load
+            (local.tee $8
+             (i32.add
+              (local.tee $5
+               (i32.add
+                (local.get $0)
+                (i32.const 16)
+               )
+              )
+              (i32.const 4)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (local.get $8)
+          )
+          (if
+           (i32.eqz
+            (local.tee $4
+             (i32.load
+              (local.get $5)
+             )
+            )
+           )
+           (block
+            (local.set $7
+             (i32.const 0)
+            )
+            (br $label$22)
+           )
+          )
+         )
+         (loop $label$27
+          (if
+           (local.tee $10
+            (i32.load
+             (local.tee $8
+              (i32.add
+               (local.get $4)
+               (i32.const 20)
+              )
+             )
+            )
+           )
+           (block
+            (local.set $4
+             (local.get $10)
+            )
+            (local.set $5
+             (local.get $8)
+            )
+            (br $label$27)
+           )
+          )
+          (if
+           (local.tee $10
+            (i32.load
+             (local.tee $8
+              (i32.add
+               (local.get $4)
+               (i32.const 16)
+              )
+             )
+            )
+           )
+           (block
+            (local.set $4
+             (local.get $10)
+            )
+            (local.set $5
+             (local.get $8)
+            )
+            (br $label$27)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $5)
+           (local.get $11)
+          )
+          (call $fimport$10)
+          (block
+           (i32.store
+            (local.get $5)
+            (i32.const 0)
+           )
+           (local.set $7
+            (local.get $4)
+           )
+          )
+         )
+        )
+        (block
+         (if
+          (i32.lt_u
+           (local.tee $5
+            (i32.load offset=8
+             (local.get $0)
+            )
+           )
+           (local.get $11)
+          )
+          (call $fimport$10)
+         )
+         (if
+          (i32.ne
+           (i32.load
+            (local.tee $8
+             (i32.add
+              (local.get $5)
+              (i32.const 12)
+             )
+            )
+           )
+           (local.get $0)
+          )
+          (call $fimport$10)
+         )
+         (if
+          (i32.eq
+           (i32.load
+            (local.tee $10
+             (i32.add
+              (local.get $4)
+              (i32.const 8)
+             )
+            )
+           )
+           (local.get $0)
+          )
+          (block
+           (i32.store
+            (local.get $8)
+            (local.get $4)
+           )
+           (i32.store
+            (local.get $10)
+            (local.get $5)
+           )
+           (local.set $7
+            (local.get $4)
+           )
+          )
+          (call $fimport$10)
+         )
+        )
+       )
+      )
+      (if
+       (local.get $12)
+       (block
+        (if
+         (i32.eq
+          (local.get $0)
+          (i32.load
+           (local.tee $5
+            (i32.add
+             (i32.shl
+              (local.tee $4
+               (i32.load offset=28
+                (local.get $0)
+               )
+              )
+              (i32.const 2)
+             )
+             (i32.const 3940)
+            )
+           )
+          )
+         )
+         (block
+          (i32.store
+           (local.get $5)
+           (local.get $7)
+          )
+          (if
+           (i32.eqz
+            (local.get $7)
+           )
+           (block
+            (i32.store
+             (i32.const 3640)
+             (i32.and
+              (i32.load
+               (i32.const 3640)
+              )
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (local.get $4)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+            (local.set $3
+             (local.get $0)
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$5)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $12)
+            (i32.load
+             (i32.const 3652)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $4
+              (i32.add
+               (local.get $12)
+               (i32.const 16)
+              )
+             )
+            )
+            (local.get $0)
+           )
+           (i32.store
+            (local.get $4)
+            (local.get $7)
+           )
+           (i32.store offset=20
+            (local.get $12)
+            (local.get $7)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.get $7)
+           )
+           (block
+            (local.set $3
+             (local.get $0)
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$5)
+           )
+          )
+         )
+        )
+        (if
+         (i32.lt_u
+          (local.get $7)
+          (local.tee $5
+           (i32.load
+            (i32.const 3652)
+           )
+          )
+         )
+         (call $fimport$10)
+        )
+        (i32.store offset=24
+         (local.get $7)
+         (local.get $12)
+        )
+        (if
+         (local.tee $4
+          (i32.load
+           (local.tee $8
+            (i32.add
+             (local.get $0)
+             (i32.const 16)
+            )
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (local.get $5)
+          )
+          (call $fimport$10)
+          (block
+           (i32.store offset=16
+            (local.get $7)
+            (local.get $4)
+           )
+           (i32.store offset=24
+            (local.get $4)
+            (local.get $7)
+           )
+          )
+         )
+        )
+        (if
+         (local.tee $4
+          (i32.load offset=4
+           (local.get $8)
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (i32.load
+            (i32.const 3652)
+           )
+          )
+          (call $fimport$10)
+          (block
+           (i32.store offset=20
+            (local.get $7)
+            (local.get $4)
+           )
+           (i32.store offset=24
+            (local.get $4)
+            (local.get $7)
+           )
+           (local.set $3
+            (local.get $0)
+           )
+           (local.set $2
+            (local.get $1)
+           )
+          )
+         )
+         (block
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+         )
+        )
+       )
+       (block
+        (local.set $3
+         (local.get $0)
+        )
+        (local.set $2
+         (local.get $1)
+        )
+       )
+      )
+     )
+    )
+   )
+   (if
+    (i32.ge_u
+     (local.get $3)
+     (local.get $6)
+    )
+    (call $fimport$10)
+   )
+   (if
+    (i32.eqz
+     (i32.and
+      (local.tee $0
+       (i32.load
+        (local.tee $1
+         (i32.add
+          (local.get $6)
+          (i32.const 4)
+         )
+        )
+       )
+      )
+      (i32.const 1)
+     )
+    )
+    (call $fimport$10)
+   )
+   (if
+    (i32.and
+     (local.get $0)
+     (i32.const 2)
+    )
+    (block
+     (i32.store
+      (local.get $1)
+      (i32.and
+       (local.get $0)
+       (i32.const -2)
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.or
+       (local.get $2)
+       (i32.const 1)
+      )
+     )
+     (i32.store
+      (i32.add
+       (local.get $3)
+       (local.get $2)
+      )
+      (local.get $2)
+     )
+    )
+    (block
+     (if
+      (i32.eq
+       (local.get $6)
+       (i32.load
+        (i32.const 3660)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3648)
+        (local.tee $0
+         (i32.add
+          (i32.load
+           (i32.const 3648)
+          )
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3660)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $0)
+         (i32.const 1)
+        )
+       )
+       (if
+        (i32.ne
+         (local.get $3)
+         (i32.load
+          (i32.const 3656)
+         )
+        )
+        (return)
+       )
+       (i32.store
+        (i32.const 3656)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 3644)
+        (i32.const 0)
+       )
+       (return)
+      )
+     )
+     (if
+      (i32.eq
+       (local.get $6)
+       (i32.load
+        (i32.const 3656)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3644)
+        (local.tee $0
+         (i32.add
+          (i32.load
+           (i32.const 3644)
+          )
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3656)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $0)
+         (i32.const 1)
+        )
+       )
+       (i32.store
+        (i32.add
+         (local.get $3)
+         (local.get $0)
+        )
+        (local.get $0)
+       )
+       (return)
+      )
+     )
+     (local.set $5
+      (i32.add
+       (i32.and
+        (local.get $0)
+        (i32.const -8)
+       )
+       (local.get $2)
+      )
+     )
+     (local.set $4
+      (i32.shr_u
+       (local.get $0)
+       (i32.const 3)
+      )
+     )
+     (block $label$61
+      (if
+       (i32.lt_u
+        (local.get $0)
+        (i32.const 256)
+       )
+       (block
+        (local.set $2
+         (i32.load offset=12
+          (local.get $6)
+         )
+        )
+        (if
+         (i32.ne
+          (local.tee $1
+           (i32.load offset=8
+            (local.get $6)
+           )
+          )
+          (local.tee $0
+           (i32.add
+            (i32.shl
+             (i32.shl
+              (local.get $4)
+              (i32.const 1)
+             )
+             (i32.const 2)
+            )
+            (i32.const 3676)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $1)
+            (i32.load
+             (i32.const 3652)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.ne
+            (i32.load offset=12
+             (local.get $1)
+            )
+            (local.get $6)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $1)
+         )
+         (block
+          (i32.store
+           (i32.const 3636)
+           (i32.and
+            (i32.load
+             (i32.const 3636)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (local.get $4)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (br $label$61)
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $0)
+         )
+         (local.set $14
+          (i32.add
+           (local.get $2)
+           (i32.const 8)
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $2)
+            (i32.load
+             (i32.const 3652)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $0
+              (i32.add
+               (local.get $2)
+               (i32.const 8)
+              )
+             )
+            )
+            (local.get $6)
+           )
+           (local.set $14
+            (local.get $0)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (i32.store offset=12
+         (local.get $1)
+         (local.get $2)
+        )
+        (i32.store
+         (local.get $14)
+         (local.get $1)
+        )
+       )
+       (block
+        (local.set $7
+         (i32.load offset=24
+          (local.get $6)
+         )
+        )
+        (block $label$73
+         (if
+          (i32.eq
+           (local.tee $0
+            (i32.load offset=12
+             (local.get $6)
+            )
+           )
+           (local.get $6)
+          )
+          (block
+           (if
+            (local.tee $0
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (local.tee $2
+                 (i32.add
+                  (local.get $6)
+                  (i32.const 16)
+                 )
+                )
+                (i32.const 4)
+               )
+              )
+             )
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (if
+             (i32.eqz
+              (local.tee $0
+               (i32.load
+                (local.get $2)
+               )
+              )
+             )
+             (block
+              (local.set $9
+               (i32.const 0)
+              )
+              (br $label$73)
+             )
+            )
+           )
+           (loop $label$78
+            (if
+             (local.tee $4
+              (i32.load
+               (local.tee $1
+                (i32.add
+                 (local.get $0)
+                 (i32.const 20)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (local.get $4)
+              )
+              (local.set $2
+               (local.get $1)
+              )
+              (br $label$78)
+             )
+            )
+            (if
+             (local.tee $4
+              (i32.load
+               (local.tee $1
+                (i32.add
+                 (local.get $0)
+                 (i32.const 16)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (local.get $4)
+              )
+              (local.set $2
+               (local.get $1)
+              )
+              (br $label$78)
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $2)
+             (i32.load
+              (i32.const 3652)
+             )
+            )
+            (call $fimport$10)
+            (block
+             (i32.store
+              (local.get $2)
+              (i32.const 0)
+             )
+             (local.set $9
+              (local.get $0)
+             )
+            )
+           )
+          )
+          (block
+           (if
+            (i32.lt_u
+             (local.tee $2
+              (i32.load offset=8
+               (local.get $6)
+              )
+             )
+             (i32.load
+              (i32.const 3652)
+             )
+            )
+            (call $fimport$10)
+           )
+           (if
+            (i32.ne
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (local.get $2)
+                (i32.const 12)
+               )
+              )
+             )
+             (local.get $6)
+            )
+            (call $fimport$10)
+           )
+           (if
+            (i32.eq
+             (i32.load
+              (local.tee $4
+               (i32.add
+                (local.get $0)
+                (i32.const 8)
+               )
+              )
+             )
+             (local.get $6)
+            )
+            (block
+             (i32.store
+              (local.get $1)
+              (local.get $0)
+             )
+             (i32.store
+              (local.get $4)
+              (local.get $2)
+             )
+             (local.set $9
+              (local.get $0)
+             )
+            )
+            (call $fimport$10)
+           )
+          )
+         )
+        )
+        (if
+         (local.get $7)
+         (block
+          (if
+           (i32.eq
+            (local.get $6)
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (i32.shl
+                (local.tee $0
+                 (i32.load offset=28
+                  (local.get $6)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 3940)
+              )
+             )
+            )
+           )
+           (block
+            (i32.store
+             (local.get $2)
+             (local.get $9)
+            )
+            (if
+             (i32.eqz
+              (local.get $9)
+             )
+             (block
+              (i32.store
+               (i32.const 3640)
+               (i32.and
+                (i32.load
+                 (i32.const 3640)
+                )
+                (i32.xor
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $0)
+                 )
+                 (i32.const -1)
+                )
+               )
+              )
+              (br $label$61)
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $7)
+              (i32.load
+               (i32.const 3652)
+              )
+             )
+             (call $fimport$10)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (local.tee $0
+                (i32.add
+                 (local.get $7)
+                 (i32.const 16)
+                )
+               )
+              )
+              (local.get $6)
+             )
+             (i32.store
+              (local.get $0)
+              (local.get $9)
+             )
+             (i32.store offset=20
+              (local.get $7)
+              (local.get $9)
+             )
+            )
+            (br_if $label$61
+             (i32.eqz
+              (local.get $9)
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $9)
+            (local.tee $2
+             (i32.load
+              (i32.const 3652)
+             )
+            )
+           )
+           (call $fimport$10)
+          )
+          (i32.store offset=24
+           (local.get $9)
+           (local.get $7)
+          )
+          (if
+           (local.tee $0
+            (i32.load
+             (local.tee $1
+              (i32.add
+               (local.get $6)
+               (i32.const 16)
+              )
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $0)
+             (local.get $2)
+            )
+            (call $fimport$10)
+            (block
+             (i32.store offset=16
+              (local.get $9)
+              (local.get $0)
+             )
+             (i32.store offset=24
+              (local.get $0)
+              (local.get $9)
+             )
+            )
+           )
+          )
+          (if
+           (local.tee $0
+            (i32.load offset=4
+             (local.get $1)
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $0)
+             (i32.load
+              (i32.const 3652)
+             )
+            )
+            (call $fimport$10)
+            (block
+             (i32.store offset=20
+              (local.get $9)
+              (local.get $0)
+             )
+             (i32.store offset=24
+              (local.get $0)
+              (local.get $9)
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.or
+       (local.get $5)
+       (i32.const 1)
+      )
+     )
+     (i32.store
+      (i32.add
+       (local.get $3)
+       (local.get $5)
+      )
+      (local.get $5)
+     )
+     (if
+      (i32.eq
+       (local.get $3)
+       (i32.load
+        (i32.const 3656)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3644)
+        (local.get $5)
+       )
+       (return)
+      )
+      (local.set $2
+       (local.get $5)
+      )
+     )
+    )
+   )
+   (local.set $1
+    (i32.shr_u
+     (local.get $2)
+     (i32.const 3)
+    )
+   )
+   (if
+    (i32.lt_u
+     (local.get $2)
+     (i32.const 256)
+    )
+    (block
+     (local.set $0
+      (i32.add
+       (i32.shl
+        (i32.shl
+         (local.get $1)
+         (i32.const 1)
+        )
+        (i32.const 2)
+       )
+       (i32.const 3676)
+      )
+     )
+     (if
+      (i32.and
+       (local.tee $2
+        (i32.load
+         (i32.const 3636)
+        )
+       )
+       (local.tee $1
+        (i32.shl
+         (i32.const 1)
+         (local.get $1)
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (local.tee $1
+         (i32.load
+          (local.tee $2
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (i32.load
+         (i32.const 3652)
+        )
+       )
+       (call $fimport$10)
+       (block
+        (local.set $15
+         (local.get $2)
+        )
+        (local.set $13
+         (local.get $1)
+        )
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3636)
+        (i32.or
+         (local.get $2)
+         (local.get $1)
+        )
+       )
+       (local.set $15
+        (i32.add
+         (local.get $0)
+         (i32.const 8)
+        )
+       )
+       (local.set $13
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (local.get $15)
+      (local.get $3)
+     )
+     (i32.store offset=12
+      (local.get $13)
+      (local.get $3)
+     )
+     (i32.store offset=8
+      (local.get $3)
+      (local.get $13)
+     )
+     (i32.store offset=12
+      (local.get $3)
+      (local.get $0)
+     )
+     (return)
+    )
+   )
+   (local.set $0
+    (i32.add
+     (i32.shl
+      (local.tee $1
+       (if (result i32)
+        (local.tee $0
+         (i32.shr_u
+          (local.get $2)
+          (i32.const 8)
+         )
+        )
+        (if (result i32)
+         (i32.gt_u
+          (local.get $2)
+          (i32.const 16777215)
+         )
+         (i32.const 31)
+         (i32.or
+          (i32.and
+           (i32.shr_u
+            (local.get $2)
+            (i32.add
+             (local.tee $0
+              (i32.add
+               (i32.sub
+                (i32.const 14)
+                (i32.or
+                 (i32.or
+                  (local.tee $4
+                   (i32.and
+                    (i32.shr_u
+                     (i32.add
+                      (local.tee $1
+                       (i32.shl
+                        (local.get $0)
+                        (local.tee $0
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (local.get $0)
+                            (i32.const 1048320)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 8)
+                         )
+                        )
+                       )
+                      )
+                      (i32.const 520192)
+                     )
+                     (i32.const 16)
+                    )
+                    (i32.const 4)
+                   )
+                  )
+                  (local.get $0)
+                 )
+                 (local.tee $1
+                  (i32.and
+                   (i32.shr_u
+                    (i32.add
+                     (local.tee $0
+                      (i32.shl
+                       (local.get $1)
+                       (local.get $4)
+                      )
+                     )
+                     (i32.const 245760)
+                    )
+                    (i32.const 16)
+                   )
+                   (i32.const 2)
+                  )
+                 )
+                )
+               )
+               (i32.shr_u
+                (i32.shl
+                 (local.get $0)
+                 (local.get $1)
+                )
+                (i32.const 15)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.shl
+           (local.get $0)
+           (i32.const 1)
+          )
+         )
+        )
+        (i32.const 0)
+       )
+      )
+      (i32.const 2)
+     )
+     (i32.const 3940)
+    )
+   )
+   (i32.store offset=28
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=20
+    (local.get $3)
+    (i32.const 0)
+   )
+   (i32.store offset=16
+    (local.get $3)
+    (i32.const 0)
+   )
+   (block $label$113
+    (if
+     (i32.and
+      (local.tee $4
+       (i32.load
+        (i32.const 3640)
+       )
+      )
+      (local.tee $5
+       (i32.shl
+        (i32.const 1)
+        (local.get $1)
+       )
+      )
+     )
+     (block
+      (local.set $0
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (local.set $4
+       (i32.sub
+        (i32.const 25)
+        (i32.shr_u
+         (local.get $1)
+         (i32.const 1)
+        )
+       )
+      )
+      (local.set $1
+       (i32.shl
+        (local.get $2)
+        (if (result i32)
+         (i32.eq
+          (local.get $1)
+          (i32.const 31)
+         )
+         (i32.const 0)
+         (local.get $4)
+        )
+       )
+      )
+      (block $label$117
+       (block $label$118
+        (block $label$119
+         (loop $label$120
+          (br_if $label$118
+           (i32.eq
+            (i32.and
+             (i32.load offset=4
+              (local.get $0)
+             )
+             (i32.const -8)
+            )
+            (local.get $2)
+           )
+          )
+          (local.set $4
+           (i32.shl
+            (local.get $1)
+            (i32.const 1)
+           )
+          )
+          (br_if $label$119
+           (i32.eqz
+            (local.tee $5
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (i32.add
+                 (local.get $0)
+                 (i32.const 16)
+                )
+                (i32.shl
+                 (i32.shr_u
+                  (local.get $1)
+                  (i32.const 31)
+                 )
+                 (i32.const 2)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (local.set $1
+           (local.get $4)
+          )
+          (local.set $0
+           (local.get $5)
+          )
+          (br $label$120)
+         )
+        )
+        (if
+         (i32.lt_u
+          (local.get $1)
+          (i32.load
+           (i32.const 3652)
+          )
+         )
+         (call $fimport$10)
+         (block
+          (i32.store
+           (local.get $1)
+           (local.get $3)
+          )
+          (i32.store offset=24
+           (local.get $3)
+           (local.get $0)
+          )
+          (i32.store offset=12
+           (local.get $3)
+           (local.get $3)
+          )
+          (i32.store offset=8
+           (local.get $3)
+           (local.get $3)
+          )
+          (br $label$113)
+         )
+        )
+        (br $label$117)
+       )
+       (if
+        (i32.and
+         (i32.ge_u
+          (local.tee $2
+           (i32.load
+            (local.tee $1
+             (i32.add
+              (local.get $0)
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (local.tee $4
+           (i32.load
+            (i32.const 3652)
+           )
+          )
+         )
+         (i32.ge_u
+          (local.get $0)
+          (local.get $4)
+         )
+        )
+        (block
+         (i32.store offset=12
+          (local.get $2)
+          (local.get $3)
+         )
+         (i32.store
+          (local.get $1)
+          (local.get $3)
+         )
+         (i32.store offset=8
+          (local.get $3)
+          (local.get $2)
+         )
+         (i32.store offset=12
+          (local.get $3)
+          (local.get $0)
+         )
+         (i32.store offset=24
+          (local.get $3)
+          (i32.const 0)
+         )
+        )
+        (call $fimport$10)
+       )
+      )
+     )
+     (block
+      (i32.store
+       (i32.const 3640)
+       (i32.or
+        (local.get $4)
+        (local.get $5)
+       )
+      )
+      (i32.store
+       (local.get $0)
+       (local.get $3)
+      )
+      (i32.store offset=24
+       (local.get $3)
+       (local.get $0)
+      )
+      (i32.store offset=12
+       (local.get $3)
+       (local.get $3)
+      )
+      (i32.store offset=8
+       (local.get $3)
+       (local.get $3)
+      )
+     )
+    )
+   )
+   (i32.store
+    (i32.const 3668)
+    (local.tee $0
+     (i32.add
+      (i32.load
+       (i32.const 3668)
+      )
+      (i32.const -1)
+     )
+    )
+   )
+   (if
+    (local.get $0)
+    (return)
+    (local.set $0
+     (i32.const 4092)
+    )
+   )
+   (loop $label$128
+    (local.set $0
+     (i32.add
+      (local.tee $2
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (i32.const 8)
+     )
+    )
+    (br_if $label$128
+     (local.get $2)
+    )
+   )
+   (i32.store
+    (i32.const 3668)
+    (i32.const -1)
+   )
+  )
+ )
+ (func $39 (; 52 ;) (type $6)
+  (nop)
+ )
+ (func $40 (; 53 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.add
+     (local.tee $2
+      (i32.load
+       (global.get $global$0)
+      )
+     )
+     (local.tee $0
+      (i32.and
+       (i32.add
+        (local.get $0)
+        (i32.const 15)
+       )
+       (i32.const -16)
+      )
+     )
+    )
+   )
+   (if
+    (i32.or
+     (i32.and
+      (i32.gt_s
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.lt_s
+       (local.get $1)
+       (local.get $2)
+      )
+     )
+     (i32.lt_s
+      (local.get $1)
+      (i32.const 0)
+     )
+    )
+    (block
+     (drop
+      (call $fimport$6)
+     )
+     (call $fimport$11
+      (i32.const 12)
+     )
+     (return
+      (i32.const -1)
+     )
+    )
+   )
+   (i32.store
+    (global.get $global$0)
+    (local.get $1)
+   )
+   (if
+    (i32.gt_s
+     (local.get $1)
+     (call $fimport$5)
+    )
+    (if
+     (i32.eqz
+      (call $fimport$4)
+     )
+     (block
+      (call $fimport$11
+       (i32.const 12)
+      )
+      (i32.store
+       (global.get $global$0)
+       (local.get $2)
+      )
+      (return
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (local.get $2)
+  )
+ )
+ (func $41 (; 54 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (i32.add
+     (local.get $0)
+     (local.get $2)
+    )
+   )
+   (if
+    (i32.ge_s
+     (local.get $2)
+     (i32.const 20)
+    )
+    (block
+     (local.set $1
+      (i32.and
+       (local.get $1)
+       (i32.const 255)
+      )
+     )
+     (if
+      (local.tee $3
+       (i32.and
+        (local.get $0)
+        (i32.const 3)
+       )
+      )
+      (block
+       (local.set $3
+        (i32.sub
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+         (local.get $3)
+        )
+       )
+       (loop $label$4
+        (if
+         (i32.lt_s
+          (local.get $0)
+          (local.get $3)
+         )
+         (block
+          (i32.store8
+           (local.get $0)
+           (local.get $1)
+          )
+          (local.set $0
+           (i32.add
+            (local.get $0)
+            (i32.const 1)
+           )
+          )
+          (br $label$4)
+         )
+        )
+       )
+      )
+     )
+     (local.set $3
+      (i32.or
+       (i32.or
+        (i32.or
+         (local.get $1)
+         (i32.shl
+          (local.get $1)
+          (i32.const 8)
+         )
+        )
+        (i32.shl
+         (local.get $1)
+         (i32.const 16)
+        )
+       )
+       (i32.shl
+        (local.get $1)
+        (i32.const 24)
+       )
+      )
+     )
+     (local.set $5
+      (i32.and
+       (local.get $4)
+       (i32.const -4)
+      )
+     )
+     (loop $label$6
+      (if
+       (i32.lt_s
+        (local.get $0)
+        (local.get $5)
+       )
+       (block
+        (i32.store
+         (local.get $0)
+         (local.get $3)
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+        )
+        (br $label$6)
+       )
+      )
+     )
+    )
+   )
+   (loop $label$8
+    (if
+     (i32.lt_s
+      (local.get $0)
+      (local.get $4)
+     )
+     (block
+      (i32.store8
+       (local.get $0)
+       (local.get $1)
+      )
+      (local.set $0
+       (i32.add
+        (local.get $0)
+        (i32.const 1)
+       )
+      )
+      (br $label$8)
+     )
+    )
+   )
+   (i32.sub
+    (local.get $0)
+    (local.get $2)
+   )
+  )
+ )
+ (func $42 (; 55 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (if
+    (i32.ge_s
+     (local.get $2)
+     (i32.const 4096)
+    )
+    (return
+     (call $fimport$12
+      (local.get $0)
+      (local.get $1)
+      (local.get $2)
+     )
+    )
+   )
+   (local.set $3
+    (local.get $0)
+   )
+   (if
+    (i32.eq
+     (i32.and
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.and
+      (local.get $1)
+      (i32.const 3)
+     )
+    )
+    (block
+     (loop $label$4
+      (if
+       (i32.and
+        (local.get $0)
+        (i32.const 3)
+       )
+       (block
+        (if
+         (i32.eqz
+          (local.get $2)
+         )
+         (return
+          (local.get $3)
+         )
+        )
+        (i32.store8
+         (local.get $0)
+         (i32.load8_s
+          (local.get $1)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 1)
+         )
+        )
+        (local.set $1
+         (i32.add
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (local.set $2
+         (i32.sub
+          (local.get $2)
+          (i32.const 1)
+         )
+        )
+        (br $label$4)
+       )
+      )
+     )
+     (loop $label$7
+      (if
+       (i32.ge_s
+        (local.get $2)
+        (i32.const 4)
+       )
+       (block
+        (i32.store
+         (local.get $0)
+         (i32.load
+          (local.get $1)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+        )
+        (local.set $1
+         (i32.add
+          (local.get $1)
+          (i32.const 4)
+         )
+        )
+        (local.set $2
+         (i32.sub
+          (local.get $2)
+          (i32.const 4)
+         )
+        )
+        (br $label$7)
+       )
+      )
+     )
+    )
+   )
+   (loop $label$9
+    (if
+     (i32.gt_s
+      (local.get $2)
+      (i32.const 0)
+     )
+     (block
+      (i32.store8
+       (local.get $0)
+       (i32.load8_s
+        (local.get $1)
+       )
+      )
+      (local.set $0
+       (i32.add
+        (local.get $0)
+        (i32.const 1)
+       )
+      )
+      (local.set $1
+       (i32.add
+        (local.get $1)
+        (i32.const 1)
+       )
+      )
+      (local.set $2
+       (i32.sub
+        (local.get $2)
+        (i32.const 1)
+       )
+      )
+      (br $label$9)
+     )
+    )
+   )
+   (local.get $3)
+  )
+ )
+ (func $43 (; 56 ;) (type $3) (result i32)
+  (i32.const 0)
+ )
+ (func $44 (; 57 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (call_indirect (type $1)
+   (local.get $1)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 1)
+    )
+    (i32.const 0)
+   )
+  )
+ )
+ (func $45 (; 58 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (call_indirect (type $0)
+   (local.get $1)
+   (local.get $2)
+   (local.get $3)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 3)
+    )
+    (i32.const 2)
+   )
+  )
+ )
+ (func $46 (; 59 ;) (type $5) (param $0 i32) (param $1 i32)
+  (call_indirect (type $2)
+   (local.get $1)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 1)
+    )
+    (i32.const 6)
+   )
+  )
+ )
+ (func $47 (; 60 ;) (type $1) (param $0 i32) (result i32)
+  (block $label$1 (result i32)
+   (call $fimport$3
+    (i32.const 0)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $48 (; 61 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (block $label$1 (result i32)
+   (call $fimport$3
+    (i32.const 1)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $49 (; 62 ;) (type $2) (param $0 i32)
+  (call $fimport$3
+   (i32.const 2)
+  )
+ )
+)
+

--- a/wasmtests/embenchen_primes.wat
+++ b/wasmtests/embenchen_primes.wat
@@ -1,0 +1,15334 @@
+(module
+ (type $0 (func (param i32 i32 i32) (result i32)))
+ (type $1 (func (param i32) (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (param i32 i32)))
+ (type $6 (func))
+ (type $7 (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $8 (func (param i32 i32 i32)))
+ (type $9 (func (param i64 i32) (result i32)))
+ (type $10 (func (param i32 i32 i32 i32 i32)))
+ (type $11 (func (param f64 i32) (result f64)))
+ (type $12 (func (param i32 i32 i32 i32) (result i32)))
+ (import "env" "memory" (memory $16 2048 2048))
+ (data (i32.const 1024) "\04\04\00\00\05")
+ (data (i32.const 1040) "\01")
+ (data (i32.const 1064) "\01\00\00\00\02\00\00\004\10\00\00\00\04")
+ (data (i32.const 1088) "\01")
+ (data (i32.const 1103) "\n\ff\ff\ff\ff")
+ (data (i32.const 1140) "error: %d\\n\00lastprime: %d.\n\00\11\00\n\00\11\11\11\00\00\00\00\05\00\00\00\00\00\00\t\00\00\00\00\0b")
+ (data (i32.const 1200) "\11\00\0f\n\11\11\11\03\n\07\00\01\13\t\0b\0b\00\00\t\06\0b\00\00\0b\00\06\11\00\00\00\11\11\11")
+ (data (i32.const 1249) "\0b")
+ (data (i32.const 1258) "\11\00\n\n\11\11\11\00\n\00\00\02\00\t\0b\00\00\00\t\00\0b\00\00\0b")
+ (data (i32.const 1307) "\0c")
+ (data (i32.const 1319) "\0c\00\00\00\00\0c\00\00\00\00\t\0c\00\00\00\00\00\0c\00\00\0c")
+ (data (i32.const 1365) "\0e")
+ (data (i32.const 1377) "\0d\00\00\00\04\0d\00\00\00\00\t\0e\00\00\00\00\00\0e\00\00\0e")
+ (data (i32.const 1423) "\10")
+ (data (i32.const 1435) "\0f\00\00\00\00\0f\00\00\00\00\t\10\00\00\00\00\00\10\00\00\10\00\00\12\00\00\00\12\12\12")
+ (data (i32.const 1490) "\12\00\00\00\12\12\12\00\00\00\00\00\00\t")
+ (data (i32.const 1539) "\0b")
+ (data (i32.const 1551) "\n\00\00\00\00\n\00\00\00\00\t\0b\00\00\00\00\00\0b\00\00\0b")
+ (data (i32.const 1597) "\0c")
+ (data (i32.const 1609) "\0c\00\00\00\00\0c\00\00\00\00\t\0c\00\00\00\00\00\0c\00\00\0c\00\000123456789ABCDEF-+   0X0x\00(null)\00-0X+0X 0X-0x+0x 0x\00inf\00INF\00nan\00NAN\00.\00T!\"\19\0d\01\02\03\11K\1c\0c\10\04\0b\1d\12\1e\'hnopqb \05\06\0f\13\14\15\1a\08\16\07($\17\18\t\n\0e\1b\1f%#\83\82}&*+<=>?CGJMXYZ[\\]^_`acdefgijklrstyz{|\00Illegal byte sequence\00Domain error\00Result not representable\00Not a tty\00Permission denied\00Operation not permitted\00No such file or directory\00No such process\00File exists\00Value too large for data type\00No space left on device\00Out of memory\00Resource busy\00Interrupted system call\00Resource temporarily unavailable\00Invalid seek\00Cross-device link\00Read-only file system\00Directory not empty\00Connection reset by peer\00Operation timed out\00Connection refused\00Host is down\00Host is unreachable\00Address in use\00Broken pipe\00I/O error\00No such device or address\00Block device required\00No such device\00Not a directory\00Is a directory\00Text file busy\00Exec format error\00Invalid argument\00Argument list too long\00Symbolic link loop\00Filename too long\00Too many open files in system\00No file descriptors available\00Bad file descriptor\00No child process\00Bad address\00File too large\00Too many links\00No locks available\00Resource deadlock would occur\00State not recoverable\00Previous owner died\00Operation canceled\00Function not implemented\00No message of desired type\00Identifier removed\00Device not a stream\00No data available\00Device timeout\00Out of streams resources\00Link has been severed\00Protocol error\00Bad message\00File descriptor in bad state\00Not a socket\00Destination address required\00Message too large\00Protocol wrong type for socket\00Protocol not available\00Protocol not supported\00Socket type not supported\00Not supported\00Protocol family not supported\00Address family not supported by protocol\00Address not available\00Network is down\00Network unreachable\00Connection reset by network\00Connection aborted\00No buffer space available\00Socket is connected\00Socket not connected\00Cannot send after socket shutdown\00Operation already in progress\00Operation in progress\00Stale file handle\00Remote I/O error\00Quota exceeded\00No medium found\00Wrong medium type\00No error information")
+ (import "env" "table" (table $timport$17 8 8 funcref))
+ (elem (global.get $gimport$19) $41 $8 $42 $13 $9 $14 $43 $15)
+ (import "env" "DYNAMICTOP_PTR" (global $gimport$0 i32))
+ (import "env" "STACKTOP" (global $gimport$1 i32))
+ (import "env" "STACK_MAX" (global $gimport$2 i32))
+ (import "env" "memoryBase" (global $gimport$18 i32))
+ (import "env" "tableBase" (global $gimport$19 i32))
+ (import "env" "abort" (func $fimport$3 (param i32)))
+ (import "env" "enlargeMemory" (func $fimport$4 (result i32)))
+ (import "env" "getTotalMemory" (func $fimport$5 (result i32)))
+ (import "env" "abortOnCannotGrowMemory" (func $fimport$6 (result i32)))
+ (import "env" "_pthread_cleanup_pop" (func $fimport$7 (param i32)))
+ (import "env" "___syscall6" (func $fimport$8 (param i32 i32) (result i32)))
+ (import "env" "_pthread_cleanup_push" (func $fimport$9 (param i32 i32)))
+ (import "env" "_abort" (func $fimport$10))
+ (import "env" "___setErrNo" (func $fimport$11 (param i32)))
+ (import "env" "_emscripten_memcpy_big" (func $fimport$12 (param i32 i32 i32) (result i32)))
+ (import "env" "___syscall54" (func $fimport$13 (param i32 i32) (result i32)))
+ (import "env" "___syscall140" (func $fimport$14 (param i32 i32) (result i32)))
+ (import "env" "___syscall146" (func $fimport$15 (param i32 i32) (result i32)))
+ (global $global$0 (mut i32) (global.get $gimport$0))
+ (global $global$1 (mut i32) (global.get $gimport$1))
+ (global $global$2 (mut i32) (global.get $gimport$2))
+ (global $global$3 (mut i32) (i32.const 0))
+ (global $global$4 (mut i32) (i32.const 0))
+ (global $global$5 (mut i32) (i32.const 0))
+ (export "_sbrk" (func $34))
+ (export "_free" (func $32))
+ (export "_main" (func $7))
+ (export "_pthread_self" (func $37))
+ (export "_memset" (func $35))
+ (export "_malloc" (func $31))
+ (export "_memcpy" (func $36))
+ (export "___errno_location" (func $11))
+ (export "runPostSets" (func $33))
+ (export "stackAlloc" (func $0))
+ (export "stackSave" (func $1))
+ (export "stackRestore" (func $2))
+ (export "establishStackSpace" (func $3))
+ (export "setThrew" (func $4))
+ (export "setTempRet0" (func $5))
+ (export "getTempRet0" (func $6))
+ (export "dynCall_ii" (func $38))
+ (export "dynCall_iiii" (func $39))
+ (export "dynCall_vi" (func $40))
+ (func $0 (; 13 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (local.get $0)
+    )
+   )
+   (global.set $global$1
+    (i32.and
+     (i32.add
+      (global.get $global$1)
+      (i32.const 15)
+     )
+     (i32.const -16)
+    )
+   )
+   (local.get $1)
+  )
+ )
+ (func $1 (; 14 ;) (type $3) (result i32)
+  (global.get $global$1)
+ )
+ (func $2 (; 15 ;) (type $2) (param $0 i32)
+  (global.set $global$1
+   (local.get $0)
+  )
+ )
+ (func $3 (; 16 ;) (type $5) (param $0 i32) (param $1 i32)
+  (block $label$1
+   (global.set $global$1
+    (local.get $0)
+   )
+   (global.set $global$2
+    (local.get $1)
+   )
+  )
+ )
+ (func $4 (; 17 ;) (type $5) (param $0 i32) (param $1 i32)
+  (if
+   (i32.eqz
+    (global.get $global$3)
+   )
+   (block
+    (global.set $global$3
+     (local.get $0)
+    )
+    (global.set $global$4
+     (local.get $1)
+    )
+   )
+  )
+ )
+ (func $5 (; 18 ;) (type $2) (param $0 i32)
+  (global.set $global$5
+   (local.get $0)
+  )
+ )
+ (func $6 (; 19 ;) (type $3) (result i32)
+  (global.get $global$5)
+ )
+ (func $7 (; 20 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 f32)
+  (block $label$1 (result i32)
+   (local.set $3
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (local.set $5
+    (i32.add
+     (local.get $3)
+     (i32.const 8)
+    )
+   )
+   (local.set $2
+    (local.get $3)
+   )
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (i32.le_s
+       (local.get $0)
+       (i32.const 1)
+      )
+     )
+     (block $label$4
+      (block $label$5
+       (block $label$6
+        (block $label$7
+         (block $label$8
+          (block $label$9
+           (block $label$10
+            (br_table $label$5 $label$10 $label$8 $label$9 $label$7 $label$6 $label$4
+             (i32.sub
+              (local.tee $0
+               (i32.load8_s
+                (i32.load offset=4
+                 (local.get $1)
+                )
+               )
+              )
+              (i32.const 48)
+             )
+            )
+           )
+           (local.set $4
+            (i32.const 33000)
+           )
+           (br $label$2)
+          )
+          (br $label$3)
+         )
+         (local.set $4
+          (i32.const 130000)
+         )
+         (br $label$2)
+        )
+        (local.set $4
+         (i32.const 610000)
+        )
+        (br $label$2)
+       )
+       (local.set $4
+        (i32.const 1010000)
+       )
+       (br $label$2)
+      )
+      (global.set $global$1
+       (local.get $3)
+      )
+      (return
+       (i32.const 0)
+      )
+     )
+     (i32.store
+      (local.get $2)
+      (i32.add
+       (local.get $0)
+       (i32.const -48)
+      )
+     )
+     (drop
+      (call $30
+       (i32.const 1140)
+       (local.get $2)
+      )
+     )
+     (global.set $global$1
+      (local.get $3)
+     )
+     (return
+      (i32.const -1)
+     )
+    )
+    (local.set $4
+     (i32.const 220000)
+    )
+   )
+   (local.set $1
+    (i32.const 2)
+   )
+   (local.set $0
+    (i32.const 0)
+   )
+   (loop $label$11
+    (block $label$12
+     (block $label$13
+      (br_if $label$13
+       (i32.eqz
+        (f32.gt
+         (local.tee $6
+          (f32.sqrt
+           (f32.convert_i32_s
+            (local.get $1)
+           )
+          )
+         )
+         (f32.const 2)
+        )
+       )
+      )
+      (local.set $2
+       (i32.const 2)
+      )
+      (loop $label$14
+       (br_if $label$12
+        (i32.eqz
+         (i32.rem_s
+          (local.get $1)
+          (local.get $2)
+         )
+        )
+       )
+       (br_if $label$14
+        (f32.lt
+         (f32.convert_i32_s
+          (local.tee $2
+           (i32.add
+            (local.get $2)
+            (i32.const 1)
+           )
+          )
+         )
+         (local.get $6)
+        )
+       )
+       (br $label$13)
+      )
+     )
+     (local.set $0
+      (i32.add
+       (local.get $0)
+       (i32.const 1)
+      )
+     )
+    )
+    (local.set $2
+     (i32.add
+      (local.get $1)
+      (i32.const 1)
+     )
+    )
+    (if
+     (i32.lt_s
+      (local.get $0)
+      (local.get $4)
+     )
+     (block
+      (local.set $1
+       (local.get $2)
+      )
+      (br $label$11)
+     )
+    )
+   )
+   (i32.store
+    (local.get $5)
+    (local.get $1)
+   )
+   (drop
+    (call $30
+     (i32.const 1152)
+     (local.get $5)
+    )
+   )
+   (global.set $global$1
+    (local.get $3)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $8 (; 21 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store
+    (local.tee $2
+     (local.get $1)
+    )
+    (i32.load offset=60
+     (local.get $0)
+    )
+   )
+   (local.set $0
+    (call $10
+     (call $fimport$8
+      (i32.const 6)
+      (local.get $2)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $1)
+   )
+   (local.get $0)
+  )
+ )
+ (func $9 (; 22 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 32)
+    )
+   )
+   (i32.store
+    (local.tee $3
+     (local.get $4)
+    )
+    (i32.load offset=60
+     (local.get $0)
+    )
+   )
+   (i32.store offset=4
+    (local.get $3)
+    (i32.const 0)
+   )
+   (i32.store offset=8
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=12
+    (local.get $3)
+    (local.tee $0
+     (i32.add
+      (local.get $4)
+      (i32.const 20)
+     )
+    )
+   )
+   (i32.store offset=16
+    (local.get $3)
+    (local.get $2)
+   )
+   (local.set $0
+    (if (result i32)
+     (i32.lt_s
+      (call $10
+       (call $fimport$14
+        (i32.const 140)
+        (local.get $3)
+       )
+      )
+      (i32.const 0)
+     )
+     (block (result i32)
+      (i32.store
+       (local.get $0)
+       (i32.const -1)
+      )
+      (i32.const -1)
+     )
+     (i32.load
+      (local.get $0)
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $0)
+  )
+ )
+ (func $10 (; 23 ;) (type $1) (param $0 i32) (result i32)
+  (if (result i32)
+   (i32.gt_u
+    (local.get $0)
+    (i32.const -4096)
+   )
+   (block (result i32)
+    (i32.store
+     (call $11)
+     (i32.sub
+      (i32.const 0)
+      (local.get $0)
+     )
+    )
+    (i32.const -1)
+   )
+   (local.get $0)
+  )
+ )
+ (func $11 (; 24 ;) (type $3) (result i32)
+  (i32.const 3640)
+ )
+ (func $12 (; 25 ;) (type $2) (param $0 i32)
+  (nop)
+ )
+ (func $13 (; 26 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 80)
+    )
+   )
+   (local.set $3
+    (local.get $4)
+   )
+   (local.set $5
+    (i32.add
+     (local.get $4)
+     (i32.const 12)
+    )
+   )
+   (i32.store offset=36
+    (local.get $0)
+    (i32.const 3)
+   )
+   (if
+    (i32.eqz
+     (i32.and
+      (i32.load
+       (local.get $0)
+      )
+      (i32.const 64)
+     )
+    )
+    (block
+     (i32.store
+      (local.get $3)
+      (i32.load offset=60
+       (local.get $0)
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.const 21505)
+     )
+     (i32.store offset=8
+      (local.get $3)
+      (local.get $5)
+     )
+     (if
+      (call $fimport$13
+       (i32.const 54)
+       (local.get $3)
+      )
+      (i32.store8 offset=75
+       (local.get $0)
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (local.set $0
+    (call $14
+     (local.get $0)
+     (local.get $1)
+     (local.get $2)
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $0)
+  )
+ )
+ (func $14 (; 27 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (block $label$1 (result i32)
+   (local.set $8
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 48)
+    )
+   )
+   (local.set $9
+    (i32.add
+     (local.get $8)
+     (i32.const 16)
+    )
+   )
+   (local.set $10
+    (local.get $8)
+   )
+   (i32.store
+    (local.tee $3
+     (i32.add
+      (local.get $8)
+      (i32.const 32)
+     )
+    )
+    (local.tee $4
+     (i32.load
+      (local.tee $6
+       (i32.add
+        (local.get $0)
+        (i32.const 28)
+       )
+      )
+     )
+    )
+   )
+   (i32.store offset=4
+    (local.get $3)
+    (local.tee $5
+     (i32.sub
+      (i32.load
+       (local.tee $11
+        (i32.add
+         (local.get $0)
+         (i32.const 20)
+        )
+       )
+      )
+      (local.get $4)
+     )
+    )
+   )
+   (i32.store offset=8
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=12
+    (local.get $3)
+    (local.get $2)
+   )
+   (local.set $13
+    (i32.add
+     (local.get $0)
+     (i32.const 60)
+    )
+   )
+   (local.set $14
+    (i32.add
+     (local.get $0)
+     (i32.const 44)
+    )
+   )
+   (local.set $1
+    (local.get $3)
+   )
+   (local.set $4
+    (i32.const 2)
+   )
+   (local.set $12
+    (i32.add
+     (local.get $5)
+     (local.get $2)
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (loop $label$5
+       (if
+        (i32.load
+         (i32.const 3596)
+        )
+        (block
+         (call $fimport$9
+          (i32.const 1)
+          (local.get $0)
+         )
+         (i32.store
+          (local.get $10)
+          (i32.load
+           (local.get $13)
+          )
+         )
+         (i32.store offset=4
+          (local.get $10)
+          (local.get $1)
+         )
+         (i32.store offset=8
+          (local.get $10)
+          (local.get $4)
+         )
+         (local.set $3
+          (call $10
+           (call $fimport$15
+            (i32.const 146)
+            (local.get $10)
+           )
+          )
+         )
+         (call $fimport$7
+          (i32.const 0)
+         )
+        )
+        (block
+         (i32.store
+          (local.get $9)
+          (i32.load
+           (local.get $13)
+          )
+         )
+         (i32.store offset=4
+          (local.get $9)
+          (local.get $1)
+         )
+         (i32.store offset=8
+          (local.get $9)
+          (local.get $4)
+         )
+         (local.set $3
+          (call $10
+           (call $fimport$15
+            (i32.const 146)
+            (local.get $9)
+           )
+          )
+         )
+        )
+       )
+       (br_if $label$4
+        (i32.eq
+         (local.get $12)
+         (local.get $3)
+        )
+       )
+       (br_if $label$3
+        (i32.lt_s
+         (local.get $3)
+         (i32.const 0)
+        )
+       )
+       (local.set $5
+        (if (result i32)
+         (i32.gt_u
+          (local.get $3)
+          (local.tee $5
+           (i32.load offset=4
+            (local.get $1)
+           )
+          )
+         )
+         (block (result i32)
+          (i32.store
+           (local.get $6)
+           (local.tee $7
+            (i32.load
+             (local.get $14)
+            )
+           )
+          )
+          (i32.store
+           (local.get $11)
+           (local.get $7)
+          )
+          (local.set $7
+           (i32.load offset=12
+            (local.get $1)
+           )
+          )
+          (local.set $1
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+          (local.set $4
+           (i32.add
+            (local.get $4)
+            (i32.const -1)
+           )
+          )
+          (i32.sub
+           (local.get $3)
+           (local.get $5)
+          )
+         )
+         (if (result i32)
+          (i32.eq
+           (local.get $4)
+           (i32.const 2)
+          )
+          (block (result i32)
+           (i32.store
+            (local.get $6)
+            (i32.add
+             (i32.load
+              (local.get $6)
+             )
+             (local.get $3)
+            )
+           )
+           (local.set $7
+            (local.get $5)
+           )
+           (local.set $4
+            (i32.const 2)
+           )
+           (local.get $3)
+          )
+          (block (result i32)
+           (local.set $7
+            (local.get $5)
+           )
+           (local.get $3)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $1)
+        (i32.add
+         (i32.load
+          (local.get $1)
+         )
+         (local.get $5)
+        )
+       )
+       (i32.store offset=4
+        (local.get $1)
+        (i32.sub
+         (local.get $7)
+         (local.get $5)
+        )
+       )
+       (local.set $12
+        (i32.sub
+         (local.get $12)
+         (local.get $3)
+        )
+       )
+       (br $label$5)
+      )
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (i32.add
+       (local.tee $1
+        (i32.load
+         (local.get $14)
+        )
+       )
+       (i32.load offset=48
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (local.get $6)
+      (local.get $1)
+     )
+     (i32.store
+      (local.get $11)
+      (local.get $1)
+     )
+     (br $label$2)
+    )
+    (i32.store offset=16
+     (local.get $0)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $6)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $11)
+     (i32.const 0)
+    )
+    (i32.store
+     (local.get $0)
+     (i32.or
+      (i32.load
+       (local.get $0)
+      )
+      (i32.const 32)
+     )
+    )
+    (local.set $2
+     (if (result i32)
+      (i32.eq
+       (local.get $4)
+       (i32.const 2)
+      )
+      (i32.const 0)
+      (i32.sub
+       (local.get $2)
+       (i32.load offset=4
+        (local.get $1)
+       )
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $8)
+   )
+   (local.get $2)
+  )
+ )
+ (func $15 (; 28 ;) (type $2) (param $0 i32)
+  (if
+   (i32.eqz
+    (i32.load offset=68
+     (local.get $0)
+    )
+   )
+   (call $12
+    (local.get $0)
+   )
+  )
+ )
+ (func $16 (; 29 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $5
+    (i32.and
+     (local.get $1)
+     (i32.const 255)
+    )
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (if
+       (i32.and
+        (local.tee $4
+         (i32.ne
+          (local.get $2)
+          (i32.const 0)
+         )
+        )
+        (i32.ne
+         (i32.and
+          (local.get $0)
+          (i32.const 3)
+         )
+         (i32.const 0)
+        )
+       )
+       (block
+        (local.set $4
+         (i32.and
+          (local.get $1)
+          (i32.const 255)
+         )
+        )
+        (local.set $3
+         (local.get $2)
+        )
+        (local.set $2
+         (local.get $0)
+        )
+        (loop $label$6
+         (if
+          (i32.eq
+           (i32.load8_s
+            (local.get $2)
+           )
+           (i32.shr_s
+            (i32.shl
+             (local.get $4)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+          )
+          (block
+           (local.set $0
+            (local.get $3)
+           )
+           (br $label$3)
+          )
+         )
+         (br_if $label$6
+          (i32.and
+           (local.tee $0
+            (i32.ne
+             (local.tee $3
+              (i32.add
+               (local.get $3)
+               (i32.const -1)
+              )
+             )
+             (i32.const 0)
+            )
+           )
+           (i32.ne
+            (i32.and
+             (local.tee $2
+              (i32.add
+               (local.get $2)
+               (i32.const 1)
+              )
+             )
+             (i32.const 3)
+            )
+            (i32.const 0)
+           )
+          )
+         )
+         (br $label$4)
+        )
+       )
+       (block
+        (local.set $3
+         (local.get $2)
+        )
+        (local.set $2
+         (local.get $0)
+        )
+        (local.set $0
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (if
+      (local.get $0)
+      (block
+       (local.set $0
+        (local.get $3)
+       )
+       (br $label$3)
+      )
+      (local.set $0
+       (i32.const 0)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.ne
+      (i32.load8_s
+       (local.get $2)
+      )
+      (i32.shr_s
+       (i32.shl
+        (local.tee $1
+         (i32.and
+          (local.get $1)
+          (i32.const 255)
+         )
+        )
+        (i32.const 24)
+       )
+       (i32.const 24)
+      )
+     )
+     (block
+      (local.set $3
+       (i32.mul
+        (local.get $5)
+        (i32.const 16843009)
+       )
+      )
+      (block $label$12
+       (block $label$13
+        (br_if $label$13
+         (i32.le_u
+          (local.get $0)
+          (i32.const 3)
+         )
+        )
+        (loop $label$14
+         (if
+          (i32.eqz
+           (i32.and
+            (i32.xor
+             (i32.and
+              (local.tee $4
+               (i32.xor
+                (i32.load
+                 (local.get $2)
+                )
+                (local.get $3)
+               )
+              )
+              (i32.const -2139062144)
+             )
+             (i32.const -2139062144)
+            )
+            (i32.add
+             (local.get $4)
+             (i32.const -16843009)
+            )
+           )
+          )
+          (block
+           (local.set $2
+            (i32.add
+             (local.get $2)
+             (i32.const 4)
+            )
+           )
+           (br_if $label$14
+            (i32.gt_u
+             (local.tee $0
+              (i32.add
+               (local.get $0)
+               (i32.const -4)
+              )
+             )
+             (i32.const 3)
+            )
+           )
+           (br $label$13)
+          )
+         )
+        )
+        (br $label$12)
+       )
+       (if
+        (i32.eqz
+         (local.get $0)
+        )
+        (block
+         (local.set $0
+          (i32.const 0)
+         )
+         (br $label$2)
+        )
+       )
+      )
+      (loop $label$17
+       (br_if $label$2
+        (i32.eq
+         (i32.load8_s
+          (local.get $2)
+         )
+         (i32.shr_s
+          (i32.shl
+           (local.get $1)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (local.set $2
+        (i32.add
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (br_if $label$17
+        (local.tee $0
+         (i32.add
+          (local.get $0)
+          (i32.const -1)
+         )
+        )
+       )
+       (local.set $0
+        (i32.const 0)
+       )
+      )
+     )
+    )
+   )
+   (if (result i32)
+    (local.get $0)
+    (local.get $2)
+    (i32.const 0)
+   )
+  )
+ )
+ (func $17 (; 30 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 224)
+    )
+   )
+   (local.set $5
+    (i32.add
+     (local.get $4)
+     (i32.const 136)
+    )
+   )
+   (i64.store align=4
+    (local.tee $3
+     (i32.add
+      (local.get $4)
+      (i32.const 80)
+     )
+    )
+    (i64.const 0)
+   )
+   (i64.store offset=8 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=16 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=24 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i64.store offset=32 align=4
+    (local.get $3)
+    (i64.const 0)
+   )
+   (i32.store
+    (local.tee $6
+     (i32.add
+      (local.get $4)
+      (i32.const 120)
+     )
+    )
+    (i32.load
+     (local.get $2)
+    )
+   )
+   (if
+    (i32.lt_s
+     (call $18
+      (i32.const 0)
+      (local.get $1)
+      (local.get $6)
+      (local.tee $2
+       (local.get $4)
+      )
+      (local.get $3)
+     )
+     (i32.const 0)
+    )
+    (local.set $1
+     (i32.const -1)
+    )
+    (block
+     (local.set $12
+      (if (result i32)
+       (i32.gt_s
+        (i32.load offset=76
+         (local.get $0)
+        )
+        (i32.const -1)
+       )
+       (call $19
+        (local.get $0)
+       )
+       (i32.const 0)
+      )
+     )
+     (local.set $7
+      (i32.load
+       (local.get $0)
+      )
+     )
+     (if
+      (i32.lt_s
+       (i32.load8_s offset=74
+        (local.get $0)
+       )
+       (i32.const 1)
+      )
+      (i32.store
+       (local.get $0)
+       (i32.and
+        (local.get $7)
+        (i32.const -33)
+       )
+      )
+     )
+     (if
+      (i32.load
+       (local.tee $8
+        (i32.add
+         (local.get $0)
+         (i32.const 48)
+        )
+       )
+      )
+      (local.set $1
+       (call $18
+        (local.get $0)
+        (local.get $1)
+        (local.get $6)
+        (local.get $2)
+        (local.get $3)
+       )
+      )
+      (block
+       (local.set $10
+        (i32.load
+         (local.tee $9
+          (i32.add
+           (local.get $0)
+           (i32.const 44)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $9)
+        (local.get $5)
+       )
+       (i32.store
+        (local.tee $13
+         (i32.add
+          (local.get $0)
+          (i32.const 28)
+         )
+        )
+        (local.get $5)
+       )
+       (i32.store
+        (local.tee $11
+         (i32.add
+          (local.get $0)
+          (i32.const 20)
+         )
+        )
+        (local.get $5)
+       )
+       (i32.store
+        (local.get $8)
+        (i32.const 80)
+       )
+       (i32.store
+        (local.tee $14
+         (i32.add
+          (local.get $0)
+          (i32.const 16)
+         )
+        )
+        (i32.add
+         (local.get $5)
+         (i32.const 80)
+        )
+       )
+       (local.set $1
+        (call $18
+         (local.get $0)
+         (local.get $1)
+         (local.get $6)
+         (local.get $2)
+         (local.get $3)
+        )
+       )
+       (if
+        (local.get $10)
+        (block
+         (drop
+          (call_indirect (type $0)
+           (local.get $0)
+           (i32.const 0)
+           (i32.const 0)
+           (i32.add
+            (i32.and
+             (i32.load offset=36
+              (local.get $0)
+             )
+             (i32.const 3)
+            )
+            (i32.const 2)
+           )
+          )
+         )
+         (if
+          (i32.eqz
+           (i32.load
+            (local.get $11)
+           )
+          )
+          (local.set $1
+           (i32.const -1)
+          )
+         )
+         (i32.store
+          (local.get $9)
+          (local.get $10)
+         )
+         (i32.store
+          (local.get $8)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $14)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $13)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $11)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (i32.store
+      (local.get $0)
+      (i32.or
+       (local.tee $2
+        (i32.load
+         (local.get $0)
+        )
+       )
+       (i32.and
+        (local.get $7)
+        (i32.const 32)
+       )
+      )
+     )
+     (if
+      (local.get $12)
+      (call $12
+       (local.get $0)
+      )
+     )
+     (if
+      (i32.and
+       (local.get $2)
+       (i32.const 32)
+      )
+      (local.set $1
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $4)
+   )
+   (local.get $1)
+  )
+ )
+ (func $18 (; 31 ;) (type $7) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 f64)
+  (local $53 f64)
+  (block $label$1 (result i32)
+   (local.set $23
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 624)
+    )
+   )
+   (local.set $20
+    (i32.add
+     (local.get $23)
+     (i32.const 16)
+    )
+   )
+   (local.set $16
+    (local.get $23)
+   )
+   (local.set $36
+    (i32.add
+     (local.get $23)
+     (i32.const 528)
+    )
+   )
+   (local.set $30
+    (i32.ne
+     (local.get $0)
+     (i32.const 0)
+    )
+   )
+   (local.set $38
+    (local.tee $21
+     (i32.add
+      (local.tee $17
+       (i32.add
+        (local.get $23)
+        (i32.const 536)
+       )
+      )
+      (i32.const 40)
+     )
+    )
+   )
+   (local.set $39
+    (i32.add
+     (local.get $17)
+     (i32.const 39)
+    )
+   )
+   (local.set $42
+    (i32.add
+     (local.tee $37
+      (i32.add
+       (local.get $23)
+       (i32.const 8)
+      )
+     )
+     (i32.const 4)
+    )
+   )
+   (local.set $43
+    (i32.sub
+     (i32.const 0)
+     (local.tee $27
+      (local.tee $19
+       (i32.add
+        (local.get $23)
+        (i32.const 588)
+       )
+      )
+     )
+    )
+   )
+   (local.set $33
+    (i32.add
+     (local.tee $17
+      (i32.add
+       (local.get $23)
+       (i32.const 576)
+      )
+     )
+     (i32.const 12)
+    )
+   )
+   (local.set $40
+    (i32.add
+     (local.get $17)
+     (i32.const 11)
+    )
+   )
+   (local.set $44
+    (i32.sub
+     (local.tee $28
+      (local.get $33)
+     )
+     (local.get $27)
+    )
+   )
+   (local.set $45
+    (i32.sub
+     (i32.const -2)
+     (local.get $27)
+    )
+   )
+   (local.set $46
+    (i32.add
+     (local.get $28)
+     (i32.const 2)
+    )
+   )
+   (local.set $48
+    (i32.add
+     (local.tee $47
+      (i32.add
+       (local.get $23)
+       (i32.const 24)
+      )
+     )
+     (i32.const 288)
+    )
+   )
+   (local.set $41
+    (local.tee $31
+     (i32.add
+      (local.get $19)
+      (i32.const 9)
+     )
+    )
+   )
+   (local.set $34
+    (i32.add
+     (local.get $19)
+     (i32.const 8)
+    )
+   )
+   (local.set $15
+    (i32.const 0)
+   )
+   (local.set $10
+    (i32.const 0)
+   )
+   (local.set $17
+    (i32.const 0)
+   )
+   (block $label$2
+    (block $label$3
+     (loop $label$4
+      (block $label$5
+       (if
+        (i32.gt_s
+         (local.get $15)
+         (i32.const -1)
+        )
+        (local.set $15
+         (if (result i32)
+          (i32.gt_s
+           (local.get $10)
+           (i32.sub
+            (i32.const 2147483647)
+            (local.get $15)
+           )
+          )
+          (block (result i32)
+           (i32.store
+            (call $11)
+            (i32.const 75)
+           )
+           (i32.const -1)
+          )
+          (i32.add
+           (local.get $10)
+           (local.get $15)
+          )
+         )
+        )
+       )
+       (br_if $label$3
+        (i32.eqz
+         (i32.shr_s
+          (i32.shl
+           (local.tee $5
+            (i32.load8_s
+             (local.get $1)
+            )
+           )
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+       )
+       (local.set $11
+        (local.get $1)
+       )
+       (block $label$9
+        (block $label$10
+         (loop $label$11
+          (block $label$12
+           (block $label$13
+            (block $label$14
+             (block $label$15
+              (br_table $label$14 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$13 $label$15 $label$13
+               (i32.sub
+                (i32.shr_s
+                 (i32.shl
+                  (local.get $5)
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const 0)
+               )
+              )
+             )
+             (local.set $5
+              (local.get $11)
+             )
+             (br $label$10)
+            )
+            (local.set $5
+             (local.get $11)
+            )
+            (br $label$12)
+           )
+           (local.set $5
+            (i32.load8_s
+             (local.tee $11
+              (i32.add
+               (local.get $11)
+               (i32.const 1)
+              )
+             )
+            )
+           )
+           (br $label$11)
+          )
+         )
+         (br $label$9)
+        )
+        (loop $label$16
+         (br_if $label$9
+          (i32.ne
+           (i32.load8_s offset=1
+            (local.get $5)
+           )
+           (i32.const 37)
+          )
+         )
+         (local.set $11
+          (i32.add
+           (local.get $11)
+           (i32.const 1)
+          )
+         )
+         (br_if $label$16
+          (i32.eq
+           (i32.load8_s
+            (local.tee $5
+             (i32.add
+              (local.get $5)
+              (i32.const 2)
+             )
+            )
+           )
+           (i32.const 37)
+          )
+         )
+        )
+       )
+       (local.set $10
+        (i32.sub
+         (local.get $11)
+         (local.get $1)
+        )
+       )
+       (if
+        (local.get $30)
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.load
+            (local.get $0)
+           )
+           (i32.const 32)
+          )
+         )
+         (drop
+          (call $20
+           (local.get $1)
+           (local.get $10)
+           (local.get $0)
+          )
+         )
+        )
+       )
+       (if
+        (local.get $10)
+        (block
+         (local.set $1
+          (local.get $5)
+         )
+         (br $label$4)
+        )
+       )
+       (local.set $10
+        (if (result i32)
+         (i32.lt_u
+          (local.tee $9
+           (i32.add
+            (i32.shr_s
+             (i32.shl
+              (local.tee $10
+               (i32.load8_s
+                (local.tee $11
+                 (i32.add
+                  (local.get $5)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const -48)
+           )
+          )
+          (i32.const 10)
+         )
+         (block (result i32)
+          (local.set $10
+           (i32.add
+            (local.get $5)
+            (i32.const 3)
+           )
+          )
+          (if
+           (local.tee $12
+            (i32.eq
+             (i32.load8_s offset=2
+              (local.get $5)
+             )
+             (i32.const 36)
+            )
+           )
+           (local.set $11
+            (local.get $10)
+           )
+          )
+          (if
+           (local.get $12)
+           (local.set $17
+            (i32.const 1)
+           )
+          )
+          (local.set $5
+           (i32.load8_s
+            (local.get $11)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.get $12)
+           )
+           (local.set $9
+            (i32.const -1)
+           )
+          )
+          (local.get $17)
+         )
+         (block (result i32)
+          (local.set $5
+           (local.get $10)
+          )
+          (local.set $9
+           (i32.const -1)
+          )
+          (local.get $17)
+         )
+        )
+       )
+       (block $label$25
+        (if
+         (i32.lt_u
+          (local.tee $12
+           (i32.add
+            (i32.shr_s
+             (i32.shl
+              (local.get $5)
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const -32)
+           )
+          )
+          (i32.const 32)
+         )
+         (block
+          (local.set $17
+           (i32.const 0)
+          )
+          (loop $label$27
+           (br_if $label$25
+            (i32.eqz
+             (i32.and
+              (i32.shl
+               (i32.const 1)
+               (local.get $12)
+              )
+              (i32.const 75913)
+             )
+            )
+           )
+           (local.set $17
+            (i32.or
+             (i32.shl
+              (i32.const 1)
+              (i32.add
+               (i32.shr_s
+                (i32.shl
+                 (local.get $5)
+                 (i32.const 24)
+                )
+                (i32.const 24)
+               )
+               (i32.const -32)
+              )
+             )
+             (local.get $17)
+            )
+           )
+           (br_if $label$27
+            (i32.lt_u
+             (local.tee $12
+              (i32.add
+               (i32.shr_s
+                (i32.shl
+                 (local.tee $5
+                  (i32.load8_s
+                   (local.tee $11
+                    (i32.add
+                     (local.get $11)
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 24)
+                )
+                (i32.const 24)
+               )
+               (i32.const -32)
+              )
+             )
+             (i32.const 32)
+            )
+           )
+          )
+         )
+         (local.set $17
+          (i32.const 0)
+         )
+        )
+       )
+       (block $label$29
+        (if
+         (i32.eq
+          (i32.shr_s
+           (i32.shl
+            (local.get $5)
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+          (i32.const 42)
+         )
+         (block
+          (local.set $11
+           (block $label$31 (result i32)
+            (block $label$32
+             (br_if $label$32
+              (i32.ge_u
+               (local.tee $12
+                (i32.add
+                 (i32.shr_s
+                  (i32.shl
+                   (local.tee $5
+                    (i32.load8_s
+                     (local.tee $7
+                      (i32.add
+                       (local.get $11)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                   )
+                   (i32.const 24)
+                  )
+                  (i32.const 24)
+                 )
+                 (i32.const -48)
+                )
+               )
+               (i32.const 10)
+              )
+             )
+             (br_if $label$32
+              (i32.ne
+               (i32.load8_s offset=2
+                (local.get $11)
+               )
+               (i32.const 36)
+              )
+             )
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $12)
+                (i32.const 2)
+               )
+              )
+              (i32.const 10)
+             )
+             (local.set $8
+              (i32.const 1)
+             )
+             (local.set $10
+              (i32.wrap_i64
+               (i64.load
+                (i32.add
+                 (local.get $3)
+                 (i32.shl
+                  (i32.add
+                   (i32.load8_s
+                    (local.get $7)
+                   )
+                   (i32.const -48)
+                  )
+                  (i32.const 3)
+                 )
+                )
+               )
+              )
+             )
+             (br $label$31
+              (i32.add
+               (local.get $11)
+               (i32.const 3)
+              )
+             )
+            )
+            (if
+             (local.get $10)
+             (block
+              (local.set $15
+               (i32.const -1)
+              )
+              (br $label$5)
+             )
+            )
+            (if
+             (i32.eqz
+              (local.get $30)
+             )
+             (block
+              (local.set $12
+               (local.get $17)
+              )
+              (local.set $17
+               (i32.const 0)
+              )
+              (local.set $11
+               (local.get $7)
+              )
+              (local.set $10
+               (i32.const 0)
+              )
+              (br $label$29)
+             )
+            )
+            (local.set $10
+             (i32.load
+              (local.tee $11
+               (i32.and
+                (i32.add
+                 (i32.load
+                  (local.get $2)
+                 )
+                 (i32.const 3)
+                )
+                (i32.const -4)
+               )
+              )
+             )
+            )
+            (i32.store
+             (local.get $2)
+             (i32.add
+              (local.get $11)
+              (i32.const 4)
+             )
+            )
+            (local.set $8
+             (i32.const 0)
+            )
+            (local.get $7)
+           )
+          )
+          (local.set $12
+           (i32.or
+            (local.get $17)
+            (i32.const 8192)
+           )
+          )
+          (local.set $7
+           (i32.sub
+            (i32.const 0)
+            (local.get $10)
+           )
+          )
+          (local.set $5
+           (i32.load8_s
+            (local.get $11)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.tee $6
+             (i32.lt_s
+              (local.get $10)
+              (i32.const 0)
+             )
+            )
+           )
+           (local.set $12
+            (local.get $17)
+           )
+          )
+          (local.set $17
+           (local.get $8)
+          )
+          (if
+           (local.get $6)
+           (local.set $10
+            (local.get $7)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.tee $12
+            (i32.add
+             (i32.shr_s
+              (i32.shl
+               (local.get $5)
+               (i32.const 24)
+              )
+              (i32.const 24)
+             )
+             (i32.const -48)
+            )
+           )
+           (i32.const 10)
+          )
+          (block
+           (local.set $7
+            (i32.const 0)
+           )
+           (local.set $5
+            (local.get $12)
+           )
+           (loop $label$39
+            (local.set $7
+             (i32.add
+              (i32.mul
+               (local.get $7)
+               (i32.const 10)
+              )
+              (local.get $5)
+             )
+            )
+            (br_if $label$39
+             (i32.lt_u
+              (local.tee $5
+               (i32.add
+                (i32.shr_s
+                 (i32.shl
+                  (local.tee $12
+                   (i32.load8_s
+                    (local.tee $11
+                     (i32.add
+                      (local.get $11)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                  )
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+            )
+           )
+           (if
+            (i32.lt_s
+             (local.get $7)
+             (i32.const 0)
+            )
+            (block
+             (local.set $15
+              (i32.const -1)
+             )
+             (br $label$5)
+            )
+            (block
+             (local.set $5
+              (local.get $12)
+             )
+             (local.set $12
+              (local.get $17)
+             )
+             (local.set $17
+              (local.get $10)
+             )
+             (local.set $10
+              (local.get $7)
+             )
+            )
+           )
+          )
+          (block
+           (local.set $12
+            (local.get $17)
+           )
+           (local.set $17
+            (local.get $10)
+           )
+           (local.set $10
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (block $label$43
+        (if
+         (i32.eq
+          (i32.shr_s
+           (i32.shl
+            (local.get $5)
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+          (i32.const 46)
+         )
+         (block
+          (if
+           (i32.ne
+            (i32.shr_s
+             (i32.shl
+              (local.tee $5
+               (i32.load8_s
+                (local.tee $7
+                 (i32.add
+                  (local.get $11)
+                  (i32.const 1)
+                 )
+                )
+               )
+              )
+              (i32.const 24)
+             )
+             (i32.const 24)
+            )
+            (i32.const 42)
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.tee $5
+               (i32.add
+                (i32.shr_s
+                 (i32.shl
+                  (local.get $5)
+                  (i32.const 24)
+                 )
+                 (i32.const 24)
+                )
+                (i32.const -48)
+               )
+              )
+              (i32.const 10)
+             )
+             (block
+              (local.set $11
+               (local.get $7)
+              )
+              (local.set $7
+               (i32.const 0)
+              )
+             )
+             (block
+              (local.set $5
+               (i32.const 0)
+              )
+              (local.set $11
+               (local.get $7)
+              )
+              (br $label$43)
+             )
+            )
+            (loop $label$48
+             (local.set $5
+              (i32.add
+               (i32.mul
+                (local.get $7)
+                (i32.const 10)
+               )
+               (local.get $5)
+              )
+             )
+             (br_if $label$43
+              (i32.ge_u
+               (local.tee $8
+                (i32.add
+                 (i32.load8_s
+                  (local.tee $11
+                   (i32.add
+                    (local.get $11)
+                    (i32.const 1)
+                   )
+                  )
+                 )
+                 (i32.const -48)
+                )
+               )
+               (i32.const 10)
+              )
+             )
+             (local.set $7
+              (local.get $5)
+             )
+             (local.set $5
+              (local.get $8)
+             )
+             (br $label$48)
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.tee $5
+             (i32.add
+              (i32.load8_s
+               (local.tee $7
+                (i32.add
+                 (local.get $11)
+                 (i32.const 2)
+                )
+               )
+              )
+              (i32.const -48)
+             )
+            )
+            (i32.const 10)
+           )
+           (if
+            (i32.eq
+             (i32.load8_s offset=3
+              (local.get $11)
+             )
+             (i32.const 36)
+            )
+            (block
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $5)
+                (i32.const 2)
+               )
+              )
+              (i32.const 10)
+             )
+             (local.set $5
+              (i32.wrap_i64
+               (i64.load
+                (i32.add
+                 (local.get $3)
+                 (i32.shl
+                  (i32.add
+                   (i32.load8_s
+                    (local.get $7)
+                   )
+                   (i32.const -48)
+                  )
+                  (i32.const 3)
+                 )
+                )
+               )
+              )
+             )
+             (local.set $11
+              (i32.add
+               (local.get $11)
+               (i32.const 4)
+              )
+             )
+             (br $label$43)
+            )
+           )
+          )
+          (if
+           (local.get $17)
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+          )
+          (local.set $11
+           (if (result i32)
+            (local.get $30)
+            (block (result i32)
+             (local.set $5
+              (i32.load
+               (local.tee $11
+                (i32.and
+                 (i32.add
+                  (i32.load
+                   (local.get $2)
+                  )
+                  (i32.const 3)
+                 )
+                 (i32.const -4)
+                )
+               )
+              )
+             )
+             (i32.store
+              (local.get $2)
+              (i32.add
+               (local.get $11)
+               (i32.const 4)
+              )
+             )
+             (local.get $7)
+            )
+            (block (result i32)
+             (local.set $5
+              (i32.const 0)
+             )
+             (local.get $7)
+            )
+           )
+          )
+         )
+         (local.set $5
+          (i32.const -1)
+         )
+        )
+       )
+       (local.set $7
+        (local.get $11)
+       )
+       (local.set $8
+        (i32.const 0)
+       )
+       (loop $label$55
+        (if
+         (i32.gt_u
+          (local.tee $6
+           (i32.add
+            (i32.load8_s
+             (local.get $7)
+            )
+            (i32.const -65)
+           )
+          )
+          (i32.const 57)
+         )
+         (block
+          (local.set $15
+           (i32.const -1)
+          )
+          (br $label$5)
+         )
+        )
+        (local.set $11
+         (i32.add
+          (local.get $7)
+          (i32.const 1)
+         )
+        )
+        (if
+         (i32.lt_u
+          (i32.add
+           (local.tee $6
+            (i32.and
+             (local.tee $13
+              (i32.load8_s
+               (i32.add
+                (i32.add
+                 (i32.mul
+                  (local.get $8)
+                  (i32.const 58)
+                 )
+                 (i32.const 1168)
+                )
+                (local.get $6)
+               )
+              )
+             )
+             (i32.const 255)
+            )
+           )
+           (i32.const -1)
+          )
+          (i32.const 8)
+         )
+         (block
+          (local.set $7
+           (local.get $11)
+          )
+          (local.set $8
+           (local.get $6)
+          )
+          (br $label$55)
+         )
+        )
+       )
+       (if
+        (i32.eqz
+         (i32.shr_s
+          (i32.shl
+           (local.get $13)
+           (i32.const 24)
+          )
+          (i32.const 24)
+         )
+        )
+        (block
+         (local.set $15
+          (i32.const -1)
+         )
+         (br $label$5)
+        )
+       )
+       (local.set $14
+        (i32.gt_s
+         (local.get $9)
+         (i32.const -1)
+        )
+       )
+       (block $label$59
+        (block $label$60
+         (if
+          (i32.eq
+           (i32.shr_s
+            (i32.shl
+             (local.get $13)
+             (i32.const 24)
+            )
+            (i32.const 24)
+           )
+           (i32.const 19)
+          )
+          (if
+           (local.get $14)
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+           (br $label$60)
+          )
+          (block
+           (if
+            (local.get $14)
+            (block
+             (i32.store
+              (i32.add
+               (local.get $4)
+               (i32.shl
+                (local.get $9)
+                (i32.const 2)
+               )
+              )
+              (local.get $6)
+             )
+             (i64.store
+              (local.get $16)
+              (i64.load
+               (i32.add
+                (local.get $3)
+                (i32.shl
+                 (local.get $9)
+                 (i32.const 3)
+                )
+               )
+              )
+             )
+             (br $label$60)
+            )
+           )
+           (if
+            (i32.eqz
+             (local.get $30)
+            )
+            (block
+             (local.set $15
+              (i32.const 0)
+             )
+             (br $label$5)
+            )
+           )
+           (call $21
+            (local.get $16)
+            (local.get $6)
+            (local.get $2)
+           )
+          )
+         )
+         (br $label$59)
+        )
+        (if
+         (i32.eqz
+          (local.get $30)
+         )
+         (block
+          (local.set $10
+           (i32.const 0)
+          )
+          (local.set $1
+           (local.get $11)
+          )
+          (br $label$4)
+         )
+        )
+       )
+       (local.set $9
+        (i32.and
+         (local.tee $7
+          (i32.load8_s
+           (local.get $7)
+          )
+         )
+         (i32.const -33)
+        )
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.ne
+           (local.get $8)
+           (i32.const 0)
+          )
+          (i32.eq
+           (i32.and
+            (local.get $7)
+            (i32.const 15)
+           )
+           (i32.const 3)
+          )
+         )
+        )
+        (local.set $9
+         (local.get $7)
+        )
+       )
+       (local.set $7
+        (i32.and
+         (local.get $12)
+         (i32.const -65537)
+        )
+       )
+       (if
+        (i32.and
+         (local.get $12)
+         (i32.const 8192)
+        )
+        (local.set $12
+         (local.get $7)
+        )
+       )
+       (block $label$70
+        (block $label$71
+         (block $label$72
+          (block $label$73
+           (block $label$74
+            (block $label$75
+             (block $label$76
+              (block $label$77
+               (block $label$78
+                (block $label$79
+                 (block $label$80
+                  (block $label$81
+                   (block $label$82
+                    (block $label$83
+                     (block $label$84
+                      (block $label$85
+                       (block $label$86
+                        (block $label$87
+                         (block $label$88
+                          (block $label$89
+                           (br_table $label$78 $label$77 $label$80 $label$77 $label$78 $label$78 $label$78 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$79 $label$77 $label$77 $label$77 $label$77 $label$87 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$77 $label$78 $label$77 $label$83 $label$85 $label$78 $label$78 $label$78 $label$77 $label$85 $label$77 $label$77 $label$77 $label$82 $label$89 $label$86 $label$88 $label$77 $label$77 $label$81 $label$77 $label$84 $label$77 $label$77 $label$87 $label$77
+                            (i32.sub
+                             (local.get $9)
+                             (i32.const 65)
+                            )
+                           )
+                          )
+                          (block $label$90
+                           (block $label$91
+                            (block $label$92
+                             (block $label$93
+                              (block $label$94
+                               (block $label$95
+                                (block $label$96
+                                 (block $label$97
+                                  (br_table $label$97 $label$96 $label$95 $label$94 $label$93 $label$90 $label$92 $label$91 $label$90
+                                   (i32.sub
+                                    (i32.shr_s
+                                     (i32.shl
+                                      (i32.and
+                                       (local.get $8)
+                                       (i32.const 255)
+                                      )
+                                      (i32.const 24)
+                                     )
+                                     (i32.const 24)
+                                    )
+                                    (i32.const 0)
+                                   )
+                                  )
+                                 )
+                                 (i32.store
+                                  (i32.load
+                                   (local.get $16)
+                                  )
+                                  (local.get $15)
+                                 )
+                                 (local.set $10
+                                  (i32.const 0)
+                                 )
+                                 (local.set $1
+                                  (local.get $11)
+                                 )
+                                 (br $label$4)
+                                )
+                                (i32.store
+                                 (i32.load
+                                  (local.get $16)
+                                 )
+                                 (local.get $15)
+                                )
+                                (local.set $10
+                                 (i32.const 0)
+                                )
+                                (local.set $1
+                                 (local.get $11)
+                                )
+                                (br $label$4)
+                               )
+                               (i64.store
+                                (i32.load
+                                 (local.get $16)
+                                )
+                                (i64.extend_i32_s
+                                 (local.get $15)
+                                )
+                               )
+                               (local.set $10
+                                (i32.const 0)
+                               )
+                               (local.set $1
+                                (local.get $11)
+                               )
+                               (br $label$4)
+                              )
+                              (i32.store16
+                               (i32.load
+                                (local.get $16)
+                               )
+                               (local.get $15)
+                              )
+                              (local.set $10
+                               (i32.const 0)
+                              )
+                              (local.set $1
+                               (local.get $11)
+                              )
+                              (br $label$4)
+                             )
+                             (i32.store8
+                              (i32.load
+                               (local.get $16)
+                              )
+                              (local.get $15)
+                             )
+                             (local.set $10
+                              (i32.const 0)
+                             )
+                             (local.set $1
+                              (local.get $11)
+                             )
+                             (br $label$4)
+                            )
+                            (i32.store
+                             (i32.load
+                              (local.get $16)
+                             )
+                             (local.get $15)
+                            )
+                            (local.set $10
+                             (i32.const 0)
+                            )
+                            (local.set $1
+                             (local.get $11)
+                            )
+                            (br $label$4)
+                           )
+                           (i64.store
+                            (i32.load
+                             (local.get $16)
+                            )
+                            (i64.extend_i32_s
+                             (local.get $15)
+                            )
+                           )
+                           (local.set $10
+                            (i32.const 0)
+                           )
+                           (local.set $1
+                            (local.get $11)
+                           )
+                           (br $label$4)
+                          )
+                          (local.set $10
+                           (i32.const 0)
+                          )
+                          (local.set $1
+                           (local.get $11)
+                          )
+                          (br $label$4)
+                         )
+                         (local.set $12
+                          (i32.or
+                           (local.get $12)
+                           (i32.const 8)
+                          )
+                         )
+                         (if
+                          (i32.le_u
+                           (local.get $5)
+                           (i32.const 8)
+                          )
+                          (local.set $5
+                           (i32.const 8)
+                          )
+                         )
+                         (local.set $9
+                          (i32.const 120)
+                         )
+                         (br $label$76)
+                        )
+                        (br $label$76)
+                       )
+                       (if
+                        (i64.eq
+                         (local.tee $50
+                          (i64.load
+                           (local.get $16)
+                          )
+                         )
+                         (i64.const 0)
+                        )
+                        (local.set $7
+                         (local.get $21)
+                        )
+                        (block
+                         (local.set $1
+                          (local.get $21)
+                         )
+                         (loop $label$101
+                          (i64.store8
+                           (local.tee $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const -1)
+                            )
+                           )
+                           (i64.or
+                            (i64.and
+                             (local.get $50)
+                             (i64.const 7)
+                            )
+                            (i64.const 48)
+                           )
+                          )
+                          (br_if $label$101
+                           (i64.ne
+                            (local.tee $50
+                             (i64.shr_u
+                              (local.get $50)
+                              (i64.const 3)
+                             )
+                            )
+                            (i64.const 0)
+                           )
+                          )
+                          (local.set $7
+                           (local.get $1)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.and
+                         (local.get $12)
+                         (i32.const 8)
+                        )
+                        (block
+                         (local.set $8
+                          (i32.add
+                           (local.tee $1
+                            (i32.sub
+                             (local.get $38)
+                             (local.get $7)
+                            )
+                           )
+                           (i32.const 1)
+                          )
+                         )
+                         (if
+                          (i32.le_s
+                           (local.get $5)
+                           (local.get $1)
+                          )
+                          (local.set $5
+                           (local.get $8)
+                          )
+                         )
+                         (local.set $6
+                          (i32.const 0)
+                         )
+                         (local.set $8
+                          (i32.const 1648)
+                         )
+                         (br $label$71)
+                        )
+                        (block
+                         (local.set $6
+                          (i32.const 0)
+                         )
+                         (local.set $8
+                          (i32.const 1648)
+                         )
+                         (br $label$71)
+                        )
+                       )
+                      )
+                      (if
+                       (i64.lt_s
+                        (local.tee $50
+                         (i64.load
+                          (local.get $16)
+                         )
+                        )
+                        (i64.const 0)
+                       )
+                       (block
+                        (i64.store
+                         (local.get $16)
+                         (local.tee $50
+                          (i64.sub
+                           (i64.const 0)
+                           (local.get $50)
+                          )
+                         )
+                        )
+                        (local.set $6
+                         (i32.const 1)
+                        )
+                        (local.set $8
+                         (i32.const 1648)
+                        )
+                        (br $label$75)
+                       )
+                      )
+                      (if
+                       (i32.and
+                        (local.get $12)
+                        (i32.const 2048)
+                       )
+                       (block
+                        (local.set $6
+                         (i32.const 1)
+                        )
+                        (local.set $8
+                         (i32.const 1649)
+                        )
+                        (br $label$75)
+                       )
+                       (block
+                        (local.set $6
+                         (local.tee $1
+                          (i32.and
+                           (local.get $12)
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (local.set $8
+                         (if (result i32)
+                          (local.get $1)
+                          (i32.const 1650)
+                          (i32.const 1648)
+                         )
+                        )
+                        (br $label$75)
+                       )
+                      )
+                     )
+                     (local.set $50
+                      (i64.load
+                       (local.get $16)
+                      )
+                     )
+                     (local.set $6
+                      (i32.const 0)
+                     )
+                     (local.set $8
+                      (i32.const 1648)
+                     )
+                     (br $label$75)
+                    )
+                    (i64.store8
+                     (local.get $39)
+                     (i64.load
+                      (local.get $16)
+                     )
+                    )
+                    (local.set $1
+                     (local.get $39)
+                    )
+                    (local.set $12
+                     (local.get $7)
+                    )
+                    (local.set $7
+                     (i32.const 1)
+                    )
+                    (local.set $6
+                     (i32.const 0)
+                    )
+                    (local.set $8
+                     (i32.const 1648)
+                    )
+                    (local.set $5
+                     (local.get $21)
+                    )
+                    (br $label$70)
+                   )
+                   (local.set $1
+                    (call $23
+                     (i32.load
+                      (call $11)
+                     )
+                    )
+                   )
+                   (br $label$74)
+                  )
+                  (if
+                   (i32.eqz
+                    (local.tee $1
+                     (i32.load
+                      (local.get $16)
+                     )
+                    )
+                   )
+                   (local.set $1
+                    (i32.const 1658)
+                   )
+                  )
+                  (br $label$74)
+                 )
+                 (i64.store32
+                  (local.get $37)
+                  (i64.load
+                   (local.get $16)
+                  )
+                 )
+                 (i32.store
+                  (local.get $42)
+                  (i32.const 0)
+                 )
+                 (i32.store
+                  (local.get $16)
+                  (local.get $37)
+                 )
+                 (local.set $7
+                  (local.get $37)
+                 )
+                 (local.set $6
+                  (i32.const -1)
+                 )
+                 (br $label$73)
+                )
+                (local.set $7
+                 (i32.load
+                  (local.get $16)
+                 )
+                )
+                (if
+                 (local.get $5)
+                 (block
+                  (local.set $6
+                   (local.get $5)
+                  )
+                  (br $label$73)
+                 )
+                 (block
+                  (call $24
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (i32.const 0)
+                   (local.get $12)
+                  )
+                  (local.set $1
+                   (i32.const 0)
+                  )
+                  (br $label$72)
+                 )
+                )
+               )
+               (local.set $52
+                (f64.load
+                 (local.get $16)
+                )
+               )
+               (i32.store
+                (local.get $20)
+                (i32.const 0)
+               )
+               (local.set $26
+                (if (result i32)
+                 (i64.lt_s
+                  (i64.reinterpret_f64
+                   (local.get $52)
+                  )
+                  (i64.const 0)
+                 )
+                 (block (result i32)
+                  (local.set $24
+                   (i32.const 1)
+                  )
+                  (local.set $52
+                   (f64.neg
+                    (local.get $52)
+                   )
+                  )
+                  (i32.const 1665)
+                 )
+                 (block (result i32)
+                  (local.set $1
+                   (i32.and
+                    (local.get $12)
+                    (i32.const 1)
+                   )
+                  )
+                  (if (result i32)
+                   (i32.and
+                    (local.get $12)
+                    (i32.const 2048)
+                   )
+                   (block (result i32)
+                    (local.set $24
+                     (i32.const 1)
+                    )
+                    (i32.const 1668)
+                   )
+                   (block (result i32)
+                    (local.set $24
+                     (local.get $1)
+                    )
+                    (if (result i32)
+                     (local.get $1)
+                     (i32.const 1671)
+                     (i32.const 1666)
+                    )
+                   )
+                  )
+                 )
+                )
+               )
+               (block $label$119
+                (if
+                 (i64.lt_u
+                  (i64.and
+                   (i64.reinterpret_f64
+                    (local.get $52)
+                   )
+                   (i64.const 9218868437227405312)
+                  )
+                  (i64.const 9218868437227405312)
+                 )
+                 (block
+                  (if
+                   (local.tee $1
+                    (f64.ne
+                     (local.tee $52
+                      (f64.mul
+                       (call $26
+                        (local.get $52)
+                        (local.get $20)
+                       )
+                       (f64.const 2)
+                      )
+                     )
+                     (f64.const 0)
+                    )
+                   )
+                   (i32.store
+                    (local.get $20)
+                    (i32.add
+                     (i32.load
+                      (local.get $20)
+                     )
+                     (i32.const -1)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.eq
+                    (local.tee $22
+                     (i32.or
+                      (local.get $9)
+                      (i32.const 32)
+                     )
+                    )
+                    (i32.const 97)
+                   )
+                   (block
+                    (local.set $1
+                     (i32.add
+                      (local.get $26)
+                      (i32.const 9)
+                     )
+                    )
+                    (if
+                     (local.tee $6
+                      (i32.and
+                       (local.get $9)
+                       (i32.const 32)
+                      )
+                     )
+                     (local.set $26
+                      (local.get $1)
+                     )
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.or
+                       (i32.gt_u
+                        (local.get $5)
+                        (i32.const 11)
+                       )
+                       (i32.eqz
+                        (local.tee $1
+                         (i32.sub
+                          (i32.const 12)
+                          (local.get $5)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (block
+                      (local.set $53
+                       (f64.const 8)
+                      )
+                      (loop $label$125
+                       (local.set $53
+                        (f64.mul
+                         (local.get $53)
+                         (f64.const 16)
+                        )
+                       )
+                       (br_if $label$125
+                        (local.tee $1
+                         (i32.add
+                          (local.get $1)
+                          (i32.const -1)
+                         )
+                        )
+                       )
+                      )
+                      (local.set $52
+                       (if (result f64)
+                        (i32.eq
+                         (i32.load8_s
+                          (local.get $26)
+                         )
+                         (i32.const 45)
+                        )
+                        (f64.neg
+                         (f64.add
+                          (local.get $53)
+                          (f64.sub
+                           (f64.neg
+                            (local.get $52)
+                           )
+                           (local.get $53)
+                          )
+                         )
+                        )
+                        (f64.sub
+                         (f64.add
+                          (local.get $52)
+                          (local.get $53)
+                         )
+                         (local.get $53)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $1
+                     (i32.sub
+                      (i32.const 0)
+                      (local.tee $7
+                       (i32.load
+                        (local.get $20)
+                       )
+                      )
+                     )
+                    )
+                    (if
+                     (i32.eq
+                      (local.tee $1
+                       (call $22
+                        (i64.extend_i32_s
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.get $7)
+                           (i32.const 0)
+                          )
+                          (local.get $1)
+                          (local.get $7)
+                         )
+                        )
+                        (local.get $33)
+                       )
+                      )
+                      (local.get $33)
+                     )
+                     (block
+                      (i32.store8
+                       (local.get $40)
+                       (i32.const 48)
+                      )
+                      (local.set $1
+                       (local.get $40)
+                      )
+                     )
+                    )
+                    (local.set $13
+                     (i32.or
+                      (local.get $24)
+                      (i32.const 2)
+                     )
+                    )
+                    (i32.store8
+                     (i32.add
+                      (local.get $1)
+                      (i32.const -1)
+                     )
+                     (i32.add
+                      (i32.and
+                       (i32.shr_s
+                        (local.get $7)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 43)
+                     )
+                    )
+                    (i32.store8
+                     (local.tee $8
+                      (i32.add
+                       (local.get $1)
+                       (i32.const -2)
+                      )
+                     )
+                     (i32.add
+                      (local.get $9)
+                      (i32.const 15)
+                     )
+                    )
+                    (local.set $9
+                     (i32.lt_s
+                      (local.get $5)
+                      (i32.const 1)
+                     )
+                    )
+                    (local.set $14
+                     (i32.eqz
+                      (i32.and
+                       (local.get $12)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                    (local.set $1
+                     (local.get $19)
+                    )
+                    (loop $label$131
+                     (i32.store8
+                      (local.get $1)
+                      (i32.or
+                       (i32.load8_u
+                        (i32.add
+                         (local.tee $7
+                          (i32.trunc_f64_s
+                           (local.get $52)
+                          )
+                         )
+                         (i32.const 1632)
+                        )
+                       )
+                       (local.get $6)
+                      )
+                     )
+                     (local.set $52
+                      (f64.mul
+                       (f64.sub
+                        (local.get $52)
+                        (f64.convert_i32_s
+                         (local.get $7)
+                        )
+                       )
+                       (f64.const 16)
+                      )
+                     )
+                     (local.set $1
+                      (block $label$132 (result i32)
+                       (if (result i32)
+                        (i32.eq
+                         (i32.sub
+                          (local.tee $7
+                           (i32.add
+                            (local.get $1)
+                            (i32.const 1)
+                           )
+                          )
+                          (local.get $27)
+                         )
+                         (i32.const 1)
+                        )
+                        (block (result i32)
+                         (drop
+                          (br_if $label$132
+                           (local.get $7)
+                           (i32.and
+                            (local.get $14)
+                            (i32.and
+                             (local.get $9)
+                             (f64.eq
+                              (local.get $52)
+                              (f64.const 0)
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.store8
+                          (local.get $7)
+                          (i32.const 46)
+                         )
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 2)
+                         )
+                        )
+                        (local.get $7)
+                       )
+                      )
+                     )
+                     (br_if $label$131
+                      (f64.ne
+                       (local.get $52)
+                       (f64.const 0)
+                      )
+                     )
+                    )
+                    (local.set $6
+                     (i32.sub
+                      (i32.add
+                       (local.get $46)
+                       (local.get $5)
+                      )
+                      (local.tee $7
+                       (local.get $8)
+                      )
+                     )
+                    )
+                    (local.set $9
+                     (i32.add
+                      (i32.sub
+                       (local.get $44)
+                       (local.get $7)
+                      )
+                      (local.get $1)
+                     )
+                    )
+                    (call $24
+                     (local.get $0)
+                     (i32.const 32)
+                     (local.get $10)
+                     (local.tee $5
+                      (i32.add
+                       (if (result i32)
+                        (i32.and
+                         (i32.ne
+                          (local.get $5)
+                          (i32.const 0)
+                         )
+                         (i32.lt_s
+                          (i32.add
+                           (local.get $45)
+                           (local.get $1)
+                          )
+                          (local.get $5)
+                         )
+                        )
+                        (local.get $6)
+                        (local.tee $6
+                         (local.get $9)
+                        )
+                       )
+                       (local.get $13)
+                      )
+                     )
+                     (local.get $12)
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $20
+                       (local.get $26)
+                       (local.get $13)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $24
+                     (local.get $0)
+                     (i32.const 48)
+                     (local.get $10)
+                     (local.get $5)
+                     (i32.xor
+                      (local.get $12)
+                      (i32.const 65536)
+                     )
+                    )
+                    (local.set $1
+                     (i32.sub
+                      (local.get $1)
+                      (local.get $27)
+                     )
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $20
+                       (local.get $19)
+                       (local.get $1)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $24
+                     (local.get $0)
+                     (i32.const 48)
+                     (i32.sub
+                      (local.get $6)
+                      (i32.add
+                       (local.get $1)
+                       (local.tee $1
+                        (i32.sub
+                         (local.get $28)
+                         (local.get $7)
+                        )
+                       )
+                      )
+                     )
+                     (i32.const 0)
+                     (i32.const 0)
+                    )
+                    (if
+                     (i32.eqz
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $20
+                       (local.get $8)
+                       (local.get $1)
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (call $24
+                     (local.get $0)
+                     (i32.const 32)
+                     (local.get $10)
+                     (local.get $5)
+                     (i32.xor
+                      (local.get $12)
+                      (i32.const 8192)
+                     )
+                    )
+                    (if
+                     (i32.ge_s
+                      (local.get $5)
+                      (local.get $10)
+                     )
+                     (local.set $10
+                      (local.get $5)
+                     )
+                    )
+                    (br $label$119)
+                   )
+                  )
+                  (if
+                   (local.get $1)
+                   (block
+                    (i32.store
+                     (local.get $20)
+                     (local.tee $6
+                      (i32.add
+                       (i32.load
+                        (local.get $20)
+                       )
+                       (i32.const -28)
+                      )
+                     )
+                    )
+                    (local.set $52
+                     (f64.mul
+                      (local.get $52)
+                      (f64.const 268435456)
+                     )
+                    )
+                   )
+                   (local.set $6
+                    (i32.load
+                     (local.get $20)
+                    )
+                   )
+                  )
+                  (local.set $8
+                   (local.tee $7
+                    (if (result i32)
+                     (i32.lt_s
+                      (local.get $6)
+                      (i32.const 0)
+                     )
+                     (local.get $47)
+                     (local.get $48)
+                    )
+                   )
+                  )
+                  (loop $label$145
+                   (i32.store
+                    (local.get $8)
+                    (local.tee $1
+                     (i32.trunc_f64_s
+                      (local.get $52)
+                     )
+                    )
+                   )
+                   (local.set $8
+                    (i32.add
+                     (local.get $8)
+                     (i32.const 4)
+                    )
+                   )
+                   (br_if $label$145
+                    (f64.ne
+                     (local.tee $52
+                      (f64.mul
+                       (f64.sub
+                        (local.get $52)
+                        (f64.convert_i32_u
+                         (local.get $1)
+                        )
+                       )
+                       (f64.const 1e9)
+                      )
+                     )
+                     (f64.const 0)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.gt_s
+                    (local.get $6)
+                    (i32.const 0)
+                   )
+                   (block
+                    (local.set $1
+                     (local.get $7)
+                    )
+                    (loop $label$147
+                     (local.set $14
+                      (if (result i32)
+                       (i32.gt_s
+                        (local.get $6)
+                        (i32.const 29)
+                       )
+                       (i32.const 29)
+                       (local.get $6)
+                      )
+                     )
+                     (block $label$150
+                      (if
+                       (i32.ge_u
+                        (local.tee $6
+                         (i32.add
+                          (local.get $8)
+                          (i32.const -4)
+                         )
+                        )
+                        (local.get $1)
+                       )
+                       (block
+                        (local.set $50
+                         (i64.extend_i32_u
+                          (local.get $14)
+                         )
+                        )
+                        (local.set $13
+                         (i32.const 0)
+                        )
+                        (loop $label$152
+                         (i64.store32
+                          (local.get $6)
+                          (i64.rem_u
+                           (local.tee $51
+                            (i64.add
+                             (i64.shl
+                              (i64.extend_i32_u
+                               (i32.load
+                                (local.get $6)
+                               )
+                              )
+                              (local.get $50)
+                             )
+                             (i64.extend_i32_u
+                              (local.get $13)
+                             )
+                            )
+                           )
+                           (i64.const 1000000000)
+                          )
+                         )
+                         (local.set $13
+                          (i32.wrap_i64
+                           (i64.div_u
+                            (local.get $51)
+                            (i64.const 1000000000)
+                           )
+                          )
+                         )
+                         (br_if $label$152
+                          (i32.ge_u
+                           (local.tee $6
+                            (i32.add
+                             (local.get $6)
+                             (i32.const -4)
+                            )
+                           )
+                           (local.get $1)
+                          )
+                         )
+                        )
+                        (br_if $label$150
+                         (i32.eqz
+                          (local.get $13)
+                         )
+                        )
+                        (i32.store
+                         (local.tee $1
+                          (i32.add
+                           (local.get $1)
+                           (i32.const -4)
+                          )
+                         )
+                         (local.get $13)
+                        )
+                       )
+                      )
+                     )
+                     (loop $label$153
+                      (if
+                       (i32.gt_u
+                        (local.get $8)
+                        (local.get $1)
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.load
+                          (local.tee $6
+                           (i32.add
+                            (local.get $8)
+                            (i32.const -4)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (local.set $8
+                          (local.get $6)
+                         )
+                         (br $label$153)
+                        )
+                       )
+                      )
+                     )
+                     (i32.store
+                      (local.get $20)
+                      (local.tee $6
+                       (i32.sub
+                        (i32.load
+                         (local.get $20)
+                        )
+                        (local.get $14)
+                       )
+                      )
+                     )
+                     (br_if $label$147
+                      (i32.gt_s
+                       (local.get $6)
+                       (i32.const 0)
+                      )
+                     )
+                    )
+                   )
+                   (local.set $1
+                    (local.get $7)
+                   )
+                  )
+                  (local.set $18
+                   (if (result i32)
+                    (i32.lt_s
+                     (local.get $5)
+                     (i32.const 0)
+                    )
+                    (i32.const 6)
+                    (local.get $5)
+                   )
+                  )
+                  (if
+                   (i32.lt_s
+                    (local.get $6)
+                    (i32.const 0)
+                   )
+                   (block
+                    (local.set $14
+                     (i32.add
+                      (i32.div_s
+                       (i32.add
+                        (local.get $18)
+                        (i32.const 25)
+                       )
+                       (i32.const 9)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                    (local.set $25
+                     (i32.eq
+                      (local.get $22)
+                      (i32.const 102)
+                     )
+                    )
+                    (local.set $5
+                     (local.get $8)
+                    )
+                    (loop $label$160
+                     (if
+                      (i32.gt_s
+                       (local.tee $13
+                        (i32.sub
+                         (i32.const 0)
+                         (local.get $6)
+                        )
+                       )
+                       (i32.const 9)
+                      )
+                      (local.set $13
+                       (i32.const 9)
+                      )
+                     )
+                     (block $label$162
+                      (if
+                       (i32.lt_u
+                        (local.get $1)
+                        (local.get $5)
+                       )
+                       (block
+                        (local.set $29
+                         (i32.add
+                          (i32.shl
+                           (i32.const 1)
+                           (local.get $13)
+                          )
+                          (i32.const -1)
+                         )
+                        )
+                        (local.set $35
+                         (i32.shr_u
+                          (i32.const 1000000000)
+                          (local.get $13)
+                         )
+                        )
+                        (local.set $6
+                         (i32.const 0)
+                        )
+                        (local.set $8
+                         (local.get $1)
+                        )
+                        (loop $label$164
+                         (i32.store
+                          (local.get $8)
+                          (i32.add
+                           (i32.shr_u
+                            (local.tee $32
+                             (i32.load
+                              (local.get $8)
+                             )
+                            )
+                            (local.get $13)
+                           )
+                           (local.get $6)
+                          )
+                         )
+                         (local.set $6
+                          (i32.mul
+                           (i32.and
+                            (local.get $32)
+                            (local.get $29)
+                           )
+                           (local.get $35)
+                          )
+                         )
+                         (br_if $label$164
+                          (i32.lt_u
+                           (local.tee $8
+                            (i32.add
+                             (local.get $8)
+                             (i32.const 4)
+                            )
+                           )
+                           (local.get $5)
+                          )
+                         )
+                        )
+                        (local.set $8
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 4)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (local.set $1
+                          (local.get $8)
+                         )
+                        )
+                        (br_if $label$162
+                         (i32.eqz
+                          (local.get $6)
+                         )
+                        )
+                        (i32.store
+                         (local.get $5)
+                         (local.get $6)
+                        )
+                        (local.set $5
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 4)
+                         )
+                        )
+                       )
+                       (block
+                        (local.set $8
+                         (i32.add
+                          (local.get $1)
+                          (i32.const 4)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (local.set $1
+                          (local.get $8)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (local.set $6
+                      (i32.add
+                       (local.tee $8
+                        (if (result i32)
+                         (local.get $25)
+                         (local.get $7)
+                         (local.get $1)
+                        )
+                       )
+                       (i32.shl
+                        (local.get $14)
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                     (if
+                      (i32.gt_s
+                       (i32.shr_s
+                        (i32.sub
+                         (local.get $5)
+                         (local.get $8)
+                        )
+                        (i32.const 2)
+                       )
+                       (local.get $14)
+                      )
+                      (local.set $5
+                       (local.get $6)
+                      )
+                     )
+                     (i32.store
+                      (local.get $20)
+                      (local.tee $6
+                       (i32.add
+                        (i32.load
+                         (local.get $20)
+                        )
+                        (local.get $13)
+                       )
+                      )
+                     )
+                     (br_if $label$160
+                      (i32.lt_s
+                       (local.get $6)
+                       (i32.const 0)
+                      )
+                     )
+                     (local.set $13
+                      (local.get $5)
+                     )
+                    )
+                   )
+                   (local.set $13
+                    (local.get $8)
+                   )
+                  )
+                  (local.set $25
+                   (local.get $7)
+                  )
+                  (block $label$172
+                   (if
+                    (i32.lt_u
+                     (local.get $1)
+                     (local.get $13)
+                    )
+                    (block
+                     (local.set $5
+                      (i32.mul
+                       (i32.shr_s
+                        (i32.sub
+                         (local.get $25)
+                         (local.get $1)
+                        )
+                        (i32.const 2)
+                       )
+                       (i32.const 9)
+                      )
+                     )
+                     (br_if $label$172
+                      (i32.lt_u
+                       (local.tee $6
+                        (i32.load
+                         (local.get $1)
+                        )
+                       )
+                       (i32.const 10)
+                      )
+                     )
+                     (local.set $8
+                      (i32.const 10)
+                     )
+                     (loop $label$174
+                      (local.set $5
+                       (i32.add
+                        (local.get $5)
+                        (i32.const 1)
+                       )
+                      )
+                      (br_if $label$174
+                       (i32.ge_u
+                        (local.get $6)
+                        (local.tee $8
+                         (i32.mul
+                          (local.get $8)
+                          (i32.const 10)
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $5
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                  (local.set $29
+                   (i32.eq
+                    (local.get $22)
+                    (i32.const 103)
+                   )
+                  )
+                  (local.set $35
+                   (i32.ne
+                    (local.get $18)
+                    (i32.const 0)
+                   )
+                  )
+                  (if
+                   (i32.lt_s
+                    (local.tee $8
+                     (i32.add
+                      (i32.sub
+                       (local.get $18)
+                       (if (result i32)
+                        (i32.ne
+                         (local.get $22)
+                         (i32.const 102)
+                        )
+                        (local.get $5)
+                        (i32.const 0)
+                       )
+                      )
+                      (i32.shr_s
+                       (i32.shl
+                        (i32.and
+                         (local.get $35)
+                         (local.get $29)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                    )
+                    (i32.add
+                     (i32.mul
+                      (i32.shr_s
+                       (i32.sub
+                        (local.get $13)
+                        (local.get $25)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 9)
+                     )
+                     (i32.const -9)
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_s
+                      (local.tee $8
+                       (i32.add
+                        (i32.rem_s
+                         (local.tee $14
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 9216)
+                          )
+                         )
+                         (i32.const 9)
+                        )
+                        (i32.const 1)
+                       )
+                      )
+                      (i32.const 9)
+                     )
+                     (block
+                      (local.set $6
+                       (i32.const 10)
+                      )
+                      (loop $label$180
+                       (local.set $6
+                        (i32.mul
+                         (local.get $6)
+                         (i32.const 10)
+                        )
+                       )
+                       (br_if $label$180
+                        (i32.ne
+                         (local.tee $8
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 1)
+                          )
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                      )
+                     )
+                     (local.set $6
+                      (i32.const 10)
+                     )
+                    )
+                    (local.set $14
+                     (i32.rem_u
+                      (local.tee $22
+                       (i32.load
+                        (local.tee $8
+                         (i32.add
+                          (i32.add
+                           (local.get $7)
+                           (i32.const 4)
+                          )
+                          (i32.shl
+                           (i32.add
+                            (i32.div_s
+                             (local.get $14)
+                             (i32.const 9)
+                            )
+                            (i32.const -1024)
+                           )
+                           (i32.const 2)
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (local.get $6)
+                     )
+                    )
+                    (block $label$182
+                     (if
+                      (i32.eqz
+                       (i32.and
+                        (local.tee $32
+                         (i32.eq
+                          (i32.add
+                           (local.get $8)
+                           (i32.const 4)
+                          )
+                          (local.get $13)
+                         )
+                        )
+                        (i32.eqz
+                         (local.get $14)
+                        )
+                       )
+                      )
+                      (block
+                       (local.set $52
+                        (if (result f64)
+                         (i32.lt_u
+                          (local.get $14)
+                          (local.tee $49
+                           (i32.div_s
+                            (local.get $6)
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                         (f64.const 0.5)
+                         (if (result f64)
+                          (i32.and
+                           (local.get $32)
+                           (i32.eq
+                            (local.get $14)
+                            (local.get $49)
+                           )
+                          )
+                          (f64.const 1)
+                          (f64.const 1.5)
+                         )
+                        )
+                       )
+                       (local.set $53
+                        (if (result f64)
+                         (i32.and
+                          (i32.div_u
+                           (local.get $22)
+                           (local.get $6)
+                          )
+                          (i32.const 1)
+                         )
+                         (f64.const 9007199254740994)
+                         (f64.const 9007199254740992)
+                        )
+                       )
+                       (block $label$190
+                        (if
+                         (local.get $24)
+                         (block
+                          (br_if $label$190
+                           (i32.ne
+                            (i32.load8_s
+                             (local.get $26)
+                            )
+                            (i32.const 45)
+                           )
+                          )
+                          (local.set $53
+                           (f64.neg
+                            (local.get $53)
+                           )
+                          )
+                          (local.set $52
+                           (f64.neg
+                            (local.get $52)
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (i32.store
+                        (local.get $8)
+                        (local.tee $14
+                         (i32.sub
+                          (local.get $22)
+                          (local.get $14)
+                         )
+                        )
+                       )
+                       (br_if $label$182
+                        (f64.eq
+                         (f64.add
+                          (local.get $53)
+                          (local.get $52)
+                         )
+                         (local.get $53)
+                        )
+                       )
+                       (i32.store
+                        (local.get $8)
+                        (local.tee $5
+                         (i32.add
+                          (local.get $14)
+                          (local.get $6)
+                         )
+                        )
+                       )
+                       (if
+                        (i32.gt_u
+                         (local.get $5)
+                         (i32.const 999999999)
+                        )
+                        (loop $label$193
+                         (i32.store
+                          (local.get $8)
+                          (i32.const 0)
+                         )
+                         (if
+                          (i32.lt_u
+                           (local.tee $8
+                            (i32.add
+                             (local.get $8)
+                             (i32.const -4)
+                            )
+                           )
+                           (local.get $1)
+                          )
+                          (i32.store
+                           (local.tee $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const -4)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                         )
+                         (i32.store
+                          (local.get $8)
+                          (local.tee $5
+                           (i32.add
+                            (i32.load
+                             (local.get $8)
+                            )
+                            (i32.const 1)
+                           )
+                          )
+                         )
+                         (br_if $label$193
+                          (i32.gt_u
+                           (local.get $5)
+                           (i32.const 999999999)
+                          )
+                         )
+                        )
+                       )
+                       (local.set $5
+                        (i32.mul
+                         (i32.shr_s
+                          (i32.sub
+                           (local.get $25)
+                           (local.get $1)
+                          )
+                          (i32.const 2)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (br_if $label$182
+                        (i32.lt_u
+                         (local.tee $14
+                          (i32.load
+                           (local.get $1)
+                          )
+                         )
+                         (i32.const 10)
+                        )
+                       )
+                       (local.set $6
+                        (i32.const 10)
+                       )
+                       (loop $label$195
+                        (local.set $5
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 1)
+                         )
+                        )
+                        (br_if $label$195
+                         (i32.ge_u
+                          (local.get $14)
+                          (local.tee $6
+                           (i32.mul
+                            (local.get $6)
+                            (i32.const 10)
+                           )
+                          )
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (local.set $14
+                     (local.get $1)
+                    )
+                    (local.set $6
+                     (local.get $5)
+                    )
+                    (if
+                     (i32.le_u
+                      (local.get $13)
+                      (local.tee $8
+                       (i32.add
+                        (local.get $8)
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.set $8
+                      (local.get $13)
+                     )
+                    )
+                   )
+                   (block
+                    (local.set $14
+                     (local.get $1)
+                    )
+                    (local.set $6
+                     (local.get $5)
+                    )
+                    (local.set $8
+                     (local.get $13)
+                    )
+                   )
+                  )
+                  (local.set $32
+                   (i32.sub
+                    (i32.const 0)
+                    (local.get $6)
+                   )
+                  )
+                  (loop $label$198
+                   (block $label$199
+                    (if
+                     (i32.le_u
+                      (local.get $8)
+                      (local.get $14)
+                     )
+                     (block
+                      (local.set $22
+                       (i32.const 0)
+                      )
+                      (br $label$199)
+                     )
+                    )
+                    (if
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $8)
+                        (i32.const -4)
+                       )
+                      )
+                     )
+                     (local.set $22
+                      (i32.const 1)
+                     )
+                     (block
+                      (local.set $8
+                       (local.get $1)
+                      )
+                      (br $label$198)
+                     )
+                    )
+                   )
+                  )
+                  (block $label$203
+                   (if
+                    (local.get $29)
+                    (block
+                     (local.set $1
+                      (if (result i32)
+                       (i32.and
+                        (i32.gt_s
+                         (local.tee $1
+                          (i32.add
+                           (i32.xor
+                            (i32.and
+                             (local.get $35)
+                             (i32.const 1)
+                            )
+                            (i32.const 1)
+                           )
+                           (local.get $18)
+                          )
+                         )
+                         (local.get $6)
+                        )
+                        (i32.gt_s
+                         (local.get $6)
+                         (i32.const -5)
+                        )
+                       )
+                       (block (result i32)
+                        (local.set $5
+                         (i32.add
+                          (local.get $9)
+                          (i32.const -1)
+                         )
+                        )
+                        (i32.sub
+                         (i32.add
+                          (local.get $1)
+                          (i32.const -1)
+                         )
+                         (local.get $6)
+                        )
+                       )
+                       (block (result i32)
+                        (local.set $5
+                         (i32.add
+                          (local.get $9)
+                          (i32.const -2)
+                         )
+                        )
+                        (i32.add
+                         (local.get $1)
+                         (i32.const -1)
+                        )
+                       )
+                      )
+                     )
+                     (br_if $label$203
+                      (local.tee $13
+                       (i32.and
+                        (local.get $12)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                     (block $label$207
+                      (if
+                       (local.get $22)
+                       (block
+                        (if
+                         (i32.eqz
+                          (local.tee $18
+                           (i32.load
+                            (i32.add
+                             (local.get $8)
+                             (i32.const -4)
+                            )
+                           )
+                          )
+                         )
+                         (block
+                          (local.set $9
+                           (i32.const 9)
+                          )
+                          (br $label$207)
+                         )
+                        )
+                        (if
+                         (i32.rem_u
+                          (local.get $18)
+                          (i32.const 10)
+                         )
+                         (block
+                          (local.set $9
+                           (i32.const 0)
+                          )
+                          (br $label$207)
+                         )
+                         (block
+                          (local.set $13
+                           (i32.const 10)
+                          )
+                          (local.set $9
+                           (i32.const 0)
+                          )
+                         )
+                        )
+                        (loop $label$212
+                         (local.set $9
+                          (i32.add
+                           (local.get $9)
+                           (i32.const 1)
+                          )
+                         )
+                         (br_if $label$212
+                          (i32.eqz
+                           (i32.rem_u
+                            (local.get $18)
+                            (local.tee $13
+                             (i32.mul
+                              (local.get $13)
+                              (i32.const 10)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (local.set $9
+                        (i32.const 9)
+                       )
+                      )
+                     )
+                     (local.set $18
+                      (i32.add
+                       (i32.mul
+                        (i32.shr_s
+                         (i32.sub
+                          (local.get $8)
+                          (local.get $25)
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 9)
+                       )
+                       (i32.const -9)
+                      )
+                     )
+                     (if
+                      (i32.eq
+                       (i32.or
+                        (local.get $5)
+                        (i32.const 32)
+                       )
+                       (i32.const 102)
+                      )
+                      (block
+                       (local.set $13
+                        (i32.const 0)
+                       )
+                       (if
+                        (i32.ge_s
+                         (local.get $1)
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.tee $9
+                            (i32.sub
+                             (local.get $18)
+                             (local.get $9)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                          (local.tee $9
+                           (i32.const 0)
+                          )
+                          (local.get $9)
+                         )
+                        )
+                        (local.set $1
+                         (local.get $9)
+                        )
+                       )
+                      )
+                      (block
+                       (local.set $13
+                        (i32.const 0)
+                       )
+                       (if
+                        (i32.ge_s
+                         (local.get $1)
+                         (if (result i32)
+                          (i32.lt_s
+                           (local.tee $9
+                            (i32.sub
+                             (i32.add
+                              (local.get $18)
+                              (local.get $6)
+                             )
+                             (local.get $9)
+                            )
+                           )
+                           (i32.const 0)
+                          )
+                          (local.tee $9
+                           (i32.const 0)
+                          )
+                          (local.get $9)
+                         )
+                        )
+                        (local.set $1
+                         (local.get $9)
+                        )
+                       )
+                      )
+                     )
+                    )
+                    (block
+                     (local.set $13
+                      (i32.and
+                       (local.get $12)
+                       (i32.const 8)
+                      )
+                     )
+                     (local.set $1
+                      (local.get $18)
+                     )
+                     (local.set $5
+                      (local.get $9)
+                     )
+                    )
+                   )
+                  )
+                  (if
+                   (local.tee $25
+                    (i32.eq
+                     (i32.or
+                      (local.get $5)
+                      (i32.const 32)
+                     )
+                     (i32.const 102)
+                    )
+                   )
+                   (block
+                    (local.set $9
+                     (i32.const 0)
+                    )
+                    (if
+                     (i32.le_s
+                      (local.get $6)
+                      (i32.const 0)
+                     )
+                     (local.set $6
+                      (i32.const 0)
+                     )
+                    )
+                   )
+                   (block
+                    (if
+                     (i32.lt_s
+                      (i32.sub
+                       (local.get $28)
+                       (local.tee $9
+                        (call $22
+                         (i64.extend_i32_s
+                          (if (result i32)
+                           (i32.lt_s
+                            (local.get $6)
+                            (i32.const 0)
+                           )
+                           (local.get $32)
+                           (local.get $6)
+                          )
+                         )
+                         (local.get $33)
+                        )
+                       )
+                      )
+                      (i32.const 2)
+                     )
+                     (loop $label$229
+                      (i32.store8
+                       (local.tee $9
+                        (i32.add
+                         (local.get $9)
+                         (i32.const -1)
+                        )
+                       )
+                       (i32.const 48)
+                      )
+                      (br_if $label$229
+                       (i32.lt_s
+                        (i32.sub
+                         (local.get $28)
+                         (local.get $9)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                    (i32.store8
+                     (i32.add
+                      (local.get $9)
+                      (i32.const -1)
+                     )
+                     (i32.add
+                      (i32.and
+                       (i32.shr_s
+                        (local.get $6)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.const 43)
+                     )
+                    )
+                    (i32.store8
+                     (local.tee $6
+                      (i32.add
+                       (local.get $9)
+                       (i32.const -2)
+                      )
+                     )
+                     (local.get $5)
+                    )
+                    (local.set $9
+                     (local.get $6)
+                    )
+                    (local.set $6
+                     (i32.sub
+                      (local.get $28)
+                      (local.get $6)
+                     )
+                    )
+                   )
+                  )
+                  (call $24
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.tee $18
+                    (i32.add
+                     (i32.add
+                      (i32.add
+                       (i32.add
+                        (local.get $24)
+                        (i32.const 1)
+                       )
+                       (local.get $1)
+                      )
+                      (i32.ne
+                       (local.tee $29
+                        (i32.or
+                         (local.get $1)
+                         (local.get $13)
+                        )
+                       )
+                       (i32.const 0)
+                      )
+                     )
+                     (local.get $6)
+                    )
+                   )
+                   (local.get $12)
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (i32.load
+                      (local.get $0)
+                     )
+                     (i32.const 32)
+                    )
+                   )
+                   (drop
+                    (call $20
+                     (local.get $26)
+                     (local.get $24)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (call $24
+                   (local.get $0)
+                   (i32.const 48)
+                   (local.get $10)
+                   (local.get $18)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 65536)
+                   )
+                  )
+                  (block $label$231
+                   (if
+                    (local.get $25)
+                    (block
+                     (local.set $6
+                      (local.tee $9
+                       (if (result i32)
+                        (i32.gt_u
+                         (local.get $14)
+                         (local.get $7)
+                        )
+                        (local.get $7)
+                        (local.get $14)
+                       )
+                      )
+                     )
+                     (loop $label$235
+                      (local.set $5
+                       (call $22
+                        (i64.extend_i32_u
+                         (i32.load
+                          (local.get $6)
+                         )
+                        )
+                        (local.get $31)
+                       )
+                      )
+                      (block $label$236
+                       (if
+                        (i32.eq
+                         (local.get $6)
+                         (local.get $9)
+                        )
+                        (block
+                         (br_if $label$236
+                          (i32.ne
+                           (local.get $5)
+                           (local.get $31)
+                          )
+                         )
+                         (i32.store8
+                          (local.get $34)
+                          (i32.const 48)
+                         )
+                         (local.set $5
+                          (local.get $34)
+                         )
+                        )
+                        (block
+                         (br_if $label$236
+                          (i32.le_u
+                           (local.get $5)
+                           (local.get $19)
+                          )
+                         )
+                         (drop
+                          (call $35
+                           (local.get $19)
+                           (i32.const 48)
+                           (i32.sub
+                            (local.get $5)
+                            (local.get $27)
+                           )
+                          )
+                         )
+                         (loop $label$239
+                          (br_if $label$239
+                           (i32.gt_u
+                            (local.tee $5
+                             (i32.add
+                              (local.get $5)
+                              (i32.const -1)
+                             )
+                            )
+                            (local.get $19)
+                           )
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.eqz
+                        (i32.and
+                         (i32.load
+                          (local.get $0)
+                         )
+                         (i32.const 32)
+                        )
+                       )
+                       (drop
+                        (call $20
+                         (local.get $5)
+                         (i32.sub
+                          (local.get $41)
+                          (local.get $5)
+                         )
+                         (local.get $0)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.le_u
+                        (local.tee $5
+                         (i32.add
+                          (local.get $6)
+                          (i32.const 4)
+                         )
+                        )
+                        (local.get $7)
+                       )
+                       (block
+                        (local.set $6
+                         (local.get $5)
+                        )
+                        (br $label$235)
+                       )
+                      )
+                     )
+                     (block $label$242
+                      (if
+                       (local.get $29)
+                       (block
+                        (br_if $label$242
+                         (i32.and
+                          (i32.load
+                           (local.get $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $20
+                          (i32.const 1700)
+                          (i32.const 1)
+                          (local.get $0)
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (if
+                      (i32.and
+                       (i32.gt_s
+                        (local.get $1)
+                        (i32.const 0)
+                       )
+                       (i32.lt_u
+                        (local.get $5)
+                        (local.get $8)
+                       )
+                      )
+                      (loop $label$245
+                       (if
+                        (i32.gt_u
+                         (local.tee $7
+                          (call $22
+                           (i64.extend_i32_u
+                            (i32.load
+                             (local.get $5)
+                            )
+                           )
+                           (local.get $31)
+                          )
+                         )
+                         (local.get $19)
+                        )
+                        (block
+                         (drop
+                          (call $35
+                           (local.get $19)
+                           (i32.const 48)
+                           (i32.sub
+                            (local.get $7)
+                            (local.get $27)
+                           )
+                          )
+                         )
+                         (loop $label$247
+                          (br_if $label$247
+                           (i32.gt_u
+                            (local.tee $7
+                             (i32.add
+                              (local.get $7)
+                              (i32.const -1)
+                             )
+                            )
+                            (local.get $19)
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.eqz
+                         (i32.and
+                          (i32.load
+                           (local.get $0)
+                          )
+                          (i32.const 32)
+                         )
+                        )
+                        (drop
+                         (call $20
+                          (local.get $7)
+                          (if (result i32)
+                           (i32.gt_s
+                            (local.get $1)
+                            (i32.const 9)
+                           )
+                           (i32.const 9)
+                           (local.get $1)
+                          )
+                          (local.get $0)
+                         )
+                        )
+                       )
+                       (local.set $7
+                        (i32.add
+                         (local.get $1)
+                         (i32.const -9)
+                        )
+                       )
+                       (if
+                        (i32.and
+                         (i32.gt_s
+                          (local.get $1)
+                          (i32.const 9)
+                         )
+                         (i32.lt_u
+                          (local.tee $5
+                           (i32.add
+                            (local.get $5)
+                            (i32.const 4)
+                           )
+                          )
+                          (local.get $8)
+                         )
+                        )
+                        (block
+                         (local.set $1
+                          (local.get $7)
+                         )
+                         (br $label$245)
+                        )
+                        (local.set $1
+                         (local.get $7)
+                        )
+                       )
+                      )
+                     )
+                     (call $24
+                      (local.get $0)
+                      (i32.const 48)
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 9)
+                      )
+                      (i32.const 9)
+                      (i32.const 0)
+                     )
+                    )
+                    (block
+                     (local.set $5
+                      (i32.add
+                       (local.get $14)
+                       (i32.const 4)
+                      )
+                     )
+                     (if
+                      (i32.eqz
+                       (local.get $22)
+                      )
+                      (local.set $8
+                       (local.get $5)
+                      )
+                     )
+                     (if
+                      (i32.gt_s
+                       (local.get $1)
+                       (i32.const -1)
+                      )
+                      (block
+                       (local.set $13
+                        (i32.eqz
+                         (local.get $13)
+                        )
+                       )
+                       (local.set $7
+                        (local.get $14)
+                       )
+                       (local.set $5
+                        (local.get $1)
+                       )
+                       (loop $label$256
+                        (if
+                         (i32.eq
+                          (local.tee $1
+                           (call $22
+                            (i64.extend_i32_u
+                             (i32.load
+                              (local.get $7)
+                             )
+                            )
+                            (local.get $31)
+                           )
+                          )
+                          (local.get $31)
+                         )
+                         (block
+                          (i32.store8
+                           (local.get $34)
+                           (i32.const 48)
+                          )
+                          (local.set $1
+                           (local.get $34)
+                          )
+                         )
+                        )
+                        (block $label$258
+                         (if
+                          (i32.eq
+                           (local.get $7)
+                           (local.get $14)
+                          )
+                          (block
+                           (if
+                            (i32.eqz
+                             (i32.and
+                              (i32.load
+                               (local.get $0)
+                              )
+                              (i32.const 32)
+                             )
+                            )
+                            (drop
+                             (call $20
+                              (local.get $1)
+                              (i32.const 1)
+                              (local.get $0)
+                             )
+                            )
+                           )
+                           (local.set $1
+                            (i32.add
+                             (local.get $1)
+                             (i32.const 1)
+                            )
+                           )
+                           (br_if $label$258
+                            (i32.and
+                             (local.get $13)
+                             (i32.lt_s
+                              (local.get $5)
+                              (i32.const 1)
+                             )
+                            )
+                           )
+                           (br_if $label$258
+                            (i32.and
+                             (i32.load
+                              (local.get $0)
+                             )
+                             (i32.const 32)
+                            )
+                           )
+                           (drop
+                            (call $20
+                             (i32.const 1700)
+                             (i32.const 1)
+                             (local.get $0)
+                            )
+                           )
+                          )
+                          (block
+                           (br_if $label$258
+                            (i32.le_u
+                             (local.get $1)
+                             (local.get $19)
+                            )
+                           )
+                           (drop
+                            (call $35
+                             (local.get $19)
+                             (i32.const 48)
+                             (i32.add
+                              (local.get $1)
+                              (local.get $43)
+                             )
+                            )
+                           )
+                           (loop $label$262
+                            (br_if $label$262
+                             (i32.gt_u
+                              (local.tee $1
+                               (i32.add
+                                (local.get $1)
+                                (i32.const -1)
+                               )
+                              )
+                              (local.get $19)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                        (local.set $6
+                         (i32.sub
+                          (local.get $41)
+                          (local.get $1)
+                         )
+                        )
+                        (if
+                         (i32.eqz
+                          (i32.and
+                           (i32.load
+                            (local.get $0)
+                           )
+                           (i32.const 32)
+                          )
+                         )
+                         (drop
+                          (call $20
+                           (local.get $1)
+                           (if (result i32)
+                            (i32.gt_s
+                             (local.get $5)
+                             (local.get $6)
+                            )
+                            (local.get $6)
+                            (local.get $5)
+                           )
+                           (local.get $0)
+                          )
+                         )
+                        )
+                        (br_if $label$256
+                         (i32.and
+                          (i32.lt_u
+                           (local.tee $7
+                            (i32.add
+                             (local.get $7)
+                             (i32.const 4)
+                            )
+                           )
+                           (local.get $8)
+                          )
+                          (i32.gt_s
+                           (local.tee $5
+                            (i32.sub
+                             (local.get $5)
+                             (local.get $6)
+                            )
+                           )
+                           (i32.const -1)
+                          )
+                         )
+                        )
+                        (local.set $1
+                         (local.get $5)
+                        )
+                       )
+                      )
+                     )
+                     (call $24
+                      (local.get $0)
+                      (i32.const 48)
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 18)
+                      )
+                      (i32.const 18)
+                      (i32.const 0)
+                     )
+                     (br_if $label$231
+                      (i32.and
+                       (i32.load
+                        (local.get $0)
+                       )
+                       (i32.const 32)
+                      )
+                     )
+                     (drop
+                      (call $20
+                       (local.get $9)
+                       (i32.sub
+                        (local.get $28)
+                        (local.get $9)
+                       )
+                       (local.get $0)
+                      )
+                     )
+                    )
+                   )
+                  )
+                  (call $24
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.get $18)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 8192)
+                   )
+                  )
+                  (if
+                   (i32.ge_s
+                    (local.get $18)
+                    (local.get $10)
+                   )
+                   (local.set $10
+                    (local.get $18)
+                   )
+                  )
+                 )
+                 (block
+                  (call $24
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.tee $8
+                    (i32.add
+                     (if (result i32)
+                      (local.tee $6
+                       (i32.or
+                        (f64.ne
+                         (local.get $52)
+                         (local.get $52)
+                        )
+                        (i32.const 0)
+                       )
+                      )
+                      (local.tee $24
+                       (i32.const 0)
+                      )
+                      (local.get $24)
+                     )
+                     (i32.const 3)
+                    )
+                   )
+                   (local.get $7)
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (local.tee $1
+                      (i32.load
+                       (local.get $0)
+                      )
+                     )
+                     (i32.const 32)
+                    )
+                   )
+                   (block
+                    (drop
+                     (call $20
+                      (local.get $26)
+                      (local.get $24)
+                      (local.get $0)
+                     )
+                    )
+                    (local.set $1
+                     (i32.load
+                      (local.get $0)
+                     )
+                    )
+                   )
+                  )
+                  (local.set $7
+                   (if (result i32)
+                    (local.tee $5
+                     (i32.ne
+                      (i32.and
+                       (local.get $9)
+                       (i32.const 32)
+                      )
+                      (i32.const 0)
+                     )
+                    )
+                    (i32.const 1684)
+                    (i32.const 1688)
+                   )
+                  )
+                  (local.set $5
+                   (if (result i32)
+                    (local.get $5)
+                    (i32.const 1692)
+                    (i32.const 1696)
+                   )
+                  )
+                  (if
+                   (i32.eqz
+                    (local.get $6)
+                   )
+                   (local.set $5
+                    (local.get $7)
+                   )
+                  )
+                  (if
+                   (i32.eqz
+                    (i32.and
+                     (local.get $1)
+                     (i32.const 32)
+                    )
+                   )
+                   (drop
+                    (call $20
+                     (local.get $5)
+                     (i32.const 3)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (call $24
+                   (local.get $0)
+                   (i32.const 32)
+                   (local.get $10)
+                   (local.get $8)
+                   (i32.xor
+                    (local.get $12)
+                    (i32.const 8192)
+                   )
+                  )
+                  (if
+                   (i32.ge_s
+                    (local.get $8)
+                    (local.get $10)
+                   )
+                   (local.set $10
+                    (local.get $8)
+                   )
+                  )
+                 )
+                )
+               )
+               (local.set $1
+                (local.get $11)
+               )
+               (br $label$4)
+              )
+              (local.set $7
+               (local.get $5)
+              )
+              (local.set $6
+               (i32.const 0)
+              )
+              (local.set $8
+               (i32.const 1648)
+              )
+              (local.set $5
+               (local.get $21)
+              )
+              (br $label$70)
+             )
+             (local.set $7
+              (i32.and
+               (local.get $9)
+               (i32.const 32)
+              )
+             )
+             (local.set $7
+              (if (result i32)
+               (i64.eq
+                (local.tee $50
+                 (i64.load
+                  (local.get $16)
+                 )
+                )
+                (i64.const 0)
+               )
+               (block (result i32)
+                (local.set $50
+                 (i64.const 0)
+                )
+                (local.get $21)
+               )
+               (block (result i32)
+                (local.set $1
+                 (local.get $21)
+                )
+                (loop $label$280
+                 (i32.store8
+                  (local.tee $1
+                   (i32.add
+                    (local.get $1)
+                    (i32.const -1)
+                   )
+                  )
+                  (i32.or
+                   (i32.load8_u
+                    (i32.add
+                     (i32.and
+                      (i32.wrap_i64
+                       (local.get $50)
+                      )
+                      (i32.const 15)
+                     )
+                     (i32.const 1632)
+                    )
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (br_if $label$280
+                  (i64.ne
+                   (local.tee $50
+                    (i64.shr_u
+                     (local.get $50)
+                     (i64.const 4)
+                    )
+                   )
+                   (i64.const 0)
+                  )
+                 )
+                )
+                (local.set $50
+                 (i64.load
+                  (local.get $16)
+                 )
+                )
+                (local.get $1)
+               )
+              )
+             )
+             (local.set $8
+              (i32.add
+               (i32.shr_s
+                (local.get $9)
+                (i32.const 4)
+               )
+               (i32.const 1648)
+              )
+             )
+             (if
+              (local.tee $1
+               (i32.or
+                (i32.eqz
+                 (i32.and
+                  (local.get $12)
+                  (i32.const 8)
+                 )
+                )
+                (i64.eq
+                 (local.get $50)
+                 (i64.const 0)
+                )
+               )
+              )
+              (local.set $8
+               (i32.const 1648)
+              )
+             )
+             (local.set $6
+              (if (result i32)
+               (local.get $1)
+               (i32.const 0)
+               (i32.const 2)
+              )
+             )
+             (br $label$71)
+            )
+            (local.set $7
+             (call $22
+              (local.get $50)
+              (local.get $21)
+             )
+            )
+            (br $label$71)
+           )
+           (local.set $14
+            (i32.eqz
+             (local.tee $13
+              (call $16
+               (local.get $1)
+               (i32.const 0)
+               (local.get $5)
+              )
+             )
+            )
+           )
+           (local.set $8
+            (i32.sub
+             (local.get $13)
+             (local.get $1)
+            )
+           )
+           (local.set $9
+            (i32.add
+             (local.get $1)
+             (local.get $5)
+            )
+           )
+           (local.set $12
+            (local.get $7)
+           )
+           (local.set $7
+            (if (result i32)
+             (local.get $14)
+             (local.get $5)
+             (local.get $8)
+            )
+           )
+           (local.set $6
+            (i32.const 0)
+           )
+           (local.set $8
+            (i32.const 1648)
+           )
+           (local.set $5
+            (if (result i32)
+             (local.get $14)
+             (local.get $9)
+             (local.get $13)
+            )
+           )
+           (br $label$70)
+          )
+          (local.set $1
+           (i32.const 0)
+          )
+          (local.set $5
+           (i32.const 0)
+          )
+          (local.set $8
+           (local.get $7)
+          )
+          (loop $label$288
+           (block $label$289
+            (br_if $label$289
+             (i32.eqz
+              (local.tee $9
+               (i32.load
+                (local.get $8)
+               )
+              )
+             )
+            )
+            (br_if $label$289
+             (i32.or
+              (i32.lt_s
+               (local.tee $5
+                (call $25
+                 (local.get $36)
+                 (local.get $9)
+                )
+               )
+               (i32.const 0)
+              )
+              (i32.gt_u
+               (local.get $5)
+               (i32.sub
+                (local.get $6)
+                (local.get $1)
+               )
+              )
+             )
+            )
+            (local.set $8
+             (i32.add
+              (local.get $8)
+              (i32.const 4)
+             )
+            )
+            (br_if $label$288
+             (i32.gt_u
+              (local.get $6)
+              (local.tee $1
+               (i32.add
+                (local.get $5)
+                (local.get $1)
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_s
+            (local.get $5)
+            (i32.const 0)
+           )
+           (block
+            (local.set $15
+             (i32.const -1)
+            )
+            (br $label$5)
+           )
+          )
+          (call $24
+           (local.get $0)
+           (i32.const 32)
+           (local.get $10)
+           (local.get $1)
+           (local.get $12)
+          )
+          (if
+           (local.get $1)
+           (block
+            (local.set $5
+             (i32.const 0)
+            )
+            (loop $label$292
+             (br_if $label$72
+              (i32.eqz
+               (local.tee $8
+                (i32.load
+                 (local.get $7)
+                )
+               )
+              )
+             )
+             (br_if $label$72
+              (i32.gt_s
+               (local.tee $5
+                (i32.add
+                 (local.tee $8
+                  (call $25
+                   (local.get $36)
+                   (local.get $8)
+                  )
+                 )
+                 (local.get $5)
+                )
+               )
+               (local.get $1)
+              )
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (i32.load
+                 (local.get $0)
+                )
+                (i32.const 32)
+               )
+              )
+              (drop
+               (call $20
+                (local.get $36)
+                (local.get $8)
+                (local.get $0)
+               )
+              )
+             )
+             (local.set $7
+              (i32.add
+               (local.get $7)
+               (i32.const 4)
+              )
+             )
+             (br_if $label$292
+              (i32.lt_u
+               (local.get $5)
+               (local.get $1)
+              )
+             )
+             (br $label$72)
+            )
+           )
+           (block
+            (local.set $1
+             (i32.const 0)
+            )
+            (br $label$72)
+           )
+          )
+         )
+         (call $24
+          (local.get $0)
+          (i32.const 32)
+          (local.get $10)
+          (local.get $1)
+          (i32.xor
+           (local.get $12)
+           (i32.const 8192)
+          )
+         )
+         (if
+          (i32.le_s
+           (local.get $10)
+           (local.get $1)
+          )
+          (local.set $10
+           (local.get $1)
+          )
+         )
+         (local.set $1
+          (local.get $11)
+         )
+         (br $label$4)
+        )
+        (local.set $1
+         (i32.and
+          (local.get $12)
+          (i32.const -65537)
+         )
+        )
+        (if
+         (i32.gt_s
+          (local.get $5)
+          (i32.const -1)
+         )
+         (local.set $12
+          (local.get $1)
+         )
+        )
+        (local.set $5
+         (if (result i32)
+          (i32.or
+           (local.get $5)
+           (local.tee $9
+            (i64.ne
+             (i64.load
+              (local.get $16)
+             )
+             (i64.const 0)
+            )
+           )
+          )
+          (block (result i32)
+           (local.set $1
+            (local.get $7)
+           )
+           (if
+            (i32.gt_s
+             (local.get $5)
+             (local.tee $7
+              (i32.add
+               (i32.xor
+                (i32.and
+                 (local.get $9)
+                 (i32.const 1)
+                )
+                (i32.const 1)
+               )
+               (i32.sub
+                (local.get $38)
+                (local.get $7)
+               )
+              )
+             )
+            )
+            (local.set $7
+             (local.get $5)
+            )
+           )
+           (local.get $21)
+          )
+          (block (result i32)
+           (local.set $1
+            (local.get $21)
+           )
+           (local.set $7
+            (i32.const 0)
+           )
+           (local.get $21)
+          )
+         )
+        )
+       )
+       (call $24
+        (local.get $0)
+        (i32.const 32)
+        (if (result i32)
+         (i32.lt_s
+          (local.get $10)
+          (local.tee $5
+           (i32.add
+            (if (result i32)
+             (i32.lt_s
+              (local.get $7)
+              (local.tee $9
+               (i32.sub
+                (local.get $5)
+                (local.get $1)
+               )
+              )
+             )
+             (local.tee $7
+              (local.get $9)
+             )
+             (local.get $7)
+            )
+            (local.get $6)
+           )
+          )
+         )
+         (local.tee $10
+          (local.get $5)
+         )
+         (local.get $10)
+        )
+        (local.get $5)
+        (local.get $12)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 32)
+         )
+        )
+        (drop
+         (call $20
+          (local.get $8)
+          (local.get $6)
+          (local.get $0)
+         )
+        )
+       )
+       (call $24
+        (local.get $0)
+        (i32.const 48)
+        (local.get $10)
+        (local.get $5)
+        (i32.xor
+         (local.get $12)
+         (i32.const 65536)
+        )
+       )
+       (call $24
+        (local.get $0)
+        (i32.const 48)
+        (local.get $7)
+        (local.get $9)
+        (i32.const 0)
+       )
+       (if
+        (i32.eqz
+         (i32.and
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 32)
+         )
+        )
+        (drop
+         (call $20
+          (local.get $1)
+          (local.get $9)
+          (local.get $0)
+         )
+        )
+       )
+       (call $24
+        (local.get $0)
+        (i32.const 32)
+        (local.get $10)
+        (local.get $5)
+        (i32.xor
+         (local.get $12)
+         (i32.const 8192)
+        )
+       )
+       (local.set $1
+        (local.get $11)
+       )
+       (br $label$4)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.eqz
+      (local.get $0)
+     )
+     (if
+      (local.get $17)
+      (block
+       (local.set $0
+        (i32.const 1)
+       )
+       (loop $label$308
+        (if
+         (local.tee $1
+          (i32.load
+           (i32.add
+            (local.get $4)
+            (i32.shl
+             (local.get $0)
+             (i32.const 2)
+            )
+           )
+          )
+         )
+         (block
+          (call $21
+           (i32.add
+            (local.get $3)
+            (i32.shl
+             (local.get $0)
+             (i32.const 3)
+            )
+           )
+           (local.get $1)
+           (local.get $2)
+          )
+          (br_if $label$308
+           (i32.lt_s
+            (local.tee $0
+             (i32.add
+              (local.get $0)
+              (i32.const 1)
+             )
+            )
+            (i32.const 10)
+           )
+          )
+          (local.set $15
+           (i32.const 1)
+          )
+          (br $label$2)
+         )
+        )
+       )
+       (loop $label$310
+        (if
+         (i32.load
+          (i32.add
+           (local.get $4)
+           (i32.shl
+            (local.get $0)
+            (i32.const 2)
+           )
+          )
+         )
+         (block
+          (local.set $15
+           (i32.const -1)
+          )
+          (br $label$2)
+         )
+        )
+        (br_if $label$310
+         (i32.lt_s
+          (local.tee $0
+           (i32.add
+            (local.get $0)
+            (i32.const 1)
+           )
+          )
+          (i32.const 10)
+         )
+        )
+        (local.set $15
+         (i32.const 1)
+        )
+       )
+      )
+      (local.set $15
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $23)
+   )
+   (local.get $15)
+  )
+ )
+ (func $19 (; 32 ;) (type $1) (param $0 i32) (result i32)
+  (i32.const 0)
+ )
+ (func $20 (; 33 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (block $label$1 (result i32)
+   (block $label$2
+    (block $label$3
+     (br_if $label$3
+      (local.tee $3
+       (i32.load
+        (local.tee $4
+         (i32.add
+          (local.get $2)
+          (i32.const 16)
+         )
+        )
+       )
+      )
+     )
+     (if
+      (call $29
+       (local.get $2)
+      )
+      (local.set $3
+       (i32.const 0)
+      )
+      (block
+       (local.set $3
+        (i32.load
+         (local.get $4)
+        )
+       )
+       (br $label$3)
+      )
+     )
+     (br $label$2)
+    )
+    (if
+     (i32.lt_u
+      (i32.sub
+       (local.get $3)
+       (local.tee $4
+        (i32.load
+         (local.tee $5
+          (i32.add
+           (local.get $2)
+           (i32.const 20)
+          )
+         )
+        )
+       )
+      )
+      (local.get $1)
+     )
+     (block
+      (local.set $3
+       (call_indirect (type $0)
+        (local.get $2)
+        (local.get $0)
+        (local.get $1)
+        (i32.add
+         (i32.and
+          (i32.load offset=36
+           (local.get $2)
+          )
+          (i32.const 3)
+         )
+         (i32.const 2)
+        )
+       )
+      )
+      (br $label$2)
+     )
+    )
+    (local.set $2
+     (block $label$7 (result i32)
+      (if (result i32)
+       (i32.gt_s
+        (i32.load8_s offset=75
+         (local.get $2)
+        )
+        (i32.const -1)
+       )
+       (block (result i32)
+        (local.set $3
+         (local.get $1)
+        )
+        (loop $label$9
+         (drop
+          (br_if $label$7
+           (i32.const 0)
+           (i32.eqz
+            (local.get $3)
+           )
+          )
+         )
+         (if
+          (i32.ne
+           (i32.load8_s
+            (i32.add
+             (local.get $0)
+             (local.tee $6
+              (i32.add
+               (local.get $3)
+               (i32.const -1)
+              )
+             )
+            )
+           )
+           (i32.const 10)
+          )
+          (block
+           (local.set $3
+            (local.get $6)
+           )
+           (br $label$9)
+          )
+         )
+        )
+        (br_if $label$2
+         (i32.lt_u
+          (call_indirect (type $0)
+           (local.get $2)
+           (local.get $0)
+           (local.get $3)
+           (i32.add
+            (i32.and
+             (i32.load offset=36
+              (local.get $2)
+             )
+             (i32.const 3)
+            )
+            (i32.const 2)
+           )
+          )
+          (local.get $3)
+         )
+        )
+        (local.set $4
+         (i32.load
+          (local.get $5)
+         )
+        )
+        (local.set $1
+         (i32.sub
+          (local.get $1)
+          (local.get $3)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (local.get $3)
+         )
+        )
+        (local.get $3)
+       )
+       (i32.const 0)
+      )
+     )
+    )
+    (drop
+     (call $36
+      (local.get $4)
+      (local.get $0)
+      (local.get $1)
+     )
+    )
+    (i32.store
+     (local.get $5)
+     (i32.add
+      (i32.load
+       (local.get $5)
+      )
+      (local.get $1)
+     )
+    )
+    (local.set $3
+     (i32.add
+      (local.get $2)
+      (local.get $1)
+     )
+    )
+   )
+   (local.get $3)
+  )
+ )
+ (func $21 (; 34 ;) (type $8) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i64)
+  (local $5 f64)
+  (block $label$1
+   (if
+    (i32.le_u
+     (local.get $1)
+     (i32.const 20)
+    )
+    (block $label$3
+     (block $label$4
+      (block $label$5
+       (block $label$6
+        (block $label$7
+         (block $label$8
+          (block $label$9
+           (block $label$10
+            (block $label$11
+             (block $label$12
+              (block $label$13
+               (br_table $label$13 $label$12 $label$11 $label$10 $label$9 $label$8 $label$7 $label$6 $label$5 $label$4 $label$3
+                (i32.sub
+                 (local.get $1)
+                 (i32.const 9)
+                )
+               )
+              )
+              (local.set $3
+               (i32.load
+                (local.tee $1
+                 (i32.and
+                  (i32.add
+                   (i32.load
+                    (local.get $2)
+                   )
+                   (i32.const 3)
+                  )
+                  (i32.const -4)
+                 )
+                )
+               )
+              )
+              (i32.store
+               (local.get $2)
+               (i32.add
+                (local.get $1)
+                (i32.const 4)
+               )
+              )
+              (i32.store
+               (local.get $0)
+               (local.get $3)
+              )
+              (br $label$1)
+             )
+             (local.set $3
+              (i32.load
+               (local.tee $1
+                (i32.and
+                 (i32.add
+                  (i32.load
+                   (local.get $2)
+                  )
+                  (i32.const 3)
+                 )
+                 (i32.const -4)
+                )
+               )
+              )
+             )
+             (i32.store
+              (local.get $2)
+              (i32.add
+               (local.get $1)
+               (i32.const 4)
+              )
+             )
+             (i64.store
+              (local.get $0)
+              (i64.extend_i32_s
+               (local.get $3)
+              )
+             )
+             (br $label$1)
+            )
+            (local.set $3
+             (i32.load
+              (local.tee $1
+               (i32.and
+                (i32.add
+                 (i32.load
+                  (local.get $2)
+                 )
+                 (i32.const 3)
+                )
+                (i32.const -4)
+               )
+              )
+             )
+            )
+            (i32.store
+             (local.get $2)
+             (i32.add
+              (local.get $1)
+              (i32.const 4)
+             )
+            )
+            (i64.store
+             (local.get $0)
+             (i64.extend_i32_u
+              (local.get $3)
+             )
+            )
+            (br $label$1)
+           )
+           (local.set $4
+            (i64.load
+             (local.tee $1
+              (i32.and
+               (i32.add
+                (i32.load
+                 (local.get $2)
+                )
+                (i32.const 7)
+               )
+               (i32.const -8)
+              )
+             )
+            )
+           )
+           (i32.store
+            (local.get $2)
+            (i32.add
+             (local.get $1)
+             (i32.const 8)
+            )
+           )
+           (i64.store
+            (local.get $0)
+            (local.get $4)
+           )
+           (br $label$1)
+          )
+          (local.set $3
+           (i32.load
+            (local.tee $1
+             (i32.and
+              (i32.add
+               (i32.load
+                (local.get $2)
+               )
+               (i32.const 3)
+              )
+              (i32.const -4)
+             )
+            )
+           )
+          )
+          (i32.store
+           (local.get $2)
+           (i32.add
+            (local.get $1)
+            (i32.const 4)
+           )
+          )
+          (i64.store
+           (local.get $0)
+           (i64.extend_i32_s
+            (i32.shr_s
+             (i32.shl
+              (i32.and
+               (local.get $3)
+               (i32.const 65535)
+              )
+              (i32.const 16)
+             )
+             (i32.const 16)
+            )
+           )
+          )
+          (br $label$1)
+         )
+         (local.set $3
+          (i32.load
+           (local.tee $1
+            (i32.and
+             (i32.add
+              (i32.load
+               (local.get $2)
+              )
+              (i32.const 3)
+             )
+             (i32.const -4)
+            )
+           )
+          )
+         )
+         (i32.store
+          (local.get $2)
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+         )
+         (i64.store
+          (local.get $0)
+          (i64.extend_i32_u
+           (i32.and
+            (local.get $3)
+            (i32.const 65535)
+           )
+          )
+         )
+         (br $label$1)
+        )
+        (local.set $3
+         (i32.load
+          (local.tee $1
+           (i32.and
+            (i32.add
+             (i32.load
+              (local.get $2)
+             )
+             (i32.const 3)
+            )
+            (i32.const -4)
+           )
+          )
+         )
+        )
+        (i32.store
+         (local.get $2)
+         (i32.add
+          (local.get $1)
+          (i32.const 4)
+         )
+        )
+        (i64.store
+         (local.get $0)
+         (i64.extend_i32_s
+          (i32.shr_s
+           (i32.shl
+            (i32.and
+             (local.get $3)
+             (i32.const 255)
+            )
+            (i32.const 24)
+           )
+           (i32.const 24)
+          )
+         )
+        )
+        (br $label$1)
+       )
+       (local.set $3
+        (i32.load
+         (local.tee $1
+          (i32.and
+           (i32.add
+            (i32.load
+             (local.get $2)
+            )
+            (i32.const 3)
+           )
+           (i32.const -4)
+          )
+         )
+        )
+       )
+       (i32.store
+        (local.get $2)
+        (i32.add
+         (local.get $1)
+         (i32.const 4)
+        )
+       )
+       (i64.store
+        (local.get $0)
+        (i64.extend_i32_u
+         (i32.and
+          (local.get $3)
+          (i32.const 255)
+         )
+        )
+       )
+       (br $label$1)
+      )
+      (local.set $5
+       (f64.load
+        (local.tee $1
+         (i32.and
+          (i32.add
+           (i32.load
+            (local.get $2)
+           )
+           (i32.const 7)
+          )
+          (i32.const -8)
+         )
+        )
+       )
+      )
+      (i32.store
+       (local.get $2)
+       (i32.add
+        (local.get $1)
+        (i32.const 8)
+       )
+      )
+      (f64.store
+       (local.get $0)
+       (local.get $5)
+      )
+      (br $label$1)
+     )
+     (local.set $5
+      (f64.load
+       (local.tee $1
+        (i32.and
+         (i32.add
+          (i32.load
+           (local.get $2)
+          )
+          (i32.const 7)
+         )
+         (i32.const -8)
+        )
+       )
+      )
+     )
+     (i32.store
+      (local.get $2)
+      (i32.add
+       (local.get $1)
+       (i32.const 8)
+      )
+     )
+     (f64.store
+      (local.get $0)
+      (local.get $5)
+     )
+    )
+   )
+  )
+ )
+ (func $22 (; 35 ;) (type $9) (param $0 i64) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i64)
+  (block $label$1 (result i32)
+   (local.set $2
+    (i32.wrap_i64
+     (local.get $0)
+    )
+   )
+   (if
+    (i64.gt_u
+     (local.get $0)
+     (i64.const 4294967295)
+    )
+    (block
+     (loop $label$3
+      (i64.store8
+       (local.tee $1
+        (i32.add
+         (local.get $1)
+         (i32.const -1)
+        )
+       )
+       (i64.or
+        (i64.rem_u
+         (local.get $0)
+         (i64.const 10)
+        )
+        (i64.const 48)
+       )
+      )
+      (local.set $4
+       (i64.div_u
+        (local.get $0)
+        (i64.const 10)
+       )
+      )
+      (if
+       (i64.gt_u
+        (local.get $0)
+        (i64.const 42949672959)
+       )
+       (block
+        (local.set $0
+         (local.get $4)
+        )
+        (br $label$3)
+       )
+      )
+     )
+     (local.set $2
+      (i32.wrap_i64
+       (local.get $4)
+      )
+     )
+    )
+   )
+   (if
+    (local.get $2)
+    (loop $label$6
+     (i32.store8
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const -1)
+       )
+      )
+      (i32.or
+       (i32.rem_u
+        (local.get $2)
+        (i32.const 10)
+       )
+       (i32.const 48)
+      )
+     )
+     (local.set $3
+      (i32.div_u
+       (local.get $2)
+       (i32.const 10)
+      )
+     )
+     (if
+      (i32.ge_u
+       (local.get $2)
+       (i32.const 10)
+      )
+      (block
+       (local.set $2
+        (local.get $3)
+       )
+       (br $label$6)
+      )
+     )
+    )
+   )
+   (local.get $1)
+  )
+ )
+ (func $23 (; 36 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.const 0)
+   )
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (loop $label$5
+       (br_if $label$4
+        (i32.eq
+         (i32.load8_u
+          (i32.add
+           (local.get $1)
+           (i32.const 1702)
+          )
+         )
+         (local.get $0)
+        )
+       )
+       (br_if $label$5
+        (i32.ne
+         (local.tee $1
+          (i32.add
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (i32.const 87)
+        )
+       )
+       (local.set $1
+        (i32.const 87)
+       )
+       (local.set $0
+        (i32.const 1790)
+       )
+       (br $label$3)
+      )
+     )
+     (if
+      (local.get $1)
+      (block
+       (local.set $0
+        (i32.const 1790)
+       )
+       (br $label$3)
+      )
+      (local.set $0
+       (i32.const 1790)
+      )
+     )
+     (br $label$2)
+    )
+    (loop $label$8
+     (local.set $2
+      (local.get $0)
+     )
+     (loop $label$9
+      (local.set $0
+       (i32.add
+        (local.get $2)
+        (i32.const 1)
+       )
+      )
+      (if
+       (i32.load8_s
+        (local.get $2)
+       )
+       (block
+        (local.set $2
+         (local.get $0)
+        )
+        (br $label$9)
+       )
+      )
+     )
+     (br_if $label$8
+      (local.tee $1
+       (i32.add
+        (local.get $1)
+        (i32.const -1)
+       )
+      )
+     )
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $24 (; 37 ;) (type $10) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (block $label$1
+   (local.set $7
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 256)
+    )
+   )
+   (local.set $6
+    (local.get $7)
+   )
+   (block $label$2
+    (if
+     (i32.and
+      (i32.gt_s
+       (local.get $2)
+       (local.get $3)
+      )
+      (i32.eqz
+       (i32.and
+        (local.get $4)
+        (i32.const 73728)
+       )
+      )
+     )
+     (block
+      (drop
+       (call $35
+        (local.get $6)
+        (local.get $1)
+        (if (result i32)
+         (i32.gt_u
+          (local.tee $5
+           (i32.sub
+            (local.get $2)
+            (local.get $3)
+           )
+          )
+          (i32.const 256)
+         )
+         (i32.const 256)
+         (local.get $5)
+        )
+       )
+      )
+      (local.set $4
+       (i32.eqz
+        (i32.and
+         (local.tee $1
+          (i32.load
+           (local.get $0)
+          )
+         )
+         (i32.const 32)
+        )
+       )
+      )
+      (if
+       (i32.gt_u
+        (local.get $5)
+        (i32.const 255)
+       )
+       (block
+        (loop $label$7
+         (if
+          (local.get $4)
+          (block
+           (drop
+            (call $20
+             (local.get $6)
+             (i32.const 256)
+             (local.get $0)
+            )
+           )
+           (local.set $1
+            (i32.load
+             (local.get $0)
+            )
+           )
+          )
+         )
+         (local.set $4
+          (i32.eqz
+           (i32.and
+            (local.get $1)
+            (i32.const 32)
+           )
+          )
+         )
+         (br_if $label$7
+          (i32.gt_u
+           (local.tee $5
+            (i32.add
+             (local.get $5)
+             (i32.const -256)
+            )
+           )
+           (i32.const 255)
+          )
+         )
+        )
+        (br_if $label$2
+         (i32.eqz
+          (local.get $4)
+         )
+        )
+        (local.set $5
+         (i32.and
+          (i32.sub
+           (local.get $2)
+           (local.get $3)
+          )
+          (i32.const 255)
+         )
+        )
+       )
+       (br_if $label$2
+        (i32.eqz
+         (local.get $4)
+        )
+       )
+      )
+      (drop
+       (call $20
+        (local.get $6)
+        (local.get $5)
+        (local.get $0)
+       )
+      )
+     )
+    )
+   )
+   (global.set $global$1
+    (local.get $7)
+   )
+  )
+ )
+ (func $25 (; 38 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (if (result i32)
+   (local.get $0)
+   (call $28
+    (local.get $0)
+    (local.get $1)
+    (i32.const 0)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $26 (; 39 ;) (type $11) (param $0 f64) (param $1 i32) (result f64)
+  (call $27
+   (local.get $0)
+   (local.get $1)
+  )
+ )
+ (func $27 (; 40 ;) (type $11) (param $0 f64) (param $1 i32) (result f64)
+  (local $2 i64)
+  (local $3 i64)
+  (block $label$1 (result f64)
+   (block $label$2
+    (block $label$3
+     (block $label$4
+      (block $label$5
+       (br_table $label$5 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$3 $label$4 $label$3
+        (i32.sub
+         (i32.shr_s
+          (i32.shl
+           (i32.and
+            (i32.and
+             (i32.wrap_i64
+              (local.tee $3
+               (i64.shr_u
+                (local.tee $2
+                 (i64.reinterpret_f64
+                  (local.get $0)
+                 )
+                )
+                (i64.const 52)
+               )
+              )
+             )
+             (i32.const 65535)
+            )
+            (i32.const 2047)
+           )
+           (i32.const 16)
+          )
+          (i32.const 16)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.store
+       (local.get $1)
+       (if (result i32)
+        (f64.ne
+         (local.get $0)
+         (f64.const 0)
+        )
+        (block (result i32)
+         (local.set $0
+          (call $27
+           (f64.mul
+            (local.get $0)
+            (f64.const 18446744073709551615)
+           )
+           (local.get $1)
+          )
+         )
+         (i32.add
+          (i32.load
+           (local.get $1)
+          )
+          (i32.const -64)
+         )
+        )
+        (i32.const 0)
+       )
+      )
+      (br $label$2)
+     )
+     (br $label$2)
+    )
+    (i32.store
+     (local.get $1)
+     (i32.add
+      (i32.and
+       (i32.wrap_i64
+        (local.get $3)
+       )
+       (i32.const 2047)
+      )
+      (i32.const -1022)
+     )
+    )
+    (local.set $0
+     (f64.reinterpret_i64
+      (i64.or
+       (i64.and
+        (local.get $2)
+        (i64.const -9218868437227405313)
+       )
+       (i64.const 4602678819172646912)
+      )
+     )
+    )
+   )
+   (local.get $0)
+  )
+ )
+ (func $28 (; 41 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (block $label$1 (result i32)
+   (if (result i32)
+    (local.get $0)
+    (block (result i32)
+     (if
+      (i32.lt_u
+       (local.get $1)
+       (i32.const 128)
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (local.get $1)
+       )
+       (br $label$1
+        (i32.const 1)
+       )
+      )
+     )
+     (if
+      (i32.lt_u
+       (local.get $1)
+       (i32.const 2048)
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 6)
+         )
+         (i32.const 192)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (br $label$1
+        (i32.const 2)
+       )
+      )
+     )
+     (if
+      (i32.or
+       (i32.lt_u
+        (local.get $1)
+        (i32.const 55296)
+       )
+       (i32.eq
+        (i32.and
+         (local.get $1)
+         (i32.const -8192)
+        )
+        (i32.const 57344)
+       )
+      )
+      (block
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 12)
+         )
+         (i32.const 224)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 6)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=2
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (br $label$1
+        (i32.const 3)
+       )
+      )
+     )
+     (if (result i32)
+      (i32.lt_u
+       (i32.add
+        (local.get $1)
+        (i32.const -65536)
+       )
+       (i32.const 1048576)
+      )
+      (block (result i32)
+       (i32.store8
+        (local.get $0)
+        (i32.or
+         (i32.shr_u
+          (local.get $1)
+          (i32.const 18)
+         )
+         (i32.const 240)
+        )
+       )
+       (i32.store8 offset=1
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 12)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=2
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (i32.shr_u
+           (local.get $1)
+           (i32.const 6)
+          )
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.store8 offset=3
+        (local.get $0)
+        (i32.or
+         (i32.and
+          (local.get $1)
+          (i32.const 63)
+         )
+         (i32.const 128)
+        )
+       )
+       (i32.const 4)
+      )
+      (block (result i32)
+       (i32.store
+        (call $11)
+        (i32.const 84)
+       )
+       (i32.const -1)
+      )
+     )
+    )
+    (i32.const 1)
+   )
+  )
+ )
+ (func $29 (; 42 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.load8_s
+     (local.tee $2
+      (i32.add
+       (local.get $0)
+       (i32.const 74)
+      )
+     )
+    )
+   )
+   (i32.store8
+    (local.get $2)
+    (i32.or
+     (i32.add
+      (local.get $1)
+      (i32.const 255)
+     )
+     (local.get $1)
+    )
+   )
+   (local.tee $0
+    (if (result i32)
+     (i32.and
+      (local.tee $1
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (i32.const 8)
+     )
+     (block (result i32)
+      (i32.store
+       (local.get $0)
+       (i32.or
+        (local.get $1)
+        (i32.const 32)
+       )
+      )
+      (i32.const -1)
+     )
+     (block (result i32)
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.store offset=28
+       (local.get $0)
+       (local.tee $1
+        (i32.load offset=44
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store offset=20
+       (local.get $0)
+       (local.get $1)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.add
+        (local.get $1)
+        (i32.load offset=48
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 0)
+     )
+    )
+   )
+  )
+ )
+ (func $30 (; 43 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (local.set $2
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (i32.store
+    (local.tee $3
+     (local.get $2)
+    )
+    (local.get $1)
+   )
+   (local.set $0
+    (call $17
+     (i32.load
+      (i32.const 1024)
+     )
+     (local.get $0)
+     (local.get $3)
+    )
+   )
+   (global.set $global$1
+    (local.get $2)
+   )
+   (local.get $0)
+  )
+ )
+ (func $31 (; 44 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (block $label$1 (result i32)
+   (local.set $14
+    (global.get $global$1)
+   )
+   (global.set $global$1
+    (i32.add
+     (global.get $global$1)
+     (i32.const 16)
+    )
+   )
+   (local.set $18
+    (local.get $14)
+   )
+   (block $label$2
+    (if
+     (i32.lt_u
+      (local.get $0)
+      (i32.const 245)
+     )
+     (block
+      (local.set $3
+       (i32.and
+        (i32.add
+         (local.get $0)
+         (i32.const 11)
+        )
+        (i32.const -8)
+       )
+      )
+      (if
+       (i32.and
+        (local.tee $0
+         (i32.shr_u
+          (local.tee $8
+           (i32.load
+            (i32.const 3644)
+           )
+          )
+          (local.tee $2
+           (i32.shr_u
+            (if (result i32)
+             (i32.lt_u
+              (local.get $0)
+              (i32.const 11)
+             )
+             (local.tee $3
+              (i32.const 16)
+             )
+             (local.get $3)
+            )
+            (i32.const 3)
+           )
+          )
+         )
+        )
+        (i32.const 3)
+       )
+       (block
+        (local.set $4
+         (i32.load
+          (local.tee $1
+           (i32.add
+            (local.tee $7
+             (i32.load
+              (local.tee $3
+               (i32.add
+                (local.tee $2
+                 (i32.add
+                  (i32.shl
+                   (i32.shl
+                    (local.tee $5
+                     (i32.add
+                      (i32.xor
+                       (i32.and
+                        (local.get $0)
+                        (i32.const 1)
+                       )
+                       (i32.const 1)
+                      )
+                      (local.get $2)
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (i32.const 2)
+                  )
+                  (i32.const 3684)
+                 )
+                )
+                (i32.const 8)
+               )
+              )
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $4)
+         )
+         (i32.store
+          (i32.const 3644)
+          (i32.and
+           (local.get $8)
+           (i32.xor
+            (i32.shl
+             (i32.const 1)
+             (local.get $5)
+            )
+            (i32.const -1)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $4)
+            (i32.load
+             (i32.const 3660)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $0
+              (i32.add
+               (local.get $4)
+               (i32.const 12)
+              )
+             )
+            )
+            (local.get $7)
+           )
+           (block
+            (i32.store
+             (local.get $0)
+             (local.get $2)
+            )
+            (i32.store
+             (local.get $3)
+             (local.get $4)
+            )
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (i32.store offset=4
+         (local.get $7)
+         (i32.or
+          (local.tee $0
+           (i32.shl
+            (local.get $5)
+            (i32.const 3)
+           )
+          )
+          (i32.const 3)
+         )
+        )
+        (i32.store
+         (local.tee $0
+          (i32.add
+           (i32.add
+            (local.get $7)
+            (local.get $0)
+           )
+           (i32.const 4)
+          )
+         )
+         (i32.or
+          (i32.load
+           (local.get $0)
+          )
+          (i32.const 1)
+         )
+        )
+        (global.set $global$1
+         (local.get $14)
+        )
+        (return
+         (local.get $1)
+        )
+       )
+      )
+      (if
+       (i32.gt_u
+        (local.get $3)
+        (local.tee $16
+         (i32.load
+          (i32.const 3652)
+         )
+        )
+       )
+       (block
+        (if
+         (local.get $0)
+         (block
+          (local.set $5
+           (i32.and
+            (i32.shr_u
+             (local.tee $0
+              (i32.add
+               (i32.and
+                (local.tee $0
+                 (i32.and
+                  (i32.shl
+                   (local.get $0)
+                   (local.get $2)
+                  )
+                  (i32.or
+                   (local.tee $0
+                    (i32.shl
+                     (i32.const 2)
+                     (local.get $2)
+                    )
+                   )
+                   (i32.sub
+                    (i32.const 0)
+                    (local.get $0)
+                   )
+                  )
+                 )
+                )
+                (i32.sub
+                 (i32.const 0)
+                 (local.get $0)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (local.set $12
+           (i32.load
+            (local.tee $5
+             (i32.add
+              (local.tee $9
+               (i32.load
+                (local.tee $2
+                 (i32.add
+                  (local.tee $4
+                   (i32.add
+                    (i32.shl
+                     (i32.shl
+                      (local.tee $11
+                       (i32.add
+                        (i32.or
+                         (i32.or
+                          (i32.or
+                           (i32.or
+                            (local.tee $0
+                             (i32.and
+                              (i32.shr_u
+                               (local.tee $2
+                                (i32.shr_u
+                                 (local.get $0)
+                                 (local.get $5)
+                                )
+                               )
+                               (i32.const 5)
+                              )
+                              (i32.const 8)
+                             )
+                            )
+                            (local.get $5)
+                           )
+                           (local.tee $0
+                            (i32.and
+                             (i32.shr_u
+                              (local.tee $2
+                               (i32.shr_u
+                                (local.get $2)
+                                (local.get $0)
+                               )
+                              )
+                              (i32.const 2)
+                             )
+                             (i32.const 4)
+                            )
+                           )
+                          )
+                          (local.tee $0
+                           (i32.and
+                            (i32.shr_u
+                             (local.tee $2
+                              (i32.shr_u
+                               (local.get $2)
+                               (local.get $0)
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 2)
+                           )
+                          )
+                         )
+                         (local.tee $0
+                          (i32.and
+                           (i32.shr_u
+                            (local.tee $2
+                             (i32.shr_u
+                              (local.get $2)
+                              (local.get $0)
+                             )
+                            )
+                            (i32.const 1)
+                           )
+                           (i32.const 1)
+                          )
+                         )
+                        )
+                        (i32.shr_u
+                         (local.get $2)
+                         (local.get $0)
+                        )
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 2)
+                    )
+                    (i32.const 3684)
+                   )
+                  )
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (if
+           (i32.eq
+            (local.get $4)
+            (local.get $12)
+           )
+           (i32.store
+            (i32.const 3644)
+            (local.tee $7
+             (i32.and
+              (local.get $8)
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (local.get $11)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $12)
+              (i32.load
+               (i32.const 3660)
+              )
+             )
+             (call $fimport$10)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (local.tee $0
+                (i32.add
+                 (local.get $12)
+                 (i32.const 12)
+                )
+               )
+              )
+              (local.get $9)
+             )
+             (block
+              (i32.store
+               (local.get $0)
+               (local.get $4)
+              )
+              (i32.store
+               (local.get $2)
+               (local.get $12)
+              )
+              (local.set $7
+               (local.get $8)
+              )
+             )
+             (call $fimport$10)
+            )
+           )
+          )
+          (i32.store offset=4
+           (local.get $9)
+           (i32.or
+            (local.get $3)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=4
+           (local.tee $4
+            (i32.add
+             (local.get $9)
+             (local.get $3)
+            )
+           )
+           (i32.or
+            (local.tee $11
+             (i32.sub
+              (i32.shl
+               (local.get $11)
+               (i32.const 3)
+              )
+              (local.get $3)
+             )
+            )
+            (i32.const 1)
+           )
+          )
+          (i32.store
+           (i32.add
+            (local.get $4)
+            (local.get $11)
+           )
+           (local.get $11)
+          )
+          (if
+           (local.get $16)
+           (block
+            (local.set $9
+             (i32.load
+              (i32.const 3664)
+             )
+            )
+            (local.set $2
+             (i32.add
+              (i32.shl
+               (i32.shl
+                (local.tee $0
+                 (i32.shr_u
+                  (local.get $16)
+                  (i32.const 3)
+                 )
+                )
+                (i32.const 1)
+               )
+               (i32.const 2)
+              )
+              (i32.const 3684)
+             )
+            )
+            (if
+             (i32.and
+              (local.get $7)
+              (local.tee $0
+               (i32.shl
+                (i32.const 1)
+                (local.get $0)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.tee $0
+                (i32.load
+                 (local.tee $3
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 8)
+                  )
+                 )
+                )
+               )
+               (i32.load
+                (i32.const 3660)
+               )
+              )
+              (call $fimport$10)
+              (block
+               (local.set $6
+                (local.get $3)
+               )
+               (local.set $1
+                (local.get $0)
+               )
+              )
+             )
+             (block
+              (i32.store
+               (i32.const 3644)
+               (i32.or
+                (local.get $7)
+                (local.get $0)
+               )
+              )
+              (local.set $6
+               (i32.add
+                (local.get $2)
+                (i32.const 8)
+               )
+              )
+              (local.set $1
+               (local.get $2)
+              )
+             )
+            )
+            (i32.store
+             (local.get $6)
+             (local.get $9)
+            )
+            (i32.store offset=12
+             (local.get $1)
+             (local.get $9)
+            )
+            (i32.store offset=8
+             (local.get $9)
+             (local.get $1)
+            )
+            (i32.store offset=12
+             (local.get $9)
+             (local.get $2)
+            )
+           )
+          )
+          (i32.store
+           (i32.const 3652)
+           (local.get $11)
+          )
+          (i32.store
+           (i32.const 3664)
+           (local.get $4)
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (local.get $5)
+          )
+         )
+        )
+        (if
+         (local.tee $6
+          (i32.load
+           (i32.const 3648)
+          )
+         )
+         (block
+          (local.set $2
+           (i32.and
+            (i32.shr_u
+             (local.tee $0
+              (i32.add
+               (i32.and
+                (local.get $6)
+                (i32.sub
+                 (i32.const 0)
+                 (local.get $6)
+                )
+               )
+               (i32.const -1)
+              )
+             )
+             (i32.const 12)
+            )
+            (i32.const 16)
+           )
+          )
+          (local.set $9
+           (i32.sub
+            (i32.and
+             (i32.load offset=4
+              (local.tee $2
+               (i32.load
+                (i32.add
+                 (i32.shl
+                  (i32.add
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (i32.or
+                       (local.tee $0
+                        (i32.and
+                         (i32.shr_u
+                          (local.tee $1
+                           (i32.shr_u
+                            (local.get $0)
+                            (local.get $2)
+                           )
+                          )
+                          (i32.const 5)
+                         )
+                         (i32.const 8)
+                        )
+                       )
+                       (local.get $2)
+                      )
+                      (local.tee $0
+                       (i32.and
+                        (i32.shr_u
+                         (local.tee $1
+                          (i32.shr_u
+                           (local.get $1)
+                           (local.get $0)
+                          )
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (local.tee $1
+                         (i32.shr_u
+                          (local.get $1)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 1)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (local.tee $1
+                        (i32.shr_u
+                         (local.get $1)
+                         (local.get $0)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.shr_u
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3948)
+                )
+               )
+              )
+             )
+             (i32.const -8)
+            )
+            (local.get $3)
+           )
+          )
+          (local.set $1
+           (local.get $2)
+          )
+          (loop $label$25
+           (block $label$26
+            (if
+             (i32.eqz
+              (local.tee $0
+               (i32.load offset=16
+                (local.get $1)
+               )
+              )
+             )
+             (br_if $label$26
+              (i32.eqz
+               (local.tee $0
+                (i32.load offset=20
+                 (local.get $1)
+                )
+               )
+              )
+             )
+            )
+            (if
+             (local.tee $7
+              (i32.lt_u
+               (local.tee $1
+                (i32.sub
+                 (i32.and
+                  (i32.load offset=4
+                   (local.get $0)
+                  )
+                  (i32.const -8)
+                 )
+                 (local.get $3)
+                )
+               )
+               (local.get $9)
+              )
+             )
+             (local.set $9
+              (local.get $1)
+             )
+            )
+            (local.set $1
+             (local.get $0)
+            )
+            (if
+             (local.get $7)
+             (local.set $2
+              (local.get $0)
+             )
+            )
+            (br $label$25)
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $2)
+            (local.tee $12
+             (i32.load
+              (i32.const 3660)
+             )
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.ge_u
+            (local.get $2)
+            (local.tee $13
+             (i32.add
+              (local.get $2)
+              (local.get $3)
+             )
+            )
+           )
+           (call $fimport$10)
+          )
+          (local.set $15
+           (i32.load offset=24
+            (local.get $2)
+           )
+          )
+          (block $label$32
+           (if
+            (i32.eq
+             (local.tee $0
+              (i32.load offset=12
+               (local.get $2)
+              )
+             )
+             (local.get $2)
+            )
+            (block
+             (if
+              (i32.eqz
+               (local.tee $0
+                (i32.load
+                 (local.tee $1
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+              )
+              (if
+               (i32.eqz
+                (local.tee $0
+                 (i32.load
+                  (local.tee $1
+                   (i32.add
+                    (local.get $2)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $4
+                 (i32.const 0)
+                )
+                (br $label$32)
+               )
+              )
+             )
+             (loop $label$36
+              (if
+               (local.tee $7
+                (i32.load
+                 (local.tee $11
+                  (i32.add
+                   (local.get $0)
+                   (i32.const 20)
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $0
+                 (local.get $7)
+                )
+                (local.set $1
+                 (local.get $11)
+                )
+                (br $label$36)
+               )
+              )
+              (if
+               (local.tee $7
+                (i32.load
+                 (local.tee $11
+                  (i32.add
+                   (local.get $0)
+                   (i32.const 16)
+                  )
+                 )
+                )
+               )
+               (block
+                (local.set $0
+                 (local.get $7)
+                )
+                (local.set $1
+                 (local.get $11)
+                )
+                (br $label$36)
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $1)
+               (local.get $12)
+              )
+              (call $fimport$10)
+              (block
+               (i32.store
+                (local.get $1)
+                (i32.const 0)
+               )
+               (local.set $4
+                (local.get $0)
+               )
+              )
+             )
+            )
+            (block
+             (if
+              (i32.lt_u
+               (local.tee $11
+                (i32.load offset=8
+                 (local.get $2)
+                )
+               )
+               (local.get $12)
+              )
+              (call $fimport$10)
+             )
+             (if
+              (i32.ne
+               (i32.load
+                (local.tee $7
+                 (i32.add
+                  (local.get $11)
+                  (i32.const 12)
+                 )
+                )
+               )
+               (local.get $2)
+              )
+              (call $fimport$10)
+             )
+             (if
+              (i32.eq
+               (i32.load
+                (local.tee $1
+                 (i32.add
+                  (local.get $0)
+                  (i32.const 8)
+                 )
+                )
+               )
+               (local.get $2)
+              )
+              (block
+               (i32.store
+                (local.get $7)
+                (local.get $0)
+               )
+               (i32.store
+                (local.get $1)
+                (local.get $11)
+               )
+               (local.set $4
+                (local.get $0)
+               )
+              )
+              (call $fimport$10)
+             )
+            )
+           )
+          )
+          (block $label$46
+           (if
+            (local.get $15)
+            (block
+             (if
+              (i32.eq
+               (local.get $2)
+               (i32.load
+                (local.tee $0
+                 (i32.add
+                  (i32.shl
+                   (local.tee $1
+                    (i32.load offset=28
+                     (local.get $2)
+                    )
+                   )
+                   (i32.const 2)
+                  )
+                  (i32.const 3948)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (local.get $0)
+                (local.get $4)
+               )
+               (if
+                (i32.eqz
+                 (local.get $4)
+                )
+                (block
+                 (i32.store
+                  (i32.const 3648)
+                  (i32.and
+                   (local.get $6)
+                   (i32.xor
+                    (i32.shl
+                     (i32.const 1)
+                     (local.get $1)
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                 )
+                 (br $label$46)
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (local.get $15)
+                 (i32.load
+                  (i32.const 3660)
+                 )
+                )
+                (call $fimport$10)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (local.tee $0
+                   (i32.add
+                    (local.get $15)
+                    (i32.const 16)
+                   )
+                  )
+                 )
+                 (local.get $2)
+                )
+                (i32.store
+                 (local.get $0)
+                 (local.get $4)
+                )
+                (i32.store offset=20
+                 (local.get $15)
+                 (local.get $4)
+                )
+               )
+               (br_if $label$46
+                (i32.eqz
+                 (local.get $4)
+                )
+               )
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $4)
+               (local.tee $0
+                (i32.load
+                 (i32.const 3660)
+                )
+               )
+              )
+              (call $fimport$10)
+             )
+             (i32.store offset=24
+              (local.get $4)
+              (local.get $15)
+             )
+             (if
+              (local.tee $1
+               (i32.load offset=16
+                (local.get $2)
+               )
+              )
+              (if
+               (i32.lt_u
+                (local.get $1)
+                (local.get $0)
+               )
+               (call $fimport$10)
+               (block
+                (i32.store offset=16
+                 (local.get $4)
+                 (local.get $1)
+                )
+                (i32.store offset=24
+                 (local.get $1)
+                 (local.get $4)
+                )
+               )
+              )
+             )
+             (if
+              (local.tee $0
+               (i32.load offset=20
+                (local.get $2)
+               )
+              )
+              (if
+               (i32.lt_u
+                (local.get $0)
+                (i32.load
+                 (i32.const 3660)
+                )
+               )
+               (call $fimport$10)
+               (block
+                (i32.store offset=20
+                 (local.get $4)
+                 (local.get $0)
+                )
+                (i32.store offset=24
+                 (local.get $0)
+                 (local.get $4)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $9)
+            (i32.const 16)
+           )
+           (block
+            (i32.store offset=4
+             (local.get $2)
+             (i32.or
+              (local.tee $0
+               (i32.add
+                (local.get $9)
+                (local.get $3)
+               )
+              )
+              (i32.const 3)
+             )
+            )
+            (i32.store
+             (local.tee $0
+              (i32.add
+               (i32.add
+                (local.get $2)
+                (local.get $0)
+               )
+               (i32.const 4)
+              )
+             )
+             (i32.or
+              (i32.load
+               (local.get $0)
+              )
+              (i32.const 1)
+             )
+            )
+           )
+           (block
+            (i32.store offset=4
+             (local.get $2)
+             (i32.or
+              (local.get $3)
+              (i32.const 3)
+             )
+            )
+            (i32.store offset=4
+             (local.get $13)
+             (i32.or
+              (local.get $9)
+              (i32.const 1)
+             )
+            )
+            (i32.store
+             (i32.add
+              (local.get $13)
+              (local.get $9)
+             )
+             (local.get $9)
+            )
+            (if
+             (local.get $16)
+             (block
+              (local.set $7
+               (i32.load
+                (i32.const 3664)
+               )
+              )
+              (local.set $3
+               (i32.add
+                (i32.shl
+                 (i32.shl
+                  (local.tee $0
+                   (i32.shr_u
+                    (local.get $16)
+                    (i32.const 3)
+                   )
+                  )
+                  (i32.const 1)
+                 )
+                 (i32.const 2)
+                )
+                (i32.const 3684)
+               )
+              )
+              (if
+               (i32.and
+                (local.get $8)
+                (local.tee $0
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $0)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.tee $0
+                  (i32.load
+                   (local.tee $1
+                    (i32.add
+                     (local.get $3)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (i32.load
+                  (i32.const 3660)
+                 )
+                )
+                (call $fimport$10)
+                (block
+                 (local.set $10
+                  (local.get $1)
+                 )
+                 (local.set $5
+                  (local.get $0)
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (i32.const 3644)
+                 (i32.or
+                  (local.get $8)
+                  (local.get $0)
+                 )
+                )
+                (local.set $10
+                 (i32.add
+                  (local.get $3)
+                  (i32.const 8)
+                 )
+                )
+                (local.set $5
+                 (local.get $3)
+                )
+               )
+              )
+              (i32.store
+               (local.get $10)
+               (local.get $7)
+              )
+              (i32.store offset=12
+               (local.get $5)
+               (local.get $7)
+              )
+              (i32.store offset=8
+               (local.get $7)
+               (local.get $5)
+              )
+              (i32.store offset=12
+               (local.get $7)
+               (local.get $3)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 3652)
+             (local.get $9)
+            )
+            (i32.store
+             (i32.const 3664)
+             (local.get $13)
+            )
+           )
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (i32.add
+            (local.get $2)
+            (i32.const 8)
+           )
+          )
+         )
+         (local.set $0
+          (local.get $3)
+         )
+        )
+       )
+       (local.set $0
+        (local.get $3)
+       )
+      )
+     )
+     (if
+      (i32.gt_u
+       (local.get $0)
+       (i32.const -65)
+      )
+      (local.set $0
+       (i32.const -1)
+      )
+      (block
+       (local.set $7
+        (i32.and
+         (local.tee $0
+          (i32.add
+           (local.get $0)
+           (i32.const 11)
+          )
+         )
+         (i32.const -8)
+        )
+       )
+       (if
+        (local.tee $5
+         (i32.load
+          (i32.const 3648)
+         )
+        )
+        (block
+         (local.set $17
+          (if (result i32)
+           (local.tee $0
+            (i32.shr_u
+             (local.get $0)
+             (i32.const 8)
+            )
+           )
+           (if (result i32)
+            (i32.gt_u
+             (local.get $7)
+             (i32.const 16777215)
+            )
+            (i32.const 31)
+            (i32.or
+             (i32.and
+              (i32.shr_u
+               (local.get $7)
+               (i32.add
+                (local.tee $0
+                 (i32.add
+                  (i32.sub
+                   (i32.const 14)
+                   (i32.or
+                    (i32.or
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (i32.add
+                         (local.tee $1
+                          (i32.shl
+                           (local.get $0)
+                           (local.tee $3
+                            (i32.and
+                             (i32.shr_u
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 1048320)
+                              )
+                              (i32.const 16)
+                             )
+                             (i32.const 8)
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 520192)
+                        )
+                        (i32.const 16)
+                       )
+                       (i32.const 4)
+                      )
+                     )
+                     (local.get $3)
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (i32.add
+                        (local.tee $1
+                         (i32.shl
+                          (local.get $1)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 245760)
+                       )
+                       (i32.const 16)
+                      )
+                      (i32.const 2)
+                     )
+                    )
+                   )
+                  )
+                  (i32.shr_u
+                   (i32.shl
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                   (i32.const 15)
+                  )
+                 )
+                )
+                (i32.const 7)
+               )
+              )
+              (i32.const 1)
+             )
+             (i32.shl
+              (local.get $0)
+              (i32.const 1)
+             )
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (local.set $3
+          (i32.sub
+           (i32.const 0)
+           (local.get $7)
+          )
+         )
+         (block $label$78
+          (block $label$79
+           (block $label$80
+            (if
+             (local.tee $1
+              (i32.load
+               (i32.add
+                (i32.shl
+                 (local.get $17)
+                 (i32.const 2)
+                )
+                (i32.const 3948)
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (i32.sub
+                (i32.const 25)
+                (i32.shr_u
+                 (local.get $17)
+                 (i32.const 1)
+                )
+               )
+              )
+              (local.set $4
+               (i32.const 0)
+              )
+              (local.set $10
+               (i32.shl
+                (local.get $7)
+                (if (result i32)
+                 (i32.eq
+                  (local.get $17)
+                  (i32.const 31)
+                 )
+                 (i32.const 0)
+                 (local.get $0)
+                )
+               )
+              )
+              (local.set $0
+               (i32.const 0)
+              )
+              (loop $label$84
+               (if
+                (i32.lt_u
+                 (local.tee $6
+                  (i32.sub
+                   (i32.and
+                    (i32.load offset=4
+                     (local.get $1)
+                    )
+                    (i32.const -8)
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (local.get $3)
+                )
+                (if
+                 (local.get $6)
+                 (block
+                  (local.set $3
+                   (local.get $6)
+                  )
+                  (local.set $0
+                   (local.get $1)
+                  )
+                 )
+                 (block
+                  (local.set $3
+                   (i32.const 0)
+                  )
+                  (local.set $0
+                   (local.get $1)
+                  )
+                  (br $label$79)
+                 )
+                )
+               )
+               (local.set $1
+                (if (result i32)
+                 (i32.or
+                  (i32.eqz
+                   (local.tee $19
+                    (i32.load offset=20
+                     (local.get $1)
+                    )
+                   )
+                  )
+                  (i32.eq
+                   (local.get $19)
+                   (local.tee $6
+                    (i32.load
+                     (i32.add
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 16)
+                      )
+                      (i32.shl
+                       (i32.shr_u
+                        (local.get $10)
+                        (i32.const 31)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (local.get $4)
+                 (local.get $19)
+                )
+               )
+               (local.set $10
+                (i32.shl
+                 (local.get $10)
+                 (i32.xor
+                  (i32.and
+                   (local.tee $4
+                    (i32.eqz
+                     (local.get $6)
+                    )
+                   )
+                   (i32.const 1)
+                  )
+                  (i32.const 1)
+                 )
+                )
+               )
+               (if
+                (local.get $4)
+                (block
+                 (local.set $4
+                  (local.get $1)
+                 )
+                 (local.set $1
+                  (local.get $0)
+                 )
+                 (br $label$80)
+                )
+                (block
+                 (local.set $4
+                  (local.get $1)
+                 )
+                 (local.set $1
+                  (local.get $6)
+                 )
+                 (br $label$84)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $4
+               (i32.const 0)
+              )
+              (local.set $1
+               (i32.const 0)
+              )
+             )
+            )
+           )
+           (br_if $label$79
+            (local.tee $0
+             (if (result i32)
+              (i32.and
+               (i32.eqz
+                (local.get $4)
+               )
+               (i32.eqz
+                (local.get $1)
+               )
+              )
+              (block (result i32)
+               (if
+                (i32.eqz
+                 (local.tee $0
+                  (i32.and
+                   (local.get $5)
+                   (i32.or
+                    (local.tee $0
+                     (i32.shl
+                      (i32.const 2)
+                      (local.get $17)
+                     )
+                    )
+                    (i32.sub
+                     (i32.const 0)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                 )
+                )
+                (block
+                 (local.set $0
+                  (local.get $7)
+                 )
+                 (br $label$2)
+                )
+               )
+               (local.set $10
+                (i32.and
+                 (i32.shr_u
+                  (local.tee $0
+                   (i32.add
+                    (i32.and
+                     (local.get $0)
+                     (i32.sub
+                      (i32.const 0)
+                      (local.get $0)
+                     )
+                    )
+                    (i32.const -1)
+                   )
+                  )
+                  (i32.const 12)
+                 )
+                 (i32.const 16)
+                )
+               )
+               (i32.load
+                (i32.add
+                 (i32.shl
+                  (i32.add
+                   (i32.or
+                    (i32.or
+                     (i32.or
+                      (i32.or
+                       (local.tee $0
+                        (i32.and
+                         (i32.shr_u
+                          (local.tee $4
+                           (i32.shr_u
+                            (local.get $0)
+                            (local.get $10)
+                           )
+                          )
+                          (i32.const 5)
+                         )
+                         (i32.const 8)
+                        )
+                       )
+                       (local.get $10)
+                      )
+                      (local.tee $0
+                       (i32.and
+                        (i32.shr_u
+                         (local.tee $4
+                          (i32.shr_u
+                           (local.get $4)
+                           (local.get $0)
+                          )
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.const 4)
+                       )
+                      )
+                     )
+                     (local.tee $0
+                      (i32.and
+                       (i32.shr_u
+                        (local.tee $4
+                         (i32.shr_u
+                          (local.get $4)
+                          (local.get $0)
+                         )
+                        )
+                        (i32.const 1)
+                       )
+                       (i32.const 2)
+                      )
+                     )
+                    )
+                    (local.tee $0
+                     (i32.and
+                      (i32.shr_u
+                       (local.tee $4
+                        (i32.shr_u
+                         (local.get $4)
+                         (local.get $0)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.shr_u
+                    (local.get $4)
+                    (local.get $0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3948)
+                )
+               )
+              )
+              (local.get $4)
+             )
+            )
+           )
+           (local.set $4
+            (local.get $1)
+           )
+           (br $label$78)
+          )
+          (loop $label$96
+           (if
+            (local.tee $10
+             (i32.lt_u
+              (local.tee $4
+               (i32.sub
+                (i32.and
+                 (i32.load offset=4
+                  (local.get $0)
+                 )
+                 (i32.const -8)
+                )
+                (local.get $7)
+               )
+              )
+              (local.get $3)
+             )
+            )
+            (local.set $3
+             (local.get $4)
+            )
+           )
+           (if
+            (local.get $10)
+            (local.set $1
+             (local.get $0)
+            )
+           )
+           (if
+            (local.tee $4
+             (i32.load offset=16
+              (local.get $0)
+             )
+            )
+            (block
+             (local.set $0
+              (local.get $4)
+             )
+             (br $label$96)
+            )
+           )
+           (br_if $label$96
+            (local.tee $0
+             (i32.load offset=20
+              (local.get $0)
+             )
+            )
+           )
+           (local.set $4
+            (local.get $1)
+           )
+          )
+         )
+         (if
+          (local.get $4)
+          (if
+           (i32.lt_u
+            (local.get $3)
+            (i32.sub
+             (i32.load
+              (i32.const 3652)
+             )
+             (local.get $7)
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $4)
+              (local.tee $12
+               (i32.load
+                (i32.const 3660)
+               )
+              )
+             )
+             (call $fimport$10)
+            )
+            (if
+             (i32.ge_u
+              (local.get $4)
+              (local.tee $6
+               (i32.add
+                (local.get $4)
+                (local.get $7)
+               )
+              )
+             )
+             (call $fimport$10)
+            )
+            (local.set $10
+             (i32.load offset=24
+              (local.get $4)
+             )
+            )
+            (block $label$104
+             (if
+              (i32.eq
+               (local.tee $0
+                (i32.load offset=12
+                 (local.get $4)
+                )
+               )
+               (local.get $4)
+              )
+              (block
+               (if
+                (i32.eqz
+                 (local.tee $0
+                  (i32.load
+                   (local.tee $1
+                    (i32.add
+                     (local.get $4)
+                     (i32.const 20)
+                    )
+                   )
+                  )
+                 )
+                )
+                (if
+                 (i32.eqz
+                  (local.tee $0
+                   (i32.load
+                    (local.tee $1
+                     (i32.add
+                      (local.get $4)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $13
+                   (i32.const 0)
+                  )
+                  (br $label$104)
+                 )
+                )
+               )
+               (loop $label$108
+                (if
+                 (local.tee $11
+                  (i32.load
+                   (local.tee $9
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 20)
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $0
+                   (local.get $11)
+                  )
+                  (local.set $1
+                   (local.get $9)
+                  )
+                  (br $label$108)
+                 )
+                )
+                (if
+                 (local.tee $11
+                  (i32.load
+                   (local.tee $9
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 16)
+                    )
+                   )
+                  )
+                 )
+                 (block
+                  (local.set $0
+                   (local.get $11)
+                  )
+                  (local.set $1
+                   (local.get $9)
+                  )
+                  (br $label$108)
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $1)
+                 (local.get $12)
+                )
+                (call $fimport$10)
+                (block
+                 (i32.store
+                  (local.get $1)
+                  (i32.const 0)
+                 )
+                 (local.set $13
+                  (local.get $0)
+                 )
+                )
+               )
+              )
+              (block
+               (if
+                (i32.lt_u
+                 (local.tee $9
+                  (i32.load offset=8
+                   (local.get $4)
+                  )
+                 )
+                 (local.get $12)
+                )
+                (call $fimport$10)
+               )
+               (if
+                (i32.ne
+                 (i32.load
+                  (local.tee $11
+                   (i32.add
+                    (local.get $9)
+                    (i32.const 12)
+                   )
+                  )
+                 )
+                 (local.get $4)
+                )
+                (call $fimport$10)
+               )
+               (if
+                (i32.eq
+                 (i32.load
+                  (local.tee $1
+                   (i32.add
+                    (local.get $0)
+                    (i32.const 8)
+                   )
+                  )
+                 )
+                 (local.get $4)
+                )
+                (block
+                 (i32.store
+                  (local.get $11)
+                  (local.get $0)
+                 )
+                 (i32.store
+                  (local.get $1)
+                  (local.get $9)
+                 )
+                 (local.set $13
+                  (local.get $0)
+                 )
+                )
+                (call $fimport$10)
+               )
+              )
+             )
+            )
+            (block $label$118
+             (if
+              (local.get $10)
+              (block
+               (if
+                (i32.eq
+                 (local.get $4)
+                 (i32.load
+                  (local.tee $0
+                   (i32.add
+                    (i32.shl
+                     (local.tee $1
+                      (i32.load offset=28
+                       (local.get $4)
+                      )
+                     )
+                     (i32.const 2)
+                    )
+                    (i32.const 3948)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (local.get $0)
+                  (local.get $13)
+                 )
+                 (if
+                  (i32.eqz
+                   (local.get $13)
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 3648)
+                    (local.tee $2
+                     (i32.and
+                      (local.get $5)
+                      (i32.xor
+                       (i32.shl
+                        (i32.const 1)
+                        (local.get $1)
+                       )
+                       (i32.const -1)
+                      )
+                     )
+                    )
+                   )
+                   (br $label$118)
+                  )
+                 )
+                )
+                (block
+                 (if
+                  (i32.lt_u
+                   (local.get $10)
+                   (i32.load
+                    (i32.const 3660)
+                   )
+                  )
+                  (call $fimport$10)
+                 )
+                 (if
+                  (i32.eq
+                   (i32.load
+                    (local.tee $0
+                     (i32.add
+                      (local.get $10)
+                      (i32.const 16)
+                     )
+                    )
+                   )
+                   (local.get $4)
+                  )
+                  (i32.store
+                   (local.get $0)
+                   (local.get $13)
+                  )
+                  (i32.store offset=20
+                   (local.get $10)
+                   (local.get $13)
+                  )
+                 )
+                 (if
+                  (i32.eqz
+                   (local.get $13)
+                  )
+                  (block
+                   (local.set $2
+                    (local.get $5)
+                   )
+                   (br $label$118)
+                  )
+                 )
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $13)
+                 (local.tee $0
+                  (i32.load
+                   (i32.const 3660)
+                  )
+                 )
+                )
+                (call $fimport$10)
+               )
+               (i32.store offset=24
+                (local.get $13)
+                (local.get $10)
+               )
+               (if
+                (local.tee $1
+                 (i32.load offset=16
+                  (local.get $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (local.get $1)
+                  (local.get $0)
+                 )
+                 (call $fimport$10)
+                 (block
+                  (i32.store offset=16
+                   (local.get $13)
+                   (local.get $1)
+                  )
+                  (i32.store offset=24
+                   (local.get $1)
+                   (local.get $13)
+                  )
+                 )
+                )
+               )
+               (if
+                (local.tee $0
+                 (i32.load offset=20
+                  (local.get $4)
+                 )
+                )
+                (if
+                 (i32.lt_u
+                  (local.get $0)
+                  (i32.load
+                   (i32.const 3660)
+                  )
+                 )
+                 (call $fimport$10)
+                 (block
+                  (i32.store offset=20
+                   (local.get $13)
+                   (local.get $0)
+                  )
+                  (i32.store offset=24
+                   (local.get $0)
+                   (local.get $13)
+                  )
+                  (local.set $2
+                   (local.get $5)
+                  )
+                 )
+                )
+                (local.set $2
+                 (local.get $5)
+                )
+               )
+              )
+              (local.set $2
+               (local.get $5)
+              )
+             )
+            )
+            (block $label$136
+             (if
+              (i32.lt_u
+               (local.get $3)
+               (i32.const 16)
+              )
+              (block
+               (i32.store offset=4
+                (local.get $4)
+                (i32.or
+                 (local.tee $0
+                  (i32.add
+                   (local.get $3)
+                   (local.get $7)
+                  )
+                 )
+                 (i32.const 3)
+                )
+               )
+               (i32.store
+                (local.tee $0
+                 (i32.add
+                  (i32.add
+                   (local.get $4)
+                   (local.get $0)
+                  )
+                  (i32.const 4)
+                 )
+                )
+                (i32.or
+                 (i32.load
+                  (local.get $0)
+                 )
+                 (i32.const 1)
+                )
+               )
+              )
+              (block
+               (i32.store offset=4
+                (local.get $4)
+                (i32.or
+                 (local.get $7)
+                 (i32.const 3)
+                )
+               )
+               (i32.store offset=4
+                (local.get $6)
+                (i32.or
+                 (local.get $3)
+                 (i32.const 1)
+                )
+               )
+               (i32.store
+                (i32.add
+                 (local.get $6)
+                 (local.get $3)
+                )
+                (local.get $3)
+               )
+               (local.set $0
+                (i32.shr_u
+                 (local.get $3)
+                 (i32.const 3)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $3)
+                 (i32.const 256)
+                )
+                (block
+                 (local.set $3
+                  (i32.add
+                   (i32.shl
+                    (i32.shl
+                     (local.get $0)
+                     (i32.const 1)
+                    )
+                    (i32.const 2)
+                   )
+                   (i32.const 3684)
+                  )
+                 )
+                 (if
+                  (i32.and
+                   (local.tee $1
+                    (i32.load
+                     (i32.const 3644)
+                    )
+                   )
+                   (local.tee $0
+                    (i32.shl
+                     (i32.const 1)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (if
+                   (i32.lt_u
+                    (local.tee $0
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $3)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                    )
+                    (i32.load
+                     (i32.const 3660)
+                    )
+                   )
+                   (call $fimport$10)
+                   (block
+                    (local.set $16
+                     (local.get $1)
+                    )
+                    (local.set $8
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (block
+                   (i32.store
+                    (i32.const 3644)
+                    (i32.or
+                     (local.get $1)
+                     (local.get $0)
+                    )
+                   )
+                   (local.set $16
+                    (i32.add
+                     (local.get $3)
+                     (i32.const 8)
+                    )
+                   )
+                   (local.set $8
+                    (local.get $3)
+                   )
+                  )
+                 )
+                 (i32.store
+                  (local.get $16)
+                  (local.get $6)
+                 )
+                 (i32.store offset=12
+                  (local.get $8)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $8)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $3)
+                 )
+                 (br $label$136)
+                )
+               )
+               (local.set $1
+                (i32.add
+                 (i32.shl
+                  (local.tee $5
+                   (if (result i32)
+                    (local.tee $0
+                     (i32.shr_u
+                      (local.get $3)
+                      (i32.const 8)
+                     )
+                    )
+                    (if (result i32)
+                     (i32.gt_u
+                      (local.get $3)
+                      (i32.const 16777215)
+                     )
+                     (i32.const 31)
+                     (i32.or
+                      (i32.and
+                       (i32.shr_u
+                        (local.get $3)
+                        (i32.add
+                         (local.tee $0
+                          (i32.add
+                           (i32.sub
+                            (i32.const 14)
+                            (i32.or
+                             (i32.or
+                              (local.tee $0
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (local.tee $1
+                                   (i32.shl
+                                    (local.get $0)
+                                    (local.tee $5
+                                     (i32.and
+                                      (i32.shr_u
+                                       (i32.add
+                                        (local.get $0)
+                                        (i32.const 1048320)
+                                       )
+                                       (i32.const 16)
+                                      )
+                                      (i32.const 8)
+                                     )
+                                    )
+                                   )
+                                  )
+                                  (i32.const 520192)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 4)
+                               )
+                              )
+                              (local.get $5)
+                             )
+                             (local.tee $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (local.tee $1
+                                  (i32.shl
+                                   (local.get $1)
+                                   (local.get $0)
+                                  )
+                                 )
+                                 (i32.const 245760)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 2)
+                              )
+                             )
+                            )
+                           )
+                           (i32.shr_u
+                            (i32.shl
+                             (local.get $1)
+                             (local.get $0)
+                            )
+                            (i32.const 15)
+                           )
+                          )
+                         )
+                         (i32.const 7)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.shl
+                       (local.get $0)
+                       (i32.const 1)
+                      )
+                     )
+                    )
+                    (i32.const 0)
+                   )
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3948)
+                )
+               )
+               (i32.store offset=28
+                (local.get $6)
+                (local.get $5)
+               )
+               (i32.store offset=4
+                (local.tee $0
+                 (i32.add
+                  (local.get $6)
+                  (i32.const 16)
+                 )
+                )
+                (i32.const 0)
+               )
+               (i32.store
+                (local.get $0)
+                (i32.const 0)
+               )
+               (if
+                (i32.eqz
+                 (i32.and
+                  (local.get $2)
+                  (local.tee $0
+                   (i32.shl
+                    (i32.const 1)
+                    (local.get $5)
+                   )
+                  )
+                 )
+                )
+                (block
+                 (i32.store
+                  (i32.const 3648)
+                  (i32.or
+                   (local.get $2)
+                   (local.get $0)
+                  )
+                 )
+                 (i32.store
+                  (local.get $1)
+                  (local.get $6)
+                 )
+                 (i32.store offset=24
+                  (local.get $6)
+                  (local.get $1)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (br $label$136)
+                )
+               )
+               (local.set $0
+                (i32.load
+                 (local.get $1)
+                )
+               )
+               (local.set $1
+                (i32.sub
+                 (i32.const 25)
+                 (i32.shr_u
+                  (local.get $5)
+                  (i32.const 1)
+                 )
+                )
+               )
+               (local.set $5
+                (i32.shl
+                 (local.get $3)
+                 (if (result i32)
+                  (i32.eq
+                   (local.get $5)
+                   (i32.const 31)
+                  )
+                  (i32.const 0)
+                  (local.get $1)
+                 )
+                )
+               )
+               (block $label$151
+                (block $label$152
+                 (block $label$153
+                  (loop $label$154
+                   (br_if $label$152
+                    (i32.eq
+                     (i32.and
+                      (i32.load offset=4
+                       (local.get $0)
+                      )
+                      (i32.const -8)
+                     )
+                     (local.get $3)
+                    )
+                   )
+                   (local.set $2
+                    (i32.shl
+                     (local.get $5)
+                     (i32.const 1)
+                    )
+                   )
+                   (br_if $label$153
+                    (i32.eqz
+                     (local.tee $1
+                      (i32.load
+                       (local.tee $5
+                        (i32.add
+                         (i32.add
+                          (local.get $0)
+                          (i32.const 16)
+                         )
+                         (i32.shl
+                          (i32.shr_u
+                           (local.get $5)
+                           (i32.const 31)
+                          )
+                          (i32.const 2)
+                         )
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (local.set $5
+                    (local.get $2)
+                   )
+                   (local.set $0
+                    (local.get $1)
+                   )
+                   (br $label$154)
+                  )
+                 )
+                 (if
+                  (i32.lt_u
+                   (local.get $5)
+                   (i32.load
+                    (i32.const 3660)
+                   )
+                  )
+                  (call $fimport$10)
+                  (block
+                   (i32.store
+                    (local.get $5)
+                    (local.get $6)
+                   )
+                   (i32.store offset=24
+                    (local.get $6)
+                    (local.get $0)
+                   )
+                   (i32.store offset=12
+                    (local.get $6)
+                    (local.get $6)
+                   )
+                   (i32.store offset=8
+                    (local.get $6)
+                    (local.get $6)
+                   )
+                   (br $label$136)
+                  )
+                 )
+                 (br $label$151)
+                )
+                (if
+                 (i32.and
+                  (i32.ge_u
+                   (local.tee $2
+                    (i32.load
+                     (local.tee $3
+                      (i32.add
+                       (local.get $0)
+                       (i32.const 8)
+                      )
+                     )
+                    )
+                   )
+                   (local.tee $1
+                    (i32.load
+                     (i32.const 3660)
+                    )
+                   )
+                  )
+                  (i32.ge_u
+                   (local.get $0)
+                   (local.get $1)
+                  )
+                 )
+                 (block
+                  (i32.store offset=12
+                   (local.get $2)
+                   (local.get $6)
+                  )
+                  (i32.store
+                   (local.get $3)
+                   (local.get $6)
+                  )
+                  (i32.store offset=8
+                   (local.get $6)
+                   (local.get $2)
+                  )
+                  (i32.store offset=12
+                   (local.get $6)
+                   (local.get $0)
+                  )
+                  (i32.store offset=24
+                   (local.get $6)
+                   (i32.const 0)
+                  )
+                 )
+                 (call $fimport$10)
+                )
+               )
+              )
+             )
+            )
+            (global.set $global$1
+             (local.get $14)
+            )
+            (return
+             (i32.add
+              (local.get $4)
+              (i32.const 8)
+             )
+            )
+           )
+           (local.set $0
+            (local.get $7)
+           )
+          )
+          (local.set $0
+           (local.get $7)
+          )
+         )
+        )
+        (local.set $0
+         (local.get $7)
+        )
+       )
+      )
+     )
+    )
+   )
+   (if
+    (i32.ge_u
+     (local.tee $1
+      (i32.load
+       (i32.const 3652)
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (local.set $2
+      (i32.load
+       (i32.const 3664)
+      )
+     )
+     (if
+      (i32.gt_u
+       (local.tee $3
+        (i32.sub
+         (local.get $1)
+         (local.get $0)
+        )
+       )
+       (i32.const 15)
+      )
+      (block
+       (i32.store
+        (i32.const 3664)
+        (local.tee $1
+         (i32.add
+          (local.get $2)
+          (local.get $0)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3652)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $1)
+        (i32.or
+         (local.get $3)
+         (i32.const 1)
+        )
+       )
+       (i32.store
+        (i32.add
+         (local.get $1)
+         (local.get $3)
+        )
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $2)
+        (i32.or
+         (local.get $0)
+         (i32.const 3)
+        )
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3652)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 3664)
+        (i32.const 0)
+       )
+       (i32.store offset=4
+        (local.get $2)
+        (i32.or
+         (local.get $1)
+         (i32.const 3)
+        )
+       )
+       (i32.store
+        (local.tee $0
+         (i32.add
+          (i32.add
+           (local.get $2)
+           (local.get $1)
+          )
+          (i32.const 4)
+         )
+        )
+        (i32.or
+         (i32.load
+          (local.get $0)
+         )
+         (i32.const 1)
+        )
+       )
+      )
+     )
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+     )
+    )
+   )
+   (if
+    (i32.gt_u
+     (local.tee $10
+      (i32.load
+       (i32.const 3656)
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (i32.store
+      (i32.const 3656)
+      (local.tee $3
+       (i32.sub
+        (local.get $10)
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (i32.const 3668)
+      (local.tee $1
+       (i32.add
+        (local.tee $2
+         (i32.load
+          (i32.const 3668)
+         )
+        )
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store offset=4
+      (local.get $1)
+      (i32.or
+       (local.get $3)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=4
+      (local.get $2)
+      (i32.or
+       (local.get $0)
+       (i32.const 3)
+      )
+     )
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+     )
+    )
+   )
+   (if
+    (i32.le_u
+     (local.tee $6
+      (i32.and
+       (local.tee $8
+        (i32.add
+         (local.tee $1
+          (if (result i32)
+           (i32.load
+            (i32.const 4116)
+           )
+           (i32.load
+            (i32.const 4124)
+           )
+           (block (result i32)
+            (i32.store
+             (i32.const 4124)
+             (i32.const 4096)
+            )
+            (i32.store
+             (i32.const 4120)
+             (i32.const 4096)
+            )
+            (i32.store
+             (i32.const 4128)
+             (i32.const -1)
+            )
+            (i32.store
+             (i32.const 4132)
+             (i32.const -1)
+            )
+            (i32.store
+             (i32.const 4136)
+             (i32.const 0)
+            )
+            (i32.store
+             (i32.const 4088)
+             (i32.const 0)
+            )
+            (i32.store
+             (local.get $18)
+             (local.tee $1
+              (i32.xor
+               (i32.and
+                (local.get $18)
+                (i32.const -16)
+               )
+               (i32.const 1431655768)
+              )
+             )
+            )
+            (i32.store
+             (i32.const 4116)
+             (local.get $1)
+            )
+            (i32.const 4096)
+           )
+          )
+         )
+         (local.tee $13
+          (i32.add
+           (local.get $0)
+           (i32.const 47)
+          )
+         )
+        )
+       )
+       (local.tee $4
+        (i32.sub
+         (i32.const 0)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (local.get $0)
+    )
+    (block
+     (global.set $global$1
+      (local.get $14)
+     )
+     (return
+      (i32.const 0)
+     )
+    )
+   )
+   (if
+    (local.tee $2
+     (i32.load
+      (i32.const 4084)
+     )
+    )
+    (if
+     (i32.or
+      (i32.le_u
+       (local.tee $1
+        (i32.add
+         (local.tee $3
+          (i32.load
+           (i32.const 4076)
+          )
+         )
+         (local.get $6)
+        )
+       )
+       (local.get $3)
+      )
+      (i32.gt_u
+       (local.get $1)
+       (local.get $2)
+      )
+     )
+     (block
+      (global.set $global$1
+       (local.get $14)
+      )
+      (return
+       (i32.const 0)
+      )
+     )
+    )
+   )
+   (local.set $7
+    (i32.add
+     (local.get $0)
+     (i32.const 48)
+    )
+   )
+   (block $label$171
+    (block $label$172
+     (if
+      (i32.eqz
+       (i32.and
+        (i32.load
+         (i32.const 4088)
+        )
+        (i32.const 4)
+       )
+      )
+      (block
+       (block $label$174
+        (block $label$175
+         (block $label$176
+          (br_if $label$176
+           (i32.eqz
+            (local.tee $3
+             (i32.load
+              (i32.const 3668)
+             )
+            )
+           )
+          )
+          (local.set $2
+           (i32.const 4092)
+          )
+          (loop $label$177
+           (block $label$178
+            (if
+             (i32.le_u
+              (local.tee $1
+               (i32.load
+                (local.get $2)
+               )
+              )
+              (local.get $3)
+             )
+             (br_if $label$178
+              (i32.gt_u
+               (i32.add
+                (local.get $1)
+                (i32.load
+                 (local.tee $5
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 4)
+                  )
+                 )
+                )
+               )
+               (local.get $3)
+              )
+             )
+            )
+            (br_if $label$176
+             (i32.eqz
+              (local.tee $1
+               (i32.load offset=8
+                (local.get $2)
+               )
+              )
+             )
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$177)
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.tee $3
+             (i32.and
+              (i32.sub
+               (local.get $8)
+               (local.get $10)
+              )
+              (local.get $4)
+             )
+            )
+            (i32.const 2147483647)
+           )
+           (if
+            (i32.eq
+             (local.tee $1
+              (call $34
+               (local.get $3)
+              )
+             )
+             (i32.add
+              (i32.load
+               (local.get $2)
+              )
+              (i32.load
+               (local.get $5)
+              )
+             )
+            )
+            (br_if $label$172
+             (i32.ne
+              (local.get $1)
+              (i32.const -1)
+             )
+            )
+            (block
+             (local.set $2
+              (local.get $1)
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$175)
+            )
+           )
+          )
+          (br $label$174)
+         )
+         (if
+          (i32.ne
+           (local.tee $1
+            (call $34
+             (i32.const 0)
+            )
+           )
+           (i32.const -1)
+          )
+          (block
+           (local.set $2
+            (i32.sub
+             (i32.and
+              (i32.add
+               (local.tee $5
+                (i32.add
+                 (local.tee $2
+                  (i32.load
+                   (i32.const 4120)
+                  )
+                 )
+                 (i32.const -1)
+                )
+               )
+               (local.tee $3
+                (local.get $1)
+               )
+              )
+              (i32.sub
+               (i32.const 0)
+               (local.get $2)
+              )
+             )
+             (local.get $3)
+            )
+           )
+           (local.set $4
+            (i32.add
+             (local.tee $3
+              (i32.add
+               (if (result i32)
+                (i32.and
+                 (local.get $5)
+                 (local.get $3)
+                )
+                (local.get $2)
+                (i32.const 0)
+               )
+               (local.get $6)
+              )
+             )
+             (local.tee $5
+              (i32.load
+               (i32.const 4076)
+              )
+             )
+            )
+           )
+           (if
+            (i32.and
+             (i32.gt_u
+              (local.get $3)
+              (local.get $0)
+             )
+             (i32.lt_u
+              (local.get $3)
+              (i32.const 2147483647)
+             )
+            )
+            (block
+             (if
+              (local.tee $2
+               (i32.load
+                (i32.const 4084)
+               )
+              )
+              (br_if $label$174
+               (i32.or
+                (i32.le_u
+                 (local.get $4)
+                 (local.get $5)
+                )
+                (i32.gt_u
+                 (local.get $4)
+                 (local.get $2)
+                )
+               )
+              )
+             )
+             (br_if $label$172
+              (i32.eq
+               (local.tee $2
+                (call $34
+                 (local.get $3)
+                )
+               )
+               (local.get $1)
+              )
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$175)
+            )
+           )
+          )
+         )
+         (br $label$174)
+        )
+        (local.set $5
+         (i32.sub
+          (i32.const 0)
+          (local.get $1)
+         )
+        )
+        (if
+         (i32.and
+          (i32.gt_u
+           (local.get $7)
+           (local.get $1)
+          )
+          (i32.and
+           (i32.lt_u
+            (local.get $1)
+            (i32.const 2147483647)
+           )
+           (i32.ne
+            (local.get $2)
+            (i32.const -1)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.tee $3
+            (i32.and
+             (i32.add
+              (i32.sub
+               (local.get $13)
+               (local.get $1)
+              )
+              (local.tee $3
+               (i32.load
+                (i32.const 4124)
+               )
+              )
+             )
+             (i32.sub
+              (i32.const 0)
+              (local.get $3)
+             )
+            )
+           )
+           (i32.const 2147483647)
+          )
+          (if
+           (i32.eq
+            (call $34
+             (local.get $3)
+            )
+            (i32.const -1)
+           )
+           (block
+            (drop
+             (call $34
+              (local.get $5)
+             )
+            )
+            (br $label$174)
+           )
+           (local.set $3
+            (i32.add
+             (local.get $3)
+             (local.get $1)
+            )
+           )
+          )
+          (local.set $3
+           (local.get $1)
+          )
+         )
+         (local.set $3
+          (local.get $1)
+         )
+        )
+        (if
+         (i32.ne
+          (local.get $2)
+          (i32.const -1)
+         )
+         (block
+          (local.set $1
+           (local.get $2)
+          )
+          (br $label$172)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 4088)
+        (i32.or
+         (i32.load
+          (i32.const 4088)
+         )
+         (i32.const 4)
+        )
+       )
+      )
+     )
+     (if
+      (i32.lt_u
+       (local.get $6)
+       (i32.const 2147483647)
+      )
+      (if
+       (i32.and
+        (i32.lt_u
+         (local.tee $1
+          (call $34
+           (local.get $6)
+          )
+         )
+         (local.tee $3
+          (call $34
+           (i32.const 0)
+          )
+         )
+        )
+        (i32.and
+         (i32.ne
+          (local.get $1)
+          (i32.const -1)
+         )
+         (i32.ne
+          (local.get $3)
+          (i32.const -1)
+         )
+        )
+       )
+       (br_if $label$172
+        (i32.gt_u
+         (local.tee $3
+          (i32.sub
+           (local.get $3)
+           (local.get $1)
+          )
+         )
+         (i32.add
+          (local.get $0)
+          (i32.const 40)
+         )
+        )
+       )
+      )
+     )
+     (br $label$171)
+    )
+    (i32.store
+     (i32.const 4076)
+     (local.tee $2
+      (i32.add
+       (i32.load
+        (i32.const 4076)
+       )
+       (local.get $3)
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (local.get $2)
+      (i32.load
+       (i32.const 4080)
+      )
+     )
+     (i32.store
+      (i32.const 4080)
+      (local.get $2)
+     )
+    )
+    (block $label$198
+     (if
+      (local.tee $8
+       (i32.load
+        (i32.const 3668)
+       )
+      )
+      (block
+       (local.set $2
+        (i32.const 4092)
+       )
+       (block $label$200
+        (block $label$201
+         (loop $label$202
+          (br_if $label$201
+           (i32.eq
+            (local.get $1)
+            (i32.add
+             (local.tee $4
+              (i32.load
+               (local.get $2)
+              )
+             )
+             (local.tee $5
+              (i32.load
+               (local.tee $7
+                (i32.add
+                 (local.get $2)
+                 (i32.const 4)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (br_if $label$202
+           (local.tee $2
+            (i32.load offset=8
+             (local.get $2)
+            )
+           )
+          )
+         )
+         (br $label$200)
+        )
+        (if
+         (i32.eqz
+          (i32.and
+           (i32.load offset=12
+            (local.get $2)
+           )
+           (i32.const 8)
+          )
+         )
+         (if
+          (i32.and
+           (i32.lt_u
+            (local.get $8)
+            (local.get $1)
+           )
+           (i32.ge_u
+            (local.get $8)
+            (local.get $4)
+           )
+          )
+          (block
+           (i32.store
+            (local.get $7)
+            (i32.add
+             (local.get $5)
+             (local.get $3)
+            )
+           )
+           (local.set $5
+            (i32.load
+             (i32.const 3656)
+            )
+           )
+           (local.set $1
+            (i32.and
+             (i32.sub
+              (i32.const 0)
+              (local.tee $2
+               (i32.add
+                (local.get $8)
+                (i32.const 8)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+           )
+           (i32.store
+            (i32.const 3668)
+            (local.tee $2
+             (i32.add
+              (local.get $8)
+              (if (result i32)
+               (i32.and
+                (local.get $2)
+                (i32.const 7)
+               )
+               (local.get $1)
+               (local.tee $1
+                (i32.const 0)
+               )
+              )
+             )
+            )
+           )
+           (i32.store
+            (i32.const 3656)
+            (local.tee $1
+             (i32.add
+              (i32.sub
+               (local.get $3)
+               (local.get $1)
+              )
+              (local.get $5)
+             )
+            )
+           )
+           (i32.store offset=4
+            (local.get $2)
+            (i32.or
+             (local.get $1)
+             (i32.const 1)
+            )
+           )
+           (i32.store offset=4
+            (i32.add
+             (local.get $2)
+             (local.get $1)
+            )
+            (i32.const 40)
+           )
+           (i32.store
+            (i32.const 3672)
+            (i32.load
+             (i32.const 4132)
+            )
+           )
+           (br $label$198)
+          )
+         )
+        )
+       )
+       (if
+        (i32.lt_u
+         (local.get $1)
+         (local.tee $2
+          (i32.load
+           (i32.const 3660)
+          )
+         )
+        )
+        (block
+         (i32.store
+          (i32.const 3660)
+          (local.get $1)
+         )
+         (local.set $2
+          (local.get $1)
+         )
+        )
+       )
+       (local.set $10
+        (i32.add
+         (local.get $1)
+         (local.get $3)
+        )
+       )
+       (local.set $5
+        (i32.const 4092)
+       )
+       (block $label$208
+        (block $label$209
+         (loop $label$210
+          (br_if $label$209
+           (i32.eq
+            (i32.load
+             (local.get $5)
+            )
+            (local.get $10)
+           )
+          )
+          (br_if $label$210
+           (local.tee $5
+            (i32.load offset=8
+             (local.get $5)
+            )
+           )
+          )
+          (local.set $5
+           (i32.const 4092)
+          )
+         )
+         (br $label$208)
+        )
+        (if
+         (i32.and
+          (i32.load offset=12
+           (local.get $5)
+          )
+          (i32.const 8)
+         )
+         (local.set $5
+          (i32.const 4092)
+         )
+         (block
+          (i32.store
+           (local.get $5)
+           (local.get $1)
+          )
+          (i32.store
+           (local.tee $5
+            (i32.add
+             (local.get $5)
+             (i32.const 4)
+            )
+           )
+           (i32.add
+            (i32.load
+             (local.get $5)
+            )
+            (local.get $3)
+           )
+          )
+          (local.set $7
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (local.tee $4
+              (i32.add
+               (local.get $1)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+          )
+          (local.set $3
+           (i32.and
+            (i32.sub
+             (i32.const 0)
+             (local.tee $5
+              (i32.add
+               (local.get $10)
+               (i32.const 8)
+              )
+             )
+            )
+            (i32.const 7)
+           )
+          )
+          (local.set $6
+           (i32.add
+            (local.tee $13
+             (i32.add
+              (local.get $1)
+              (if (result i32)
+               (i32.and
+                (local.get $4)
+                (i32.const 7)
+               )
+               (local.get $7)
+               (i32.const 0)
+              )
+             )
+            )
+            (local.get $0)
+           )
+          )
+          (local.set $7
+           (i32.sub
+            (i32.sub
+             (local.tee $4
+              (i32.add
+               (local.get $10)
+               (if (result i32)
+                (i32.and
+                 (local.get $5)
+                 (i32.const 7)
+                )
+                (local.get $3)
+                (i32.const 0)
+               )
+              )
+             )
+             (local.get $13)
+            )
+            (local.get $0)
+           )
+          )
+          (i32.store offset=4
+           (local.get $13)
+           (i32.or
+            (local.get $0)
+            (i32.const 3)
+           )
+          )
+          (block $label$217
+           (if
+            (i32.eq
+             (local.get $4)
+             (local.get $8)
+            )
+            (block
+             (i32.store
+              (i32.const 3656)
+              (local.tee $0
+               (i32.add
+                (i32.load
+                 (i32.const 3656)
+                )
+                (local.get $7)
+               )
+              )
+             )
+             (i32.store
+              (i32.const 3668)
+              (local.get $6)
+             )
+             (i32.store offset=4
+              (local.get $6)
+              (i32.or
+               (local.get $0)
+               (i32.const 1)
+              )
+             )
+            )
+            (block
+             (if
+              (i32.eq
+               (local.get $4)
+               (i32.load
+                (i32.const 3664)
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 3652)
+                (local.tee $0
+                 (i32.add
+                  (i32.load
+                   (i32.const 3652)
+                  )
+                  (local.get $7)
+                 )
+                )
+               )
+               (i32.store
+                (i32.const 3664)
+                (local.get $6)
+               )
+               (i32.store offset=4
+                (local.get $6)
+                (i32.or
+                 (local.get $0)
+                 (i32.const 1)
+                )
+               )
+               (i32.store
+                (i32.add
+                 (local.get $6)
+                 (local.get $0)
+                )
+                (local.get $0)
+               )
+               (br $label$217)
+              )
+             )
+             (i32.store
+              (local.tee $0
+               (i32.add
+                (local.tee $0
+                 (if (result i32)
+                  (i32.eq
+                   (i32.and
+                    (local.tee $0
+                     (i32.load offset=4
+                      (local.get $4)
+                     )
+                    )
+                    (i32.const 3)
+                   )
+                   (i32.const 1)
+                  )
+                  (block (result i32)
+                   (local.set $11
+                    (i32.and
+                     (local.get $0)
+                     (i32.const -8)
+                    )
+                   )
+                   (local.set $1
+                    (i32.shr_u
+                     (local.get $0)
+                     (i32.const 3)
+                    )
+                   )
+                   (block $label$222
+                    (if
+                     (i32.lt_u
+                      (local.get $0)
+                      (i32.const 256)
+                     )
+                     (block
+                      (local.set $5
+                       (i32.load offset=12
+                        (local.get $4)
+                       )
+                      )
+                      (block $label$224
+                       (if
+                        (i32.ne
+                         (local.tee $3
+                          (i32.load offset=8
+                           (local.get $4)
+                          )
+                         )
+                         (local.tee $0
+                          (i32.add
+                           (i32.shl
+                            (i32.shl
+                             (local.get $1)
+                             (i32.const 1)
+                            )
+                            (i32.const 2)
+                           )
+                           (i32.const 3684)
+                          )
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $3)
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                         )
+                         (br_if $label$224
+                          (i32.eq
+                           (i32.load offset=12
+                            (local.get $3)
+                           )
+                           (local.get $4)
+                          )
+                         )
+                         (call $fimport$10)
+                        )
+                       )
+                      )
+                      (if
+                       (i32.eq
+                        (local.get $5)
+                        (local.get $3)
+                       )
+                       (block
+                        (i32.store
+                         (i32.const 3644)
+                         (i32.and
+                          (i32.load
+                           (i32.const 3644)
+                          )
+                          (i32.xor
+                           (i32.shl
+                            (i32.const 1)
+                            (local.get $1)
+                           )
+                           (i32.const -1)
+                          )
+                         )
+                        )
+                        (br $label$222)
+                       )
+                      )
+                      (block $label$228
+                       (if
+                        (i32.eq
+                         (local.get $5)
+                         (local.get $0)
+                        )
+                        (local.set $20
+                         (i32.add
+                          (local.get $5)
+                          (i32.const 8)
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $5)
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $0
+                             (i32.add
+                              (local.get $5)
+                              (i32.const 8)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (block
+                           (local.set $20
+                            (local.get $0)
+                           )
+                           (br $label$228)
+                          )
+                         )
+                         (call $fimport$10)
+                        )
+                       )
+                      )
+                      (i32.store offset=12
+                       (local.get $3)
+                       (local.get $5)
+                      )
+                      (i32.store
+                       (local.get $20)
+                       (local.get $3)
+                      )
+                     )
+                     (block
+                      (local.set $8
+                       (i32.load offset=24
+                        (local.get $4)
+                       )
+                      )
+                      (block $label$234
+                       (if
+                        (i32.eq
+                         (local.tee $0
+                          (i32.load offset=12
+                           (local.get $4)
+                          )
+                         )
+                         (local.get $4)
+                        )
+                        (block
+                         (if
+                          (i32.eqz
+                           (local.tee $0
+                            (i32.load
+                             (local.tee $1
+                              (i32.add
+                               (local.tee $3
+                                (i32.add
+                                 (local.get $4)
+                                 (i32.const 16)
+                                )
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (if
+                           (local.tee $0
+                            (i32.load
+                             (local.get $3)
+                            )
+                           )
+                           (local.set $1
+                            (local.get $3)
+                           )
+                           (block
+                            (local.set $12
+                             (i32.const 0)
+                            )
+                            (br $label$234)
+                           )
+                          )
+                         )
+                         (loop $label$239
+                          (if
+                           (local.tee $3
+                            (i32.load
+                             (local.tee $5
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 20)
+                              )
+                             )
+                            )
+                           )
+                           (block
+                            (local.set $0
+                             (local.get $3)
+                            )
+                            (local.set $1
+                             (local.get $5)
+                            )
+                            (br $label$239)
+                           )
+                          )
+                          (if
+                           (local.tee $3
+                            (i32.load
+                             (local.tee $5
+                              (i32.add
+                               (local.get $0)
+                               (i32.const 16)
+                              )
+                             )
+                            )
+                           )
+                           (block
+                            (local.set $0
+                             (local.get $3)
+                            )
+                            (local.set $1
+                             (local.get $5)
+                            )
+                            (br $label$239)
+                           )
+                          )
+                         )
+                         (if
+                          (i32.lt_u
+                           (local.get $1)
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                          (block
+                           (i32.store
+                            (local.get $1)
+                            (i32.const 0)
+                           )
+                           (local.set $12
+                            (local.get $0)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.tee $5
+                            (i32.load offset=8
+                             (local.get $4)
+                            )
+                           )
+                           (local.get $2)
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.ne
+                           (i32.load
+                            (local.tee $3
+                             (i32.add
+                              (local.get $5)
+                              (i32.const 12)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $1
+                             (i32.add
+                              (local.get $0)
+                              (i32.const 8)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (block
+                           (i32.store
+                            (local.get $3)
+                            (local.get $0)
+                           )
+                           (i32.store
+                            (local.get $1)
+                            (local.get $5)
+                           )
+                           (local.set $12
+                            (local.get $0)
+                           )
+                          )
+                          (call $fimport$10)
+                         )
+                        )
+                       )
+                      )
+                      (br_if $label$222
+                       (i32.eqz
+                        (local.get $8)
+                       )
+                      )
+                      (block $label$249
+                       (if
+                        (i32.eq
+                         (local.get $4)
+                         (i32.load
+                          (local.tee $0
+                           (i32.add
+                            (i32.shl
+                             (local.tee $1
+                              (i32.load offset=28
+                               (local.get $4)
+                              )
+                             )
+                             (i32.const 2)
+                            )
+                            (i32.const 3948)
+                           )
+                          )
+                         )
+                        )
+                        (block
+                         (i32.store
+                          (local.get $0)
+                          (local.get $12)
+                         )
+                         (br_if $label$249
+                          (local.get $12)
+                         )
+                         (i32.store
+                          (i32.const 3648)
+                          (i32.and
+                           (i32.load
+                            (i32.const 3648)
+                           )
+                           (i32.xor
+                            (i32.shl
+                             (i32.const 1)
+                             (local.get $1)
+                            )
+                            (i32.const -1)
+                           )
+                          )
+                         )
+                         (br $label$222)
+                        )
+                        (block
+                         (if
+                          (i32.lt_u
+                           (local.get $8)
+                           (i32.load
+                            (i32.const 3660)
+                           )
+                          )
+                          (call $fimport$10)
+                         )
+                         (if
+                          (i32.eq
+                           (i32.load
+                            (local.tee $0
+                             (i32.add
+                              (local.get $8)
+                              (i32.const 16)
+                             )
+                            )
+                           )
+                           (local.get $4)
+                          )
+                          (i32.store
+                           (local.get $0)
+                           (local.get $12)
+                          )
+                          (i32.store offset=20
+                           (local.get $8)
+                           (local.get $12)
+                          )
+                         )
+                         (br_if $label$222
+                          (i32.eqz
+                           (local.get $12)
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (local.get $12)
+                        (local.tee $1
+                         (i32.load
+                          (i32.const 3660)
+                         )
+                        )
+                       )
+                       (call $fimport$10)
+                      )
+                      (i32.store offset=24
+                       (local.get $12)
+                       (local.get $8)
+                      )
+                      (if
+                       (local.tee $3
+                        (i32.load
+                         (local.tee $0
+                          (i32.add
+                           (local.get $4)
+                           (i32.const 16)
+                          )
+                         )
+                        )
+                       )
+                       (if
+                        (i32.lt_u
+                         (local.get $3)
+                         (local.get $1)
+                        )
+                        (call $fimport$10)
+                        (block
+                         (i32.store offset=16
+                          (local.get $12)
+                          (local.get $3)
+                         )
+                         (i32.store offset=24
+                          (local.get $3)
+                          (local.get $12)
+                         )
+                        )
+                       )
+                      )
+                      (br_if $label$222
+                       (i32.eqz
+                        (local.tee $0
+                         (i32.load offset=4
+                          (local.get $0)
+                         )
+                        )
+                       )
+                      )
+                      (if
+                       (i32.lt_u
+                        (local.get $0)
+                        (i32.load
+                         (i32.const 3660)
+                        )
+                       )
+                       (call $fimport$10)
+                       (block
+                        (i32.store offset=20
+                         (local.get $12)
+                         (local.get $0)
+                        )
+                        (i32.store offset=24
+                         (local.get $0)
+                         (local.get $12)
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (local.set $7
+                    (i32.add
+                     (local.get $11)
+                     (local.get $7)
+                    )
+                   )
+                   (i32.add
+                    (local.get $4)
+                    (local.get $11)
+                   )
+                  )
+                  (local.get $4)
+                 )
+                )
+                (i32.const 4)
+               )
+              )
+              (i32.and
+               (i32.load
+                (local.get $0)
+               )
+               (i32.const -2)
+              )
+             )
+             (i32.store offset=4
+              (local.get $6)
+              (i32.or
+               (local.get $7)
+               (i32.const 1)
+              )
+             )
+             (i32.store
+              (i32.add
+               (local.get $6)
+               (local.get $7)
+              )
+              (local.get $7)
+             )
+             (local.set $0
+              (i32.shr_u
+               (local.get $7)
+               (i32.const 3)
+              )
+             )
+             (if
+              (i32.lt_u
+               (local.get $7)
+               (i32.const 256)
+              )
+              (block
+               (local.set $3
+                (i32.add
+                 (i32.shl
+                  (i32.shl
+                   (local.get $0)
+                   (i32.const 1)
+                  )
+                  (i32.const 2)
+                 )
+                 (i32.const 3684)
+                )
+               )
+               (block $label$263
+                (if
+                 (i32.and
+                  (local.tee $1
+                   (i32.load
+                    (i32.const 3644)
+                   )
+                  )
+                  (local.tee $0
+                   (i32.shl
+                    (i32.const 1)
+                    (local.get $0)
+                   )
+                  )
+                 )
+                 (block
+                  (if
+                   (i32.ge_u
+                    (local.tee $0
+                     (i32.load
+                      (local.tee $1
+                       (i32.add
+                        (local.get $3)
+                        (i32.const 8)
+                       )
+                      )
+                     )
+                    )
+                    (i32.load
+                     (i32.const 3660)
+                    )
+                   )
+                   (block
+                    (local.set $21
+                     (local.get $1)
+                    )
+                    (local.set $9
+                     (local.get $0)
+                    )
+                    (br $label$263)
+                   )
+                  )
+                  (call $fimport$10)
+                 )
+                 (block
+                  (i32.store
+                   (i32.const 3644)
+                   (i32.or
+                    (local.get $1)
+                    (local.get $0)
+                   )
+                  )
+                  (local.set $21
+                   (i32.add
+                    (local.get $3)
+                    (i32.const 8)
+                   )
+                  )
+                  (local.set $9
+                   (local.get $3)
+                  )
+                 )
+                )
+               )
+               (i32.store
+                (local.get $21)
+                (local.get $6)
+               )
+               (i32.store offset=12
+                (local.get $9)
+                (local.get $6)
+               )
+               (i32.store offset=8
+                (local.get $6)
+                (local.get $9)
+               )
+               (i32.store offset=12
+                (local.get $6)
+                (local.get $3)
+               )
+               (br $label$217)
+              )
+             )
+             (local.set $3
+              (i32.add
+               (i32.shl
+                (local.tee $2
+                 (block $label$267 (result i32)
+                  (if (result i32)
+                   (local.tee $0
+                    (i32.shr_u
+                     (local.get $7)
+                     (i32.const 8)
+                    )
+                   )
+                   (block (result i32)
+                    (drop
+                     (br_if $label$267
+                      (i32.const 31)
+                      (i32.gt_u
+                       (local.get $7)
+                       (i32.const 16777215)
+                      )
+                     )
+                    )
+                    (i32.or
+                     (i32.and
+                      (i32.shr_u
+                       (local.get $7)
+                       (i32.add
+                        (local.tee $0
+                         (i32.add
+                          (i32.sub
+                           (i32.const 14)
+                           (i32.or
+                            (i32.or
+                             (local.tee $0
+                              (i32.and
+                               (i32.shr_u
+                                (i32.add
+                                 (local.tee $1
+                                  (i32.shl
+                                   (local.get $0)
+                                   (local.tee $3
+                                    (i32.and
+                                     (i32.shr_u
+                                      (i32.add
+                                       (local.get $0)
+                                       (i32.const 1048320)
+                                      )
+                                      (i32.const 16)
+                                     )
+                                     (i32.const 8)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (i32.const 520192)
+                                )
+                                (i32.const 16)
+                               )
+                               (i32.const 4)
+                              )
+                             )
+                             (local.get $3)
+                            )
+                            (local.tee $0
+                             (i32.and
+                              (i32.shr_u
+                               (i32.add
+                                (local.tee $1
+                                 (i32.shl
+                                  (local.get $1)
+                                  (local.get $0)
+                                 )
+                                )
+                                (i32.const 245760)
+                               )
+                               (i32.const 16)
+                              )
+                              (i32.const 2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.shr_u
+                           (i32.shl
+                            (local.get $1)
+                            (local.get $0)
+                           )
+                           (i32.const 15)
+                          )
+                         )
+                        )
+                        (i32.const 7)
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.shl
+                      (local.get $0)
+                      (i32.const 1)
+                     )
+                    )
+                   )
+                   (i32.const 0)
+                  )
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 3948)
+              )
+             )
+             (i32.store offset=28
+              (local.get $6)
+              (local.get $2)
+             )
+             (i32.store offset=4
+              (local.tee $0
+               (i32.add
+                (local.get $6)
+                (i32.const 16)
+               )
+              )
+              (i32.const 0)
+             )
+             (i32.store
+              (local.get $0)
+              (i32.const 0)
+             )
+             (if
+              (i32.eqz
+               (i32.and
+                (local.tee $1
+                 (i32.load
+                  (i32.const 3648)
+                 )
+                )
+                (local.tee $0
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $2)
+                 )
+                )
+               )
+              )
+              (block
+               (i32.store
+                (i32.const 3648)
+                (i32.or
+                 (local.get $1)
+                 (local.get $0)
+                )
+               )
+               (i32.store
+                (local.get $3)
+                (local.get $6)
+               )
+               (i32.store offset=24
+                (local.get $6)
+                (local.get $3)
+               )
+               (i32.store offset=12
+                (local.get $6)
+                (local.get $6)
+               )
+               (i32.store offset=8
+                (local.get $6)
+                (local.get $6)
+               )
+               (br $label$217)
+              )
+             )
+             (local.set $0
+              (i32.load
+               (local.get $3)
+              )
+             )
+             (local.set $1
+              (i32.sub
+               (i32.const 25)
+               (i32.shr_u
+                (local.get $2)
+                (i32.const 1)
+               )
+              )
+             )
+             (local.set $2
+              (i32.shl
+               (local.get $7)
+               (if (result i32)
+                (i32.eq
+                 (local.get $2)
+                 (i32.const 31)
+                )
+                (i32.const 0)
+                (local.get $1)
+               )
+              )
+             )
+             (block $label$273
+              (block $label$274
+               (block $label$275
+                (loop $label$276
+                 (br_if $label$274
+                  (i32.eq
+                   (i32.and
+                    (i32.load offset=4
+                     (local.get $0)
+                    )
+                    (i32.const -8)
+                   )
+                   (local.get $7)
+                  )
+                 )
+                 (local.set $3
+                  (i32.shl
+                   (local.get $2)
+                   (i32.const 1)
+                  )
+                 )
+                 (br_if $label$275
+                  (i32.eqz
+                   (local.tee $1
+                    (i32.load
+                     (local.tee $2
+                      (i32.add
+                       (i32.add
+                        (local.get $0)
+                        (i32.const 16)
+                       )
+                       (i32.shl
+                        (i32.shr_u
+                         (local.get $2)
+                         (i32.const 31)
+                        )
+                        (i32.const 2)
+                       )
+                      )
+                     )
+                    )
+                   )
+                  )
+                 )
+                 (local.set $2
+                  (local.get $3)
+                 )
+                 (local.set $0
+                  (local.get $1)
+                 )
+                 (br $label$276)
+                )
+               )
+               (if
+                (i32.lt_u
+                 (local.get $2)
+                 (i32.load
+                  (i32.const 3660)
+                 )
+                )
+                (call $fimport$10)
+                (block
+                 (i32.store
+                  (local.get $2)
+                  (local.get $6)
+                 )
+                 (i32.store offset=24
+                  (local.get $6)
+                  (local.get $0)
+                 )
+                 (i32.store offset=12
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (i32.store offset=8
+                  (local.get $6)
+                  (local.get $6)
+                 )
+                 (br $label$217)
+                )
+               )
+               (br $label$273)
+              )
+              (if
+               (i32.and
+                (i32.ge_u
+                 (local.tee $2
+                  (i32.load
+                   (local.tee $3
+                    (i32.add
+                     (local.get $0)
+                     (i32.const 8)
+                    )
+                   )
+                  )
+                 )
+                 (local.tee $1
+                  (i32.load
+                   (i32.const 3660)
+                  )
+                 )
+                )
+                (i32.ge_u
+                 (local.get $0)
+                 (local.get $1)
+                )
+               )
+               (block
+                (i32.store offset=12
+                 (local.get $2)
+                 (local.get $6)
+                )
+                (i32.store
+                 (local.get $3)
+                 (local.get $6)
+                )
+                (i32.store offset=8
+                 (local.get $6)
+                 (local.get $2)
+                )
+                (i32.store offset=12
+                 (local.get $6)
+                 (local.get $0)
+                )
+                (i32.store offset=24
+                 (local.get $6)
+                 (i32.const 0)
+                )
+               )
+               (call $fimport$10)
+              )
+             )
+            )
+           )
+          )
+          (global.set $global$1
+           (local.get $14)
+          )
+          (return
+           (i32.add
+            (local.get $13)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+       )
+       (loop $label$281
+        (block $label$282
+         (if
+          (i32.le_u
+           (local.tee $2
+            (i32.load
+             (local.get $5)
+            )
+           )
+           (local.get $8)
+          )
+          (br_if $label$282
+           (i32.gt_u
+            (local.tee $13
+             (i32.add
+              (local.get $2)
+              (i32.load offset=4
+               (local.get $5)
+              )
+             )
+            )
+            (local.get $8)
+           )
+          )
+         )
+         (local.set $5
+          (i32.load offset=8
+           (local.get $5)
+          )
+         )
+         (br $label$281)
+        )
+       )
+       (local.set $2
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $5
+           (i32.add
+            (local.tee $7
+             (i32.add
+              (local.get $13)
+              (i32.const -47)
+             )
+            )
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (local.set $10
+        (i32.add
+         (local.tee $7
+          (if (result i32)
+           (i32.lt_u
+            (local.tee $2
+             (i32.add
+              (local.get $7)
+              (if (result i32)
+               (i32.and
+                (local.get $5)
+                (i32.const 7)
+               )
+               (local.get $2)
+               (i32.const 0)
+              )
+             )
+            )
+            (local.tee $12
+             (i32.add
+              (local.get $8)
+              (i32.const 16)
+             )
+            )
+           )
+           (local.get $8)
+           (local.get $2)
+          )
+         )
+         (i32.const 8)
+        )
+       )
+       (local.set $5
+        (i32.add
+         (local.get $7)
+         (i32.const 24)
+        )
+       )
+       (local.set $9
+        (i32.add
+         (local.get $3)
+         (i32.const -40)
+        )
+       )
+       (local.set $2
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $4
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (i32.store
+        (i32.const 3668)
+        (local.tee $4
+         (i32.add
+          (local.get $1)
+          (if (result i32)
+           (i32.and
+            (local.get $4)
+            (i32.const 7)
+           )
+           (local.get $2)
+           (local.tee $2
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3656)
+        (local.tee $2
+         (i32.sub
+          (local.get $9)
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store offset=4
+        (local.get $4)
+        (i32.or
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (local.get $4)
+         (local.get $2)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 3672)
+        (i32.load
+         (i32.const 4132)
+        )
+       )
+       (i32.store
+        (local.tee $2
+         (i32.add
+          (local.get $7)
+          (i32.const 4)
+         )
+        )
+        (i32.const 27)
+       )
+       (i64.store align=4
+        (local.get $10)
+        (i64.load align=4
+         (i32.const 4092)
+        )
+       )
+       (i64.store offset=8 align=4
+        (local.get $10)
+        (i64.load align=4
+         (i32.const 4100)
+        )
+       )
+       (i32.store
+        (i32.const 4092)
+        (local.get $1)
+       )
+       (i32.store
+        (i32.const 4096)
+        (local.get $3)
+       )
+       (i32.store
+        (i32.const 4104)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 4100)
+        (local.get $10)
+       )
+       (local.set $1
+        (local.get $5)
+       )
+       (loop $label$290
+        (i32.store
+         (local.tee $1
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+         )
+         (i32.const 7)
+        )
+        (br_if $label$290
+         (i32.lt_u
+          (i32.add
+           (local.get $1)
+           (i32.const 4)
+          )
+          (local.get $13)
+         )
+        )
+       )
+       (if
+        (i32.ne
+         (local.get $7)
+         (local.get $8)
+        )
+        (block
+         (i32.store
+          (local.get $2)
+          (i32.and
+           (i32.load
+            (local.get $2)
+           )
+           (i32.const -2)
+          )
+         )
+         (i32.store offset=4
+          (local.get $8)
+          (i32.or
+           (local.tee $4
+            (i32.sub
+             (local.get $7)
+             (local.get $8)
+            )
+           )
+           (i32.const 1)
+          )
+         )
+         (i32.store
+          (local.get $7)
+          (local.get $4)
+         )
+         (local.set $1
+          (i32.shr_u
+           (local.get $4)
+           (i32.const 3)
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (i32.const 256)
+          )
+          (block
+           (local.set $2
+            (i32.add
+             (i32.shl
+              (i32.shl
+               (local.get $1)
+               (i32.const 1)
+              )
+              (i32.const 2)
+             )
+             (i32.const 3684)
+            )
+           )
+           (if
+            (i32.and
+             (local.tee $3
+              (i32.load
+               (i32.const 3644)
+              )
+             )
+             (local.tee $1
+              (i32.shl
+               (i32.const 1)
+               (local.get $1)
+              )
+             )
+            )
+            (if
+             (i32.lt_u
+              (local.tee $1
+               (i32.load
+                (local.tee $3
+                 (i32.add
+                  (local.get $2)
+                  (i32.const 8)
+                 )
+                )
+               )
+              )
+              (i32.load
+               (i32.const 3660)
+              )
+             )
+             (call $fimport$10)
+             (block
+              (local.set $15
+               (local.get $3)
+              )
+              (local.set $11
+               (local.get $1)
+              )
+             )
+            )
+            (block
+             (i32.store
+              (i32.const 3644)
+              (i32.or
+               (local.get $3)
+               (local.get $1)
+              )
+             )
+             (local.set $15
+              (i32.add
+               (local.get $2)
+               (i32.const 8)
+              )
+             )
+             (local.set $11
+              (local.get $2)
+             )
+            )
+           )
+           (i32.store
+            (local.get $15)
+            (local.get $8)
+           )
+           (i32.store offset=12
+            (local.get $11)
+            (local.get $8)
+           )
+           (i32.store offset=8
+            (local.get $8)
+            (local.get $11)
+           )
+           (i32.store offset=12
+            (local.get $8)
+            (local.get $2)
+           )
+           (br $label$198)
+          )
+         )
+         (local.set $2
+          (i32.add
+           (i32.shl
+            (local.tee $5
+             (if (result i32)
+              (local.tee $1
+               (i32.shr_u
+                (local.get $4)
+                (i32.const 8)
+               )
+              )
+              (if (result i32)
+               (i32.gt_u
+                (local.get $4)
+                (i32.const 16777215)
+               )
+               (i32.const 31)
+               (i32.or
+                (i32.and
+                 (i32.shr_u
+                  (local.get $4)
+                  (i32.add
+                   (local.tee $1
+                    (i32.add
+                     (i32.sub
+                      (i32.const 14)
+                      (i32.or
+                       (i32.or
+                        (local.tee $1
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (local.tee $3
+                             (i32.shl
+                              (local.get $1)
+                              (local.tee $2
+                               (i32.and
+                                (i32.shr_u
+                                 (i32.add
+                                  (local.get $1)
+                                  (i32.const 1048320)
+                                 )
+                                 (i32.const 16)
+                                )
+                                (i32.const 8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 520192)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 4)
+                         )
+                        )
+                        (local.get $2)
+                       )
+                       (local.tee $1
+                        (i32.and
+                         (i32.shr_u
+                          (i32.add
+                           (local.tee $3
+                            (i32.shl
+                             (local.get $3)
+                             (local.get $1)
+                            )
+                           )
+                           (i32.const 245760)
+                          )
+                          (i32.const 16)
+                         )
+                         (i32.const 2)
+                        )
+                       )
+                      )
+                     )
+                     (i32.shr_u
+                      (i32.shl
+                       (local.get $3)
+                       (local.get $1)
+                      )
+                      (i32.const 15)
+                     )
+                    )
+                   )
+                   (i32.const 7)
+                  )
+                 )
+                 (i32.const 1)
+                )
+                (i32.shl
+                 (local.get $1)
+                 (i32.const 1)
+                )
+               )
+              )
+              (i32.const 0)
+             )
+            )
+            (i32.const 2)
+           )
+           (i32.const 3948)
+          )
+         )
+         (i32.store offset=28
+          (local.get $8)
+          (local.get $5)
+         )
+         (i32.store offset=20
+          (local.get $8)
+          (i32.const 0)
+         )
+         (i32.store
+          (local.get $12)
+          (i32.const 0)
+         )
+         (if
+          (i32.eqz
+           (i32.and
+            (local.tee $3
+             (i32.load
+              (i32.const 3648)
+             )
+            )
+            (local.tee $1
+             (i32.shl
+              (i32.const 1)
+              (local.get $5)
+             )
+            )
+           )
+          )
+          (block
+           (i32.store
+            (i32.const 3648)
+            (i32.or
+             (local.get $3)
+             (local.get $1)
+            )
+           )
+           (i32.store
+            (local.get $2)
+            (local.get $8)
+           )
+           (i32.store offset=24
+            (local.get $8)
+            (local.get $2)
+           )
+           (i32.store offset=12
+            (local.get $8)
+            (local.get $8)
+           )
+           (i32.store offset=8
+            (local.get $8)
+            (local.get $8)
+           )
+           (br $label$198)
+          )
+         )
+         (local.set $1
+          (i32.load
+           (local.get $2)
+          )
+         )
+         (local.set $3
+          (i32.sub
+           (i32.const 25)
+           (i32.shr_u
+            (local.get $5)
+            (i32.const 1)
+           )
+          )
+         )
+         (local.set $5
+          (i32.shl
+           (local.get $4)
+           (if (result i32)
+            (i32.eq
+             (local.get $5)
+             (i32.const 31)
+            )
+            (i32.const 0)
+            (local.get $3)
+           )
+          )
+         )
+         (block $label$304
+          (block $label$305
+           (block $label$306
+            (loop $label$307
+             (br_if $label$305
+              (i32.eq
+               (i32.and
+                (i32.load offset=4
+                 (local.get $1)
+                )
+                (i32.const -8)
+               )
+               (local.get $4)
+              )
+             )
+             (local.set $2
+              (i32.shl
+               (local.get $5)
+               (i32.const 1)
+              )
+             )
+             (br_if $label$306
+              (i32.eqz
+               (local.tee $3
+                (i32.load
+                 (local.tee $5
+                  (i32.add
+                   (i32.add
+                    (local.get $1)
+                    (i32.const 16)
+                   )
+                   (i32.shl
+                    (i32.shr_u
+                     (local.get $5)
+                     (i32.const 31)
+                    )
+                    (i32.const 2)
+                   )
+                  )
+                 )
+                )
+               )
+              )
+             )
+             (local.set $5
+              (local.get $2)
+             )
+             (local.set $1
+              (local.get $3)
+             )
+             (br $label$307)
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $5)
+             (i32.load
+              (i32.const 3660)
+             )
+            )
+            (call $fimport$10)
+            (block
+             (i32.store
+              (local.get $5)
+              (local.get $8)
+             )
+             (i32.store offset=24
+              (local.get $8)
+              (local.get $1)
+             )
+             (i32.store offset=12
+              (local.get $8)
+              (local.get $8)
+             )
+             (i32.store offset=8
+              (local.get $8)
+              (local.get $8)
+             )
+             (br $label$198)
+            )
+           )
+           (br $label$304)
+          )
+          (if
+           (i32.and
+            (i32.ge_u
+             (local.tee $5
+              (i32.load
+               (local.tee $2
+                (i32.add
+                 (local.get $1)
+                 (i32.const 8)
+                )
+               )
+              )
+             )
+             (local.tee $3
+              (i32.load
+               (i32.const 3660)
+              )
+             )
+            )
+            (i32.ge_u
+             (local.get $1)
+             (local.get $3)
+            )
+           )
+           (block
+            (i32.store offset=12
+             (local.get $5)
+             (local.get $8)
+            )
+            (i32.store
+             (local.get $2)
+             (local.get $8)
+            )
+            (i32.store offset=8
+             (local.get $8)
+             (local.get $5)
+            )
+            (i32.store offset=12
+             (local.get $8)
+             (local.get $1)
+            )
+            (i32.store offset=24
+             (local.get $8)
+             (i32.const 0)
+            )
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+       )
+      )
+      (block
+       (if
+        (i32.or
+         (i32.eqz
+          (local.tee $2
+           (i32.load
+            (i32.const 3660)
+           )
+          )
+         )
+         (i32.lt_u
+          (local.get $1)
+          (local.get $2)
+         )
+        )
+        (i32.store
+         (i32.const 3660)
+         (local.get $1)
+        )
+       )
+       (i32.store
+        (i32.const 4092)
+        (local.get $1)
+       )
+       (i32.store
+        (i32.const 4096)
+        (local.get $3)
+       )
+       (i32.store
+        (i32.const 4104)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 3680)
+        (i32.load
+         (i32.const 4116)
+        )
+       )
+       (i32.store
+        (i32.const 3676)
+        (i32.const -1)
+       )
+       (local.set $2
+        (i32.const 0)
+       )
+       (loop $label$314
+        (i32.store offset=12
+         (local.tee $5
+          (i32.add
+           (i32.shl
+            (i32.shl
+             (local.get $2)
+             (i32.const 1)
+            )
+            (i32.const 2)
+           )
+           (i32.const 3684)
+          )
+         )
+         (local.get $5)
+        )
+        (i32.store offset=8
+         (local.get $5)
+         (local.get $5)
+        )
+        (br_if $label$314
+         (i32.ne
+          (local.tee $2
+           (i32.add
+            (local.get $2)
+            (i32.const 1)
+           )
+          )
+          (i32.const 32)
+         )
+        )
+       )
+       (local.set $5
+        (i32.add
+         (local.get $3)
+         (i32.const -40)
+        )
+       )
+       (local.set $3
+        (i32.and
+         (i32.sub
+          (i32.const 0)
+          (local.tee $2
+           (i32.add
+            (local.get $1)
+            (i32.const 8)
+           )
+          )
+         )
+         (i32.const 7)
+        )
+       )
+       (i32.store
+        (i32.const 3668)
+        (local.tee $3
+         (i32.add
+          (local.get $1)
+          (local.tee $1
+           (if (result i32)
+            (i32.and
+             (local.get $2)
+             (i32.const 7)
+            )
+            (local.get $3)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3656)
+        (local.tee $1
+         (i32.sub
+          (local.get $5)
+          (local.get $1)
+         )
+        )
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $1)
+         (i32.const 1)
+        )
+       )
+       (i32.store offset=4
+        (i32.add
+         (local.get $3)
+         (local.get $1)
+        )
+        (i32.const 40)
+       )
+       (i32.store
+        (i32.const 3672)
+        (i32.load
+         (i32.const 4132)
+        )
+       )
+      )
+     )
+    )
+    (if
+     (i32.gt_u
+      (local.tee $1
+       (i32.load
+        (i32.const 3656)
+       )
+      )
+      (local.get $0)
+     )
+     (block
+      (i32.store
+       (i32.const 3656)
+       (local.tee $3
+        (i32.sub
+         (local.get $1)
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store
+       (i32.const 3668)
+       (local.tee $1
+        (i32.add
+         (local.tee $2
+          (i32.load
+           (i32.const 3668)
+          )
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store offset=4
+       (local.get $1)
+       (i32.or
+        (local.get $3)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=4
+       (local.get $2)
+       (i32.or
+        (local.get $0)
+        (i32.const 3)
+       )
+      )
+      (global.set $global$1
+       (local.get $14)
+      )
+      (return
+       (i32.add
+        (local.get $2)
+        (i32.const 8)
+       )
+      )
+     )
+    )
+   )
+   (i32.store
+    (call $11)
+    (i32.const 12)
+   )
+   (global.set $global$1
+    (local.get $14)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $32 (; 45 ;) (type $2) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (block $label$1
+   (if
+    (i32.eqz
+     (local.get $0)
+    )
+    (return)
+   )
+   (if
+    (i32.lt_u
+     (local.tee $1
+      (i32.add
+       (local.get $0)
+       (i32.const -8)
+      )
+     )
+     (local.tee $11
+      (i32.load
+       (i32.const 3660)
+      )
+     )
+    )
+    (call $fimport$10)
+   )
+   (if
+    (i32.eq
+     (local.tee $8
+      (i32.and
+       (local.tee $0
+        (i32.load
+         (i32.add
+          (local.get $0)
+          (i32.const -4)
+         )
+        )
+       )
+       (i32.const 3)
+      )
+     )
+     (i32.const 1)
+    )
+    (call $fimport$10)
+   )
+   (local.set $6
+    (i32.add
+     (local.get $1)
+     (local.tee $4
+      (i32.and
+       (local.get $0)
+       (i32.const -8)
+      )
+     )
+    )
+   )
+   (block $label$5
+    (if
+     (i32.and
+      (local.get $0)
+      (i32.const 1)
+     )
+     (block
+      (local.set $3
+       (local.get $1)
+      )
+      (local.set $2
+       (local.get $4)
+      )
+     )
+     (block
+      (if
+       (i32.eqz
+        (local.get $8)
+       )
+       (return)
+      )
+      (if
+       (i32.lt_u
+        (local.tee $0
+         (i32.add
+          (local.get $1)
+          (i32.sub
+           (i32.const 0)
+           (local.tee $8
+            (i32.load
+             (local.get $1)
+            )
+           )
+          )
+         )
+        )
+        (local.get $11)
+       )
+       (call $fimport$10)
+      )
+      (local.set $1
+       (i32.add
+        (local.get $8)
+        (local.get $4)
+       )
+      )
+      (if
+       (i32.eq
+        (local.get $0)
+        (i32.load
+         (i32.const 3664)
+        )
+       )
+       (block
+        (if
+         (i32.ne
+          (i32.and
+           (local.tee $3
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (local.get $6)
+               (i32.const 4)
+              )
+             )
+            )
+           )
+           (i32.const 3)
+          )
+          (i32.const 3)
+         )
+         (block
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+          (br $label$5)
+         )
+        )
+        (i32.store
+         (i32.const 3652)
+         (local.get $1)
+        )
+        (i32.store
+         (local.get $2)
+         (i32.and
+          (local.get $3)
+          (i32.const -2)
+         )
+        )
+        (i32.store offset=4
+         (local.get $0)
+         (i32.or
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (i32.store
+         (i32.add
+          (local.get $0)
+          (local.get $1)
+         )
+         (local.get $1)
+        )
+        (return)
+       )
+      )
+      (local.set $10
+       (i32.shr_u
+        (local.get $8)
+        (i32.const 3)
+       )
+      )
+      (if
+       (i32.lt_u
+        (local.get $8)
+        (i32.const 256)
+       )
+       (block
+        (local.set $3
+         (i32.load offset=12
+          (local.get $0)
+         )
+        )
+        (if
+         (i32.ne
+          (local.tee $4
+           (i32.load offset=8
+            (local.get $0)
+           )
+          )
+          (local.tee $2
+           (i32.add
+            (i32.shl
+             (i32.shl
+              (local.get $10)
+              (i32.const 1)
+             )
+             (i32.const 2)
+            )
+            (i32.const 3684)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $4)
+            (local.get $11)
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.ne
+            (i32.load offset=12
+             (local.get $4)
+            )
+            (local.get $0)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $3)
+          (local.get $4)
+         )
+         (block
+          (i32.store
+           (i32.const 3644)
+           (i32.and
+            (i32.load
+             (i32.const 3644)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (local.get $10)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+          (br $label$5)
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $3)
+          (local.get $2)
+         )
+         (local.set $5
+          (i32.add
+           (local.get $3)
+           (i32.const 8)
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $3)
+            (local.get $11)
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (local.get $3)
+               (i32.const 8)
+              )
+             )
+            )
+            (local.get $0)
+           )
+           (local.set $5
+            (local.get $2)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (i32.store offset=12
+         (local.get $4)
+         (local.get $3)
+        )
+        (i32.store
+         (local.get $5)
+         (local.get $4)
+        )
+        (local.set $3
+         (local.get $0)
+        )
+        (local.set $2
+         (local.get $1)
+        )
+        (br $label$5)
+       )
+      )
+      (local.set $12
+       (i32.load offset=24
+        (local.get $0)
+       )
+      )
+      (block $label$22
+       (if
+        (i32.eq
+         (local.tee $4
+          (i32.load offset=12
+           (local.get $0)
+          )
+         )
+         (local.get $0)
+        )
+        (block
+         (if
+          (local.tee $4
+           (i32.load
+            (local.tee $8
+             (i32.add
+              (local.tee $5
+               (i32.add
+                (local.get $0)
+                (i32.const 16)
+               )
+              )
+              (i32.const 4)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (local.get $8)
+          )
+          (if
+           (i32.eqz
+            (local.tee $4
+             (i32.load
+              (local.get $5)
+             )
+            )
+           )
+           (block
+            (local.set $7
+             (i32.const 0)
+            )
+            (br $label$22)
+           )
+          )
+         )
+         (loop $label$27
+          (if
+           (local.tee $10
+            (i32.load
+             (local.tee $8
+              (i32.add
+               (local.get $4)
+               (i32.const 20)
+              )
+             )
+            )
+           )
+           (block
+            (local.set $4
+             (local.get $10)
+            )
+            (local.set $5
+             (local.get $8)
+            )
+            (br $label$27)
+           )
+          )
+          (if
+           (local.tee $10
+            (i32.load
+             (local.tee $8
+              (i32.add
+               (local.get $4)
+               (i32.const 16)
+              )
+             )
+            )
+           )
+           (block
+            (local.set $4
+             (local.get $10)
+            )
+            (local.set $5
+             (local.get $8)
+            )
+            (br $label$27)
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $5)
+           (local.get $11)
+          )
+          (call $fimport$10)
+          (block
+           (i32.store
+            (local.get $5)
+            (i32.const 0)
+           )
+           (local.set $7
+            (local.get $4)
+           )
+          )
+         )
+        )
+        (block
+         (if
+          (i32.lt_u
+           (local.tee $5
+            (i32.load offset=8
+             (local.get $0)
+            )
+           )
+           (local.get $11)
+          )
+          (call $fimport$10)
+         )
+         (if
+          (i32.ne
+           (i32.load
+            (local.tee $8
+             (i32.add
+              (local.get $5)
+              (i32.const 12)
+             )
+            )
+           )
+           (local.get $0)
+          )
+          (call $fimport$10)
+         )
+         (if
+          (i32.eq
+           (i32.load
+            (local.tee $10
+             (i32.add
+              (local.get $4)
+              (i32.const 8)
+             )
+            )
+           )
+           (local.get $0)
+          )
+          (block
+           (i32.store
+            (local.get $8)
+            (local.get $4)
+           )
+           (i32.store
+            (local.get $10)
+            (local.get $5)
+           )
+           (local.set $7
+            (local.get $4)
+           )
+          )
+          (call $fimport$10)
+         )
+        )
+       )
+      )
+      (if
+       (local.get $12)
+       (block
+        (if
+         (i32.eq
+          (local.get $0)
+          (i32.load
+           (local.tee $5
+            (i32.add
+             (i32.shl
+              (local.tee $4
+               (i32.load offset=28
+                (local.get $0)
+               )
+              )
+              (i32.const 2)
+             )
+             (i32.const 3948)
+            )
+           )
+          )
+         )
+         (block
+          (i32.store
+           (local.get $5)
+           (local.get $7)
+          )
+          (if
+           (i32.eqz
+            (local.get $7)
+           )
+           (block
+            (i32.store
+             (i32.const 3648)
+             (i32.and
+              (i32.load
+               (i32.const 3648)
+              )
+              (i32.xor
+               (i32.shl
+                (i32.const 1)
+                (local.get $4)
+               )
+               (i32.const -1)
+              )
+             )
+            )
+            (local.set $3
+             (local.get $0)
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$5)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $12)
+            (i32.load
+             (i32.const 3660)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $4
+              (i32.add
+               (local.get $12)
+               (i32.const 16)
+              )
+             )
+            )
+            (local.get $0)
+           )
+           (i32.store
+            (local.get $4)
+            (local.get $7)
+           )
+           (i32.store offset=20
+            (local.get $12)
+            (local.get $7)
+           )
+          )
+          (if
+           (i32.eqz
+            (local.get $7)
+           )
+           (block
+            (local.set $3
+             (local.get $0)
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (br $label$5)
+           )
+          )
+         )
+        )
+        (if
+         (i32.lt_u
+          (local.get $7)
+          (local.tee $5
+           (i32.load
+            (i32.const 3660)
+           )
+          )
+         )
+         (call $fimport$10)
+        )
+        (i32.store offset=24
+         (local.get $7)
+         (local.get $12)
+        )
+        (if
+         (local.tee $4
+          (i32.load
+           (local.tee $8
+            (i32.add
+             (local.get $0)
+             (i32.const 16)
+            )
+           )
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (local.get $5)
+          )
+          (call $fimport$10)
+          (block
+           (i32.store offset=16
+            (local.get $7)
+            (local.get $4)
+           )
+           (i32.store offset=24
+            (local.get $4)
+            (local.get $7)
+           )
+          )
+         )
+        )
+        (if
+         (local.tee $4
+          (i32.load offset=4
+           (local.get $8)
+          )
+         )
+         (if
+          (i32.lt_u
+           (local.get $4)
+           (i32.load
+            (i32.const 3660)
+           )
+          )
+          (call $fimport$10)
+          (block
+           (i32.store offset=20
+            (local.get $7)
+            (local.get $4)
+           )
+           (i32.store offset=24
+            (local.get $4)
+            (local.get $7)
+           )
+           (local.set $3
+            (local.get $0)
+           )
+           (local.set $2
+            (local.get $1)
+           )
+          )
+         )
+         (block
+          (local.set $3
+           (local.get $0)
+          )
+          (local.set $2
+           (local.get $1)
+          )
+         )
+        )
+       )
+       (block
+        (local.set $3
+         (local.get $0)
+        )
+        (local.set $2
+         (local.get $1)
+        )
+       )
+      )
+     )
+    )
+   )
+   (if
+    (i32.ge_u
+     (local.get $3)
+     (local.get $6)
+    )
+    (call $fimport$10)
+   )
+   (if
+    (i32.eqz
+     (i32.and
+      (local.tee $0
+       (i32.load
+        (local.tee $1
+         (i32.add
+          (local.get $6)
+          (i32.const 4)
+         )
+        )
+       )
+      )
+      (i32.const 1)
+     )
+    )
+    (call $fimport$10)
+   )
+   (if
+    (i32.and
+     (local.get $0)
+     (i32.const 2)
+    )
+    (block
+     (i32.store
+      (local.get $1)
+      (i32.and
+       (local.get $0)
+       (i32.const -2)
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.or
+       (local.get $2)
+       (i32.const 1)
+      )
+     )
+     (i32.store
+      (i32.add
+       (local.get $3)
+       (local.get $2)
+      )
+      (local.get $2)
+     )
+    )
+    (block
+     (if
+      (i32.eq
+       (local.get $6)
+       (i32.load
+        (i32.const 3668)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3656)
+        (local.tee $0
+         (i32.add
+          (i32.load
+           (i32.const 3656)
+          )
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3668)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $0)
+         (i32.const 1)
+        )
+       )
+       (if
+        (i32.ne
+         (local.get $3)
+         (i32.load
+          (i32.const 3664)
+         )
+        )
+        (return)
+       )
+       (i32.store
+        (i32.const 3664)
+        (i32.const 0)
+       )
+       (i32.store
+        (i32.const 3652)
+        (i32.const 0)
+       )
+       (return)
+      )
+     )
+     (if
+      (i32.eq
+       (local.get $6)
+       (i32.load
+        (i32.const 3664)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3652)
+        (local.tee $0
+         (i32.add
+          (i32.load
+           (i32.const 3652)
+          )
+          (local.get $2)
+         )
+        )
+       )
+       (i32.store
+        (i32.const 3664)
+        (local.get $3)
+       )
+       (i32.store offset=4
+        (local.get $3)
+        (i32.or
+         (local.get $0)
+         (i32.const 1)
+        )
+       )
+       (i32.store
+        (i32.add
+         (local.get $3)
+         (local.get $0)
+        )
+        (local.get $0)
+       )
+       (return)
+      )
+     )
+     (local.set $5
+      (i32.add
+       (i32.and
+        (local.get $0)
+        (i32.const -8)
+       )
+       (local.get $2)
+      )
+     )
+     (local.set $4
+      (i32.shr_u
+       (local.get $0)
+       (i32.const 3)
+      )
+     )
+     (block $label$61
+      (if
+       (i32.lt_u
+        (local.get $0)
+        (i32.const 256)
+       )
+       (block
+        (local.set $2
+         (i32.load offset=12
+          (local.get $6)
+         )
+        )
+        (if
+         (i32.ne
+          (local.tee $1
+           (i32.load offset=8
+            (local.get $6)
+           )
+          )
+          (local.tee $0
+           (i32.add
+            (i32.shl
+             (i32.shl
+              (local.get $4)
+              (i32.const 1)
+             )
+             (i32.const 2)
+            )
+            (i32.const 3684)
+           )
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $1)
+            (i32.load
+             (i32.const 3660)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.ne
+            (i32.load offset=12
+             (local.get $1)
+            )
+            (local.get $6)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $1)
+         )
+         (block
+          (i32.store
+           (i32.const 3644)
+           (i32.and
+            (i32.load
+             (i32.const 3644)
+            )
+            (i32.xor
+             (i32.shl
+              (i32.const 1)
+              (local.get $4)
+             )
+             (i32.const -1)
+            )
+           )
+          )
+          (br $label$61)
+         )
+        )
+        (if
+         (i32.eq
+          (local.get $2)
+          (local.get $0)
+         )
+         (local.set $14
+          (i32.add
+           (local.get $2)
+           (i32.const 8)
+          )
+         )
+         (block
+          (if
+           (i32.lt_u
+            (local.get $2)
+            (i32.load
+             (i32.const 3660)
+            )
+           )
+           (call $fimport$10)
+          )
+          (if
+           (i32.eq
+            (i32.load
+             (local.tee $0
+              (i32.add
+               (local.get $2)
+               (i32.const 8)
+              )
+             )
+            )
+            (local.get $6)
+           )
+           (local.set $14
+            (local.get $0)
+           )
+           (call $fimport$10)
+          )
+         )
+        )
+        (i32.store offset=12
+         (local.get $1)
+         (local.get $2)
+        )
+        (i32.store
+         (local.get $14)
+         (local.get $1)
+        )
+       )
+       (block
+        (local.set $7
+         (i32.load offset=24
+          (local.get $6)
+         )
+        )
+        (block $label$73
+         (if
+          (i32.eq
+           (local.tee $0
+            (i32.load offset=12
+             (local.get $6)
+            )
+           )
+           (local.get $6)
+          )
+          (block
+           (if
+            (local.tee $0
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (local.tee $2
+                 (i32.add
+                  (local.get $6)
+                  (i32.const 16)
+                 )
+                )
+                (i32.const 4)
+               )
+              )
+             )
+            )
+            (local.set $2
+             (local.get $1)
+            )
+            (if
+             (i32.eqz
+              (local.tee $0
+               (i32.load
+                (local.get $2)
+               )
+              )
+             )
+             (block
+              (local.set $9
+               (i32.const 0)
+              )
+              (br $label$73)
+             )
+            )
+           )
+           (loop $label$78
+            (if
+             (local.tee $4
+              (i32.load
+               (local.tee $1
+                (i32.add
+                 (local.get $0)
+                 (i32.const 20)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (local.get $4)
+              )
+              (local.set $2
+               (local.get $1)
+              )
+              (br $label$78)
+             )
+            )
+            (if
+             (local.tee $4
+              (i32.load
+               (local.tee $1
+                (i32.add
+                 (local.get $0)
+                 (i32.const 16)
+                )
+               )
+              )
+             )
+             (block
+              (local.set $0
+               (local.get $4)
+              )
+              (local.set $2
+               (local.get $1)
+              )
+              (br $label$78)
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $2)
+             (i32.load
+              (i32.const 3660)
+             )
+            )
+            (call $fimport$10)
+            (block
+             (i32.store
+              (local.get $2)
+              (i32.const 0)
+             )
+             (local.set $9
+              (local.get $0)
+             )
+            )
+           )
+          )
+          (block
+           (if
+            (i32.lt_u
+             (local.tee $2
+              (i32.load offset=8
+               (local.get $6)
+              )
+             )
+             (i32.load
+              (i32.const 3660)
+             )
+            )
+            (call $fimport$10)
+           )
+           (if
+            (i32.ne
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (local.get $2)
+                (i32.const 12)
+               )
+              )
+             )
+             (local.get $6)
+            )
+            (call $fimport$10)
+           )
+           (if
+            (i32.eq
+             (i32.load
+              (local.tee $4
+               (i32.add
+                (local.get $0)
+                (i32.const 8)
+               )
+              )
+             )
+             (local.get $6)
+            )
+            (block
+             (i32.store
+              (local.get $1)
+              (local.get $0)
+             )
+             (i32.store
+              (local.get $4)
+              (local.get $2)
+             )
+             (local.set $9
+              (local.get $0)
+             )
+            )
+            (call $fimport$10)
+           )
+          )
+         )
+        )
+        (if
+         (local.get $7)
+         (block
+          (if
+           (i32.eq
+            (local.get $6)
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (i32.shl
+                (local.tee $0
+                 (i32.load offset=28
+                  (local.get $6)
+                 )
+                )
+                (i32.const 2)
+               )
+               (i32.const 3948)
+              )
+             )
+            )
+           )
+           (block
+            (i32.store
+             (local.get $2)
+             (local.get $9)
+            )
+            (if
+             (i32.eqz
+              (local.get $9)
+             )
+             (block
+              (i32.store
+               (i32.const 3648)
+               (i32.and
+                (i32.load
+                 (i32.const 3648)
+                )
+                (i32.xor
+                 (i32.shl
+                  (i32.const 1)
+                  (local.get $0)
+                 )
+                 (i32.const -1)
+                )
+               )
+              )
+              (br $label$61)
+             )
+            )
+           )
+           (block
+            (if
+             (i32.lt_u
+              (local.get $7)
+              (i32.load
+               (i32.const 3660)
+              )
+             )
+             (call $fimport$10)
+            )
+            (if
+             (i32.eq
+              (i32.load
+               (local.tee $0
+                (i32.add
+                 (local.get $7)
+                 (i32.const 16)
+                )
+               )
+              )
+              (local.get $6)
+             )
+             (i32.store
+              (local.get $0)
+              (local.get $9)
+             )
+             (i32.store offset=20
+              (local.get $7)
+              (local.get $9)
+             )
+            )
+            (br_if $label$61
+             (i32.eqz
+              (local.get $9)
+             )
+            )
+           )
+          )
+          (if
+           (i32.lt_u
+            (local.get $9)
+            (local.tee $2
+             (i32.load
+              (i32.const 3660)
+             )
+            )
+           )
+           (call $fimport$10)
+          )
+          (i32.store offset=24
+           (local.get $9)
+           (local.get $7)
+          )
+          (if
+           (local.tee $0
+            (i32.load
+             (local.tee $1
+              (i32.add
+               (local.get $6)
+               (i32.const 16)
+              )
+             )
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $0)
+             (local.get $2)
+            )
+            (call $fimport$10)
+            (block
+             (i32.store offset=16
+              (local.get $9)
+              (local.get $0)
+             )
+             (i32.store offset=24
+              (local.get $0)
+              (local.get $9)
+             )
+            )
+           )
+          )
+          (if
+           (local.tee $0
+            (i32.load offset=4
+             (local.get $1)
+            )
+           )
+           (if
+            (i32.lt_u
+             (local.get $0)
+             (i32.load
+              (i32.const 3660)
+             )
+            )
+            (call $fimport$10)
+            (block
+             (i32.store offset=20
+              (local.get $9)
+              (local.get $0)
+             )
+             (i32.store offset=24
+              (local.get $0)
+              (local.get $9)
+             )
+            )
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+     (i32.store offset=4
+      (local.get $3)
+      (i32.or
+       (local.get $5)
+       (i32.const 1)
+      )
+     )
+     (i32.store
+      (i32.add
+       (local.get $3)
+       (local.get $5)
+      )
+      (local.get $5)
+     )
+     (if
+      (i32.eq
+       (local.get $3)
+       (i32.load
+        (i32.const 3664)
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3652)
+        (local.get $5)
+       )
+       (return)
+      )
+      (local.set $2
+       (local.get $5)
+      )
+     )
+    )
+   )
+   (local.set $1
+    (i32.shr_u
+     (local.get $2)
+     (i32.const 3)
+    )
+   )
+   (if
+    (i32.lt_u
+     (local.get $2)
+     (i32.const 256)
+    )
+    (block
+     (local.set $0
+      (i32.add
+       (i32.shl
+        (i32.shl
+         (local.get $1)
+         (i32.const 1)
+        )
+        (i32.const 2)
+       )
+       (i32.const 3684)
+      )
+     )
+     (if
+      (i32.and
+       (local.tee $2
+        (i32.load
+         (i32.const 3644)
+        )
+       )
+       (local.tee $1
+        (i32.shl
+         (i32.const 1)
+         (local.get $1)
+        )
+       )
+      )
+      (if
+       (i32.lt_u
+        (local.tee $1
+         (i32.load
+          (local.tee $2
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (i32.load
+         (i32.const 3660)
+        )
+       )
+       (call $fimport$10)
+       (block
+        (local.set $15
+         (local.get $2)
+        )
+        (local.set $13
+         (local.get $1)
+        )
+       )
+      )
+      (block
+       (i32.store
+        (i32.const 3644)
+        (i32.or
+         (local.get $2)
+         (local.get $1)
+        )
+       )
+       (local.set $15
+        (i32.add
+         (local.get $0)
+         (i32.const 8)
+        )
+       )
+       (local.set $13
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store
+      (local.get $15)
+      (local.get $3)
+     )
+     (i32.store offset=12
+      (local.get $13)
+      (local.get $3)
+     )
+     (i32.store offset=8
+      (local.get $3)
+      (local.get $13)
+     )
+     (i32.store offset=12
+      (local.get $3)
+      (local.get $0)
+     )
+     (return)
+    )
+   )
+   (local.set $0
+    (i32.add
+     (i32.shl
+      (local.tee $1
+       (if (result i32)
+        (local.tee $0
+         (i32.shr_u
+          (local.get $2)
+          (i32.const 8)
+         )
+        )
+        (if (result i32)
+         (i32.gt_u
+          (local.get $2)
+          (i32.const 16777215)
+         )
+         (i32.const 31)
+         (i32.or
+          (i32.and
+           (i32.shr_u
+            (local.get $2)
+            (i32.add
+             (local.tee $0
+              (i32.add
+               (i32.sub
+                (i32.const 14)
+                (i32.or
+                 (i32.or
+                  (local.tee $4
+                   (i32.and
+                    (i32.shr_u
+                     (i32.add
+                      (local.tee $1
+                       (i32.shl
+                        (local.get $0)
+                        (local.tee $0
+                         (i32.and
+                          (i32.shr_u
+                           (i32.add
+                            (local.get $0)
+                            (i32.const 1048320)
+                           )
+                           (i32.const 16)
+                          )
+                          (i32.const 8)
+                         )
+                        )
+                       )
+                      )
+                      (i32.const 520192)
+                     )
+                     (i32.const 16)
+                    )
+                    (i32.const 4)
+                   )
+                  )
+                  (local.get $0)
+                 )
+                 (local.tee $1
+                  (i32.and
+                   (i32.shr_u
+                    (i32.add
+                     (local.tee $0
+                      (i32.shl
+                       (local.get $1)
+                       (local.get $4)
+                      )
+                     )
+                     (i32.const 245760)
+                    )
+                    (i32.const 16)
+                   )
+                   (i32.const 2)
+                  )
+                 )
+                )
+               )
+               (i32.shr_u
+                (i32.shl
+                 (local.get $0)
+                 (local.get $1)
+                )
+                (i32.const 15)
+               )
+              )
+             )
+             (i32.const 7)
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.shl
+           (local.get $0)
+           (i32.const 1)
+          )
+         )
+        )
+        (i32.const 0)
+       )
+      )
+      (i32.const 2)
+     )
+     (i32.const 3948)
+    )
+   )
+   (i32.store offset=28
+    (local.get $3)
+    (local.get $1)
+   )
+   (i32.store offset=20
+    (local.get $3)
+    (i32.const 0)
+   )
+   (i32.store offset=16
+    (local.get $3)
+    (i32.const 0)
+   )
+   (block $label$113
+    (if
+     (i32.and
+      (local.tee $4
+       (i32.load
+        (i32.const 3648)
+       )
+      )
+      (local.tee $5
+       (i32.shl
+        (i32.const 1)
+        (local.get $1)
+       )
+      )
+     )
+     (block
+      (local.set $0
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (local.set $4
+       (i32.sub
+        (i32.const 25)
+        (i32.shr_u
+         (local.get $1)
+         (i32.const 1)
+        )
+       )
+      )
+      (local.set $1
+       (i32.shl
+        (local.get $2)
+        (if (result i32)
+         (i32.eq
+          (local.get $1)
+          (i32.const 31)
+         )
+         (i32.const 0)
+         (local.get $4)
+        )
+       )
+      )
+      (block $label$117
+       (block $label$118
+        (block $label$119
+         (loop $label$120
+          (br_if $label$118
+           (i32.eq
+            (i32.and
+             (i32.load offset=4
+              (local.get $0)
+             )
+             (i32.const -8)
+            )
+            (local.get $2)
+           )
+          )
+          (local.set $4
+           (i32.shl
+            (local.get $1)
+            (i32.const 1)
+           )
+          )
+          (br_if $label$119
+           (i32.eqz
+            (local.tee $5
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (i32.add
+                 (local.get $0)
+                 (i32.const 16)
+                )
+                (i32.shl
+                 (i32.shr_u
+                  (local.get $1)
+                  (i32.const 31)
+                 )
+                 (i32.const 2)
+                )
+               )
+              )
+             )
+            )
+           )
+          )
+          (local.set $1
+           (local.get $4)
+          )
+          (local.set $0
+           (local.get $5)
+          )
+          (br $label$120)
+         )
+        )
+        (if
+         (i32.lt_u
+          (local.get $1)
+          (i32.load
+           (i32.const 3660)
+          )
+         )
+         (call $fimport$10)
+         (block
+          (i32.store
+           (local.get $1)
+           (local.get $3)
+          )
+          (i32.store offset=24
+           (local.get $3)
+           (local.get $0)
+          )
+          (i32.store offset=12
+           (local.get $3)
+           (local.get $3)
+          )
+          (i32.store offset=8
+           (local.get $3)
+           (local.get $3)
+          )
+          (br $label$113)
+         )
+        )
+        (br $label$117)
+       )
+       (if
+        (i32.and
+         (i32.ge_u
+          (local.tee $2
+           (i32.load
+            (local.tee $1
+             (i32.add
+              (local.get $0)
+              (i32.const 8)
+             )
+            )
+           )
+          )
+          (local.tee $4
+           (i32.load
+            (i32.const 3660)
+           )
+          )
+         )
+         (i32.ge_u
+          (local.get $0)
+          (local.get $4)
+         )
+        )
+        (block
+         (i32.store offset=12
+          (local.get $2)
+          (local.get $3)
+         )
+         (i32.store
+          (local.get $1)
+          (local.get $3)
+         )
+         (i32.store offset=8
+          (local.get $3)
+          (local.get $2)
+         )
+         (i32.store offset=12
+          (local.get $3)
+          (local.get $0)
+         )
+         (i32.store offset=24
+          (local.get $3)
+          (i32.const 0)
+         )
+        )
+        (call $fimport$10)
+       )
+      )
+     )
+     (block
+      (i32.store
+       (i32.const 3648)
+       (i32.or
+        (local.get $4)
+        (local.get $5)
+       )
+      )
+      (i32.store
+       (local.get $0)
+       (local.get $3)
+      )
+      (i32.store offset=24
+       (local.get $3)
+       (local.get $0)
+      )
+      (i32.store offset=12
+       (local.get $3)
+       (local.get $3)
+      )
+      (i32.store offset=8
+       (local.get $3)
+       (local.get $3)
+      )
+     )
+    )
+   )
+   (i32.store
+    (i32.const 3676)
+    (local.tee $0
+     (i32.add
+      (i32.load
+       (i32.const 3676)
+      )
+      (i32.const -1)
+     )
+    )
+   )
+   (if
+    (local.get $0)
+    (return)
+    (local.set $0
+     (i32.const 4100)
+    )
+   )
+   (loop $label$128
+    (local.set $0
+     (i32.add
+      (local.tee $2
+       (i32.load
+        (local.get $0)
+       )
+      )
+      (i32.const 8)
+     )
+    )
+    (br_if $label$128
+     (local.get $2)
+    )
+   )
+   (i32.store
+    (i32.const 3676)
+    (i32.const -1)
+   )
+  )
+ )
+ (func $33 (; 46 ;) (type $6)
+  (nop)
+ )
+ (func $34 (; 47 ;) (type $1) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (block $label$1 (result i32)
+   (local.set $1
+    (i32.add
+     (local.tee $2
+      (i32.load
+       (global.get $global$0)
+      )
+     )
+     (local.tee $0
+      (i32.and
+       (i32.add
+        (local.get $0)
+        (i32.const 15)
+       )
+       (i32.const -16)
+      )
+     )
+    )
+   )
+   (if
+    (i32.or
+     (i32.and
+      (i32.gt_s
+       (local.get $0)
+       (i32.const 0)
+      )
+      (i32.lt_s
+       (local.get $1)
+       (local.get $2)
+      )
+     )
+     (i32.lt_s
+      (local.get $1)
+      (i32.const 0)
+     )
+    )
+    (block
+     (drop
+      (call $fimport$6)
+     )
+     (call $fimport$11
+      (i32.const 12)
+     )
+     (return
+      (i32.const -1)
+     )
+    )
+   )
+   (i32.store
+    (global.get $global$0)
+    (local.get $1)
+   )
+   (if
+    (i32.gt_s
+     (local.get $1)
+     (call $fimport$5)
+    )
+    (if
+     (i32.eqz
+      (call $fimport$4)
+     )
+     (block
+      (call $fimport$11
+       (i32.const 12)
+      )
+      (i32.store
+       (global.get $global$0)
+       (local.get $2)
+      )
+      (return
+       (i32.const -1)
+      )
+     )
+    )
+   )
+   (local.get $2)
+  )
+ )
+ (func $35 (; 48 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (block $label$1 (result i32)
+   (local.set $4
+    (i32.add
+     (local.get $0)
+     (local.get $2)
+    )
+   )
+   (if
+    (i32.ge_s
+     (local.get $2)
+     (i32.const 20)
+    )
+    (block
+     (local.set $1
+      (i32.and
+       (local.get $1)
+       (i32.const 255)
+      )
+     )
+     (if
+      (local.tee $3
+       (i32.and
+        (local.get $0)
+        (i32.const 3)
+       )
+      )
+      (block
+       (local.set $3
+        (i32.sub
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+         (local.get $3)
+        )
+       )
+       (loop $label$4
+        (if
+         (i32.lt_s
+          (local.get $0)
+          (local.get $3)
+         )
+         (block
+          (i32.store8
+           (local.get $0)
+           (local.get $1)
+          )
+          (local.set $0
+           (i32.add
+            (local.get $0)
+            (i32.const 1)
+           )
+          )
+          (br $label$4)
+         )
+        )
+       )
+      )
+     )
+     (local.set $3
+      (i32.or
+       (i32.or
+        (i32.or
+         (local.get $1)
+         (i32.shl
+          (local.get $1)
+          (i32.const 8)
+         )
+        )
+        (i32.shl
+         (local.get $1)
+         (i32.const 16)
+        )
+       )
+       (i32.shl
+        (local.get $1)
+        (i32.const 24)
+       )
+      )
+     )
+     (local.set $5
+      (i32.and
+       (local.get $4)
+       (i32.const -4)
+      )
+     )
+     (loop $label$6
+      (if
+       (i32.lt_s
+        (local.get $0)
+        (local.get $5)
+       )
+       (block
+        (i32.store
+         (local.get $0)
+         (local.get $3)
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+        )
+        (br $label$6)
+       )
+      )
+     )
+    )
+   )
+   (loop $label$8
+    (if
+     (i32.lt_s
+      (local.get $0)
+      (local.get $4)
+     )
+     (block
+      (i32.store8
+       (local.get $0)
+       (local.get $1)
+      )
+      (local.set $0
+       (i32.add
+        (local.get $0)
+        (i32.const 1)
+       )
+      )
+      (br $label$8)
+     )
+    )
+   )
+   (i32.sub
+    (local.get $0)
+    (local.get $2)
+   )
+  )
+ )
+ (func $36 (; 49 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (block $label$1 (result i32)
+   (if
+    (i32.ge_s
+     (local.get $2)
+     (i32.const 4096)
+    )
+    (return
+     (call $fimport$12
+      (local.get $0)
+      (local.get $1)
+      (local.get $2)
+     )
+    )
+   )
+   (local.set $3
+    (local.get $0)
+   )
+   (if
+    (i32.eq
+     (i32.and
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.and
+      (local.get $1)
+      (i32.const 3)
+     )
+    )
+    (block
+     (loop $label$4
+      (if
+       (i32.and
+        (local.get $0)
+        (i32.const 3)
+       )
+       (block
+        (if
+         (i32.eqz
+          (local.get $2)
+         )
+         (return
+          (local.get $3)
+         )
+        )
+        (i32.store8
+         (local.get $0)
+         (i32.load8_s
+          (local.get $1)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 1)
+         )
+        )
+        (local.set $1
+         (i32.add
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (local.set $2
+         (i32.sub
+          (local.get $2)
+          (i32.const 1)
+         )
+        )
+        (br $label$4)
+       )
+      )
+     )
+     (loop $label$7
+      (if
+       (i32.ge_s
+        (local.get $2)
+        (i32.const 4)
+       )
+       (block
+        (i32.store
+         (local.get $0)
+         (i32.load
+          (local.get $1)
+         )
+        )
+        (local.set $0
+         (i32.add
+          (local.get $0)
+          (i32.const 4)
+         )
+        )
+        (local.set $1
+         (i32.add
+          (local.get $1)
+          (i32.const 4)
+         )
+        )
+        (local.set $2
+         (i32.sub
+          (local.get $2)
+          (i32.const 4)
+         )
+        )
+        (br $label$7)
+       )
+      )
+     )
+    )
+   )
+   (loop $label$9
+    (if
+     (i32.gt_s
+      (local.get $2)
+      (i32.const 0)
+     )
+     (block
+      (i32.store8
+       (local.get $0)
+       (i32.load8_s
+        (local.get $1)
+       )
+      )
+      (local.set $0
+       (i32.add
+        (local.get $0)
+        (i32.const 1)
+       )
+      )
+      (local.set $1
+       (i32.add
+        (local.get $1)
+        (i32.const 1)
+       )
+      )
+      (local.set $2
+       (i32.sub
+        (local.get $2)
+        (i32.const 1)
+       )
+      )
+      (br $label$9)
+     )
+    )
+   )
+   (local.get $3)
+  )
+ )
+ (func $37 (; 50 ;) (type $3) (result i32)
+  (i32.const 0)
+ )
+ (func $38 (; 51 ;) (type $4) (param $0 i32) (param $1 i32) (result i32)
+  (call_indirect (type $1)
+   (local.get $1)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 1)
+    )
+    (i32.const 0)
+   )
+  )
+ )
+ (func $39 (; 52 ;) (type $12) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (call_indirect (type $0)
+   (local.get $1)
+   (local.get $2)
+   (local.get $3)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 3)
+    )
+    (i32.const 2)
+   )
+  )
+ )
+ (func $40 (; 53 ;) (type $5) (param $0 i32) (param $1 i32)
+  (call_indirect (type $2)
+   (local.get $1)
+   (i32.add
+    (i32.and
+     (local.get $0)
+     (i32.const 1)
+    )
+    (i32.const 6)
+   )
+  )
+ )
+ (func $41 (; 54 ;) (type $1) (param $0 i32) (result i32)
+  (block $label$1 (result i32)
+   (call $fimport$3
+    (i32.const 0)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $42 (; 55 ;) (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (block $label$1 (result i32)
+   (call $fimport$3
+    (i32.const 1)
+   )
+   (i32.const 0)
+  )
+ )
+ (func $43 (; 56 ;) (type $2) (param $0 i32)
+  (call $fimport$3
+   (i32.const 2)
+  )
+ )
+)
+

--- a/wasmtests/rust_fannkuch.wat
+++ b/wasmtests/rust_fannkuch.wat
@@ -1,0 +1,2511 @@
+(module
+ (type $0 (func (param i32 i32 i32) (result i32)))
+ (type $1 (func (param i32 i32) (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (param i32) (result i32)))
+ (type $4 (func (param i32 i32)))
+ (type $5 (func (param i64 i32) (result i32)))
+ (type $6 (func (param i32) (result i64)))
+ (type $7 (func))
+ (type $8 (func (param i32 i32)))
+ (type $9 (func (param i32 i32 i32) (result i32)))
+ (memory $0 17)
+ (data (i32.const 1048576) "src/lib.rs\00\00\00\00\00\00attempt to divide by zero\00\00\00\00\00\00\00attempt to divide with overflow\00index out of bounds: the len is  but the index is 00010203040506070809101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081828384858687888990919293949596979899called `Option::unwrap()` on a `None` valuesrc/libcore/option.rssrc/lib.rs")
+ (data (i32.const 1048982) "\10\00\n\00\00\00%\00\00\00\1d\00\00\00\10\00\10\00\19\00\00\00\00\00\10\00\n\00\00\00&\00\00\00\15\00\00\000\00\10\00\1f\00\00\00\00\00\10\00\n\00\00\00&\00\00\00\15\00\00\00\00\00\10\00\n\00\00\00.\00\00\00\15\00\00\00\00\00\10\00\n\00\00\000\00\00\00\15\00\00\00\00\00\10\00\n\00\00\00-\00\00\00\11\00\00\00\00\00\10\00\n\00\00\00E\00\00\00\17\00\00\00\00\00\10\00\n\00\00\00q\00\00\00\"\00\00\00\00\00\10\00\n\00\00\00s\00\00\00\11\00\00\00P\00\10\00 \00\00\00p\00\10\00\12\00\00\00\02\00\00\00\00\00\00\00\01\00\00\00\03\00\00\00J\01\10\00+\00\00\00u\01\10\00\15\00\00\00Y\01\00\00\15\00\00\00\8a\01\10\00\n\00\00\00\08\00\00\00\t\00\00\00\8a\01\10\00\n\00\00\00\n\00\00\00\14")
+ (table $0 4 4 funcref)
+ (elem (i32.const 1) $4 $7 $8)
+ (global $global$0 (mut i32) (i32.const 1048576))
+ (global $global$1 i32 (i32.const 1049244))
+ (global $global$2 i32 (i32.const 1049244))
+ (export "memory" (memory $0))
+ (export "__heap_base" (global $global$1))
+ (export "__data_end" (global $global$2))
+ (export "run_fannkuch" (func $10))
+ (func $0 (; 0 ;) (type $7)
+  (local $0 i32)
+  (local $1 i32)
+  (local.set $0
+   (i32.const 1)
+  )
+  (block $label$1
+   (block $label$2
+    (block $label$3
+     (if
+      (i32.eq
+       (i32.load
+        (i32.const 1049232)
+       )
+       (i32.const 1)
+      )
+      (block
+       (i32.store
+        (i32.const 1049236)
+        (local.tee $0
+         (i32.add
+          (i32.load
+           (i32.const 1049236)
+          )
+          (i32.const 1)
+         )
+        )
+       )
+       (br_if $label$3
+        (i32.lt_u
+         (local.get $0)
+         (i32.const 3)
+        )
+       )
+       (br $label$2)
+      )
+     )
+     (i64.store
+      (i32.const 1049232)
+      (i64.const 4294967297)
+     )
+    )
+    (br_if $label$2
+     (i32.le_s
+      (local.tee $1
+       (i32.load
+        (i32.const 1049240)
+       )
+      )
+      (i32.const -1)
+     )
+    )
+    (i32.store
+     (i32.const 1049240)
+     (local.get $1)
+    )
+    (br_if $label$1
+     (i32.lt_u
+      (local.get $0)
+      (i32.const 2)
+     )
+    )
+   )
+   (unreachable)
+  )
+  (unreachable)
+ )
+ (func $1 (; 1 ;) (type $2) (param $0 i32)
+  (local $1 i32)
+  (global.set $global$0
+   (local.tee $1
+    (i32.sub
+     (global.get $global$0)
+     (i32.const 16)
+    )
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.load offset=8
+     (local.get $0)
+    )
+   )
+   (block
+    (call $2
+     (i32.const 1049172)
+    )
+    (unreachable)
+   )
+  )
+  (i64.store offset=8
+   (local.get $1)
+   (i64.load align=4
+    (i32.add
+     (local.get $0)
+     (i32.const 20)
+    )
+   )
+  )
+  (i64.store
+   (local.get $1)
+   (i64.load offset=12 align=4
+    (local.get $0)
+   )
+  )
+  (call $0)
+  (unreachable)
+ )
+ (func $2 (; 2 ;) (type $2) (param $0 i32)
+  (local $1 i32)
+  (local $2 i64)
+  (local $3 i64)
+  (local $4 i64)
+  (global.set $global$0
+   (local.tee $1
+    (i32.sub
+     (global.get $global$0)
+     (i32.const 48)
+    )
+   )
+  )
+  (local.set $2
+   (i64.load offset=8 align=4
+    (local.get $0)
+   )
+  )
+  (local.set $3
+   (i64.load offset=16 align=4
+    (local.get $0)
+   )
+  )
+  (local.set $4
+   (i64.load align=4
+    (local.get $0)
+   )
+  )
+  (i32.store
+   (i32.add
+    (local.get $1)
+    (i32.const 20)
+   )
+   (i32.const 0)
+  )
+  (i64.store offset=24
+   (local.get $1)
+   (local.get $4)
+  )
+  (i32.store offset=16
+   (local.get $1)
+   (i32.const 1048656)
+  )
+  (i64.store offset=4 align=4
+   (local.get $1)
+   (i64.const 1)
+  )
+  (i32.store
+   (local.get $1)
+   (i32.add
+    (local.get $1)
+    (i32.const 24)
+   )
+  )
+  (i64.store offset=40
+   (local.get $1)
+   (local.get $3)
+  )
+  (i64.store offset=32
+   (local.get $1)
+   (local.get $2)
+  )
+  (call $5
+   (local.get $1)
+   (i32.add
+    (local.get $1)
+    (i32.const 32)
+   )
+  )
+  (unreachable)
+ )
+ (func $3 (; 3 ;) (type $8) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (global.set $global$0
+   (local.tee $2
+    (i32.sub
+     (global.get $global$0)
+     (i32.const 48)
+    )
+   )
+  )
+  (i32.store offset=4
+   (local.get $2)
+   (i32.const 16)
+  )
+  (i32.store
+   (local.get $2)
+   (local.get $1)
+  )
+  (i32.store
+   (i32.add
+    (local.get $2)
+    (i32.const 44)
+   )
+   (i32.const 1)
+  )
+  (i32.store
+   (i32.add
+    (local.get $2)
+    (i32.const 28)
+   )
+   (i32.const 2)
+  )
+  (i32.store offset=36
+   (local.get $2)
+   (i32.const 1)
+  )
+  (i64.store offset=12 align=4
+   (local.get $2)
+   (i64.const 2)
+  )
+  (i32.store offset=8
+   (local.get $2)
+   (i32.const 1049140)
+  )
+  (i32.store offset=40
+   (local.get $2)
+   (local.get $2)
+  )
+  (i32.store offset=32
+   (local.get $2)
+   (i32.add
+    (local.get $2)
+    (i32.const 4)
+   )
+  )
+  (i32.store offset=24
+   (local.get $2)
+   (i32.add
+    (local.get $2)
+    (i32.const 32)
+   )
+  )
+  (call $5
+   (i32.add
+    (local.get $2)
+    (i32.const 8)
+   )
+   (local.get $0)
+  )
+  (unreachable)
+ )
+ (func $4 (; 4 ;) (type $1) (param $0 i32) (param $1 i32) (result i32)
+  (call $6
+   (i64.load32_u
+    (local.get $0)
+   )
+   (local.get $1)
+  )
+ )
+ (func $5 (; 5 ;) (type $4) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i64)
+  (global.set $global$0
+   (local.tee $2
+    (i32.sub
+     (global.get $global$0)
+     (i32.const 32)
+    )
+   )
+  )
+  (local.set $3
+   (i64.load align=4
+    (local.get $1)
+   )
+  )
+  (i64.store align=4
+   (i32.add
+    (local.get $2)
+    (i32.const 20)
+   )
+   (i64.load offset=8 align=4
+    (local.get $1)
+   )
+  )
+  (i64.store offset=12 align=4
+   (local.get $2)
+   (local.get $3)
+  )
+  (i32.store offset=8
+   (local.get $2)
+   (local.get $0)
+  )
+  (i32.store offset=4
+   (local.get $2)
+   (i32.const 1049156)
+  )
+  (i32.store
+   (local.get $2)
+   (i32.const 1048656)
+  )
+  (call $1
+   (local.get $2)
+  )
+  (unreachable)
+ )
+ (func $6 (; 6 ;) (type $5) (param $0 i64) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i64)
+  (local $14 i32)
+  (local $15 i32)
+  (global.set $global$0
+   (local.tee $6
+    (i32.sub
+     (global.get $global$0)
+     (i32.const 48)
+    )
+   )
+  )
+  (local.set $2
+   (i32.const 39)
+  )
+  (block $label$1
+   (block $label$2
+    (if
+     (i64.ge_u
+      (local.get $0)
+      (i64.const 10000)
+     )
+     (block
+      (loop $label$4
+       (i32.store16 align=1
+        (i32.add
+         (local.tee $3
+          (i32.add
+           (i32.add
+            (local.get $6)
+            (i32.const 9)
+           )
+           (local.get $2)
+          )
+         )
+         (i32.const -4)
+        )
+        (i32.load16_u align=1
+         (i32.add
+          (i32.shl
+           (local.tee $5
+            (i32.div_u
+             (local.tee $4
+              (i32.wrap_i64
+               (i64.add
+                (local.get $0)
+                (i64.mul
+                 (local.tee $13
+                  (i64.div_u
+                   (local.get $0)
+                   (i64.const 10000)
+                  )
+                 )
+                 (i64.const -10000)
+                )
+               )
+              )
+             )
+             (i32.const 100)
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.const 1048706)
+         )
+        )
+       )
+       (i32.store16 align=1
+        (i32.add
+         (local.get $3)
+         (i32.const -2)
+        )
+        (i32.load16_u align=1
+         (i32.add
+          (i32.shl
+           (i32.add
+            (i32.mul
+             (local.get $5)
+             (i32.const -100)
+            )
+            (local.get $4)
+           )
+           (i32.const 1)
+          )
+          (i32.const 1048706)
+         )
+        )
+       )
+       (local.set $2
+        (i32.add
+         (local.get $2)
+         (i32.const -4)
+        )
+       )
+       (br_if $label$4
+        (block (result i32)
+         (local.set $14
+          (i64.gt_u
+           (local.get $0)
+           (i64.const 99999999)
+          )
+         )
+         (local.set $0
+          (local.get $13)
+         )
+         (local.get $14)
+        )
+       )
+      )
+      (br_if $label$1
+       (i32.le_s
+        (local.tee $3
+         (i32.wrap_i64
+          (local.get $13)
+         )
+        )
+        (i32.const 99)
+       )
+      )
+      (br $label$2)
+     )
+    )
+    (br_if $label$1
+     (i32.le_s
+      (local.tee $3
+       (i32.wrap_i64
+        (local.tee $13
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 99)
+     )
+    )
+   )
+   (i32.store16 align=1
+    (i32.add
+     (local.tee $2
+      (i32.add
+       (local.get $2)
+       (i32.const -2)
+      )
+     )
+     (i32.add
+      (local.get $6)
+      (i32.const 9)
+     )
+    )
+    (i32.load16_u align=1
+     (i32.add
+      (i32.shl
+       (i32.and
+        (i32.add
+         (i32.mul
+          (local.tee $3
+           (i32.div_u
+            (i32.and
+             (local.tee $4
+              (i32.wrap_i64
+               (local.get $13)
+              )
+             )
+             (i32.const 65535)
+            )
+            (i32.const 100)
+           )
+          )
+          (i32.const -100)
+         )
+         (local.get $4)
+        )
+        (i32.const 65535)
+       )
+       (i32.const 1)
+      )
+      (i32.const 1048706)
+     )
+    )
+   )
+  )
+  (block $label$5
+   (if
+    (i32.le_s
+     (local.get $3)
+     (i32.const 9)
+    )
+    (block
+     (i32.store8
+      (i32.add
+       (local.tee $2
+        (i32.add
+         (local.get $2)
+         (i32.const -1)
+        )
+       )
+       (i32.add
+        (local.get $6)
+        (i32.const 9)
+       )
+      )
+      (i32.add
+       (local.get $3)
+       (i32.const 48)
+      )
+     )
+     (br $label$5)
+    )
+   )
+   (i32.store16 align=1
+    (i32.add
+     (local.tee $2
+      (i32.add
+       (local.get $2)
+       (i32.const -2)
+      )
+     )
+     (i32.add
+      (local.get $6)
+      (i32.const 9)
+     )
+    )
+    (i32.load16_u align=1
+     (i32.add
+      (i32.shl
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.const 1048706)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (i32.sub
+    (i32.const 39)
+    (local.get $2)
+   )
+  )
+  (local.set $3
+   (i32.const 1)
+  )
+  (local.set $8
+   (select
+    (i32.const 43)
+    (i32.const 1114112)
+    (local.tee $11
+     (i32.and
+      (local.tee $4
+       (i32.load
+        (local.get $1)
+       )
+      )
+      (i32.const 1)
+     )
+    )
+   )
+  )
+  (local.set $9
+   (i32.and
+    (i32.shr_s
+     (i32.shl
+      (local.get $4)
+      (i32.const 29)
+     )
+     (i32.const 31)
+    )
+    (i32.const 1048656)
+   )
+  )
+  (local.set $10
+   (i32.add
+    (i32.add
+     (local.get $6)
+     (i32.const 9)
+    )
+    (local.get $2)
+   )
+  )
+  (block $label$7
+   (block $label$8
+    (block $label$9
+     (block $label$10
+      (block $label$11
+       (block $label$12
+        (block $label$13
+         (block $label$14
+          (local.set $3
+           (block $label$15 (result i32)
+            (block $label$16
+             (block $label$17
+              (block $label$18
+               (block $label$19
+                (if
+                 (i32.eq
+                  (i32.load offset=8
+                   (local.get $1)
+                  )
+                  (i32.const 1)
+                 )
+                 (block
+                  (br_if $label$19
+                   (i32.le_u
+                    (local.tee $5
+                     (i32.load
+                      (i32.add
+                       (local.get $1)
+                       (i32.const 12)
+                      )
+                     )
+                    )
+                    (local.tee $2
+                     (i32.add
+                      (local.get $7)
+                      (local.get $11)
+                     )
+                    )
+                   )
+                  )
+                  (br_if $label$18
+                   (i32.and
+                    (local.get $4)
+                    (i32.const 8)
+                   )
+                  )
+                  (local.set $4
+                   (i32.sub
+                    (local.get $5)
+                    (local.get $2)
+                   )
+                  )
+                  (br_if $label$17
+                   (i32.eqz
+                    (i32.and
+                     (local.tee $3
+                      (select
+                       (i32.const 1)
+                       (local.tee $3
+                        (i32.load8_u offset=48
+                         (local.get $1)
+                        )
+                       )
+                       (i32.eq
+                        (local.get $3)
+                        (i32.const 3)
+                       )
+                      )
+                     )
+                     (i32.const 3)
+                    )
+                   )
+                  )
+                  (br_if $label$16
+                   (i32.eq
+                    (local.get $3)
+                    (i32.const 2)
+                   )
+                  )
+                  (local.set $5
+                   (i32.const 0)
+                  )
+                  (br $label$15
+                   (local.get $4)
+                  )
+                 )
+                )
+                (br_if $label$9
+                 (call $9
+                  (local.get $1)
+                  (local.get $8)
+                  (local.get $9)
+                 )
+                )
+                (br $label$8)
+               )
+               (br_if $label$9
+                (call $9
+                 (local.get $1)
+                 (local.get $8)
+                 (local.get $9)
+                )
+               )
+               (br $label$8)
+              )
+              (i32.store8 offset=48
+               (local.get $1)
+               (i32.const 1)
+              )
+              (i32.store offset=4
+               (local.get $1)
+               (i32.const 48)
+              )
+              (br_if $label$9
+               (call $9
+                (local.get $1)
+                (local.get $8)
+                (local.get $9)
+               )
+              )
+              (local.set $3
+               (i32.sub
+                (local.get $5)
+                (local.get $2)
+               )
+              )
+              (br_if $label$14
+               (i32.eqz
+                (i32.and
+                 (local.tee $4
+                  (select
+                   (i32.const 1)
+                   (local.tee $4
+                    (i32.load8_u
+                     (i32.add
+                      (local.get $1)
+                      (i32.const 48)
+                     )
+                    )
+                   )
+                   (i32.eq
+                    (local.get $4)
+                    (i32.const 3)
+                   )
+                  )
+                 )
+                 (i32.const 3)
+                )
+               )
+              )
+              (br_if $label$13
+               (i32.eq
+                (local.get $4)
+                (i32.const 2)
+               )
+              )
+              (local.set $4
+               (i32.const 0)
+              )
+              (br $label$12)
+             )
+             (local.set $5
+              (local.get $4)
+             )
+             (br $label$15
+              (i32.const 0)
+             )
+            )
+            (local.set $5
+             (i32.shr_u
+              (i32.add
+               (local.get $4)
+               (i32.const 1)
+              )
+              (i32.const 1)
+             )
+            )
+            (i32.shr_u
+             (local.get $4)
+             (i32.const 1)
+            )
+           )
+          )
+          (local.set $2
+           (i32.const -1)
+          )
+          (local.set $4
+           (i32.add
+            (local.get $1)
+            (i32.const 4)
+           )
+          )
+          (local.set $11
+           (i32.add
+            (local.get $1)
+            (i32.const 24)
+           )
+          )
+          (local.set $12
+           (i32.add
+            (local.get $1)
+            (i32.const 28)
+           )
+          )
+          (block $label$21
+           (loop $label$22
+            (br_if $label$21
+             (i32.ge_u
+              (local.tee $2
+               (i32.add
+                (local.get $2)
+                (i32.const 1)
+               )
+              )
+              (local.get $3)
+             )
+            )
+            (br_if $label$22
+             (i32.eqz
+              (call_indirect (type $1)
+               (i32.load
+                (local.get $11)
+               )
+               (i32.load
+                (local.get $4)
+               )
+               (i32.load offset=16
+                (i32.load
+                 (local.get $12)
+                )
+               )
+              )
+             )
+            )
+           )
+           (br $label$7)
+          )
+          (local.set $4
+           (i32.load
+            (i32.add
+             (local.get $1)
+             (i32.const 4)
+            )
+           )
+          )
+          (local.set $3
+           (i32.const 1)
+          )
+          (br_if $label$9
+           (call $9
+            (local.get $1)
+            (local.get $8)
+            (local.get $9)
+           )
+          )
+          (br_if $label$9
+           (call_indirect (type $0)
+            (i32.load
+             (local.tee $2
+              (i32.add
+               (local.get $1)
+               (i32.const 24)
+              )
+             )
+            )
+            (local.get $10)
+            (local.get $7)
+            (i32.load offset=12
+             (i32.load
+              (local.tee $1
+               (i32.add
+                (local.get $1)
+                (i32.const 28)
+               )
+              )
+             )
+            )
+           )
+          )
+          (local.set $7
+           (i32.load
+            (local.get $2)
+           )
+          )
+          (local.set $2
+           (i32.const -1)
+          )
+          (local.set $1
+           (i32.add
+            (i32.load
+             (local.get $1)
+            )
+            (i32.const 16)
+           )
+          )
+          (loop $label$23
+           (br_if $label$11
+            (i32.ge_u
+             (local.tee $2
+              (i32.add
+               (local.get $2)
+               (i32.const 1)
+              )
+             )
+             (local.get $5)
+            )
+           )
+           (br_if $label$23
+            (i32.eqz
+             (call_indirect (type $1)
+              (local.get $7)
+              (local.get $4)
+              (i32.load
+               (local.get $1)
+              )
+             )
+            )
+           )
+          )
+          (br $label$9)
+         )
+         (local.set $4
+          (local.get $3)
+         )
+         (local.set $3
+          (i32.const 0)
+         )
+         (br $label$12)
+        )
+        (local.set $4
+         (i32.shr_u
+          (i32.add
+           (local.get $3)
+           (i32.const 1)
+          )
+          (i32.const 1)
+         )
+        )
+        (local.set $3
+         (i32.shr_u
+          (local.get $3)
+          (i32.const 1)
+         )
+        )
+       )
+       (local.set $2
+        (i32.const -1)
+       )
+       (local.set $5
+        (i32.add
+         (local.get $1)
+         (i32.const 4)
+        )
+       )
+       (local.set $8
+        (i32.add
+         (local.get $1)
+         (i32.const 24)
+        )
+       )
+       (local.set $9
+        (i32.add
+         (local.get $1)
+         (i32.const 28)
+        )
+       )
+       (block $label$24
+        (loop $label$25
+         (br_if $label$24
+          (i32.ge_u
+           (local.tee $2
+            (i32.add
+             (local.get $2)
+             (i32.const 1)
+            )
+           )
+           (local.get $3)
+          )
+         )
+         (br_if $label$25
+          (i32.eqz
+           (call_indirect (type $1)
+            (i32.load
+             (local.get $8)
+            )
+            (i32.load
+             (local.get $5)
+            )
+            (i32.load offset=16
+             (i32.load
+              (local.get $9)
+             )
+            )
+           )
+          )
+         )
+        )
+        (br $label$7)
+       )
+       (local.set $5
+        (i32.load
+         (i32.add
+          (local.get $1)
+          (i32.const 4)
+         )
+        )
+       )
+       (local.set $3
+        (i32.const 1)
+       )
+       (br_if $label$9
+        (call_indirect (type $0)
+         (i32.load
+          (local.tee $2
+           (i32.add
+            (local.get $1)
+            (i32.const 24)
+           )
+          )
+         )
+         (local.get $10)
+         (local.get $7)
+         (i32.load offset=12
+          (i32.load
+           (local.tee $1
+            (i32.add
+             (local.get $1)
+             (i32.const 28)
+            )
+           )
+          )
+         )
+        )
+       )
+       (local.set $7
+        (i32.load
+         (local.get $2)
+        )
+       )
+       (local.set $2
+        (i32.const -1)
+       )
+       (local.set $1
+        (i32.add
+         (i32.load
+          (local.get $1)
+         )
+         (i32.const 16)
+        )
+       )
+       (loop $label$26
+        (br_if $label$10
+         (i32.ge_u
+          (local.tee $2
+           (i32.add
+            (local.get $2)
+            (i32.const 1)
+           )
+          )
+          (local.get $4)
+         )
+        )
+        (br_if $label$26
+         (i32.eqz
+          (call_indirect (type $1)
+           (local.get $7)
+           (local.get $5)
+           (i32.load
+            (local.get $1)
+           )
+          )
+         )
+        )
+       )
+       (br $label$9)
+      )
+      (global.set $global$0
+       (i32.add
+        (local.get $6)
+        (i32.const 48)
+       )
+      )
+      (return
+       (i32.const 0)
+      )
+     )
+     (local.set $3
+      (i32.const 0)
+     )
+    )
+    (global.set $global$0
+     (i32.add
+      (local.get $6)
+      (i32.const 48)
+     )
+    )
+    (return
+     (local.get $3)
+    )
+   )
+   (return
+    (block (result i32)
+     (local.set $15
+      (call_indirect (type $0)
+       (i32.load offset=24
+        (local.get $1)
+       )
+       (local.get $10)
+       (local.get $7)
+       (i32.load offset=12
+        (i32.load
+         (i32.add
+          (local.get $1)
+          (i32.const 28)
+         )
+        )
+       )
+      )
+     )
+     (global.set $global$0
+      (i32.add
+       (local.get $6)
+       (i32.const 48)
+      )
+     )
+     (local.get $15)
+    )
+   )
+  )
+  (global.set $global$0
+   (i32.add
+    (local.get $6)
+    (i32.const 48)
+   )
+  )
+  (i32.const 1)
+ )
+ (func $7 (; 7 ;) (type $2) (param $0 i32)
+  (nop)
+ )
+ (func $8 (; 8 ;) (type $6) (param $0 i32) (result i64)
+  (i64.const -2357177763932378009)
+ )
+ (func $9 (; 9 ;) (type $9) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (block $label$1
+   (return
+    (block $label$2 (result i32)
+     (if
+      (i32.ne
+       (local.get $1)
+       (i32.const 1114112)
+      )
+      (drop
+       (br_if $label$2
+        (i32.const 1)
+        (call_indirect (type $1)
+         (i32.load offset=24
+          (local.get $0)
+         )
+         (local.get $1)
+         (i32.load offset=16
+          (i32.load
+           (i32.add
+            (local.get $0)
+            (i32.const 28)
+           )
+          )
+         )
+        )
+       )
+      )
+     )
+     (br_if $label$1
+      (i32.eqz
+       (local.get $2)
+      )
+     )
+     (call_indirect (type $0)
+      (i32.load offset=24
+       (local.get $0)
+      )
+      (local.get $2)
+      (i32.const 0)
+      (i32.load offset=12
+       (i32.load
+        (i32.add
+         (local.get $0)
+         (i32.const 28)
+        )
+       )
+      )
+     )
+    )
+   )
+  )
+  (i32.const 0)
+ )
+ (func $10 (; 10 ;) (type $3) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (global.set $global$0
+   (local.tee $1
+    (i32.sub
+     (global.get $global$0)
+     (i32.const 256)
+    )
+   )
+  )
+  (i64.store offset=56 align=4
+   (local.get $1)
+   (i64.const 4294967297)
+  )
+  (i64.store offset=48 align=4
+   (local.get $1)
+   (i64.const 4294967297)
+  )
+  (i64.store offset=40 align=4
+   (local.get $1)
+   (i64.const 4294967297)
+  )
+  (i64.store offset=32 align=4
+   (local.get $1)
+   (i64.const 4294967297)
+  )
+  (i64.store offset=24 align=4
+   (local.get $1)
+   (i64.const 4294967297)
+  )
+  (i64.store offset=16 align=4
+   (local.get $1)
+   (i64.const 4294967297)
+  )
+  (i64.store offset=8 align=4
+   (local.get $1)
+   (i64.const 4294967297)
+  )
+  (i64.store align=4
+   (local.get $1)
+   (i64.const 4294967297)
+  )
+  (block $label$1
+   (if
+    (i32.ge_u
+     (local.tee $11
+      (i32.add
+       (local.get $0)
+       (i32.const 1)
+      )
+     )
+     (i32.const 2)
+    )
+    (block
+     (local.set $3
+      (local.get $1)
+     )
+     (local.set $2
+      (i32.const 1)
+     )
+     (loop $label$3
+      (br_if $label$1
+       (i32.ge_u
+        (local.get $2)
+        (i32.const 16)
+       )
+      )
+      (i32.store
+       (local.tee $4
+        (i32.add
+         (local.get $3)
+         (i32.const 4)
+        )
+       )
+       (i32.mul
+        (i32.load
+         (local.get $3)
+        )
+        (local.get $2)
+       )
+      )
+      (local.set $3
+       (local.get $4)
+      )
+      (local.set $2
+       (local.tee $4
+        (i32.add
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+      )
+      (br_if $label$3
+       (i32.lt_u
+        (local.get $4)
+        (local.get $11)
+       )
+      )
+     )
+    )
+   )
+   (if
+    (i32.lt_u
+     (local.get $0)
+     (i32.const 16)
+    )
+    (block
+     (local.set $20
+      (i32.const 1)
+     )
+     (local.set $21
+      (local.tee $9
+       (i32.load
+        (i32.add
+         (local.get $1)
+         (i32.shl
+          (local.get $0)
+          (i32.const 2)
+         )
+        )
+       )
+      )
+     )
+     (if
+      (i32.ge_u
+       (local.get $9)
+       (i32.const 24)
+      )
+      (local.set $20
+       (select
+        (i32.const 24)
+        (i32.const 25)
+        (i32.eq
+         (local.get $9)
+         (i32.mul
+          (local.tee $21
+           (i32.div_u
+            (local.get $9)
+            (i32.const 24)
+           )
+          )
+          (i32.const 24)
+         )
+        )
+       )
+      )
+     )
+     (local.set $40
+      (i32.sub
+       (i32.const 0)
+       (local.get $0)
+      )
+     )
+     (local.set $12
+      (i32.add
+       (local.get $1)
+       (i32.const 196)
+      )
+     )
+     (local.set $41
+      (i32.add
+       (local.get $1)
+       (i32.const 132)
+      )
+     )
+     (local.set $42
+      (i32.add
+       (local.get $1)
+       (i32.const 124)
+      )
+     )
+     (local.set $11
+      (i32.add
+       (local.get $1)
+       (i32.const 68)
+      )
+     )
+     (local.set $43
+      (i32.lt_u
+       (local.get $0)
+       (i32.const 2)
+      )
+     )
+     (loop $label$6
+      (i64.store
+       (i32.add
+        (local.get $1)
+        (i32.const 120)
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (i32.add
+        (local.get $1)
+        (i32.const 112)
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (i32.add
+        (local.get $1)
+        (i32.const 104)
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (i32.add
+        (local.get $1)
+        (i32.const 96)
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (i32.add
+        (local.get $1)
+        (i32.const 88)
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (i32.add
+        (local.get $1)
+        (i32.const 80)
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (i32.add
+        (local.get $1)
+        (i32.const 72)
+       )
+       (i64.const 0)
+      )
+      (i64.store offset=64
+       (local.get $1)
+       (i64.const 0)
+      )
+      (i64.store
+       (local.tee $26
+        (i32.add
+         (local.get $1)
+         (i32.const 184)
+        )
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (local.tee $27
+        (i32.add
+         (local.get $1)
+         (i32.const 176)
+        )
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (local.tee $28
+        (i32.add
+         (local.get $1)
+         (i32.const 168)
+        )
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (local.tee $29
+        (i32.add
+         (local.get $1)
+         (i32.const 160)
+        )
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (local.tee $30
+        (i32.add
+         (local.get $1)
+         (i32.const 152)
+        )
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (local.tee $31
+        (i32.add
+         (local.get $1)
+         (i32.const 144)
+        )
+       )
+       (i64.const 0)
+      )
+      (i64.store
+       (local.tee $32
+        (i32.add
+         (local.get $1)
+         (i32.const 136)
+        )
+       )
+       (i64.const 0)
+      )
+      (i64.store offset=128
+       (local.get $1)
+       (i64.const 0)
+      )
+      (i64.store align=4
+       (local.tee $33
+        (i32.add
+         (local.get $1)
+         (i32.const 248)
+        )
+       )
+       (i64.const 64424509454)
+      )
+      (i64.store align=4
+       (local.tee $34
+        (i32.add
+         (local.get $1)
+         (i32.const 240)
+        )
+       )
+       (i64.const 55834574860)
+      )
+      (i64.store align=4
+       (local.tee $35
+        (i32.add
+         (local.get $1)
+         (i32.const 232)
+        )
+       )
+       (i64.const 47244640266)
+      )
+      (i64.store align=4
+       (local.tee $36
+        (i32.add
+         (local.get $1)
+         (i32.const 224)
+        )
+       )
+       (i64.const 38654705672)
+      )
+      (i64.store align=4
+       (local.tee $37
+        (i32.add
+         (local.get $1)
+         (i32.const 216)
+        )
+       )
+       (i64.const 30064771078)
+      )
+      (i64.store align=4
+       (local.tee $38
+        (i32.add
+         (local.get $1)
+         (i32.const 208)
+        )
+       )
+       (i64.const 21474836484)
+      )
+      (i64.store align=4
+       (local.tee $39
+        (i32.add
+         (local.get $1)
+         (i32.const 200)
+        )
+       )
+       (i64.const 12884901890)
+      )
+      (i64.store offset=192 align=4
+       (local.get $1)
+       (i64.const 4294967296)
+      )
+      (local.set $7
+       (i32.mul
+        (local.get $13)
+        (local.get $21)
+       )
+      )
+      (local.set $2
+       (block $label$7 (result i32)
+        (block $label$8
+         (if
+          (i32.eqz
+           (local.get $43)
+          )
+          (block
+           (local.set $23
+            (local.get $40)
+           )
+           (local.set $14
+            (local.get $7)
+           )
+           (local.set $15
+            (local.get $0)
+           )
+           (local.set $5
+            (i32.const 0)
+           )
+           (br $label$8)
+          )
+         )
+         (br $label$7
+          (i32.const 0)
+         )
+        )
+        (i32.const 1)
+       )
+      )
+      (loop $label$10
+       (block $label$11
+        (block $label$12
+         (local.set $2
+          (block $label$13 (result i32)
+           (block $label$14
+            (block $label$15
+             (block $label$16
+              (block $label$17
+               (block $label$18
+                (block $label$19
+                 (if
+                  (i32.eqz
+                   (local.get $2)
+                  )
+                  (block
+                   (local.set $13
+                    (i32.add
+                     (local.get $13)
+                     (i32.const 1)
+                    )
+                   )
+                   (local.set $44
+                    (i32.add
+                     (select
+                      (local.get $9)
+                      (local.tee $3
+                       (i32.add
+                        (local.get $7)
+                        (local.get $21)
+                       )
+                      )
+                      (i32.gt_u
+                       (local.get $3)
+                       (local.get $9)
+                      )
+                     )
+                     (i32.const -1)
+                    )
+                   )
+                   (local.set $24
+                    (i32.const 0)
+                   )
+                   (br_if $label$19
+                    (i32.ge_s
+                     (local.tee $6
+                      (i32.load offset=192
+                       (local.get $1)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                   )
+                   (br $label$18)
+                  )
+                 )
+                 (block $label$21
+                  (block $label$22
+                   (block $label$23
+                    (block $label$24
+                     (block $label$25
+                      (block $label$26
+                       (block $label$27
+                        (block $label$28
+                         (block $label$29
+                          (block $label$30
+                           (block $label$31
+                            (br_table $label$31 $label$30 $label$29
+                             (local.get $5)
+                            )
+                           )
+                           (br_if $label$24
+                            (i32.ge_u
+                             (local.tee $4
+                              (i32.add
+                               (local.get $15)
+                               (i32.const -1)
+                              )
+                             )
+                             (i32.const 16)
+                            )
+                           )
+                           (br_if $label$23
+                            (i32.eqz
+                             (local.tee $3
+                              (i32.load
+                               (i32.add
+                                (local.get $1)
+                                (local.tee $2
+                                 (i32.shl
+                                  (local.get $4)
+                                  (i32.const 2)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                            )
+                           )
+                           (if
+                            (i32.eq
+                             (local.get $14)
+                             (i32.const -2147483648)
+                            )
+                            (br_if $label$22
+                             (i32.eq
+                              (local.get $3)
+                              (i32.const -1)
+                             )
+                            )
+                           )
+                           (i32.store
+                            (i32.add
+                             (i32.sub
+                              (local.get $1)
+                              (i32.const -64)
+                             )
+                             (local.get $2)
+                            )
+                            (local.tee $16
+                             (i32.div_s
+                              (local.get $14)
+                              (local.get $3)
+                             )
+                            )
+                           )
+                           (i64.store
+                            (local.get $32)
+                            (i64.load align=4
+                             (local.get $39)
+                            )
+                           )
+                           (i64.store
+                            (local.get $31)
+                            (i64.load align=4
+                             (local.get $38)
+                            )
+                           )
+                           (i64.store
+                            (local.get $30)
+                            (i64.load align=4
+                             (local.get $37)
+                            )
+                           )
+                           (i64.store
+                            (local.get $29)
+                            (i64.load align=4
+                             (local.get $36)
+                            )
+                           )
+                           (i64.store
+                            (local.get $28)
+                            (i64.load align=4
+                             (local.get $35)
+                            )
+                           )
+                           (i64.store
+                            (local.get $27)
+                            (i64.load align=4
+                             (local.get $34)
+                            )
+                           )
+                           (i64.store
+                            (local.get $26)
+                            (i64.load align=4
+                             (local.get $33)
+                            )
+                           )
+                           (i64.store offset=128
+                            (local.get $1)
+                            (i64.load offset=192 align=4
+                             (local.get $1)
+                            )
+                           )
+                           (local.set $45
+                            (i32.add
+                             (local.get $16)
+                             (local.get $23)
+                            )
+                           )
+                           (local.set $14
+                            (i32.sub
+                             (local.get $14)
+                             (i32.mul
+                              (local.get $3)
+                              (local.get $16)
+                             )
+                            )
+                           )
+                           (local.set $2
+                            (i32.const 0)
+                           )
+                           (local.set $8
+                            (i32.add
+                             (local.get $1)
+                             (i32.const 192)
+                            )
+                           )
+                           (loop $label$33
+                            (block $label$34
+                             (if
+                              (i32.gt_u
+                               (local.tee $3
+                                (i32.add
+                                 (local.get $2)
+                                 (local.get $16)
+                                )
+                               )
+                               (local.get $4)
+                              )
+                              (block
+                               (br_if $label$27
+                                (i32.gt_u
+                                 (local.tee $46
+                                  (i32.add
+                                   (local.get $2)
+                                   (local.get $45)
+                                  )
+                                 )
+                                 (i32.const 15)
+                                )
+                               )
+                               (local.set $3
+                                (i32.sub
+                                 (local.get $3)
+                                 (local.get $15)
+                                )
+                               )
+                               (br_if $label$34
+                                (i32.le_u
+                                 (local.get $2)
+                                 (i32.const 15)
+                                )
+                               )
+                               (br $label$28)
+                              )
+                             )
+                             (br_if $label$26
+                              (i32.ge_u
+                               (local.get $3)
+                               (i32.const 16)
+                              )
+                             )
+                             (br_if $label$28
+                              (i32.gt_u
+                               (local.get $2)
+                               (i32.const 15)
+                              )
+                             )
+                            )
+                            (i32.store
+                             (local.get $8)
+                             (i32.load
+                              (i32.add
+                               (i32.add
+                                (local.get $1)
+                                (i32.const 128)
+                               )
+                               (i32.shl
+                                (local.get $3)
+                                (i32.const 2)
+                               )
+                              )
+                             )
+                            )
+                            (local.set $8
+                             (i32.add
+                              (local.get $8)
+                              (i32.const 4)
+                             )
+                            )
+                            (br_if $label$33
+                             (i32.lt_u
+                              (local.tee $2
+                               (i32.add
+                                (local.get $2)
+                                (i32.const 1)
+                               )
+                              )
+                              (local.get $15)
+                             )
+                            )
+                           )
+                           (local.set $23
+                            (i32.add
+                             (local.get $23)
+                             (i32.const 1)
+                            )
+                           )
+                           (br_if $label$21
+                            (i32.gt_u
+                             (local.tee $15
+                              (local.get $4)
+                             )
+                             (i32.const 1)
+                            )
+                           )
+                           (local.set $2
+                            (i32.const 0)
+                           )
+                           (br $label$10)
+                          )
+                          (i64.store
+                           (local.get $26)
+                           (i64.load align=4
+                            (local.get $33)
+                           )
+                          )
+                          (i64.store
+                           (local.get $27)
+                           (i64.load align=4
+                            (local.get $34)
+                           )
+                          )
+                          (i64.store
+                           (local.get $28)
+                           (i64.load align=4
+                            (local.get $35)
+                           )
+                          )
+                          (i64.store
+                           (local.get $29)
+                           (i64.load align=4
+                            (local.get $36)
+                           )
+                          )
+                          (i64.store
+                           (local.get $30)
+                           (i64.load align=4
+                            (local.get $37)
+                           )
+                          )
+                          (i64.store
+                           (local.get $31)
+                           (i64.load align=4
+                            (local.get $38)
+                           )
+                          )
+                          (i64.store
+                           (local.get $32)
+                           (i64.load align=4
+                            (local.get $39)
+                           )
+                          )
+                          (i64.store offset=128
+                           (local.get $1)
+                           (i64.load offset=192 align=4
+                            (local.get $1)
+                           )
+                          )
+                          (br_if $label$25
+                           (i32.gt_u
+                            (local.get $6)
+                            (i32.const 15)
+                           )
+                          )
+                          (local.set $17
+                           (i32.const 1)
+                          )
+                          (local.set $10
+                           (local.get $6)
+                          )
+                          (br $label$13
+                           (i32.const 0)
+                          )
+                         )
+                         (if
+                          (i32.lt_u
+                           (local.get $7)
+                           (local.get $44)
+                          )
+                          (block
+                           (local.set $25
+                            (i32.load
+                             (local.get $12)
+                            )
+                           )
+                           (i32.store
+                            (local.get $12)
+                            (local.get $6)
+                           )
+                           (i32.store offset=192
+                            (local.get $1)
+                            (local.get $25)
+                           )
+                           (local.set $18
+                            (local.get $11)
+                           )
+                           (br_if $label$11
+                            (i32.lt_s
+                             (local.tee $2
+                              (i32.load offset=68
+                               (local.get $1)
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                           )
+                           (local.set $19
+                            (i32.const 1)
+                           )
+                           (br $label$14)
+                          )
+                         )
+                         (local.set $22
+                          (i32.add
+                           (local.get $22)
+                           (local.get $24)
+                          )
+                         )
+                         (br_if $label$6
+                          (i32.lt_u
+                           (local.get $13)
+                           (local.get $20)
+                          )
+                         )
+                         (global.set $global$0
+                          (i32.add
+                           (local.get $1)
+                           (i32.const 256)
+                          )
+                         )
+                         (return
+                          (local.get $22)
+                         )
+                        )
+                        (call $3
+                         (i32.const 1049076)
+                         (local.get $2)
+                        )
+                        (unreachable)
+                       )
+                       (call $3
+                        (i32.const 1049060)
+                        (local.get $46)
+                       )
+                       (unreachable)
+                      )
+                      (call $3
+                       (i32.const 1049044)
+                       (i32.add
+                        (local.get $2)
+                        (local.get $16)
+                       )
+                      )
+                      (unreachable)
+                     )
+                     (local.set $10
+                      (local.get $6)
+                     )
+                     (br $label$12)
+                    )
+                    (call $3
+                     (i32.const 1048980)
+                     (local.get $4)
+                    )
+                    (unreachable)
+                   )
+                   (call $2
+                    (i32.const 1048996)
+                   )
+                   (unreachable)
+                  )
+                  (call $2
+                   (i32.const 1049020)
+                  )
+                  (unreachable)
+                 )
+                 (local.set $5
+                  (i32.const 0)
+                 )
+                 (br $label$17)
+                )
+                (local.set $5
+                 (i32.const 1)
+                )
+                (br $label$16)
+               )
+               (local.set $5
+                (i32.const 2)
+               )
+               (br $label$15)
+              )
+              (local.set $2
+               (i32.const 1)
+              )
+              (br $label$10)
+             )
+             (local.set $2
+              (i32.const 1)
+             )
+             (br $label$10)
+            )
+            (local.set $2
+             (i32.const 1)
+            )
+            (br $label$10)
+           )
+           (i32.const 1)
+          )
+         )
+         (loop $label$37
+          (block $label$38
+           (block $label$39
+            (if
+             (i32.eqz
+              (local.get $2)
+             )
+             (block
+              (if
+               (local.tee $10
+                (i32.load
+                 (local.tee $5
+                  (i32.add
+                   (local.tee $4
+                    (i32.shl
+                     (local.tee $3
+                      (local.get $10)
+                     )
+                     (i32.const 2)
+                    )
+                   )
+                   (i32.add
+                    (local.get $1)
+                    (i32.const 128)
+                   )
+                  )
+                 )
+                )
+               )
+               (block
+                (i32.store
+                 (local.get $5)
+                 (local.get $3)
+                )
+                (block $label$42
+                 (br_if $label$42
+                  (i32.lt_u
+                   (local.get $3)
+                   (i32.const 3)
+                  )
+                 )
+                 (br_if $label$42
+                  (i32.eqz
+                   (local.tee $8
+                    (i32.shr_u
+                     (i32.add
+                      (local.get $3)
+                      (i32.const -1)
+                     )
+                     (i32.const 1)
+                    )
+                   )
+                  )
+                 )
+                 (local.set $2
+                  (i32.add
+                   (local.get $4)
+                   (local.get $42)
+                  )
+                 )
+                 (local.set $3
+                  (local.get $41)
+                 )
+                 (loop $label$43
+                  (local.set $4
+                   (i32.load
+                    (local.get $3)
+                   )
+                  )
+                  (i32.store
+                   (local.get $3)
+                   (i32.load
+                    (local.get $2)
+                   )
+                  )
+                  (i32.store
+                   (local.get $2)
+                   (local.get $4)
+                  )
+                  (local.set $3
+                   (i32.add
+                    (local.get $3)
+                    (i32.const 4)
+                   )
+                  )
+                  (local.set $2
+                   (i32.add
+                    (local.get $2)
+                    (i32.const -4)
+                   )
+                  )
+                  (br_if $label$43
+                   (local.tee $8
+                    (i32.add
+                     (local.get $8)
+                     (i32.const -1)
+                    )
+                   )
+                  )
+                 )
+                )
+                (local.set $17
+                 (i32.add
+                  (local.get $17)
+                  (i32.const 1)
+                 )
+                )
+                (br_if $label$38
+                 (i32.lt_u
+                  (local.get $10)
+                  (i32.const 16)
+                 )
+                )
+                (br $label$12)
+               )
+              )
+              (local.set $24
+               (i32.add
+                (select
+                 (i32.sub
+                  (i32.const 0)
+                  (local.get $17)
+                 )
+                 (local.get $17)
+                 (i32.and
+                  (local.get $7)
+                  (i32.const 1)
+                 )
+                )
+                (local.get $24)
+               )
+              )
+              (local.set $5
+               (i32.const 2)
+              )
+              (br $label$39)
+             )
+            )
+            (local.set $2
+             (i32.const 0)
+            )
+            (i32.store
+             (local.get $18)
+             (i32.const 0)
+            )
+            (i32.store offset=192
+             (local.get $1)
+             (local.tee $4
+              (local.get $6)
+             )
+            )
+            (local.set $5
+             (i32.add
+              (local.get $19)
+              (i32.const 1)
+             )
+            )
+            (local.set $3
+             (local.get $12)
+            )
+            (block $label$44
+             (block $label$45
+              (loop $label$46
+               (br_if $label$45
+                (i32.ge_u
+                 (i32.add
+                  (local.get $2)
+                  (i32.const 2)
+                 )
+                 (i32.const 16)
+                )
+               )
+               (i32.store
+                (local.get $3)
+                (i32.load
+                 (local.tee $3
+                  (i32.add
+                   (local.get $3)
+                   (i32.const 4)
+                  )
+                 )
+                )
+               )
+               (br_if $label$46
+                (i32.lt_u
+                 (local.tee $2
+                  (i32.add
+                   (local.get $2)
+                   (i32.const 1)
+                  )
+                 )
+                 (local.get $19)
+                )
+               )
+              )
+              (br_if $label$44
+               (i32.ge_u
+                (local.get $5)
+                (i32.const 16)
+               )
+              )
+              (i32.store
+               (i32.add
+                (local.tee $3
+                 (i32.shl
+                  (local.get $5)
+                  (i32.const 2)
+                 )
+                )
+                (i32.add
+                 (local.get $1)
+                 (i32.const 192)
+                )
+               )
+               (local.get $25)
+              )
+              (br_if $label$11
+               (i32.le_s
+                (local.tee $2
+                 (i32.load
+                  (local.tee $18
+                   (i32.add
+                    (i32.sub
+                     (local.get $1)
+                     (i32.const -64)
+                    )
+                    (local.get $3)
+                   )
+                  )
+                 )
+                )
+                (local.get $19)
+               )
+              )
+              (local.set $6
+               (i32.load
+                (local.get $12)
+               )
+              )
+              (local.set $19
+               (local.get $5)
+              )
+              (local.set $25
+               (local.get $4)
+              )
+              (local.set $2
+               (i32.const 1)
+              )
+              (br $label$37)
+             )
+             (call $3
+              (i32.const 1049108)
+              (i32.add
+               (local.get $2)
+               (i32.const 2)
+              )
+             )
+             (unreachable)
+            )
+            (call $3
+             (i32.const 1049124)
+             (local.get $5)
+            )
+            (unreachable)
+           )
+           (local.set $2
+            (i32.const 1)
+           )
+           (br $label$10)
+          )
+          (local.set $2
+           (i32.const 0)
+          )
+          (br $label$37)
+         )
+        )
+        (call $3
+         (i32.const 1049092)
+         (local.get $10)
+        )
+        (unreachable)
+       )
+       (local.set $7
+        (i32.add
+         (local.get $7)
+         (i32.const 1)
+        )
+       )
+       (i32.store
+        (local.get $18)
+        (i32.add
+         (local.get $2)
+         (i32.const 1)
+        )
+       )
+       (block $label$47
+        (block $label$48
+         (if
+          (i32.ge_s
+           (local.tee $6
+            (i32.load offset=192
+             (local.get $1)
+            )
+           )
+           (i32.const 1)
+          )
+          (block
+           (local.set $5
+            (i32.const 1)
+           )
+           (br $label$48)
+          )
+         )
+         (local.set $5
+          (i32.const 2)
+         )
+         (br $label$47)
+        )
+        (local.set $2
+         (i32.const 1)
+        )
+        (br $label$10)
+       )
+       (local.set $2
+        (i32.const 1)
+       )
+       (br $label$10)
+      )
+     )
+    )
+   )
+   (call $3
+    (i32.const 1049212)
+    (local.get $0)
+   )
+   (unreachable)
+  )
+  (call $3
+   (i32.const 1049196)
+   (local.get $2)
+  )
+  (unreachable)
+ )
+)
+


### PR DESCRIPTION
It seems important to not break translation of large, existing, realistic wasm code bases when touching the translator. I propose to add some test cases in this PR, taken from [Embenchen](https://github.com/lars-t-hansen/embenchen) or [wasm-collection](https://github.com/sunfishcode/wasm-collection/tree/master/misc-valid), so they serve as large tests for translation. They all compile in less than 2.5 seconds on my machine with `cargo run wasm`, and would have helped catching stuff like #1132.

I think a next step would be to *compile* wasm test cases in automation, since we don't do this during testing. They would serve as large integration tests, again, but they're useful to have, in addition to all the unit test cases we're adding as we improve Cranelift.

Marking as WIP, because this won't pass automation right now :innocent:. 