### PR TITLE
i128-isplit-forward-jump.clif:  brz followed by trap

### DIFF
--- a/filetests/isa/x86/i128-isplit-forward-jump.clif
+++ b/filetests/isa/x86/i128-isplit-forward-jump.clif
@@ -18,5 +18,8 @@ ebb5:
     v27 = bxor.i128 v2, v2
     v32 = iconst.i32 0
     brz v32, ebb2
+    jump ebb6
+
+ebb6:
     trap user0
 }


### PR DESCRIPTION
This fix the last test case which prevent merging #1008.