### PR TITLE
New contribution guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,16 @@
+---
+name: "Bug report"
+about: "Report a bug or a crash in Cranelift."
+labels: 'bug'
+---
+
+Thanks for opening a bug report on Cranelift! Please answer the questions below
+if they're relevant and delete this text before submitting.
+
+- What are the steps to reproduce the issue? Can you include a CLIF test case,
+  ideally reduced with the `bugpoint` clif-util command?
+- What do you expect to happen? What does actually happen? Does it panic, and
+  if so, with which assertion?
+- Which Cranelift version / commit hash / branch are you using?
+- If relevant, can you include some extra information about your environment?
+  (Rust version, operating system, architecture...)

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,15 @@
+---
+name: "Improvement"
+about: "A feature request or code improvement."
+---
+
+Please try to describe precisely what you would like to do in Cranelift and/or
+expect from it. You can answer the questions below if they're relevant and
+delete this text before submitting. Thanks for opening an issue!
+
+- What is the feature or code improvement you would like to do in Cranelift?
+- What is the value of adding this in Cranelift?
+- Do you have an implementation plan, and/or ideas for data structures or
+  algorithms to use?
+- Have you considered alternative implementations? If so, how are they better
+  or worse than your proposal?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+- [ ] This has been discussed in issue #..., or if not, please tell us why
+  here.
+- [ ] A short description of what this does, why it is needed; if the
+  description becomes long, the matter should probably be discussed in an issue
+  first.
+- [ ] This PR contains test cases, if meaningful.
+- [ ] A reviewer from the core maintainer team has been assigned for this PR.
+  If you don't know who could review this, please indicate so and/or ping
+  `bnjbvr`. The list of suggested reviewers on the right can help you.
+
+<!-- Please ensure all communication adheres to the [code of
+conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,8 @@ version. See the [rustfmt quickstart] for setup.
 [format-all.sh] is a script for running the appropriate version of rustfmt,
 which may be convenient when there are multiple versions installed.
 
-[rustfmt-preview]: https://github.com/rust-lang-nursery/rustfmt
-[rustfmt quickstart]: https://github.com/rust-lang-nursery/rustfmt#quick-start
+[rustfmt-preview]: https://github.com/rust-lang/rustfmt
+[rustfmt quickstart]: https://github.com/rust-lang/rustfmt#quick-start
 [format-all.sh]: https://github.com/CraneStation/cranelift/blob/master/format-all.sh
 
 ### Rustc version support
@@ -90,7 +90,20 @@ We use [issues] for asking questions and tracking bugs and unimplemented
 features, and [pull requests] (PRs) for tracking and reviewing code
 submissions.
 
-When submitting PRs:
+### Before submitting a PR
+
+Consider opening an issue to talk about it. PRs without corresponding issues
+are appropriate for fairly narrow technical matters, not for fixes to
+user-facing bugs or for feature implementations, especially when those features
+might have multiple implementation strategies that usefully could be discussed.
+
+Our issue templates might help you through the process.
+
+### When submitting PRs
+
+ - Please fill in the pull request template as appropriate. It is usually
+   helpful, it speeds up the review process and helps understanding the changes
+   brought by the PR.
 
  - Write clear commit messages that start with a one-line summary of the
    change (and if it's difficult to summarize in one line, consider
@@ -106,8 +119,14 @@ When submitting PRs:
  - For pull requests that fix existing issues, use [issue keywords]. Note that
    not all pull requests need to have accompanying issues.
 
-Anyone may submit a pull request, and anyone may comment on or review others'
-pull requests. Pull requests are merged by members of the [Core Team].
+ - Assign the review to somebody from the [Core Team], either using suggestions
+   in the list proposed by Github, or somebody else if you have a specific
+   person in mind.
+
+ - When updating your pull request, please make sure to re-request review if
+   the request has been cancelled.
+
+### Focused commits or squashing
 
 We generally squash sequences of incremental-development commits together into
 logical commits (though keeping logical commits focused). Developers may do
@@ -115,8 +134,16 @@ this themselves before submitting a PR or during the PR process, or Core Team
 members may do it when merging a PR. Ideally, the continuous-integration tests
 should pass at each logical commit.
 
-Core Team members may push minor changes directly, though should create PRs
-for significant changes.
+### Review and merge
+
+Anyone may submit a pull request, and anyone may comment on or review others'
+pull requests. However, one review from somebody in the [Core Team] is required
+before the Core Team merges it.
+
+Even Core Team members should create PRs for every change, including minor work
+items (version bump, removing warnings, etc.): this is helpful to keep track of
+what has happened on the repository. Very minor changes may be merged without a
+review, although it is always preferred to have one.
 
 [issues]: https://guides.github.com/features/issues/
 [pull requests]: https://help.github.com/articles/about-pull-requests/


### PR DESCRIPTION
This sets up the following things:

- two issue templates, one for bug reports, one for "the rest". They include questions so as to make it easier to propose new ideas, reduce the number of back-and-forths between contributors and maintainers, and generally improve the quality of bug reports and contributions.
- a pull request template. (There is no way to add several of them.) Again, it has a few questions that may or may not be worth answering.
- This also updates the CONTRIBUTING file:
  - to suggest opening more issues for new features and non-trivial work items.
  - to suggest that every change, including version bumps and other tiny changes, should go through a pull request, so they don't fall under the radar of other contributors.

This set of changes has been discussed internally first, and we think it should help improving the quality of contributions, making it easier for reviewer to review patches, reducing review latency, and generally improving the project's quality by having fewer defects and maintaining great overall performance.

[You can play with both templates on my own fork](https://github.com/bnjbvr/cranelift/): when creating a new issue the templates will nicely show up, ditto when creating a new PR (I've got a few branches, so you can try opening PRs proposing to merge one of them into another one).

Everybody's opinion would be appreciated on this PR. I am not an English native so wording likely needs polishing. cc @CraneStation/core-team 