### PR TITLE
Fix build by marking tests as incompatible with basic-blocks. Closes #1152

### DIFF
--- a/filetests/regalloc/solver-fixedconflict-var-3.clif
+++ b/filetests/regalloc/solver-fixedconflict-var-3.clif
@@ -2,6 +2,7 @@ test compile
 set opt_level=speed
 set enable_pinned_reg=true
 target x86_64 haswell
+feature !"basic-blocks"
 
 function u0:0(i32, i32, i32, i64 vmctx) -> i64 uext system_v {
 ebb0(v0: i32, v1: i32, v2: i32, v3: i64):

--- a/filetests/regalloc/solver-fixedconflict-var.clif
+++ b/filetests/regalloc/solver-fixedconflict-var.clif
@@ -2,6 +2,7 @@ test compile
 set opt_level=speed
 set enable_pinned_reg=true
 target x86_64 haswell
+feature !"basic-blocks"
 
 ;; Test for the issue #1123; https://github.com/CraneStation/cranelift/issues/1123
 


### PR DESCRIPTION
There are two options for fixing the build:

1. Rewrite the tests so that they pass the basic-blocks verifier.
2. Make the test feature-gated on the absence of the `basic-blocks` feature.

Many tests are already disabled by `basic-blocks` (and therefore are now off by default! We need to fix that soon). I added these to the list because I think we should probably fix these tests by just allowing `trap` to be treated as, effectively, a valid jump instruction for the purposes of a terminal `BranchGroup`.