### PR TITLE
[wasm] Make the ModuleTranslationState ctor public

### DIFF
--- a/cranelift-wasm/src/state/module_state.rs
+++ b/cranelift-wasm/src/state/module_state.rs
@@ -19,7 +19,8 @@ pub struct ModuleTranslationState {
 }
 
 impl ModuleTranslationState {
-    pub(crate) fn new() -> Self {
+    /// Creates a new empty ModuleTranslationState.
+    pub fn new() -> Self {
         ModuleTranslationState {
             wasm_types: PrimaryMap::new(),
         }


### PR DESCRIPTION
It's useful for consumers which don't want to translate a whole module,
but just need translation of functions, like Spidermonkey.

@fitzgen PTAL.