### PR TITLE
Many multi-value returns

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1421,16 +1421,60 @@ pub(crate) fn define(
     //
     // Encode movzbq as movzbl, because it's equivalent and shorter.
     e.enc32(
+        bint.bind(I8).bind(B1),
+        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+    );
+    e.enc32(
+        bint.bind(I8).bind(B8),
+        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+    );
+    e.enc32(
+        bint.bind(I16).bind(B1),
+        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+    );
+    e.enc32(
+        bint.bind(I16).bind(B8),
+        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+    );
+    e.enc32(
         bint.bind(I32).bind(B1),
+        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+    );
+    e.enc32(
+        bint.bind(I32).bind(B8),
         rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
     );
 
     e.enc64(
-        bint.bind(I64).bind(B1),
+        bint.bind(I8).bind(B1),
         rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
     );
     e.enc64(
-        bint.bind(I64).bind(B1),
+        bint.bind(I8).bind(B1),
+        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+    );
+    e.enc64(
+        bint.bind(I8).bind(B8),
+        rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
+    );
+    e.enc64(
+        bint.bind(I8).bind(B8),
+        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+    );
+    e.enc64(
+        bint.bind(I16).bind(B1),
+        rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
+    );
+    e.enc64(
+        bint.bind(I16).bind(B1),
+        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+    );
+    e.enc64(
+        bint.bind(I16).bind(B8),
+        rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
+    );
+    e.enc64(
+        bint.bind(I16).bind(B8),
         rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
     );
     e.enc64(
@@ -1439,6 +1483,14 @@ pub(crate) fn define(
     );
     e.enc64(
         bint.bind(I32).bind(B1),
+        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+    );
+    e.enc64(
+        bint.bind(I64).bind(B1),
+        rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
+    );
+    e.enc64(
+        bint.bind(I64).bind(B1),
         rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
     );
 

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1420,79 +1420,24 @@ pub(crate) fn define(
     // or 1.
     //
     // Encode movzbq as movzbl, because it's equivalent and shorter.
-    e.enc32(
-        bint.bind(I8).bind(B1),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-    e.enc32(
-        bint.bind(I8).bind(B8),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-    e.enc32(
-        bint.bind(I16).bind(B1),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-    e.enc32(
-        bint.bind(I16).bind(B8),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-    e.enc32(
-        bint.bind(I32).bind(B1),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-    e.enc32(
-        bint.bind(I32).bind(B8),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-
-    e.enc64(
-        bint.bind(I8).bind(B1),
-        rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
-    );
-    e.enc64(
-        bint.bind(I8).bind(B1),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-    e.enc64(
-        bint.bind(I8).bind(B8),
-        rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
-    );
-    e.enc64(
-        bint.bind(I8).bind(B8),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-    e.enc64(
-        bint.bind(I16).bind(B1),
-        rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
-    );
-    e.enc64(
-        bint.bind(I16).bind(B1),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-    e.enc64(
-        bint.bind(I16).bind(B8),
-        rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
-    );
-    e.enc64(
-        bint.bind(I16).bind(B8),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-    e.enc64(
-        bint.bind(I32).bind(B1),
-        rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
-    );
-    e.enc64(
-        bint.bind(I32).bind(B1),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
-    e.enc64(
-        bint.bind(I64).bind(B1),
-        rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
-    );
-    e.enc64(
-        bint.bind(I64).bind(B1),
-        rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
-    );
+    for &to in &[I8, I16, I32, I64] {
+        for &from in &[B1, B8] {
+            e.enc64(
+                bint.bind(to).bind(from),
+                rec_urm_noflags.opcodes(&MOVZX_BYTE).rex(),
+            );
+            e.enc64(
+                bint.bind(to).bind(from),
+                rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+            );
+            if to != I64 {
+                e.enc32(
+                    bint.bind(to).bind(from),
+                    rec_urm_noflags_abcd.opcodes(&MOVZX_BYTE),
+                );
+            }
+        }
+    }
 
     // Numerical conversions.
 

--- a/cranelift-codegen/src/ir/dfg.rs
+++ b/cranelift-codegen/src/ir/dfg.rs
@@ -62,6 +62,9 @@ pub struct DataFlowGraph {
     /// well as the external function references.
     pub signatures: PrimaryMap<SigRef, Signature>,
 
+    /// The pre-legalization signature for each entry in `signatures`, if any.
+    pub old_signatures: SecondaryMap<SigRef, Option<Signature>>,
+
     /// External function references. These are functions that can be called directly.
     pub ext_funcs: PrimaryMap<FuncRef, ExtFuncData>,
 
@@ -85,6 +88,7 @@ impl DataFlowGraph {
             value_lists: ValueListPool::new(),
             values: PrimaryMap::new(),
             signatures: PrimaryMap::new(),
+            old_signatures: SecondaryMap::new(),
             ext_funcs: PrimaryMap::new(),
             values_labels: None,
             constants: ConstantPool::new(),

--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -56,6 +56,22 @@ impl Signature {
         self.params.iter().rposition(|arg| arg.purpose == purpose)
     }
 
+    /// Find the index of a presumed unique special-purpose parameter.
+    pub fn special_return_index(&self, purpose: ArgumentPurpose) -> Option<usize> {
+        self.returns.iter().rposition(|arg| arg.purpose == purpose)
+    }
+
+    /// Does this signature have a parameter whose `ArgumentPurpose` is
+    /// `purpose`?
+    pub fn uses_special_param(&self, purpose: ArgumentPurpose) -> bool {
+        self.special_param_index(purpose).is_some()
+    }
+
+    /// Does this signature have a return whose `ArgumentPurpose` is `purpose`?
+    pub fn uses_special_return(&self, purpose: ArgumentPurpose) -> bool {
+        self.special_return_index(purpose).is_some()
+    }
+
     /// How many special parameters does this function have?
     pub fn num_special_params(&self) -> usize {
         self.params
@@ -74,8 +90,7 @@ impl Signature {
 
     /// Does this signature take an struct return pointer parameter?
     pub fn uses_struct_return_param(&self) -> bool {
-        self.special_param_index(ArgumentPurpose::StructReturn)
-            .is_some()
+        self.uses_special_param(ArgumentPurpose::StructReturn)
     }
 
     /// Does this return more than one normal value? (Pre-sret legalization)

--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -55,6 +55,37 @@ impl Signature {
     pub fn special_param_index(&self, purpose: ArgumentPurpose) -> Option<usize> {
         self.params.iter().rposition(|arg| arg.purpose == purpose)
     }
+
+    /// How many special parameters does this function have?
+    pub fn num_special_params(&self) -> usize {
+        self.params
+            .iter()
+            .filter(|p| p.purpose != ArgumentPurpose::Normal)
+            .count()
+    }
+
+    /// How many special returns does this function have?
+    pub fn num_special_returns(&self) -> usize {
+        self.returns
+            .iter()
+            .filter(|r| r.purpose != ArgumentPurpose::Normal)
+            .count()
+    }
+
+    /// Does this signature take an `sret` return pointer parameter?
+    pub fn uses_sret(&self) -> bool {
+        self.special_param_index(ArgumentPurpose::StructReturn)
+            .is_some()
+    }
+
+    /// Does this return more than one normal value? (Pre-sret legalization)
+    pub fn is_multi_return(&self) -> bool {
+        self.returns
+            .iter()
+            .filter(|r| r.purpose == ArgumentPurpose::Normal)
+            .count()
+            > 1
+    }
 }
 
 /// Wrapper type capable of displaying a `Signature` with correct register names.

--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -93,7 +93,8 @@ impl Signature {
         self.uses_special_param(ArgumentPurpose::StructReturn)
     }
 
-    /// Does this return more than one normal value? (Pre-sret legalization)
+    /// Does this return more than one normal value? (Pre-struct return
+    /// legalization)
     pub fn is_multi_return(&self) -> bool {
         self.returns
             .iter()

--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -72,8 +72,8 @@ impl Signature {
             .count()
     }
 
-    /// Does this signature take an `sret` return pointer parameter?
-    pub fn uses_sret(&self) -> bool {
+    /// Does this signature take an struct return pointer parameter?
+    pub fn uses_struct_return_param(&self) -> bool {
         self.special_param_index(ArgumentPurpose::StructReturn)
             .is_some()
     }

--- a/cranelift-codegen/src/ir/function.rs
+++ b/cranelift-codegen/src/ir/function.rs
@@ -34,6 +34,10 @@ pub struct Function {
     /// Signature of this function.
     pub signature: Signature,
 
+    /// The old signature of this function, before the most recent legalization,
+    /// if any.
+    pub old_signature: Option<Signature>,
+
     /// Stack slots allocated in this function.
     pub stack_slots: StackSlots,
 
@@ -96,6 +100,7 @@ impl Function {
         Self {
             name,
             signature: sig,
+            old_signature: None,
             stack_slots: StackSlots::new(),
             global_values: PrimaryMap::new(),
             heaps: PrimaryMap::new(),

--- a/cranelift-codegen/src/ir/stackslot.rs
+++ b/cranelift-codegen/src/ir/stackslot.rs
@@ -64,6 +64,14 @@ pub enum StackSlotKind {
     /// stack slots are only valid while setting up a call.
     OutgoingArg,
 
+    /// Space for incoming return values passed via return pointer.
+    ///
+    /// If there are more return values than registers available for the callee's calling
+    /// convention, or the return value is larger than the available registers' space, then we
+    /// allocate stack space in this frame and pass a pointer to the callee, which then writes its
+    /// return values into this space.
+    RetPtr,
+
     /// An emergency spill slot.
     ///
     /// Emergency slots are allocated late when the register's constraint solver needs extra space
@@ -81,6 +89,7 @@ impl FromStr for StackSlotKind {
             "spill_slot" => Ok(SpillSlot),
             "incoming_arg" => Ok(IncomingArg),
             "outgoing_arg" => Ok(OutgoingArg),
+            "ret_ptr" => Ok(RetPtr),
             "emergency_slot" => Ok(EmergencySlot),
             _ => Err(()),
         }
@@ -95,6 +104,7 @@ impl fmt::Display for StackSlotKind {
             SpillSlot => "spill_slot",
             IncomingArg => "incoming_arg",
             OutgoingArg => "outgoing_arg",
+            RetPtr => "ret_ptr",
             EmergencySlot => "emergency_slot",
         })
     }

--- a/cranelift-codegen/src/ir/stackslot.rs
+++ b/cranelift-codegen/src/ir/stackslot.rs
@@ -64,13 +64,14 @@ pub enum StackSlotKind {
     /// stack slots are only valid while setting up a call.
     OutgoingArg,
 
-    /// Space for incoming return values passed via return pointer.
+    /// Space allocated in the caller's frame for the callee's return values
+    /// that are passed out via return pointer.
     ///
     /// If there are more return values than registers available for the callee's calling
     /// convention, or the return value is larger than the available registers' space, then we
     /// allocate stack space in this frame and pass a pointer to the callee, which then writes its
     /// return values into this space.
-    RetPtr,
+    StructReturnSlot,
 
     /// An emergency spill slot.
     ///
@@ -89,7 +90,7 @@ impl FromStr for StackSlotKind {
             "spill_slot" => Ok(SpillSlot),
             "incoming_arg" => Ok(IncomingArg),
             "outgoing_arg" => Ok(OutgoingArg),
-            "ret_ptr" => Ok(RetPtr),
+            "sret_slot" => Ok(StructReturnSlot),
             "emergency_slot" => Ok(EmergencySlot),
             _ => Err(()),
         }
@@ -104,7 +105,7 @@ impl fmt::Display for StackSlotKind {
             SpillSlot => "spill_slot",
             IncomingArg => "incoming_arg",
             OutgoingArg => "outgoing_arg",
-            RetPtr => "ret_ptr",
+            StructReturnSlot => "sret_slot",
             EmergencySlot => "emergency_slot",
         })
     }

--- a/cranelift-codegen/src/isa/arm32/abi.rs
+++ b/cranelift-codegen/src/isa/arm32/abi.rs
@@ -6,6 +6,7 @@ use crate::abi::{legalize_args, ArgAction, ArgAssigner, ValueConversion};
 use crate::ir::{self, AbiParam, ArgumentExtension, ArgumentLoc, Type};
 use crate::isa::RegClass;
 use crate::regalloc::RegisterSet;
+use alloc::borrow::Cow;
 use core::i32;
 use target_lexicon::Triple;
 
@@ -78,11 +79,13 @@ impl ArgAssigner for Args {
 }
 
 /// Legalize `sig`.
-pub fn legalize_signature(sig: &mut ir::Signature, triple: &Triple, _current: bool) {
+pub fn legalize_signature(sig: &mut Cow<ir::Signature>, triple: &Triple, _current: bool) {
     let bits = triple.pointer_width().unwrap().bits();
 
     let mut args = Args::new(bits);
-    legalize_args(&mut sig.params, &mut args);
+    if let Some(new_params) = legalize_args(&sig.params, &mut args) {
+        sig.to_mut().params = new_params;
+    }
 }
 
 /// Get register class for a type appearing in a legalized signature.

--- a/cranelift-codegen/src/isa/arm32/mod.rs
+++ b/cranelift-codegen/src/isa/arm32/mod.rs
@@ -15,6 +15,7 @@ use crate::isa::enc_tables::{self as shared_enc_tables, lookup_enclist, Encoding
 use crate::isa::Builder as IsaBuilder;
 use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use core::fmt;
 use target_lexicon::{Architecture, Triple};
@@ -100,7 +101,7 @@ impl TargetIsa for Isa {
         )
     }
 
-    fn legalize_signature(&self, sig: &mut ir::Signature, current: bool) {
+    fn legalize_signature(&self, sig: &mut Cow<ir::Signature>, current: bool) {
         abi::legalize_signature(sig, &self.triple, current)
     }
 

--- a/cranelift-codegen/src/isa/arm64/abi.rs
+++ b/cranelift-codegen/src/isa/arm64/abi.rs
@@ -5,10 +5,11 @@ use crate::ir;
 use crate::isa::RegClass;
 use crate::regalloc::RegisterSet;
 use crate::settings as shared_settings;
+use alloc::borrow::Cow;
 
 /// Legalize `sig`.
 pub fn legalize_signature(
-    _sig: &mut ir::Signature,
+    _sig: &mut Cow<ir::Signature>,
     _flags: &shared_settings::Flags,
     _current: bool,
 ) {

--- a/cranelift-codegen/src/isa/arm64/mod.rs
+++ b/cranelift-codegen/src/isa/arm64/mod.rs
@@ -15,6 +15,7 @@ use crate::isa::enc_tables::{lookup_enclist, Encodings};
 use crate::isa::Builder as IsaBuilder;
 use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use core::fmt;
 use target_lexicon::Triple;
@@ -88,7 +89,7 @@ impl TargetIsa for Isa {
         )
     }
 
-    fn legalize_signature(&self, sig: &mut ir::Signature, current: bool) {
+    fn legalize_signature(&self, sig: &mut Cow<ir::Signature>, current: bool) {
         abi::legalize_signature(sig, &self.shared_flags, current)
     }
 

--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -63,6 +63,7 @@ use crate::result::CodegenResult;
 use crate::settings;
 use crate::settings::SetResult;
 use crate::timing;
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt;
@@ -315,7 +316,7 @@ pub trait TargetIsa: fmt::Display + Sync {
     /// Arguments and return values for the caller's frame pointer and other callee-saved registers
     /// should not be added by this function. These arguments are not added until after register
     /// allocation.
-    fn legalize_signature(&self, sig: &mut ir::Signature, current: bool);
+    fn legalize_signature(&self, sig: &mut Cow<ir::Signature>, current: bool);
 
     /// Get the register class that should be used to represent an ABI argument or return value of
     /// type `ty`. This should be the top-level register class that contains the argument

--- a/cranelift-codegen/src/isa/riscv/mod.rs
+++ b/cranelift-codegen/src/isa/riscv/mod.rs
@@ -15,6 +15,7 @@ use crate::isa::enc_tables::{self as shared_enc_tables, lookup_enclist, Encoding
 use crate::isa::Builder as IsaBuilder;
 use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use core::fmt;
 use target_lexicon::{PointerWidth, Triple};
@@ -95,7 +96,7 @@ impl TargetIsa for Isa {
         )
     }
 
-    fn legalize_signature(&self, sig: &mut ir::Signature, current: bool) {
+    fn legalize_signature(&self, sig: &mut Cow<ir::Signature>, current: bool) {
         abi::legalize_signature(sig, &self.triple, &self.isa_flags, current)
     }
 

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -195,6 +195,26 @@ fn num_return_registers_required<'a>(
     let mut fprs_required = 0;
 
     for param in return_params {
+        match param.location {
+            ArgumentLoc::Unassigned => {
+                // Let this fall through so that we assign it a location and
+                // account for how many registers it ends up requiring below...
+            }
+            ArgumentLoc::Reg(_) => {
+                // This is already assigned to a register. Count it.
+                if param.value_type.is_float() {
+                    fprs_required += 1;
+                } else {
+                    gprs_required += 1;
+                }
+                continue;
+            }
+            _ => {
+                // It is already assigned, but not to a register. Skip it.
+                continue;
+            }
+        }
+
         // We're going to mutate the type as it gets converted, so make our own
         // copy that isn't visible to the outside world.
         let mut param = param.clone();

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -221,7 +221,7 @@ fn num_return_registers_required<'a>(
 
         let mut split_factor = 1;
 
-        'converting_param: loop {
+        loop {
             match assigner.assign(&param) {
                 ArgAction::Convert(ValueConversion::IntSplit) => {
                     split_factor *= 2;
@@ -246,13 +246,13 @@ fn num_return_registers_required<'a>(
 
                     // But we also have to call `assign` once for each split value, to
                     // update `assigner`'s internal state.
-                    'draining_assignments: for _ in 1..split_factor {
+                    for _ in 1..split_factor {
                         match assigner.assign(&param) {
                             ArgAction::Assign(_)
                             | ArgAction::Convert(ValueConversion::IntBits)
                             | ArgAction::Convert(ValueConversion::Sext(_))
                             | ArgAction::Convert(ValueConversion::Uext(_)) => {
-                                continue 'draining_assignments;
+                                continue;
                             }
                             otherwise => panic!(
                                 "unexpected action after first split succeeded: {:?}",
@@ -262,7 +262,7 @@ fn num_return_registers_required<'a>(
                     }
 
                     // Continue to the next param.
-                    break 'converting_param;
+                    break;
                 }
                 ArgAction::Assign(loc) => panic!(
                     "unexpected location assignment, should have had enough registers: {:?}",

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -313,7 +313,7 @@ pub fn legalize_signature(
             num_registers_required(bits, sig.call_conv, shared_flags, isa_flags, &sig.returns);
         gprs_required > ret_regs.len() || fprs_required > ret_fpr_limit
     } {
-        debug_assert!(!sig.uses_sret());
+        debug_assert!(!sig.uses_struct_return_param());
 
         // We're using the first register for the return pointer parameter.
         let mut ret_ptr_param = AbiParam {

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -302,6 +302,7 @@ pub fn legalize_signature(
     } else {
         (&RET_GPRS[..], 2)
     };
+
     let mut rets = Args::new(
         bits,
         ret_regs,

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -167,6 +167,89 @@ impl ArgAssigner for Args {
     }
 }
 
+/// Get the number of general-purpose and floating-point registers required to
+/// hold the given ABI parameters.
+fn num_registers_required<'a>(
+    word_bit_size: u8,
+    call_conv: CallConv,
+    shared_flags: &shared_settings::Flags,
+    isa_flags: &isa_settings::Flags,
+    params: impl IntoIterator<Item = &'a AbiParam>,
+) -> (usize, usize) {
+    let gprs = &[RU::rax; 128];
+    let mut assigner = Args::new(
+        word_bit_size,
+        gprs,
+        std::usize::MAX,
+        call_conv,
+        shared_flags,
+        isa_flags,
+    );
+
+    let mut gprs_required = 0;
+    let mut fprs_required = 0;
+
+    for p in params {
+        // We're going to mutate the type as it gets converted, so make our own
+        // copy that isn't visible to the outside world.
+        let mut p = p.clone();
+
+        let mut split_factor = 1;
+
+        'converting_param: loop {
+            match assigner.assign(&p) {
+                ArgAction::Convert(ValueConversion::IntSplit) => {
+                    split_factor *= 2;
+                    p.value_type = p.value_type.half_width().unwrap();
+                }
+                ArgAction::Convert(ValueConversion::VectorSplit) => {
+                    split_factor *= 2;
+                    p.value_type = p.value_type.half_vector().unwrap();
+                }
+                ArgAction::Assign(ArgumentLoc::Reg(_))
+                | ArgAction::Convert(ValueConversion::IntBits)
+                | ArgAction::Convert(ValueConversion::Sext(_))
+                | ArgAction::Convert(ValueConversion::Uext(_)) => {
+                    // Ok! We can fit this (potentially split) value into a
+                    // register! Add the number of params we split the parameter
+                    // into to our current counts.
+                    if p.value_type.is_float() {
+                        fprs_required += split_factor;
+                    } else {
+                        gprs_required += split_factor;
+                    }
+
+                    // But we also have to call `assign` once for each split value, to
+                    // update `assigner`'s internal state.
+                    'draining_assignments: for _ in 1..split_factor {
+                        match assigner.assign(&p) {
+                            ArgAction::Assign(_)
+                            | ArgAction::Convert(ValueConversion::IntBits)
+                            | ArgAction::Convert(ValueConversion::Sext(_))
+                            | ArgAction::Convert(ValueConversion::Uext(_)) => {
+                                continue 'draining_assignments;
+                            }
+                            otherwise => panic!(
+                                "unexpected action after first split succeeded: {:?}",
+                                otherwise
+                            ),
+                        }
+                    }
+
+                    // Continue to the next param.
+                    break 'converting_param;
+                }
+                ArgAction::Assign(loc) => panic!(
+                    "unexpected location assignment, should have had enough registers: {:?}",
+                    loc
+                ),
+            }
+        }
+    }
+
+    (gprs_required, fprs_required)
+}
+
 /// Legalize `sig`.
 pub fn legalize_signature(
     sig: &mut Cow<ir::Signature>,
@@ -208,25 +291,76 @@ pub fn legalize_signature(
         }
     }
 
-    if let Some(new_params) = legalize_args(&sig.params, &mut args) {
-        sig.to_mut().params = new_params;
-    }
-
-    let (regs, fpr_limit) = if sig.call_conv.extends_windows_fastcall() {
+    let (ret_regs, ret_fpr_limit) = if sig.call_conv.extends_windows_fastcall() {
         // windows-x64 calling convention only uses XMM0 or RAX for return values
         (&RET_GPRS_WIN_FASTCALL_X64[..], 1)
     } else {
         (&RET_GPRS[..], 2)
     };
-
     let mut rets = Args::new(
         bits,
-        regs,
-        fpr_limit,
+        ret_regs,
+        ret_fpr_limit,
         sig.call_conv,
         shared_flags,
         isa_flags,
     );
+
+    if sig.is_multi_return() && {
+        // Even if it is multi-return, see if the return values will fit into
+        // our available return registers.
+        let (gprs_required, fprs_required) =
+            num_registers_required(bits, sig.call_conv, shared_flags, isa_flags, &sig.returns);
+        gprs_required > ret_regs.len() || fprs_required > ret_fpr_limit
+    } {
+        debug_assert!(!sig.uses_sret());
+
+        // We're using the first register for the return pointer parameter.
+        let mut ret_ptr_param = AbiParam {
+            value_type: args.pointer_type,
+            purpose: ArgumentPurpose::StructReturn,
+            extension: ArgumentExtension::None,
+            location: ArgumentLoc::Unassigned,
+        };
+        match args.assign(&ret_ptr_param) {
+            ArgAction::Assign(ArgumentLoc::Reg(reg)) => {
+                ret_ptr_param.location = ArgumentLoc::Reg(reg);
+                sig.to_mut().params.push(ret_ptr_param);
+            }
+            _ => unreachable!("return pointer should always get a register assignment"),
+        }
+
+        // We're using the first return register for the return pointer (like
+        // sys v does).
+        let mut ret_ptr_return = AbiParam {
+            value_type: args.pointer_type,
+            purpose: ArgumentPurpose::StructReturn,
+            extension: ArgumentExtension::None,
+            location: ArgumentLoc::Unassigned,
+        };
+        match rets.assign(&ret_ptr_return) {
+            ArgAction::Assign(ArgumentLoc::Reg(reg)) => {
+                ret_ptr_return.location = ArgumentLoc::Reg(reg);
+                sig.to_mut().returns.push(ret_ptr_return);
+            }
+            _ => unreachable!("return pointer should always get a register assignment"),
+        }
+
+        sig.to_mut().returns.retain(|ret| {
+            // Either this is the return pointer, in which case we want to keep
+            // it, or else assume that it is assigned for a reason and doesn't
+            // conflict with our return pointering legalization.
+            debug_assert_eq!(
+                ret.location.is_assigned(),
+                ret.purpose != ArgumentPurpose::Normal
+            );
+            ret.location.is_assigned()
+        });
+    }
+
+    if let Some(new_params) = legalize_args(&sig.params, &mut args) {
+        sig.to_mut().params = new_params;
+    }
 
     if let Some(new_returns) = legalize_args(&sig.returns, &mut rets) {
         sig.to_mut().returns = new_returns;

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -189,22 +189,22 @@ fn num_registers_required<'a>(
     let mut gprs_required = 0;
     let mut fprs_required = 0;
 
-    for p in params {
+    for param in params {
         // We're going to mutate the type as it gets converted, so make our own
         // copy that isn't visible to the outside world.
-        let mut p = p.clone();
+        let mut param = param.clone();
 
         let mut split_factor = 1;
 
         'converting_param: loop {
-            match assigner.assign(&p) {
+            match assigner.assign(&param) {
                 ArgAction::Convert(ValueConversion::IntSplit) => {
                     split_factor *= 2;
-                    p.value_type = p.value_type.half_width().unwrap();
+                    param.value_type = param.value_type.half_width().unwrap();
                 }
                 ArgAction::Convert(ValueConversion::VectorSplit) => {
                     split_factor *= 2;
-                    p.value_type = p.value_type.half_vector().unwrap();
+                    param.value_type = param.value_type.half_vector().unwrap();
                 }
                 ArgAction::Assign(ArgumentLoc::Reg(_))
                 | ArgAction::Convert(ValueConversion::IntBits)
@@ -213,7 +213,7 @@ fn num_registers_required<'a>(
                     // Ok! We can fit this (potentially split) value into a
                     // register! Add the number of params we split the parameter
                     // into to our current counts.
-                    if p.value_type.is_float() {
+                    if param.value_type.is_float() {
                         fprs_required += split_factor;
                     } else {
                         gprs_required += split_factor;
@@ -222,7 +222,7 @@ fn num_registers_required<'a>(
                     // But we also have to call `assign` once for each split value, to
                     // update `assigner`'s internal state.
                     'draining_assignments: for _ in 1..split_factor {
-                        match assigner.assign(&p) {
+                        match assigner.assign(&param) {
                             ArgAction::Assign(_)
                             | ArgAction::Convert(ValueConversion::IntBits)
                             | ArgAction::Convert(ValueConversion::Sext(_))

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -176,11 +176,16 @@ fn num_registers_required<'a>(
     isa_flags: &isa_settings::Flags,
     params: impl IntoIterator<Item = &'a AbiParam>,
 ) -> (usize, usize) {
+    // Pretend we have "infinite" registers to give out, since we aren't
+    // actually assigning `AbiParam`s to registers yet, just seeing how many
+    // registers we would need in order to fit all the `AbiParam`s in registers.
     let gprs = &[RU::rax; 128];
+    let fpr_limit = std::usize::MAX;
+
     let mut assigner = Args::new(
         word_bit_size,
         gprs,
-        std::usize::MAX,
+        fpr_limit,
         call_conv,
         shared_flags,
         isa_flags,

--- a/cranelift-codegen/src/isa/x86/mod.rs
+++ b/cranelift-codegen/src/isa/x86/mod.rs
@@ -18,6 +18,7 @@ use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
 use crate::result::CodegenResult;
 use crate::timing;
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt;
@@ -107,7 +108,7 @@ impl TargetIsa for Isa {
         )
     }
 
-    fn legalize_signature(&self, sig: &mut ir::Signature, current: bool) {
+    fn legalize_signature(&self, sig: &mut Cow<ir::Signature>, current: bool) {
         abi::legalize_signature(
             sig,
             &self.triple,

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -723,16 +723,17 @@ fn legalized_type_for_sret(ty: Type) -> Type {
 /// unmodified) legalized value and its type.
 fn legalize_type_for_sret_store(
     pos: &mut FuncCursor,
-    mut val: Value,
-    mut ty: Type,
+    val: Value,
+    ty: Type,
 ) -> (Value, Type) {
     if ty.is_bool() {
         let bits = std::cmp::max(8, ty.bits());
-        ty = Type::int(bits).unwrap();
-        val = pos.ins().bint(ty, val);
+        let ty = Type::int(bits).unwrap();
+        let val = pos.ins().bint(ty, val);
+        (val, ty)
+    } else {
+        (val, ty)
     }
-
-    (val, ty)
 }
 
 /// Insert ABI conversion code before and after the call instruction at `pos`.

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -1052,11 +1052,11 @@ mod tests {
             (5, 4, 8),
         ] {
             let actual = round_up_to_multiple_of_pow2(n, to);
-            println!(
+            assert_eq!(
+                actual, expected,
                 "round_up_to_multiple_of_pow2(n = {}, to = {}) = {} (expected {})",
                 n, to, actual, expected
             );
-            assert_eq!(actual, expected);
         }
     }
 }

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -371,9 +371,9 @@ fn legalize_sret_call(isa: &dyn TargetIsa, pos: &mut FuncCursor, sig_ref: SigRef
     // need to add it to the `call` instruction's results list.
     //
     // Additionally, when the sret is explicitly returned in this calling
-    // convention, then use when loading the sret returns back into ssa values
-    // to avoid keeping the original `sret_arg` live and potentially having to
-    // do spills and fills.
+    // convention, then use it when loading the sret returns back into ssa
+    // values to avoid keeping the original `sret_arg` live and potentially
+    // having to do spills and fills.
     let sret = if pos.func.dfg.signatures[sig_ref]
         .returns
         .last()

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -721,11 +721,7 @@ fn legalized_type_for_sret(ty: Type) -> Type {
 /// Insert any legalization code required to ensure that `val` can be stored
 /// into the `sret` memory. Returns the (potentially new, potentially
 /// unmodified) legalized value and its type.
-fn legalize_type_for_sret_store(
-    pos: &mut FuncCursor,
-    val: Value,
-    ty: Type,
-) -> (Value, Type) {
+fn legalize_type_for_sret_store(pos: &mut FuncCursor, val: Value, ty: Type) -> (Value, Type) {
     if ty.is_bool() {
         let bits = std::cmp::max(8, ty.bits());
         let ty = Type::int(bits).unwrap();

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -927,7 +927,7 @@ fn round_up_to_multiple_of_pow2(n: u32, to: u32) -> u32 {
     //     (n + to - 1) / to * to
     //
     // Consider the numerator: `n + to - 1`. This is ensuring that if there is
-    // any remainder for `n / to`, than the result of the division is one
+    // any remainder for `n / to`, then the result of the division is one
     // greater than `n / to`, and that otherwise we get exactly the same result
     // as `n / to` due to integer division rounding off the remainder. In other
     // words, we only round up if `n` is not aligned to `to`.

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -371,7 +371,7 @@ fn legalize_sret_call(isa: &dyn TargetIsa, pos: &mut FuncCursor, sig_ref: SigRef
         std::cmp::max(off, (slot_offset + slot_size) as u32)
     });
     let stack_slot = pos.func.stack_slots.push(StackSlotData {
-        kind: StackSlotKind::RetPtr,
+        kind: StackSlotKind::StructReturnSlot,
         size: sret_slot_size,
         offset: Some(round_up_to_multiple_of_pow2(stack_offset, max_align) as i32),
     });

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -770,7 +770,11 @@ pub fn handle_call_abi(
     let sig = &pos.func.dfg.signatures[sig_ref];
     let old_sig = &pos.func.dfg.old_signatures[sig_ref];
 
-    if sig.uses_sret() && old_sig.as_ref().map_or(false, |s| !s.uses_sret()) {
+    if sig.uses_struct_return_param()
+        && old_sig
+            .as_ref()
+            .map_or(false, |s| !s.uses_struct_return_param())
+    {
         legalize_sret_call(isa, pos, sig_ref, inst);
     } else {
         // OK, we need to fix the call arguments to match the ABI signature.

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -878,7 +878,14 @@ pub fn handle_return_abi(inst: Inst, func: &mut Function, cfg: &ControlFlowGraph
         if let Some(sret) = sret {
             let mut offset = 0;
             let num_regular_rets = vlist.len(&pos.func.dfg.value_lists) - special_args;
-            for _ in 0..num_regular_rets {
+            for i in 0..num_regular_rets {
+                debug_assert_eq!(
+                    pos.func.old_signature.as_ref().unwrap().returns[i].purpose,
+                    ArgumentPurpose::Normal,
+                );
+
+                // The next return value to process is always at `0`, since the
+                // list is emptied as we iterate.
                 let v = vlist.get(0, &pos.func.dfg.value_lists).unwrap();
                 let ty = pos.func.dfg.value_type(v);
                 let (v, ty) = legalize_type_for_sret_store(pos, v, ty);

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -365,9 +365,7 @@ fn legalize_sret_call(isa: &dyn TargetIsa, pos: &mut FuncCursor, sig_ref: SigRef
     // Append the sret pointer to the `call` instruction's arguments.
     let ptr_type = Type::triple_pointer_type(isa.triple());
     let sret_arg = pos.ins().stack_addr(ptr_type, stack_slot, 0);
-    let mut args = pos.func.dfg[call].take_value_list().unwrap();
-    args.push(sret_arg, &mut pos.func.dfg.value_lists);
-    pos.func.dfg[call].put_value_list(args);
+    pos.func.dfg.append_inst_arg(call, sret_arg);
 
     // The sret pointer might be returned by the signature as well. If so, we
     // need to add it to the `call` instruction's results list.

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -374,15 +374,12 @@ fn legalize_sret_call(isa: &dyn TargetIsa, pos: &mut FuncCursor, sig_ref: SigRef
     // convention, then use it when loading the sret returns back into ssa
     // values to avoid keeping the original `sret_arg` live and potentially
     // having to do spills and fills.
-    let sret = if pos.func.dfg.signatures[sig_ref]
-        .returns
-        .last()
-        .map_or(false, |r| r.purpose == ArgumentPurpose::StructReturn)
-    {
-        pos.func.dfg.append_result(call, ptr_type)
-    } else {
-        sret_arg
-    };
+    let sret =
+        if pos.func.dfg.signatures[sig_ref].uses_special_return(ArgumentPurpose::StructReturn) {
+            pos.func.dfg.append_result(call, ptr_type)
+        } else {
+            sret_arg
+        };
 
     // Finally, load each of the call's return values out of the sret stack
     // slot.

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -280,6 +280,8 @@ fn legalize_sret_call(isa: &dyn TargetIsa, pos: &mut FuncCursor, sig_ref: SigRef
             old_ret_list.len(&pos.func.dfg.value_lists)
         );
 
+        // Assert that the only difference in special parameters is that there
+        // is an appended struct return pointer parameter.
         let old_special_params: Vec<_> = old_sig
             .params
             .iter()
@@ -300,6 +302,9 @@ fn legalize_sret_call(isa: &dyn TargetIsa, pos: &mut FuncCursor, sig_ref: SigRef
             ArgumentPurpose::StructReturn
         );
 
+        // If the special returns have changed at all, then the only change
+        // should be that the struct return pointer is returned back out of the
+        // function, so that callers don't have to load its stack address again.
         let old_special_returns: Vec<_> = old_sig
             .returns
             .iter()

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -733,12 +733,12 @@ fn legalize_type_for_sret_load(
 
                 if ty.is_bool() {
                     new_ty = new_ty.as_bool_pedantic();
-                    v = pos.ins().raw_bitcast(new_ty, v)
-                }
+                    v = pos.ins().raw_bitcast(new_ty, v);
 
-                if ty.bits() < new_ty.bits() {
-                    new_ty = ty;
-                    v = pos.ins().breduce(new_ty, v);
+                    if ty.bits() < new_ty.bits() {
+                        new_ty = ty;
+                        v = pos.ins().breduce(new_ty, v);
+                    }
                 }
 
                 v

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -55,7 +55,7 @@ fn legalize_inst(
 
     // Check for ABI boundaries that need to be converted to the legalized signature.
     if opcode.is_call() {
-        if boundary::handle_call_abi(inst, pos.func, cfg) {
+        if boundary::handle_call_abi(isa, inst, pos.func, cfg) {
             return LegalizeInstResult::Legalized;
         }
     } else if opcode.is_return() {

--- a/cranelift-codegen/src/stack_layout.rs
+++ b/cranelift-codegen/src/stack_layout.rs
@@ -58,7 +58,7 @@ pub fn layout_stack(frame: &mut StackSlots, alignment: StackSize) -> CodegenResu
                     .ok_or(CodegenError::ImplLimitExceeded)?;
                 outgoing_max = max(outgoing_max, offset);
             }
-            StackSlotKind::RetPtr => {
+            StackSlotKind::StructReturnSlot => {
                 debug_assert!(slot.offset.unwrap() >= 0);
                 let offset = slot
                     .offset
@@ -86,7 +86,7 @@ pub fn layout_stack(frame: &mut StackSlots, alignment: StackSize) -> CodegenResu
             // Pick out explicit and spill slots with exact alignment `min_align`.
             match slot.kind {
                 StackSlotKind::SpillSlot
-                | StackSlotKind::RetPtr
+                | StackSlotKind::StructReturnSlot
                 | StackSlotKind::ExplicitSlot
                 | StackSlotKind::EmergencySlot => {
                     if slot.alignment(alignment) != min_align {

--- a/filetests/wasm/multi-val-b1.clif
+++ b/filetests/wasm/multi-val-b1.clif
@@ -27,7 +27,7 @@ ebb0(v0: b1, v1: b1, v2: b1, v3: b1):
 
 function %call_4_b1s() {
 ; check: function %call_4_b1s(i64 fp [%rbp], i64 csr [%rbx]) -> i64 fp [%rbp], i64 csr [%rbx] fast {
-; nextln:    ss0 = ret_ptr 4, offset 0
+; nextln:    ss0 = sret_slot 4, offset 0
 
     fn0 = colocated %return_4_b1s(b1, b1, b1, b1) -> b1, b1, b1, b1
     ; check: sig0 = (b1 [%rsi], b1 [%rdx], b1 [%rcx], b1 [%r8], i64 sret [%rdi]) -> i64 sret [%rax] fast

--- a/filetests/wasm/multi-val-b1.clif
+++ b/filetests/wasm/multi-val-b1.clif
@@ -27,7 +27,7 @@ ebb0(v0: b1, v1: b1, v2: b1, v3: b1):
 
 function %call_4_b1s() {
 ; check: function %call_4_b1s(i64 fp [%rbp], i64 csr [%rbx]) -> i64 fp [%rbp], i64 csr [%rbx] fast {
-; nextln:    ss0 = sret_slot 4, offset 0
+; nextln:    ss0 = sret_slot 4, offset -28
 
     fn0 = colocated %return_4_b1s(b1, b1, b1, b1) -> b1, b1, b1, b1
     ; check: sig0 = (b1 [%rsi], b1 [%rdx], b1 [%rcx], b1 [%r8], i64 sret [%rdi]) -> i64 sret [%rax] fast
@@ -40,8 +40,10 @@ ebb0:
     v2 = bconst.b1 true
     v3 = bconst.b1 false
 
+    ; check: v8 = stack_addr.i64 ss0
     v4, v5, v6, v7 = call fn0(v0, v1, v2, v3)
-    ; check:  v22 = uload8.i32 notrap aligned v9
+    ; check:  v9 = call fn0(v0, v1, v2, v3, v8)
+    ; nextln: v22 = uload8.i32 notrap aligned v9
     ; nextln: v10 = ireduce.i8 v22
     ; nextln: v11 = raw_bitcast.b8 v10
     ; nextln: v12 = breduce.b1 v11

--- a/filetests/wasm/multi-val-b1.clif
+++ b/filetests/wasm/multi-val-b1.clif
@@ -1,0 +1,66 @@
+test compile
+target x86_64 haswell
+
+;; `b1` return values need to be legalized into bytes so that they can be stored
+;; in memory.
+
+function %return_4_b1s(b1, b1, b1, b1) -> b1, b1, b1, b1 {
+;; check: function %return_4_b1s(b1 [%rsi], b1 [%rdx], b1 [%rcx], b1 [%r8], i64 sret [%rdi], i64 fp [%rbp]) -> i64 sret [%rax], i64 fp [%rbp] fast {
+
+ebb0(v0: b1, v1: b1, v2: b1, v3: b1):
+; check: ebb0(v0: b1 [%rsi], v1: b1 [%rdx], v2: b1 [%rcx], v3: b1 [%r8], v4: i64 [%rdi], v13: i64 [%rbp]):
+
+    return v0, v1, v2, v3
+    ; check:  v5 = bint.i8 v0
+    ; nextln: v9 = uextend.i32 v5
+    ; nextln: istore8 notrap aligned v9, v4
+    ; nextln: v6 = bint.i8 v1
+    ; nextln: v10 = uextend.i32 v6
+    ; nextln: istore8 notrap aligned v10, v4+1
+    ; nextln: v7 = bint.i8 v2
+    ; nextln: v11 = uextend.i32 v7
+    ; nextln: istore8 notrap aligned v11, v4+2
+    ; nextln: v8 = bint.i8 v3
+    ; nextln: v12 = uextend.i32 v8
+    ; nextln: istore8 notrap aligned v12, v4+3
+}
+
+function %call_4_b1s() {
+; check: function %call_4_b1s(i64 fp [%rbp], i64 csr [%rbx]) -> i64 fp [%rbp], i64 csr [%rbx] fast {
+; nextln:    ss0 = ret_ptr 4, offset 0
+
+    fn0 = colocated %return_4_b1s(b1, b1, b1, b1) -> b1, b1, b1, b1
+    ; check: sig0 = (b1 [%rsi], b1 [%rdx], b1 [%rcx], b1 [%r8], i64 sret [%rdi]) -> i64 sret [%rax] fast
+
+ebb0:
+; check: ebb0(v26: i64 [%rbp], v27: i64 [%rbx]):
+
+    v0 = bconst.b1 true
+    v1 = bconst.b1 false
+    v2 = bconst.b1 true
+    v3 = bconst.b1 false
+
+    v4, v5, v6, v7 = call fn0(v0, v1, v2, v3)
+    ; check:  v22 = uload8.i32 notrap aligned v9
+    ; nextln: v10 = ireduce.i8 v22
+    ; nextln: v11 = raw_bitcast.b8 v10
+    ; nextln: v12 = breduce.b1 v11
+    ; nextln: v4 -> v12
+    ; nextln: v23 = uload8.i32 notrap aligned v9+1
+    ; nextln: v13 = ireduce.i8 v23
+    ; nextln: v14 = raw_bitcast.b8 v13
+    ; nextln: v15 = breduce.b1 v14
+    ; nextln: v5 -> v15
+    ; nextln: v24 = uload8.i32 notrap aligned v9+2
+    ; nextln: v16 = ireduce.i8 v24
+    ; nextln: v17 = raw_bitcast.b8 v16
+    ; nextln: v18 = breduce.b1 v17
+    ; nextln: v6 -> v18
+    ; nextln: v25 = uload8.i32 notrap aligned v9+3
+    ; nextln: v19 = ireduce.i8 v25
+    ; nextln: v20 = raw_bitcast.b8 v19
+    ; nextln: v21 = breduce.b1 v20
+    ; nextln: v7 -> v21
+
+    return
+}

--- a/filetests/wasm/multi-val-call-indirect.clif
+++ b/filetests/wasm/multi-val-call-indirect.clif
@@ -1,0 +1,26 @@
+test legalizer
+target x86_64 haswell
+
+;; Indirect calls with many returns.
+
+function %call_indirect_many_rets(i64) {
+    ; check: ss0 = ret_ptr 32, offset 0
+
+    sig0 = () -> i64, i64, i64, i64
+    ; check: sig0 = (i64 sret [%rdi]) -> i64 sret [%rax] fast
+
+ebb0(v0: i64):
+    v1, v2, v3, v4 = call_indirect sig0, v0()
+    ; check:  v5 = stack_addr.i64 ss0
+    ; nextln: v6 = call_indirect sig0, v0(v5)
+    ; nextln: v7 = load.i64 notrap aligned v6
+    ; nextln: v1 -> v7
+    ; nextln: v8 = load.i64 notrap aligned v6+8
+    ; nextln: v2 -> v8
+    ; nextln: v9 = load.i64 notrap aligned v6+16
+    ; nextln: v3 -> v9
+    ; nextln: v10 = load.i64 notrap aligned v6+24
+    ; nextln: v4 -> v10
+
+    return
+}

--- a/filetests/wasm/multi-val-call-indirect.clif
+++ b/filetests/wasm/multi-val-call-indirect.clif
@@ -4,7 +4,7 @@ target x86_64 haswell
 ;; Indirect calls with many returns.
 
 function %call_indirect_many_rets(i64) {
-    ; check: ss0 = sret_slot 32, offset 0
+    ; check: ss0 = sret_slot 32
 
     sig0 = () -> i64, i64, i64, i64
     ; check: sig0 = (i64 sret [%rdi]) -> i64 sret [%rax] fast

--- a/filetests/wasm/multi-val-call-indirect.clif
+++ b/filetests/wasm/multi-val-call-indirect.clif
@@ -4,7 +4,7 @@ target x86_64 haswell
 ;; Indirect calls with many returns.
 
 function %call_indirect_many_rets(i64) {
-    ; check: ss0 = ret_ptr 32, offset 0
+    ; check: ss0 = sret_slot 32, offset 0
 
     sig0 = () -> i64, i64, i64, i64
     ; check: sig0 = (i64 sret [%rdi]) -> i64 sret [%rax] fast

--- a/filetests/wasm/multi-val-f32.clif
+++ b/filetests/wasm/multi-val-f32.clif
@@ -1,0 +1,44 @@
+test compile
+target x86_64 haswell
+
+;; Returning many f32s
+
+function %return_2_f32s() -> f32, f32 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = f32const 0x1.0
+    return v0, v1
+}
+
+function %return_3_f32s() -> f32, f32, f32 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = f32const 0x1.0
+    v2 = f32const 0x2.0
+    return v0, v1, v2
+}
+
+function %return_4_f32s() -> f32, f32, f32, f32 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = f32const 0x1.0
+    v2 = f32const 0x2.0
+    v3 = f32const 0x3.0
+    return v0, v1, v2, v3
+}
+
+;; Calling functions that return many f32s
+
+function %call() -> f32 {
+    fn0 = %a() -> f32, f32
+    fn1 = %b(f32, f32) -> f32, f32, f32
+    fn2 = %c(f32, f32, f32) -> f32, f32, f32, f32
+ebb0:
+    v0, v1 = call fn0()
+    v2, v3, v4 = call fn1(v0, v1)
+    v5, v6, v7, v8 = call fn2(v2, v3, v4)
+    v9 = fadd v5, v6
+    v10 = fadd v7, v8
+    v11 = fadd v9, v10
+    return v11
+}

--- a/filetests/wasm/multi-val-f64.clif
+++ b/filetests/wasm/multi-val-f64.clif
@@ -1,0 +1,44 @@
+test compile
+target x86_64 haswell
+
+;; Returning many f64s
+
+function %return_2_f64s() -> f64, f64 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = f64const 0x1.0
+    return v0, v1
+}
+
+function %return_3_f64s() -> f64, f64, f64 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = f64const 0x1.0
+    v2 = f64const 0x2.0
+    return v0, v1, v2
+}
+
+function %return_4_f64s() -> f64, f64, f64, f64 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = f64const 0x1.0
+    v2 = f64const 0x2.0
+    v3 = f64const 0x3.0
+    return v0, v1, v2, v3
+}
+
+;; Calling functions that return many f64s
+
+function %call() -> f64 {
+    fn0 = %a() -> f64, f64
+    fn1 = %b(f64, f64) -> f64, f64, f64
+    fn2 = %c(f64, f64, f64) -> f64, f64, f64, f64
+ebb0:
+    v0, v1 = call fn0()
+    v2, v3, v4 = call fn1(v0, v1)
+    v5, v6, v7, v8 = call fn2(v2, v3, v4)
+    v9 = fadd v5, v6
+    v10 = fadd v7, v8
+    v11 = fadd v9, v10
+    return v11
+}

--- a/filetests/wasm/multi-val-i32.clif
+++ b/filetests/wasm/multi-val-i32.clif
@@ -1,0 +1,44 @@
+test compile
+target x86_64 haswell
+
+;; Returning many i32s
+
+function %return_2_i32s() -> i32, i32 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i32 1
+    return v0, v1
+}
+
+function %return_3_i32s() -> i32, i32, i32 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i32 1
+    v2 = iconst.i32 2
+    return v0, v1, v2
+}
+
+function %return_4_i32s() -> i32, i32, i32, i32 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i32 1
+    v2 = iconst.i32 2
+    v3 = iconst.i32 3
+    return v0, v1, v2, v3
+}
+
+;; Calling functions that return many i32s
+
+function %call() -> i32 {
+    fn0 = %a() -> i32, i32
+    fn1 = %b(i32, i32) -> i32, i32, i32
+    fn2 = %c(i32, i32, i32) -> i32, i32, i32, i32
+ebb0:
+    v0, v1 = call fn0()
+    v2, v3, v4 = call fn1(v0, v1)
+    v5, v6, v7, v8 = call fn2(v2, v3, v4)
+    v9 = iadd v5, v6
+    v10 = iadd v7, v8
+    v11 = iadd v9, v10
+    return v11
+}

--- a/filetests/wasm/multi-val-i64.clif
+++ b/filetests/wasm/multi-val-i64.clif
@@ -1,0 +1,44 @@
+test compile
+target x86_64 haswell
+
+;; Returning many i64s
+
+function %return_2_i64s() -> i64, i64 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconst.i64 1
+    return v0, v1
+}
+
+function %return_3_i64s() -> i64, i64, i64 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconst.i64 1
+    v2 = iconst.i64 2
+    return v0, v1, v2
+}
+
+function %return_4_i64s() -> i64, i64, i64, i64 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconst.i64 1
+    v2 = iconst.i64 2
+    v3 = iconst.i64 3
+    return v0, v1, v2, v3
+}
+
+;; Calling functions that return many i64s
+
+function %call() -> i64 {
+    fn0 = %a() -> i64, i64
+    fn1 = %b(i64, i64) -> i64, i64, i64
+    fn2 = %c(i64, i64, i64) -> i64, i64, i64, i64
+ebb0:
+    v0, v1 = call fn0()
+    v2, v3, v4 = call fn1(v0, v1)
+    v5, v6, v7, v8 = call fn2(v2, v3, v4)
+    v9 = iadd v5, v6
+    v10 = iadd v7, v8
+    v11 = iadd v9, v10
+    return v11
+}

--- a/filetests/wasm/multi-val-mixed.clif
+++ b/filetests/wasm/multi-val-mixed.clif
@@ -1,0 +1,2098 @@
+test compile
+target x86_64 haswell
+
+;; Returning many mixed values.
+;;
+;; This test was generated programmatically with this python script:
+;;
+;; ```
+;; from itertools import permutations
+;;
+;; def make_val(i, r):
+;;     val = None
+;;     op = None
+;;     if r == "f32":
+;;         val = "0x0.0"
+;;         op = "f32const"
+;;     elif r == "f64":
+;;         val = "0x0.0"
+;;         op = "f64const"
+;;     elif r == "i32":
+;;         val = "0"
+;;         op = "iconst.i32"
+;;     elif r == "i64":
+;;         val = "0"
+;;         op = "iconst.i64"
+;;     elif r == "b1":
+;;         val = "true"
+;;         op = "bconst.b1"
+;;     else:
+;;         raise Exception("bad r = " + str(r))
+;;     return "    v" + str(i) + " = " + op + " " + val
+;;
+;; def make_returner(results):
+;;     results = list(results)
+;;     head = "function %return_" + "_".join(results) + "() -> " + ", ".join(results) + " {\n"
+;;     ebb = "ebb0:\n"
+;;     vals = [make_val(i, r) for i, r in enumerate(results)]
+;;     ret = "    return " + ", ".join(("v" + str(i) for i in range(0, len(results))))
+;;     return head + ebb + "\n".join(vals) + "\n" + ret + "\n}\n"
+;;
+;; def make_caller(results):
+;;     results = list(results)
+;;     head = "function %call_" + "_".join(results) + "() {\n"
+;;     fn_decl = "    fn0 = %foo() -> " + ",".join(results) + "\n"
+;;     ebb = "ebb0:\n"
+;;     ret_vars = ["v" + str(i) for i, r in enumerate(results)]
+;;     call = "    " + ",".join(ret_vars) + " = call fn0()\n"
+;;     ret = "    return\n"
+;;     tail = "}\n"
+;;     return head + fn_decl + ebb + call + ret + tail
+;;
+;; for results in permutations(["i32", "i64", "f32", "f64", "b1"]):
+;;     print make_returner(results)
+;;     print make_caller(results)
+;; ```
+;;
+;; If you're modifying this test, it is likely easier to modify the script and
+;; regenerate the test.
+
+function %return_i32_i64_f32_f64_b1() -> i32, i64, f32, f64, b1 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i64 0
+    v2 = f32const 0x0.0
+    v3 = f64const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_i64_f32_f64_b1() {
+    fn0 = %foo() -> i32,i64,f32,f64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_i64_f32_b1_f64() -> i32, i64, f32, b1, f64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i64 0
+    v2 = f32const 0x0.0
+    v3 = bconst.b1 true
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_i64_f32_b1_f64() {
+    fn0 = %foo() -> i32,i64,f32,b1,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_i64_f64_f32_b1() -> i32, i64, f64, f32, b1 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i64 0
+    v2 = f64const 0x0.0
+    v3 = f32const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_i64_f64_f32_b1() {
+    fn0 = %foo() -> i32,i64,f64,f32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_i64_f64_b1_f32() -> i32, i64, f64, b1, f32 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i64 0
+    v2 = f64const 0x0.0
+    v3 = bconst.b1 true
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_i64_f64_b1_f32() {
+    fn0 = %foo() -> i32,i64,f64,b1,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_i64_b1_f32_f64() -> i32, i64, b1, f32, f64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i64 0
+    v2 = bconst.b1 true
+    v3 = f32const 0x0.0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_i64_b1_f32_f64() {
+    fn0 = %foo() -> i32,i64,b1,f32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_i64_b1_f64_f32() -> i32, i64, b1, f64, f32 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i64 0
+    v2 = bconst.b1 true
+    v3 = f64const 0x0.0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_i64_b1_f64_f32() {
+    fn0 = %foo() -> i32,i64,b1,f64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f32_i64_f64_b1() -> i32, f32, i64, f64, b1 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f32const 0x0.0
+    v2 = iconst.i64 0
+    v3 = f64const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f32_i64_f64_b1() {
+    fn0 = %foo() -> i32,f32,i64,f64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f32_i64_b1_f64() -> i32, f32, i64, b1, f64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f32const 0x0.0
+    v2 = iconst.i64 0
+    v3 = bconst.b1 true
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f32_i64_b1_f64() {
+    fn0 = %foo() -> i32,f32,i64,b1,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f32_f64_i64_b1() -> i32, f32, f64, i64, b1 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f32const 0x0.0
+    v2 = f64const 0x0.0
+    v3 = iconst.i64 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f32_f64_i64_b1() {
+    fn0 = %foo() -> i32,f32,f64,i64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f32_f64_b1_i64() -> i32, f32, f64, b1, i64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f32const 0x0.0
+    v2 = f64const 0x0.0
+    v3 = bconst.b1 true
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f32_f64_b1_i64() {
+    fn0 = %foo() -> i32,f32,f64,b1,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f32_b1_i64_f64() -> i32, f32, b1, i64, f64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f32const 0x0.0
+    v2 = bconst.b1 true
+    v3 = iconst.i64 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f32_b1_i64_f64() {
+    fn0 = %foo() -> i32,f32,b1,i64,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f32_b1_f64_i64() -> i32, f32, b1, f64, i64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f32const 0x0.0
+    v2 = bconst.b1 true
+    v3 = f64const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f32_b1_f64_i64() {
+    fn0 = %foo() -> i32,f32,b1,f64,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f64_i64_f32_b1() -> i32, f64, i64, f32, b1 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f64const 0x0.0
+    v2 = iconst.i64 0
+    v3 = f32const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f64_i64_f32_b1() {
+    fn0 = %foo() -> i32,f64,i64,f32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f64_i64_b1_f32() -> i32, f64, i64, b1, f32 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f64const 0x0.0
+    v2 = iconst.i64 0
+    v3 = bconst.b1 true
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f64_i64_b1_f32() {
+    fn0 = %foo() -> i32,f64,i64,b1,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f64_f32_i64_b1() -> i32, f64, f32, i64, b1 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f64const 0x0.0
+    v2 = f32const 0x0.0
+    v3 = iconst.i64 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f64_f32_i64_b1() {
+    fn0 = %foo() -> i32,f64,f32,i64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f64_f32_b1_i64() -> i32, f64, f32, b1, i64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f64const 0x0.0
+    v2 = f32const 0x0.0
+    v3 = bconst.b1 true
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f64_f32_b1_i64() {
+    fn0 = %foo() -> i32,f64,f32,b1,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f64_b1_i64_f32() -> i32, f64, b1, i64, f32 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f64const 0x0.0
+    v2 = bconst.b1 true
+    v3 = iconst.i64 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f64_b1_i64_f32() {
+    fn0 = %foo() -> i32,f64,b1,i64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_f64_b1_f32_i64() -> i32, f64, b1, f32, i64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = f64const 0x0.0
+    v2 = bconst.b1 true
+    v3 = f32const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_f64_b1_f32_i64() {
+    fn0 = %foo() -> i32,f64,b1,f32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_b1_i64_f32_f64() -> i32, b1, i64, f32, f64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = bconst.b1 true
+    v2 = iconst.i64 0
+    v3 = f32const 0x0.0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_b1_i64_f32_f64() {
+    fn0 = %foo() -> i32,b1,i64,f32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_b1_i64_f64_f32() -> i32, b1, i64, f64, f32 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = bconst.b1 true
+    v2 = iconst.i64 0
+    v3 = f64const 0x0.0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_b1_i64_f64_f32() {
+    fn0 = %foo() -> i32,b1,i64,f64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_b1_f32_i64_f64() -> i32, b1, f32, i64, f64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = bconst.b1 true
+    v2 = f32const 0x0.0
+    v3 = iconst.i64 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_b1_f32_i64_f64() {
+    fn0 = %foo() -> i32,b1,f32,i64,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_b1_f32_f64_i64() -> i32, b1, f32, f64, i64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = bconst.b1 true
+    v2 = f32const 0x0.0
+    v3 = f64const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_b1_f32_f64_i64() {
+    fn0 = %foo() -> i32,b1,f32,f64,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_b1_f64_i64_f32() -> i32, b1, f64, i64, f32 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = bconst.b1 true
+    v2 = f64const 0x0.0
+    v3 = iconst.i64 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_b1_f64_i64_f32() {
+    fn0 = %foo() -> i32,b1,f64,i64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i32_b1_f64_f32_i64() -> i32, b1, f64, f32, i64 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = bconst.b1 true
+    v2 = f64const 0x0.0
+    v3 = f32const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i32_b1_f64_f32_i64() {
+    fn0 = %foo() -> i32,b1,f64,f32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_i32_f32_f64_b1() -> i64, i32, f32, f64, b1 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconst.i32 0
+    v2 = f32const 0x0.0
+    v3 = f64const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_i32_f32_f64_b1() {
+    fn0 = %foo() -> i64,i32,f32,f64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_i32_f32_b1_f64() -> i64, i32, f32, b1, f64 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconst.i32 0
+    v2 = f32const 0x0.0
+    v3 = bconst.b1 true
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_i32_f32_b1_f64() {
+    fn0 = %foo() -> i64,i32,f32,b1,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_i32_f64_f32_b1() -> i64, i32, f64, f32, b1 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconst.i32 0
+    v2 = f64const 0x0.0
+    v3 = f32const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_i32_f64_f32_b1() {
+    fn0 = %foo() -> i64,i32,f64,f32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_i32_f64_b1_f32() -> i64, i32, f64, b1, f32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconst.i32 0
+    v2 = f64const 0x0.0
+    v3 = bconst.b1 true
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_i32_f64_b1_f32() {
+    fn0 = %foo() -> i64,i32,f64,b1,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_i32_b1_f32_f64() -> i64, i32, b1, f32, f64 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconst.i32 0
+    v2 = bconst.b1 true
+    v3 = f32const 0x0.0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_i32_b1_f32_f64() {
+    fn0 = %foo() -> i64,i32,b1,f32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_i32_b1_f64_f32() -> i64, i32, b1, f64, f32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconst.i32 0
+    v2 = bconst.b1 true
+    v3 = f64const 0x0.0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_i32_b1_f64_f32() {
+    fn0 = %foo() -> i64,i32,b1,f64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f32_i32_f64_b1() -> i64, f32, i32, f64, b1 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f32const 0x0.0
+    v2 = iconst.i32 0
+    v3 = f64const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f32_i32_f64_b1() {
+    fn0 = %foo() -> i64,f32,i32,f64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f32_i32_b1_f64() -> i64, f32, i32, b1, f64 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f32const 0x0.0
+    v2 = iconst.i32 0
+    v3 = bconst.b1 true
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f32_i32_b1_f64() {
+    fn0 = %foo() -> i64,f32,i32,b1,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f32_f64_i32_b1() -> i64, f32, f64, i32, b1 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f32const 0x0.0
+    v2 = f64const 0x0.0
+    v3 = iconst.i32 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f32_f64_i32_b1() {
+    fn0 = %foo() -> i64,f32,f64,i32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f32_f64_b1_i32() -> i64, f32, f64, b1, i32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f32const 0x0.0
+    v2 = f64const 0x0.0
+    v3 = bconst.b1 true
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f32_f64_b1_i32() {
+    fn0 = %foo() -> i64,f32,f64,b1,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f32_b1_i32_f64() -> i64, f32, b1, i32, f64 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f32const 0x0.0
+    v2 = bconst.b1 true
+    v3 = iconst.i32 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f32_b1_i32_f64() {
+    fn0 = %foo() -> i64,f32,b1,i32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f32_b1_f64_i32() -> i64, f32, b1, f64, i32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f32const 0x0.0
+    v2 = bconst.b1 true
+    v3 = f64const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f32_b1_f64_i32() {
+    fn0 = %foo() -> i64,f32,b1,f64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f64_i32_f32_b1() -> i64, f64, i32, f32, b1 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f64const 0x0.0
+    v2 = iconst.i32 0
+    v3 = f32const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f64_i32_f32_b1() {
+    fn0 = %foo() -> i64,f64,i32,f32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f64_i32_b1_f32() -> i64, f64, i32, b1, f32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f64const 0x0.0
+    v2 = iconst.i32 0
+    v3 = bconst.b1 true
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f64_i32_b1_f32() {
+    fn0 = %foo() -> i64,f64,i32,b1,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f64_f32_i32_b1() -> i64, f64, f32, i32, b1 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f64const 0x0.0
+    v2 = f32const 0x0.0
+    v3 = iconst.i32 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f64_f32_i32_b1() {
+    fn0 = %foo() -> i64,f64,f32,i32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f64_f32_b1_i32() -> i64, f64, f32, b1, i32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f64const 0x0.0
+    v2 = f32const 0x0.0
+    v3 = bconst.b1 true
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f64_f32_b1_i32() {
+    fn0 = %foo() -> i64,f64,f32,b1,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f64_b1_i32_f32() -> i64, f64, b1, i32, f32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f64const 0x0.0
+    v2 = bconst.b1 true
+    v3 = iconst.i32 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f64_b1_i32_f32() {
+    fn0 = %foo() -> i64,f64,b1,i32,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_f64_b1_f32_i32() -> i64, f64, b1, f32, i32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = f64const 0x0.0
+    v2 = bconst.b1 true
+    v3 = f32const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_f64_b1_f32_i32() {
+    fn0 = %foo() -> i64,f64,b1,f32,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_b1_i32_f32_f64() -> i64, b1, i32, f32, f64 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = bconst.b1 true
+    v2 = iconst.i32 0
+    v3 = f32const 0x0.0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_b1_i32_f32_f64() {
+    fn0 = %foo() -> i64,b1,i32,f32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_b1_i32_f64_f32() -> i64, b1, i32, f64, f32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = bconst.b1 true
+    v2 = iconst.i32 0
+    v3 = f64const 0x0.0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_b1_i32_f64_f32() {
+    fn0 = %foo() -> i64,b1,i32,f64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_b1_f32_i32_f64() -> i64, b1, f32, i32, f64 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = bconst.b1 true
+    v2 = f32const 0x0.0
+    v3 = iconst.i32 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_b1_f32_i32_f64() {
+    fn0 = %foo() -> i64,b1,f32,i32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_b1_f32_f64_i32() -> i64, b1, f32, f64, i32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = bconst.b1 true
+    v2 = f32const 0x0.0
+    v3 = f64const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_b1_f32_f64_i32() {
+    fn0 = %foo() -> i64,b1,f32,f64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_b1_f64_i32_f32() -> i64, b1, f64, i32, f32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = bconst.b1 true
+    v2 = f64const 0x0.0
+    v3 = iconst.i32 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_b1_f64_i32_f32() {
+    fn0 = %foo() -> i64,b1,f64,i32,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_i64_b1_f64_f32_i32() -> i64, b1, f64, f32, i32 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = bconst.b1 true
+    v2 = f64const 0x0.0
+    v3 = f32const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_i64_b1_f64_f32_i32() {
+    fn0 = %foo() -> i64,b1,f64,f32,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i32_i64_f64_b1() -> f32, i32, i64, f64, b1 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i32 0
+    v2 = iconst.i64 0
+    v3 = f64const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i32_i64_f64_b1() {
+    fn0 = %foo() -> f32,i32,i64,f64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i32_i64_b1_f64() -> f32, i32, i64, b1, f64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i32 0
+    v2 = iconst.i64 0
+    v3 = bconst.b1 true
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i32_i64_b1_f64() {
+    fn0 = %foo() -> f32,i32,i64,b1,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i32_f64_i64_b1() -> f32, i32, f64, i64, b1 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i32 0
+    v2 = f64const 0x0.0
+    v3 = iconst.i64 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i32_f64_i64_b1() {
+    fn0 = %foo() -> f32,i32,f64,i64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i32_f64_b1_i64() -> f32, i32, f64, b1, i64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i32 0
+    v2 = f64const 0x0.0
+    v3 = bconst.b1 true
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i32_f64_b1_i64() {
+    fn0 = %foo() -> f32,i32,f64,b1,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i32_b1_i64_f64() -> f32, i32, b1, i64, f64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i32 0
+    v2 = bconst.b1 true
+    v3 = iconst.i64 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i32_b1_i64_f64() {
+    fn0 = %foo() -> f32,i32,b1,i64,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i32_b1_f64_i64() -> f32, i32, b1, f64, i64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i32 0
+    v2 = bconst.b1 true
+    v3 = f64const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i32_b1_f64_i64() {
+    fn0 = %foo() -> f32,i32,b1,f64,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i64_i32_f64_b1() -> f32, i64, i32, f64, b1 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i64 0
+    v2 = iconst.i32 0
+    v3 = f64const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i64_i32_f64_b1() {
+    fn0 = %foo() -> f32,i64,i32,f64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i64_i32_b1_f64() -> f32, i64, i32, b1, f64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i64 0
+    v2 = iconst.i32 0
+    v3 = bconst.b1 true
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i64_i32_b1_f64() {
+    fn0 = %foo() -> f32,i64,i32,b1,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i64_f64_i32_b1() -> f32, i64, f64, i32, b1 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i64 0
+    v2 = f64const 0x0.0
+    v3 = iconst.i32 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i64_f64_i32_b1() {
+    fn0 = %foo() -> f32,i64,f64,i32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i64_f64_b1_i32() -> f32, i64, f64, b1, i32 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i64 0
+    v2 = f64const 0x0.0
+    v3 = bconst.b1 true
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i64_f64_b1_i32() {
+    fn0 = %foo() -> f32,i64,f64,b1,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i64_b1_i32_f64() -> f32, i64, b1, i32, f64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i64 0
+    v2 = bconst.b1 true
+    v3 = iconst.i32 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i64_b1_i32_f64() {
+    fn0 = %foo() -> f32,i64,b1,i32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_i64_b1_f64_i32() -> f32, i64, b1, f64, i32 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = iconst.i64 0
+    v2 = bconst.b1 true
+    v3 = f64const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_i64_b1_f64_i32() {
+    fn0 = %foo() -> f32,i64,b1,f64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_f64_i32_i64_b1() -> f32, f64, i32, i64, b1 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = f64const 0x0.0
+    v2 = iconst.i32 0
+    v3 = iconst.i64 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_f64_i32_i64_b1() {
+    fn0 = %foo() -> f32,f64,i32,i64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_f64_i32_b1_i64() -> f32, f64, i32, b1, i64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = f64const 0x0.0
+    v2 = iconst.i32 0
+    v3 = bconst.b1 true
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_f64_i32_b1_i64() {
+    fn0 = %foo() -> f32,f64,i32,b1,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_f64_i64_i32_b1() -> f32, f64, i64, i32, b1 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = f64const 0x0.0
+    v2 = iconst.i64 0
+    v3 = iconst.i32 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_f64_i64_i32_b1() {
+    fn0 = %foo() -> f32,f64,i64,i32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_f64_i64_b1_i32() -> f32, f64, i64, b1, i32 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = f64const 0x0.0
+    v2 = iconst.i64 0
+    v3 = bconst.b1 true
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_f64_i64_b1_i32() {
+    fn0 = %foo() -> f32,f64,i64,b1,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_f64_b1_i32_i64() -> f32, f64, b1, i32, i64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = f64const 0x0.0
+    v2 = bconst.b1 true
+    v3 = iconst.i32 0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_f64_b1_i32_i64() {
+    fn0 = %foo() -> f32,f64,b1,i32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_f64_b1_i64_i32() -> f32, f64, b1, i64, i32 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = f64const 0x0.0
+    v2 = bconst.b1 true
+    v3 = iconst.i64 0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_f64_b1_i64_i32() {
+    fn0 = %foo() -> f32,f64,b1,i64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_b1_i32_i64_f64() -> f32, b1, i32, i64, f64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = bconst.b1 true
+    v2 = iconst.i32 0
+    v3 = iconst.i64 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_b1_i32_i64_f64() {
+    fn0 = %foo() -> f32,b1,i32,i64,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_b1_i32_f64_i64() -> f32, b1, i32, f64, i64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = bconst.b1 true
+    v2 = iconst.i32 0
+    v3 = f64const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_b1_i32_f64_i64() {
+    fn0 = %foo() -> f32,b1,i32,f64,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_b1_i64_i32_f64() -> f32, b1, i64, i32, f64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = bconst.b1 true
+    v2 = iconst.i64 0
+    v3 = iconst.i32 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_b1_i64_i32_f64() {
+    fn0 = %foo() -> f32,b1,i64,i32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_b1_i64_f64_i32() -> f32, b1, i64, f64, i32 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = bconst.b1 true
+    v2 = iconst.i64 0
+    v3 = f64const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_b1_i64_f64_i32() {
+    fn0 = %foo() -> f32,b1,i64,f64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_b1_f64_i32_i64() -> f32, b1, f64, i32, i64 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = bconst.b1 true
+    v2 = f64const 0x0.0
+    v3 = iconst.i32 0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_b1_f64_i32_i64() {
+    fn0 = %foo() -> f32,b1,f64,i32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f32_b1_f64_i64_i32() -> f32, b1, f64, i64, i32 {
+ebb0:
+    v0 = f32const 0x0.0
+    v1 = bconst.b1 true
+    v2 = f64const 0x0.0
+    v3 = iconst.i64 0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f32_b1_f64_i64_i32() {
+    fn0 = %foo() -> f32,b1,f64,i64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i32_i64_f32_b1() -> f64, i32, i64, f32, b1 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i32 0
+    v2 = iconst.i64 0
+    v3 = f32const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i32_i64_f32_b1() {
+    fn0 = %foo() -> f64,i32,i64,f32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i32_i64_b1_f32() -> f64, i32, i64, b1, f32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i32 0
+    v2 = iconst.i64 0
+    v3 = bconst.b1 true
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i32_i64_b1_f32() {
+    fn0 = %foo() -> f64,i32,i64,b1,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i32_f32_i64_b1() -> f64, i32, f32, i64, b1 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i32 0
+    v2 = f32const 0x0.0
+    v3 = iconst.i64 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i32_f32_i64_b1() {
+    fn0 = %foo() -> f64,i32,f32,i64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i32_f32_b1_i64() -> f64, i32, f32, b1, i64 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i32 0
+    v2 = f32const 0x0.0
+    v3 = bconst.b1 true
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i32_f32_b1_i64() {
+    fn0 = %foo() -> f64,i32,f32,b1,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i32_b1_i64_f32() -> f64, i32, b1, i64, f32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i32 0
+    v2 = bconst.b1 true
+    v3 = iconst.i64 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i32_b1_i64_f32() {
+    fn0 = %foo() -> f64,i32,b1,i64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i32_b1_f32_i64() -> f64, i32, b1, f32, i64 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i32 0
+    v2 = bconst.b1 true
+    v3 = f32const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i32_b1_f32_i64() {
+    fn0 = %foo() -> f64,i32,b1,f32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i64_i32_f32_b1() -> f64, i64, i32, f32, b1 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i64 0
+    v2 = iconst.i32 0
+    v3 = f32const 0x0.0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i64_i32_f32_b1() {
+    fn0 = %foo() -> f64,i64,i32,f32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i64_i32_b1_f32() -> f64, i64, i32, b1, f32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i64 0
+    v2 = iconst.i32 0
+    v3 = bconst.b1 true
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i64_i32_b1_f32() {
+    fn0 = %foo() -> f64,i64,i32,b1,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i64_f32_i32_b1() -> f64, i64, f32, i32, b1 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i64 0
+    v2 = f32const 0x0.0
+    v3 = iconst.i32 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i64_f32_i32_b1() {
+    fn0 = %foo() -> f64,i64,f32,i32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i64_f32_b1_i32() -> f64, i64, f32, b1, i32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i64 0
+    v2 = f32const 0x0.0
+    v3 = bconst.b1 true
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i64_f32_b1_i32() {
+    fn0 = %foo() -> f64,i64,f32,b1,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i64_b1_i32_f32() -> f64, i64, b1, i32, f32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i64 0
+    v2 = bconst.b1 true
+    v3 = iconst.i32 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i64_b1_i32_f32() {
+    fn0 = %foo() -> f64,i64,b1,i32,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_i64_b1_f32_i32() -> f64, i64, b1, f32, i32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = iconst.i64 0
+    v2 = bconst.b1 true
+    v3 = f32const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_i64_b1_f32_i32() {
+    fn0 = %foo() -> f64,i64,b1,f32,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_f32_i32_i64_b1() -> f64, f32, i32, i64, b1 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = f32const 0x0.0
+    v2 = iconst.i32 0
+    v3 = iconst.i64 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_f32_i32_i64_b1() {
+    fn0 = %foo() -> f64,f32,i32,i64,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_f32_i32_b1_i64() -> f64, f32, i32, b1, i64 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = f32const 0x0.0
+    v2 = iconst.i32 0
+    v3 = bconst.b1 true
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_f32_i32_b1_i64() {
+    fn0 = %foo() -> f64,f32,i32,b1,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_f32_i64_i32_b1() -> f64, f32, i64, i32, b1 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = f32const 0x0.0
+    v2 = iconst.i64 0
+    v3 = iconst.i32 0
+    v4 = bconst.b1 true
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_f32_i64_i32_b1() {
+    fn0 = %foo() -> f64,f32,i64,i32,b1
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_f32_i64_b1_i32() -> f64, f32, i64, b1, i32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = f32const 0x0.0
+    v2 = iconst.i64 0
+    v3 = bconst.b1 true
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_f32_i64_b1_i32() {
+    fn0 = %foo() -> f64,f32,i64,b1,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_f32_b1_i32_i64() -> f64, f32, b1, i32, i64 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = f32const 0x0.0
+    v2 = bconst.b1 true
+    v3 = iconst.i32 0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_f32_b1_i32_i64() {
+    fn0 = %foo() -> f64,f32,b1,i32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_f32_b1_i64_i32() -> f64, f32, b1, i64, i32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = f32const 0x0.0
+    v2 = bconst.b1 true
+    v3 = iconst.i64 0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_f32_b1_i64_i32() {
+    fn0 = %foo() -> f64,f32,b1,i64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_b1_i32_i64_f32() -> f64, b1, i32, i64, f32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = bconst.b1 true
+    v2 = iconst.i32 0
+    v3 = iconst.i64 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_b1_i32_i64_f32() {
+    fn0 = %foo() -> f64,b1,i32,i64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_b1_i32_f32_i64() -> f64, b1, i32, f32, i64 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = bconst.b1 true
+    v2 = iconst.i32 0
+    v3 = f32const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_b1_i32_f32_i64() {
+    fn0 = %foo() -> f64,b1,i32,f32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_b1_i64_i32_f32() -> f64, b1, i64, i32, f32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = bconst.b1 true
+    v2 = iconst.i64 0
+    v3 = iconst.i32 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_b1_i64_i32_f32() {
+    fn0 = %foo() -> f64,b1,i64,i32,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_b1_i64_f32_i32() -> f64, b1, i64, f32, i32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = bconst.b1 true
+    v2 = iconst.i64 0
+    v3 = f32const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_b1_i64_f32_i32() {
+    fn0 = %foo() -> f64,b1,i64,f32,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_b1_f32_i32_i64() -> f64, b1, f32, i32, i64 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = bconst.b1 true
+    v2 = f32const 0x0.0
+    v3 = iconst.i32 0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_b1_f32_i32_i64() {
+    fn0 = %foo() -> f64,b1,f32,i32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_f64_b1_f32_i64_i32() -> f64, b1, f32, i64, i32 {
+ebb0:
+    v0 = f64const 0x0.0
+    v1 = bconst.b1 true
+    v2 = f32const 0x0.0
+    v3 = iconst.i64 0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_f64_b1_f32_i64_i32() {
+    fn0 = %foo() -> f64,b1,f32,i64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i32_i64_f32_f64() -> b1, i32, i64, f32, f64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i32 0
+    v2 = iconst.i64 0
+    v3 = f32const 0x0.0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i32_i64_f32_f64() {
+    fn0 = %foo() -> b1,i32,i64,f32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i32_i64_f64_f32() -> b1, i32, i64, f64, f32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i32 0
+    v2 = iconst.i64 0
+    v3 = f64const 0x0.0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i32_i64_f64_f32() {
+    fn0 = %foo() -> b1,i32,i64,f64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i32_f32_i64_f64() -> b1, i32, f32, i64, f64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i32 0
+    v2 = f32const 0x0.0
+    v3 = iconst.i64 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i32_f32_i64_f64() {
+    fn0 = %foo() -> b1,i32,f32,i64,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i32_f32_f64_i64() -> b1, i32, f32, f64, i64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i32 0
+    v2 = f32const 0x0.0
+    v3 = f64const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i32_f32_f64_i64() {
+    fn0 = %foo() -> b1,i32,f32,f64,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i32_f64_i64_f32() -> b1, i32, f64, i64, f32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i32 0
+    v2 = f64const 0x0.0
+    v3 = iconst.i64 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i32_f64_i64_f32() {
+    fn0 = %foo() -> b1,i32,f64,i64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i32_f64_f32_i64() -> b1, i32, f64, f32, i64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i32 0
+    v2 = f64const 0x0.0
+    v3 = f32const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i32_f64_f32_i64() {
+    fn0 = %foo() -> b1,i32,f64,f32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i64_i32_f32_f64() -> b1, i64, i32, f32, f64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i64 0
+    v2 = iconst.i32 0
+    v3 = f32const 0x0.0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i64_i32_f32_f64() {
+    fn0 = %foo() -> b1,i64,i32,f32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i64_i32_f64_f32() -> b1, i64, i32, f64, f32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i64 0
+    v2 = iconst.i32 0
+    v3 = f64const 0x0.0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i64_i32_f64_f32() {
+    fn0 = %foo() -> b1,i64,i32,f64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i64_f32_i32_f64() -> b1, i64, f32, i32, f64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i64 0
+    v2 = f32const 0x0.0
+    v3 = iconst.i32 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i64_f32_i32_f64() {
+    fn0 = %foo() -> b1,i64,f32,i32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i64_f32_f64_i32() -> b1, i64, f32, f64, i32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i64 0
+    v2 = f32const 0x0.0
+    v3 = f64const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i64_f32_f64_i32() {
+    fn0 = %foo() -> b1,i64,f32,f64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i64_f64_i32_f32() -> b1, i64, f64, i32, f32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i64 0
+    v2 = f64const 0x0.0
+    v3 = iconst.i32 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i64_f64_i32_f32() {
+    fn0 = %foo() -> b1,i64,f64,i32,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_i64_f64_f32_i32() -> b1, i64, f64, f32, i32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = iconst.i64 0
+    v2 = f64const 0x0.0
+    v3 = f32const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_i64_f64_f32_i32() {
+    fn0 = %foo() -> b1,i64,f64,f32,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f32_i32_i64_f64() -> b1, f32, i32, i64, f64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f32const 0x0.0
+    v2 = iconst.i32 0
+    v3 = iconst.i64 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f32_i32_i64_f64() {
+    fn0 = %foo() -> b1,f32,i32,i64,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f32_i32_f64_i64() -> b1, f32, i32, f64, i64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f32const 0x0.0
+    v2 = iconst.i32 0
+    v3 = f64const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f32_i32_f64_i64() {
+    fn0 = %foo() -> b1,f32,i32,f64,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f32_i64_i32_f64() -> b1, f32, i64, i32, f64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f32const 0x0.0
+    v2 = iconst.i64 0
+    v3 = iconst.i32 0
+    v4 = f64const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f32_i64_i32_f64() {
+    fn0 = %foo() -> b1,f32,i64,i32,f64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f32_i64_f64_i32() -> b1, f32, i64, f64, i32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f32const 0x0.0
+    v2 = iconst.i64 0
+    v3 = f64const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f32_i64_f64_i32() {
+    fn0 = %foo() -> b1,f32,i64,f64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f32_f64_i32_i64() -> b1, f32, f64, i32, i64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f32const 0x0.0
+    v2 = f64const 0x0.0
+    v3 = iconst.i32 0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f32_f64_i32_i64() {
+    fn0 = %foo() -> b1,f32,f64,i32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f32_f64_i64_i32() -> b1, f32, f64, i64, i32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f32const 0x0.0
+    v2 = f64const 0x0.0
+    v3 = iconst.i64 0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f32_f64_i64_i32() {
+    fn0 = %foo() -> b1,f32,f64,i64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f64_i32_i64_f32() -> b1, f64, i32, i64, f32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f64const 0x0.0
+    v2 = iconst.i32 0
+    v3 = iconst.i64 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f64_i32_i64_f32() {
+    fn0 = %foo() -> b1,f64,i32,i64,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f64_i32_f32_i64() -> b1, f64, i32, f32, i64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f64const 0x0.0
+    v2 = iconst.i32 0
+    v3 = f32const 0x0.0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f64_i32_f32_i64() {
+    fn0 = %foo() -> b1,f64,i32,f32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f64_i64_i32_f32() -> b1, f64, i64, i32, f32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f64const 0x0.0
+    v2 = iconst.i64 0
+    v3 = iconst.i32 0
+    v4 = f32const 0x0.0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f64_i64_i32_f32() {
+    fn0 = %foo() -> b1,f64,i64,i32,f32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f64_i64_f32_i32() -> b1, f64, i64, f32, i32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f64const 0x0.0
+    v2 = iconst.i64 0
+    v3 = f32const 0x0.0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f64_i64_f32_i32() {
+    fn0 = %foo() -> b1,f64,i64,f32,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f64_f32_i32_i64() -> b1, f64, f32, i32, i64 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f64const 0x0.0
+    v2 = f32const 0x0.0
+    v3 = iconst.i32 0
+    v4 = iconst.i64 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f64_f32_i32_i64() {
+    fn0 = %foo() -> b1,f64,f32,i32,i64
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}
+
+function %return_b1_f64_f32_i64_i32() -> b1, f64, f32, i64, i32 {
+ebb0:
+    v0 = bconst.b1 true
+    v1 = f64const 0x0.0
+    v2 = f32const 0x0.0
+    v3 = iconst.i64 0
+    v4 = iconst.i32 0
+    return v0, v1, v2, v3, v4
+}
+
+function %call_b1_f64_f32_i64_i32() {
+    fn0 = %foo() -> b1,f64,f32,i64,i32
+ebb0:
+    v0,v1,v2,v3,v4 = call fn0()
+    return
+}

--- a/filetests/wasm/multi-val-reuse-ret-ptr-stack-slot.clif
+++ b/filetests/wasm/multi-val-reuse-ret-ptr-stack-slot.clif
@@ -1,0 +1,61 @@
+test legalizer
+target x86_64 haswell
+
+;; Test that we don't reuse `sret` stack slots for multiple calls. We could do
+;; this one day, but it would require some care to ensure that we don't have
+;; subsequent calls overwrite the results of previous calls.
+
+function %foo() -> i32, f32 {
+    ; check:  ss0 = ret_ptr 20, offset 0
+    ; nextln: ss1 = ret_ptr 20, offset 20
+
+    fn0 = %f() -> i32, i32, i32, i32, i32
+    fn1 = %g() -> f32, f32, f32, f32, f32
+    ; check:  sig0 = (i64 sret [%rdi]) -> i64 sret [%rax] fast
+    ; nextln: sig1 = (i64 sret [%rdi]) -> i64 sret [%rax] fast
+    ; nextln: fn0 = %f sig0
+    ; nextln: fn1 = %g sig1
+
+ebb0:
+    v0, v1, v2, v3, v4 = call fn0()
+    ; check:  v18 = stack_addr.i64 ss0
+    ; nextln: v25 = func_addr.i64 fn0
+    ; nextln: v19 = call_indirect sig0, v25(v18)
+    ; nextln: v20 = load.i32 notrap aligned v19
+    ; nextln: v0 -> v20
+    ; nextln: v21 = load.i32 notrap aligned v19+4
+    ; nextln: v1 -> v21
+    ; nextln: v22 = load.i32 notrap aligned v19+8
+    ; nextln: v2 -> v22
+    ; nextln: v23 = load.i32 notrap aligned v19+12
+    ; nextln: v3 -> v23
+    ; nextln: v24 = load.i32 notrap aligned v19+16
+    ; nextln: v4 -> v24
+
+    v5, v6, v7, v8, v9 = call fn1()
+    ; check:  v26 = stack_addr.i64 ss1
+    ; nextln: v33 = func_addr.i64 fn1
+    ; nextln: v27 = call_indirect sig1, v33(v26)
+    ; nextln: v28 = load.f32 notrap aligned v27
+    ; nextln: v5 -> v28
+    ; nextln: v29 = load.f32 notrap aligned v27+4
+    ; nextln: v6 -> v29
+    ; nextln: v30 = load.f32 notrap aligned v27+8
+    ; nextln: v7 -> v30
+    ; nextln: v31 = load.f32 notrap aligned v27+12
+    ; nextln: v8 -> v31
+    ; nextln: v32 = load.f32 notrap aligned v27+16
+    ; nextln: v9 -> v32
+
+    v10 = iadd v0, v1
+    v11 = iadd v2, v3
+    v12 = iadd v10, v11
+    v13 = iadd v12, v4
+
+    v14 = fadd v5, v6
+    v15 = fadd v7, v8
+    v16 = fadd v14, v15
+    v17 = fadd v16, v9
+
+    return v13, v17
+}

--- a/filetests/wasm/multi-val-reuse-ret-ptr-stack-slot.clif
+++ b/filetests/wasm/multi-val-reuse-ret-ptr-stack-slot.clif
@@ -6,8 +6,8 @@ target x86_64 haswell
 ;; subsequent calls overwrite the results of previous calls.
 
 function %foo() -> i32, f32 {
-    ; check:  ss0 = ret_ptr 20, offset 0
-    ; nextln: ss1 = ret_ptr 20, offset 20
+    ; check:  ss0 = sret_slot 20, offset 0
+    ; nextln: ss1 = sret_slot 20, offset 20
 
     fn0 = %f() -> i32, i32, i32, i32, i32
     fn1 = %g() -> f32, f32, f32, f32, f32

--- a/filetests/wasm/multi-val-reuse-ret-ptr-stack-slot.clif
+++ b/filetests/wasm/multi-val-reuse-ret-ptr-stack-slot.clif
@@ -6,8 +6,8 @@ target x86_64 haswell
 ;; subsequent calls overwrite the results of previous calls.
 
 function %foo() -> i32, f32 {
-    ; check:  ss0 = sret_slot 20, offset 0
-    ; nextln: ss1 = sret_slot 20, offset 20
+    ; check:  ss0 = sret_slot 20
+    ; nextln: ss1 = sret_slot 20
 
     fn0 = %f() -> i32, i32, i32, i32, i32
     fn1 = %g() -> f32, f32, f32, f32, f32

--- a/filetests/wasm/multi-val-sret-slot-alignment.clif
+++ b/filetests/wasm/multi-val-sret-slot-alignment.clif
@@ -1,0 +1,51 @@
+test legalizer
+target x86_64 haswell
+
+;; Need to insert padding after the `i8`s so that the `i32` and `i64` are
+;; aligned.
+
+function %returner() -> i8, i32, i8, i64 {
+; check: function %returner(i64 sret [%rdi]) -> i64 sret [%rax] fast {
+
+ebb0:
+; check: ebb0(v4: i64):
+
+    v0 = iconst.i8 0
+    v1 = iconst.i32 1
+    v2 = iconst.i8 2
+    v3 = iconst.i64 3
+    return v0, v1, v2, v3
+    ; check:  v6 = uextend.i32 v0
+    ; nextln: istore8 notrap aligned v6, v4
+    ; nextln: store notrap aligned v1, v4+4
+    ; nextln: v7 = uextend.i32 v2
+    ; nextln: istore8 notrap aligned v7, v4+8
+    ; nextln: store notrap aligned v3, v4+16
+    ; nextln: return v4
+}
+
+function %caller() {
+    ; check:  ss0 = ret_ptr 24, offset 0
+
+    fn0 = %returner() -> i8, i32, i8, i64
+    ; check:  sig0 = (i64 sret [%rdi]) -> i64 sret [%rax] fast
+    ; nextln: fn0 = %returner sig0
+
+ebb0:
+    v0, v1, v2, v3 = call fn0()
+    ; check:  v4 = stack_addr.i64 ss0
+    ; nextln: v10 = func_addr.i64 fn0
+    ; nextln: v5 = call_indirect sig0, v10(v4)
+    ; nextln: v11 = uload8.i32 notrap aligned v5
+    ; nextln: v6 = ireduce.i8 v11
+    ; nextln: v0 -> v6
+    ; nextln: v7 = load.i32 notrap aligned v5+4
+    ; nextln: v1 -> v7
+    ; nextln: v12 = uload8.i32 notrap aligned v5+8
+    ; nextln: v8 = ireduce.i8 v12
+    ; nextln: v2 -> v8
+    ; nextln: v9 = load.i64 notrap aligned v5+16
+    ; nextln: v3 -> v9
+
+    return
+}

--- a/filetests/wasm/multi-val-sret-slot-alignment.clif
+++ b/filetests/wasm/multi-val-sret-slot-alignment.clif
@@ -25,7 +25,7 @@ ebb0:
 }
 
 function %caller() {
-    ; check:  ss0 = ret_ptr 24, offset 0
+    ; check:  ss0 = sret_slot 24, offset 0
 
     fn0 = %returner() -> i8, i32, i8, i64
     ; check:  sig0 = (i64 sret [%rdi]) -> i64 sret [%rax] fast

--- a/filetests/wasm/multi-val-sret-slot-alignment.clif
+++ b/filetests/wasm/multi-val-sret-slot-alignment.clif
@@ -25,7 +25,7 @@ ebb0:
 }
 
 function %caller() {
-    ; check:  ss0 = sret_slot 24, offset 0
+    ; check:  ss0 = sret_slot 24
 
     fn0 = %returner() -> i8, i32, i8, i64
     ; check:  sig0 = (i64 sret [%rdi]) -> i64 sret [%rax] fast

--- a/filetests/wasm/multi-val-take-many-and-return-many.clif
+++ b/filetests/wasm/multi-val-take-many-and-return-many.clif
@@ -1,0 +1,18 @@
+test compile
+target x86_64 haswell
+
+function %returner(i32, i64, f32, f64) -> i32, i64, f32, f64 {
+ebb0(v0: i32, v1: i64, v2: f32, v3: f64):
+    return v0, v1, v2, v3
+}
+
+function %caller() {
+    fn0 = %returner(i32, i64, f32, f64) -> i32, i64, f32, f64
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i64 1
+    v2 = f32const 0x2.0
+    v3 = f64const 0x3.0
+    v4, v5, v6, v7 = call fn0(v0, v1, v2, v3)
+    return
+}

--- a/filetests/wasm/multi-val-tons-of-results.clif
+++ b/filetests/wasm/multi-val-tons-of-results.clif
@@ -1,0 +1,34 @@
+test compile
+target x86_64 haswell
+
+function %return_20_i32s() -> i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 {
+ebb0:
+    v0 = iconst.i32 0
+    v1 = iconst.i32 1
+    v2 = iconst.i32 2
+    v3 = iconst.i32 3
+    v4 = iconst.i32 4
+    v5 = iconst.i32 5
+    v6 = iconst.i32 6
+    v7 = iconst.i32 7
+    v8 = iconst.i32 8
+    v9 = iconst.i32 9
+    v10 = iconst.i32 10
+    v11 = iconst.i32 11
+    v12 = iconst.i32 12
+    v13 = iconst.i32 13
+    v14 = iconst.i32 14
+    v15 = iconst.i32 15
+    v16 = iconst.i32 16
+    v17 = iconst.i32 17
+    v18 = iconst.i32 18
+    v19 = iconst.i32 19
+    return v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19
+}
+
+function %call_20_i32s() {
+    fn0 = %return_20_i32s() -> i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
+ebb0:
+    v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19 = call fn0()
+    return
+}


### PR DESCRIPTION
~~**Do not merge! This is a work-in-progress!**~~ EDIT: ready for review now :)

I'm working on supporting arbitrarily many return values (although we will need to enforce some reasonable upper bound) in cranelift functions, and therefore in Wasm as well.

The approach I've been trying is to:

* Make use of the `sret` special argument for passing in a return pointer, pointing to space allocated in the caller's stack frame for the return values.

* Introduce new `ArgumentLocation` and `ValueLocation` variants for essentially "offset `x` from this function's `sret` parameter": `*(sret + x)`.

* During legalization, we rewrite signatures, calls, and returns to introduce usage of the `sret` return pointer parameter. Specifically,

  * `legalize_signature` will add the `sret` parameter and assign offsets for each return value (currently implemented),

  * `handle_call_abi` will rewrite multi-value calls to allocate a stack slot for the return values, pass a pointer to that space as the `sret` argument, and then load the return values out of the stack slot (not yet implemented),

  * and `handle_return_abi` will rewrite multi-value returns to store the values into the `sret` return pointer at the proper offsets, and return the `sret` return pointer in a register.

This almost works! However, I'm running into a little trouble during register allocation.

Consider this function that returns four `i64`s:

```
function %return_4_i64s() -> i64, i64, i64, i64 fast {
ebb0:
    v0 = iconst.i64 0
    v1 = iconst.i64 1
    v2 = iconst.i64 2
    v3 = iconst.i64 3
    return v0, v1, v2, v3
}
```

After legalization, we see that an `sret` parameter has been added, that all the returns are assigned to offsets from the `sret`, and that we are storing the return values at those offsets just before returning. Great!

```
function %return_4_i64s(i64 sret [%rdi]) -> i64 [sret(0x0)], i64 [sret(0x8)], i64 [sret(0x10)], i64 [sret(0x18)], i64 sret [%rax] fast {
                                ebb0(v4: i64):
[RexOp1pu_id#b8,sret(0)]            v0 = iconst.i64 0
[RexOp1pu_id#b8,sret(8)]            v1 = iconst.i64 1
[RexOp1pu_id#b8,sret(16)]           v2 = iconst.i64 2
[RexOp1pu_id#b8,sret(24)]           v3 = iconst.i64 3
[RexOp1st#8089]                     store notrap aligned v0, v4
[RexOp1stDisp8#8089]                store notrap aligned v1, v4+8
[RexOp1stDisp8#8089]                store notrap aligned v2, v4+16
[RexOp1stDisp8#8089]                store notrap aligned v3, v4+24
[Op1ret#c3]                         return v0, v1, v2, v3, v4
}
```

However, when register allocation comes along, it unnecessarily inserts an instruction to move `v0` from `%rax` to `%rsi`. I'm a bit confused why this is happening, since I update the `ValueLocation` to an offset from the `sret`, and it shouldn't even think that `v0` is live in `%rax`! Anyways, even if this unnecessary instruction were included, things would otherwise work, except that the register allocator also recorded the new location of `v0` as `%rsi`, which means that now the verifier complains that teh arguments are in the wrong places!

```
function %return_4_i64s(i64 sret [%rdi]) -> i64 [sret(0x0)], i64 [sret(0x8)], i64 [sret(0x10)], i64 [sret(0x18)], i64 sret [%rax] fast {
                                ebb0(v4: i64 [%rdi]):
[RexOp1pu_id#b8,%rax]               v0 = iconst.i64 0
[RexOp1pu_id#b8,%rcx]               v1 = iconst.i64 1
[RexOp1pu_id#b8,%rdx]               v2 = iconst.i64 2
[RexOp1pu_id#b8,%rbx]               v3 = iconst.i64 3
[RexOp1st#8089]                     store notrap aligned v0, v4
[RexOp1stDisp8#8089]                store notrap aligned v1, v4+8
[RexOp1stDisp8#8089]                store notrap aligned v2, v4+16
[RexOp1stDisp8#8089]                store notrap aligned v3, v4+24
[RexOp1rmov#8089]                   regmove v0, %rax -> %rsi
[RexOp1rmov#8089]                   regmove v4, %rdi -> %rax
[Op1ret#c3]                         return v0, v1, v2, v3, v4
;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
; error: inst4: ABI expects v0 at return pointer offset 0, got %rsi

}
```

Any idea what might be going on and what I should do from here?

<details>

<summary>Full debug logs</summary>

```
     Running `target/debug/clif-util compile -dtp /home/fitzgen/cranelift/filetests/wasm/multi-val-return-i64.clif --target x86_64`
 DEBUG cranelift_codegen::timing::details > timing: Starting Parsing textual Cranelift IR, (during <no pass>)
 DEBUG cranelift_codegen::timing::details > timing: Ending Parsing textual Cranelift IR
 DEBUG cranelift_codegen::timing::details > timing: Starting Compilation passes, (during <no pass>)
 DEBUG cranelift_codegen::timing::details > timing: Starting Verify Cranelift IR, (during Compilation passes)
 DEBUG cranelift_codegen::timing::details > timing: Starting Control flow graph, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details > timing: Ending Control flow graph
 DEBUG cranelift_codegen::timing::details > timing: Starting Dominator tree, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details > timing: Ending Dominator tree
 DEBUG cranelift_codegen::timing::details > timing: Starting Verify CPU flags, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details > timing: Ending Verify CPU flags
 DEBUG cranelift_codegen::timing::details > timing: Ending Verify Cranelift IR
 DEBUG cranelift_codegen::context         > Compiling:
function %return_4_i64s() -> i64, i64, i64, i64 fast {
ebb0:
    v0 = iconst.i64 0
    v1 = iconst.i64 1
    v2 = iconst.i64 2
    v3 = iconst.i64 3
    return v0, v1, v2, v3
}

 DEBUG cranelift_codegen::timing::details > timing: Starting Control flow graph, (during Compilation passes)
 DEBUG cranelift_codegen::timing::details > timing: Ending Control flow graph
 DEBUG cranelift_codegen::timing::details > timing: Starting Legalization, (during Compilation passes)
 DEBUG cranelift_codegen::legalizer::boundary > Adding 1 special-purpose arguments to return v0, v1, v2, v3
 DEBUG cranelift_codegen::timing::details     > timing: Ending Legalization
 DEBUG cranelift_codegen::context             > Legalized:
function %return_4_i64s(i64 sret [%rdi]) -> i64 [sret(0x0)], i64 [sret(0x8)], i64 [sret(0x10)], i64 [sret(0x18)], i64 sret [%rax] fast {
                                ebb0(v4: i64):
[RexOp1pu_id#b8,sret(0)]            v0 = iconst.i64 0
[RexOp1pu_id#b8,sret(8)]            v1 = iconst.i64 1
[RexOp1pu_id#b8,sret(16)]           v2 = iconst.i64 2
[RexOp1pu_id#b8,sret(24)]           v3 = iconst.i64 3
[RexOp1st#8089]                     store notrap aligned v0, v4
[RexOp1stDisp8#8089]                store notrap aligned v1, v4+8
[RexOp1stDisp8#8089]                store notrap aligned v2, v4+16
[RexOp1stDisp8#8089]                store notrap aligned v3, v4+24
[Op1ret#c3]                         return v0, v1, v2, v3, v4
}

 DEBUG cranelift_codegen::timing::details     > timing: Starting Verify Cranelift IR, (during Compilation passes)
 DEBUG cranelift_codegen::timing::details     > timing: Starting Control flow graph, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details     > timing: Ending Control flow graph
 DEBUG cranelift_codegen::timing::details     > timing: Starting Dominator tree, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details     > timing: Ending Dominator tree
 DEBUG cranelift_codegen::timing::details     > timing: Starting Verify CPU flags, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details     > timing: Ending Verify CPU flags
 DEBUG cranelift_codegen::timing::details     > timing: Ending Verify Cranelift IR
 DEBUG cranelift_codegen::timing::details     > timing: Starting Dominator tree, (during Compilation passes)
 DEBUG cranelift_codegen::timing::details     > timing: Ending Dominator tree
 DEBUG cranelift_codegen::timing::details     > timing: Starting Remove unreachable blocks, (during Compilation passes)
 DEBUG cranelift_codegen::timing::details     > timing: Ending Remove unreachable blocks
 DEBUG cranelift_codegen::timing::details     > timing: Starting Verify Cranelift IR, (during Compilation passes)
 DEBUG cranelift_codegen::timing::details     > timing: Starting Control flow graph, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details     > timing: Ending Control flow graph
 DEBUG cranelift_codegen::timing::details     > timing: Starting Dominator tree, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details     > timing: Ending Dominator tree
 DEBUG cranelift_codegen::timing::details     > timing: Starting Verify CPU flags, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details     > timing: Ending Verify CPU flags
 DEBUG cranelift_codegen::timing::details     > timing: Ending Verify Cranelift IR
 DEBUG cranelift_codegen::timing::details     > timing: Starting Register allocation, (during Compilation passes)
 DEBUG cranelift_codegen::timing::details     > timing: Starting RA liveness analysis, (during Register allocation)
 DEBUG cranelift_codegen::timing::details     > timing: Ending RA liveness analysis
 DEBUG cranelift_codegen::timing::details     > timing: Starting Verify live ranges, (during Register allocation)
 DEBUG cranelift_codegen::timing::details     > timing: Ending Verify live ranges
 DEBUG cranelift_codegen::timing::details     > timing: Starting RA coalescing CSSA, (during Register allocation)
 DEBUG cranelift_codegen::regalloc::coalescing > Coalescing for:
function %return_4_i64s(i64 sret [%rdi]) -> i64 [sret(0x0)], i64 [sret(0x8)], i64 [sret(0x10)], i64 [sret(0x18)], i64 sret [%rax] fast {
                                ebb0(v4: i64):
[RexOp1pu_id#b8,sret(0)]            v0 = iconst.i64 0
[RexOp1pu_id#b8,sret(8)]            v1 = iconst.i64 1
[RexOp1pu_id#b8,sret(16)]           v2 = iconst.i64 2
[RexOp1pu_id#b8,sret(24)]           v3 = iconst.i64 3
[RexOp1st#8089]                     store notrap aligned v0, v4
[RexOp1stDisp8#8089]                store notrap aligned v1, v4+8
[RexOp1stDisp8#8089]                store notrap aligned v2, v4+16
[RexOp1stDisp8#8089]                store notrap aligned v3, v4+24
[Op1ret#c3]                         return v0, v1, v2, v3, v4
}

 DEBUG cranelift_codegen::regalloc::coalescing > After union-find phase:
 DEBUG cranelift_codegen::timing::details      > timing: Ending RA coalescing CSSA
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify Cranelift IR, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Starting Control flow graph, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Control flow graph
 DEBUG cranelift_codegen::timing::details      > timing: Starting Dominator tree, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Dominator tree
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify CPU flags, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify CPU flags
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify Cranelift IR
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify live ranges, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify live ranges
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify CSSA, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify CSSA
 DEBUG cranelift_codegen::timing::details      > timing: Starting RA spilling, (during Register allocation)
 DEBUG cranelift_codegen::regalloc::spilling   > Spilling for:
function %return_4_i64s(i64 sret [%rdi]) -> i64 [sret(0x0)], i64 [sret(0x8)], i64 [sret(0x10)], i64 [sret(0x18)], i64 sret [%rax] fast {
                                ebb0(v4: i64):
[RexOp1pu_id#b8,sret(0)]            v0 = iconst.i64 0
[RexOp1pu_id#b8,sret(8)]            v1 = iconst.i64 1
[RexOp1pu_id#b8,sret(16)]           v2 = iconst.i64 2
[RexOp1pu_id#b8,sret(24)]           v3 = iconst.i64 3
[RexOp1st#8089]                     store notrap aligned v0, v4
[RexOp1stDisp8#8089]                store notrap aligned v1, v4+8
[RexOp1stDisp8#8089]                store notrap aligned v2, v4+16
[RexOp1stDisp8#8089]                store notrap aligned v3, v4+24
[Op1ret#c3]                         return v0, v1, v2, v3, v4
}

 DEBUG cranelift_codegen::regalloc::spilling   > Spilling ebb0:
 DEBUG cranelift_codegen::regalloc::spilling   > Inst v0 = iconst.i64 0, Pressure[ 1+0/14 0+0/16 ]
 DEBUG cranelift_codegen::regalloc::spilling   > Inst v1 = iconst.i64 1, Pressure[ 2+0/14 0+0/16 ]
 DEBUG cranelift_codegen::regalloc::spilling   > Inst v2 = iconst.i64 2, Pressure[ 3+0/14 0+0/16 ]
 DEBUG cranelift_codegen::regalloc::spilling   > Inst v3 = iconst.i64 3, Pressure[ 4+0/14 0+0/16 ]
 DEBUG cranelift_codegen::regalloc::spilling   > Inst store.i64 notrap aligned v0, v4, Pressure[ 5+0/14 0+0/16 ]
 DEBUG cranelift_codegen::regalloc::spilling   > Inst store.i64 notrap aligned v1, v4+8, Pressure[ 5+0/14 0+0/16 ]
 DEBUG cranelift_codegen::regalloc::spilling   > Inst store.i64 notrap aligned v2, v4+16, Pressure[ 5+0/14 0+0/16 ]
 DEBUG cranelift_codegen::regalloc::spilling   > Inst store.i64 notrap aligned v3, v4+24, Pressure[ 5+0/14 0+0/16 ]
 DEBUG cranelift_codegen::regalloc::spilling   > Inst return v0, v1, v2, v3, v4, Pressure[ 5+0/14 0+0/16 ]
 DEBUG cranelift_codegen::regalloc::spilling   >   reguse: v4@op4/fixed
 DEBUG cranelift_codegen::timing::details      > timing: Ending RA spilling
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify Cranelift IR, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Starting Control flow graph, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Control flow graph
 DEBUG cranelift_codegen::timing::details      > timing: Starting Dominator tree, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Dominator tree
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify CPU flags, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify CPU flags
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify Cranelift IR
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify live ranges, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify live ranges
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify CSSA, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify CSSA
 DEBUG cranelift_codegen::timing::details      > timing: Starting RA reloading, (during Register allocation)
 DEBUG cranelift_codegen::regalloc::reload     > Reload for:
function %return_4_i64s(i64 sret [%rdi]) -> i64 [sret(0x0)], i64 [sret(0x8)], i64 [sret(0x10)], i64 [sret(0x18)], i64 sret [%rax] fast {
                                ebb0(v4: i64):
[RexOp1pu_id#b8,sret(0)]            v0 = iconst.i64 0
[RexOp1pu_id#b8,sret(8)]            v1 = iconst.i64 1
[RexOp1pu_id#b8,sret(16)]           v2 = iconst.i64 2
[RexOp1pu_id#b8,sret(24)]           v3 = iconst.i64 3
[RexOp1st#8089]                     store notrap aligned v0, v4
[RexOp1stDisp8#8089]                store notrap aligned v1, v4+8
[RexOp1stDisp8#8089]                store notrap aligned v2, v4+16
[RexOp1stDisp8#8089]                store notrap aligned v3, v4+24
[Op1ret#c3]                         return v0, v1, v2, v3, v4
}

 DEBUG cranelift_codegen::regalloc::reload     > Reloading ebb0:
 DEBUG cranelift_codegen::timing::details      > timing: Ending RA reloading
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify Cranelift IR, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Starting Control flow graph, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Control flow graph
 DEBUG cranelift_codegen::timing::details      > timing: Starting Dominator tree, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Dominator tree
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify CPU flags, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify CPU flags
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify Cranelift IR
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify live ranges, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify live ranges
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify CSSA, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify CSSA
 DEBUG cranelift_codegen::timing::details      > timing: Starting RA coloring, (during Register allocation)
 DEBUG cranelift_codegen::regalloc::coloring   > Coloring for:
function %return_4_i64s(i64 sret [%rdi]) -> i64 [sret(0x0)], i64 [sret(0x8)], i64 [sret(0x10)], i64 [sret(0x18)], i64 sret [%rax] fast {
                                ebb0(v4: i64):
[RexOp1pu_id#b8,sret(0)]            v0 = iconst.i64 0
[RexOp1pu_id#b8,sret(8)]            v1 = iconst.i64 1
[RexOp1pu_id#b8,sret(16)]           v2 = iconst.i64 2
[RexOp1pu_id#b8,sret(24)]           v3 = iconst.i64 3
[RexOp1st#8089]                     store notrap aligned v0, v4
[RexOp1stDisp8#8089]                store notrap aligned v1, v4+8
[RexOp1stDisp8#8089]                store notrap aligned v2, v4+16
[RexOp1stDisp8#8089]                store notrap aligned v3, v4+24
[Op1ret#c3]                         return v0, v1, v2, v3, v4
}

 DEBUG cranelift_codegen::regalloc::coloring   > Coloring ebb0:
 DEBUG cranelift_codegen::regalloc::coloring   > Start ebb0 with entry-diversion set to
      { }
 DEBUG cranelift_codegen::regalloc::coloring   > Coloring v0 = iconst.i64 0
    from [ GPR: acdb--s-89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     glob [ GPR: acdb--sd89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     color v0 -> %rax
 DEBUG cranelift_codegen::regalloc::coloring   > Coloring v1 = iconst.i64 1
    from [ GPR: -cdb--s-89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     glob [ GPR: acdb--sd89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     color v1 -> %rcx
 DEBUG cranelift_codegen::regalloc::coloring   > Coloring v2 = iconst.i64 2
    from [ GPR: --db--s-89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     glob [ GPR: acdb--sd89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     color v2 -> %rdx
 DEBUG cranelift_codegen::regalloc::coloring   > Coloring v3 = iconst.i64 3
    from [ GPR: ---b--s-89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     glob [ GPR: acdb--sd89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     color v3 -> %rbx
 DEBUG cranelift_codegen::regalloc::coloring   > Coloring store.i64 notrap aligned v0, v4
    from [ GPR: ------s-89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     glob [ GPR: acdb--sd89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   > Coloring store.i64 notrap aligned v1, v4+8
    from [ GPR: ------s-89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     glob [ GPR: acdb--sd89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   > Coloring store.i64 notrap aligned v2, v4+16
    from [ GPR: ------s-89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     glob [ GPR: acdb--sd89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   > Coloring store.i64 notrap aligned v3, v4+24
    from [ GPR: ------s-89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   >     glob [ GPR: acdb--sd89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::coloring   > Coloring return v0, v1, v2, v3, v4
    from [ GPR: ------s-89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::solver     > reassign_in(v4:GPR, %rdi -> %rax)
 DEBUG cranelift_codegen::regalloc::solver     > add_var(v0:GPR, from=%rax)
 DEBUG cranelift_codegen::regalloc::solver     > -> new var: v0(GPR, from %rax, in, out)
 DEBUG cranelift_codegen::regalloc::coloring   >     kill v4 in %rdi (local GPR)
 DEBUG cranelift_codegen::regalloc::coloring   >     kill v0 in %rax (local GPR)
 DEBUG cranelift_codegen::regalloc::coloring   >     kill v1 in %rcx (local GPR)
 DEBUG cranelift_codegen::regalloc::coloring   >     kill v2 in %rdx (local GPR)
 DEBUG cranelift_codegen::regalloc::coloring   >     kill v3 in %rbx (local GPR)
 DEBUG cranelift_codegen::regalloc::coloring   >     glob [ GPR: acdb--sd89012345 FPR: 0123456789012345 FLAG: f ]
 DEBUG cranelift_codegen::regalloc::solver     > collect_moves: [v0:GPR(%rax -> %rsi), v4:GPR(%rdi -> %rax)]
 DEBUG cranelift_codegen::regalloc::solver     > move #0: v0:GPR(%rax -> %rsi)
 DEBUG cranelift_codegen::regalloc::solver     > move #1: v4:GPR(%rdi -> %rax)
 DEBUG cranelift_codegen::timing::details      > timing: Ending RA coloring
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify Cranelift IR, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Starting Control flow graph, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Control flow graph
 DEBUG cranelift_codegen::timing::details      > timing: Starting Dominator tree, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Dominator tree
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify CPU flags, (during Verify Cranelift IR)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify CPU flags
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify Cranelift IR
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify live ranges, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify live ranges
 DEBUG cranelift_codegen::timing::details      > timing: Starting Verify value locations, (during Register allocation)
 DEBUG cranelift_codegen::timing::details      > timing: Ending Verify value locations
 DEBUG cranelift_codegen::timing::details      > timing: Ending Register allocation
 DEBUG cranelift_codegen::timing::details      > timing: Ending Compilation passes
function %return_4_i64s(i64 sret [%rdi]) -> i64 [sret(0x0)], i64 [sret(0x8)], i64 [sret(0x10)], i64 [sret(0x18)], i64 sret [%rax] fast {
                                ebb0(v4: i64 [%rdi]):
[RexOp1pu_id#b8,%rax]               v0 = iconst.i64 0
[RexOp1pu_id#b8,%rcx]               v1 = iconst.i64 1
[RexOp1pu_id#b8,%rdx]               v2 = iconst.i64 2
[RexOp1pu_id#b8,%rbx]               v3 = iconst.i64 3
[RexOp1st#8089]                     store notrap aligned v0, v4
[RexOp1stDisp8#8089]                store notrap aligned v1, v4+8
[RexOp1stDisp8#8089]                store notrap aligned v2, v4+16
[RexOp1stDisp8#8089]                store notrap aligned v3, v4+24
[RexOp1rmov#8089]                   regmove v0, %rax -> %rsi
[RexOp1rmov#8089]                   regmove v4, %rdi -> %rax
[Op1ret#c3]                         return v0, v1, v2, v3, v4
;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
; error: inst4: ABI expects v0 at return pointer offset 0, got %rsi

}

; 1 verifier error detected (see above). Compilation aborted.
```

</details>

----------

One idea I was considering (but don't actually know if this is a good idea or just a kludgy workaround) was introducing a `sret_store` (or `store_copy`) instruction that would return a new copy of the value that is located at the stored location (similar to `copy` and `spill`).

Basically, this would turn the previous example into:

```
function %return_4_i64s(i64 sret [%rdi]) -> i64 [sret(0x0)], i64 [sret(0x8)], i64 [sret(0x10)], i64 [sret(0x18)], i64 sret [%rax] fast {
ebb0(v4: i64):
    v0 = iconst.i64 0
    v1 = iconst.i64 1
    v2 = iconst.i64 2
    v3 = iconst.i64 3
    v5 = sret_store v4+0, v0
    v6 = sret_store v4+8, v0
    v7 = sret_store v4+16, v0
    v8 = sret_store v4+24, v0
    return v5, v6, v7, v8, v4
```

But I didn't really want to pursue this further without getting feedback from y'all.

-----------------

Thanks!
