### PR TITLE
Add x86 SIMD band_not and bitselect

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1982,6 +1982,10 @@ pub(crate) fn define<'defs>(
         let band = band.bind(vector(ty, sse_vector_size));
         e.enc_32_64(band, rec_fa.opcodes(&PAND));
 
+        // and not (note flipped recipe operands to match band_not order)
+        let band_not = band_not.bind(vector(ty, sse_vector_size));
+        e.enc_32_64(band_not, rec_fax.opcodes(&PANDN));
+
         // or
         let bor = bor.bind(vector(ty, sse_vector_size));
         e.enc_32_64(bor, rec_fa.opcodes(&POR));

--- a/cranelift-codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/opcodes.rs
@@ -266,6 +266,9 @@ pub static PADDUSW: [u8; 3] = [0x66, 0x0f, 0xdd];
 /// Bitwise AND of xmm2/m128 and xmm1 (SSE2).
 pub static PAND: [u8; 3] = [0x66, 0x0f, 0xdb];
 
+/// Bitwise AND NOT of xmm2/m128 and xmm1 (SSE2).
+pub static PANDN: [u8; 3] = [0x66, 0x0f, 0xdf];
+
 /// Compare packed data for equal (SSE2).
 pub static PCMPEQB: [u8; 3] = [0x66, 0x0f, 0x74];
 

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -1199,6 +1199,22 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
+    let c = &operand_doc("c", Any, "Controlling value to test");
+    ig.push(
+        Inst::new(
+            "bitselect",
+            r#"
+        Conditional select of bits.
+
+        For each bit in `c`, this instruction selects the corresponding bit from `x` if the bit 
+        in `c` is 1 and the corresponding bit from `y` if the bit in `c` is 0. See also: 
+        `select`, `vselect`.
+        "#,
+        )
+        .operands_in(vec![c, x, y])
+        .operands_out(vec![a]),
+    );
+
     let x = &operand("x", Any);
 
     ig.push(

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -1138,6 +1138,15 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let b_mod_bitwidth = builder.ins().band_imm(b, bitwidth - 1);
             state.push1(builder.ins().sshr(bitcast_a, b_mod_bitwidth))
         }
+        Operator::V128Bitselect => {
+            let (a, b, c) = state.pop3();
+            let bitcast_a = optionally_bitcast_vector(a, I8X16, builder);
+            let bitcast_b = optionally_bitcast_vector(b, I8X16, builder);
+            let bitcast_c = optionally_bitcast_vector(c, I8X16, builder);
+            // The CLIF operand ordering is slightly different and the types of all three
+            // operands must match (hence the bitcast).
+            state.push1(builder.ins().bitselect(bitcast_c, bitcast_a, bitcast_b))
+        }
         Operator::I8x16Eq
         | Operator::I8x16Ne
         | Operator::I8x16LtS
@@ -1180,7 +1189,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::F64x2Gt
         | Operator::F64x2Le
         | Operator::F64x2Ge
-        | Operator::V128Bitselect
         | Operator::I8x16AnyTrue
         | Operator::I8x16AllTrue
         | Operator::I8x16Shl

--- a/filetests/isa/x86/simd-bitwise-legalize.clif
+++ b/filetests/isa/x86/simd-bitwise-legalize.clif
@@ -31,3 +31,15 @@ ebb0:
     ; nextln: v2 = x86_psra v1, v3
     return v2
 }
+
+function %bitselect_i16x8() -> i16x8 {
+ebb0:
+    v0 = vconst.i16x8 [0 0 0 0 0 0 0 0]
+    v1 = vconst.i16x8 [0 0 0 0 0 0 0 0]
+    v2 = vconst.i16x8 [0 0 0 0 0 0 0 0]
+    v3 = bitselect v0, v1, v2
+    ; check: v4 = band v1, v0
+    ; nextln: v5 = band_not v2, v0
+    ; nextln: v3 = bor v4, v5
+    return v3
+}

--- a/filetests/isa/x86/simd-bitwise-run.clif
+++ b/filetests/isa/x86/simd-bitwise-run.clif
@@ -105,3 +105,25 @@ ebb0:
     return v7
 }
 ; run
+
+function %bitselect_i8x16() -> b1 {
+ebb0:
+    v0 = vconst.i8x16 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 255]  ; the selector vector
+    v1 = vconst.i8x16 [127 0 0 0 0 0 0 0 0 0 0 0 0 0 0 42] ; for each 1-bit in v0 the bit of v1 is selected
+    v2 = vconst.i8x16 [42 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127] ; for each 0-bit in v0 the bit of v2 is selected
+    v3 = bitselect v0, v1, v2
+
+    v4 = extractlane v3, 0
+    v5 = icmp_imm eq v4, 42
+
+    v6 = extractlane v3, 1
+    v7 = icmp_imm eq v6, 0
+
+    v8 = extractlane v3, 15
+    v9 = icmp_imm eq v8, 42
+
+    v10 = band v5, v7
+    v11 = band v10, v9
+    return v11
+}
+; run

--- a/filetests/isa/x86/simd-logical-binemit.clif
+++ b/filetests/isa/x86/simd-logical-binemit.clif
@@ -19,3 +19,9 @@ ebb0(v0: b32x4 [%xmm4], v1: b32x4 [%xmm0]):
 [-, %xmm4]  v2 = bxor v0, v1      ; bin: 66 0f ef e0
             return v2
 }
+
+function %band_not_b64x2(b64x2, b64x2) -> b64x2 {
+ebb0(v0: b64x2 [%xmm6], v1: b64x2 [%xmm3]):
+[-, %xmm3]  v2 = band_not v0, v1      ; bin: 66 0f df de
+            return v2
+}

--- a/filetests/isa/x86/simd-logical-run.clif
+++ b/filetests/isa/x86/simd-logical-run.clif
@@ -1,0 +1,23 @@
+test run
+set enable_simd
+target x86_64 skylake
+
+function %bnot() -> b32 {
+ebb0:
+    v0 = vconst.b32x4 [true true true false]
+    v1 = bnot v0
+    v2 = extractlane v1, 3
+    return v2
+}
+; run
+
+function %band_not() -> b1 {
+ebb0:
+    v0 = vconst.i16x8 [1 0 0 0 0 0 0 0]
+    v1 = vconst.i16x8 [0 0 0 0 0 0 0 0]
+    v2 = band_not v0, v1
+    v3 = extractlane v2, 0
+    v4 = icmp_imm eq v3, 1
+    return v4
+}
+; run


### PR DESCRIPTION
These changes add:
 - an encoding for SIMD `band_not`; this is used for legalizing `bitselect` and will likely be necessary due to changes in the SIMD spec (https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md#bitwise-and-not)
 - a new `bitselect` instructions to describe the specific semantics needed; `vselect` and `select` almost fit but not quite
 - a legalization of `bitselect` for x86 using 3 instructions: `band`, `band_not`, and `or`