### PR TITLE
cranelift-wasm: Fix reachability tracking for `if .. else .. end`

### DIFF
--- a/wasmtests/if-reachability-translation-0.wat
+++ b/wasmtests/if-reachability-translation-0.wat
@@ -1,0 +1,12 @@
+;; An unreachable `if` means that the consequent, alternative, and following
+;; block are also unreachable.
+
+(module
+  (func (param i32) (result i32)
+    unreachable
+    if  ;; label = @2
+      nop
+    else
+      nop
+    end
+    i32.const 0))

--- a/wasmtests/if-reachability-translation-1.wat
+++ b/wasmtests/if-reachability-translation-1.wat
@@ -1,0 +1,12 @@
+;; Reachable `if` head and reachable consequent and alternative means that the
+;; following block is also reachable.
+
+(module
+  (func (param i32) (result i32)
+    local.get 0
+    if  ;; label = @2
+      nop
+    else
+      nop
+    end
+    i32.const 0))

--- a/wasmtests/if-reachability-translation-2.wat
+++ b/wasmtests/if-reachability-translation-2.wat
@@ -1,0 +1,12 @@
+;; Reachable `if` head and unreachable consequent and reachable alternative
+;; means that the following block is also reachable.
+
+(module
+  (func (param i32) (result i32)
+    local.get 0
+    if
+      unreachable
+    else
+      nop
+    end
+    i32.const 0))

--- a/wasmtests/if-reachability-translation-3.wat
+++ b/wasmtests/if-reachability-translation-3.wat
@@ -1,0 +1,12 @@
+;; Reachable `if` head and consequent and unreachable alternative means that the
+;; following block is also reachable.
+
+(module
+  (func (param i32) (result i32)
+    local.get 0
+    if
+      nop
+    else
+      unreachable
+    end
+    i32.const 0))

--- a/wasmtests/if-reachability-translation-4.wat
+++ b/wasmtests/if-reachability-translation-4.wat
@@ -1,0 +1,12 @@
+;; Reachable `if` head and unreachable consequent and alternative means that the
+;; following block is unreachable.
+
+(module
+  (func (param i32) (result i32)
+    local.get 0
+    if
+      unreachable
+    else
+      unreachable
+    end
+    i32.const 0))

--- a/wasmtests/if-reachability-translation-5.wat
+++ b/wasmtests/if-reachability-translation-5.wat
@@ -1,0 +1,14 @@
+;; Reachable `if` head and unreachable consequent and alternative, but with a
+;; branch out of the consequent, means that the following block is reachable.
+
+(module
+  (func (param i32 i32) (result i32)
+    local.get 0
+    if
+      local.get 1
+      br_if 0
+      unreachable
+    else
+      unreachable
+    end
+    i32.const 0))

--- a/wasmtests/if-reachability-translation-6.wat
+++ b/wasmtests/if-reachability-translation-6.wat
@@ -1,0 +1,14 @@
+;; Reachable `if` head and unreachable consequent and alternative, but with a
+;; branch out of the alternative, means that the following block is reachable.
+
+(module
+  (func (param i32 i32) (result i32)
+    local.get 0
+    if
+      unreachable
+    else
+      local.get 1
+      br_if 0
+      unreachable
+    end
+    i32.const 0))


### PR DESCRIPTION
We weren't previously keeping track of quite the right information for whether an `if .. else .. end`'s following block was reachable or not. It should be reachable if the head is reachable and either the consequent or alternative end reachable (and therefore fall through to the following block) or do an early `br_if` to it.

This commit rejiggers `ControlStackFrame::If` to keep track of reachability at the end of the consequent (we don't need to keep track of it at the end of the alternative, since that is simply `state.reachable`) and adds Wasm tests for every reachability situation we can encounter with `if .. else .. end`.

Fixes #1132