### PR TITLE
Fix test merge conflict from #1127

### DIFF
--- a/filetests/regalloc/solver-fixedconflict-var-3.clif
+++ b/filetests/regalloc/solver-fixedconflict-var-3.clif
@@ -11,6 +11,9 @@ ebb0(v0: i32, v1: i32, v2: i32, v3: i64):
     v17 = popcnt v16
     v192 = ifcmp_imm v17, -1
     brif eq v192, ebb12
+    jump ebb1
+
+ebb1:
     trap user0
 
 ebb12:
@@ -23,6 +26,9 @@ ebb12:
     v31 -> v204
     v210 = ifcmp_imm v31, -1
     brif eq v210, ebb18
+    jump ebb13
+
+ebb13:
     trap user0
 
 ebb18:
@@ -33,6 +39,9 @@ ebb19(v32: i32):
     v35 = iconst.i32 0
     v218 = ifcmp_imm v35, -1
     brif eq v218, ebb21
+    jump ebb20
+
+ebb20:
     trap user0
 
 ebb21:
@@ -44,6 +53,9 @@ ebb22(v36: i32):
     v40 -> v136
     v227 = ifcmp_imm v136, -1
     brif eq v227, ebb24
+    jump ebb23
+
+ebb23:
     trap user0
 
 ebb24:
@@ -55,6 +67,9 @@ ebb25(v41: i32):
     v45 -> v142
     v236 = ifcmp_imm v142, -1
     brif eq v236, ebb27
+    jump ebb26
+
+ebb26:
     trap user0
 
 ebb27:
@@ -65,6 +80,9 @@ ebb28(v46: i32):
     v49 = iconst.i32 0
     v244 = ifcmp_imm v49, -1
     brif eq v244, ebb30
+    jump ebb29
+
+ebb29:
     trap user0
 
 ebb30:
@@ -93,6 +111,9 @@ ebb35:
     v280 = iconst.i32 0
     v281 = fcmp uno v61, v61
     brnz v281, ebb41(v280)
+    jump ebb36
+
+ebb36:
     trap user0
 
 ebb41(v62: i32):
@@ -103,6 +124,9 @@ ebb41(v62: i32):
     v75 -> v160
     v308 = ifcmp_imm v160, -1
     brif eq v308, ebb52
+    jump ebb42
+
+ebb42:
     trap user0
 
 ebb52:

--- a/filetests/regalloc/solver-fixedconflict-var.clif
+++ b/filetests/regalloc/solver-fixedconflict-var.clif
@@ -24,24 +24,34 @@ ebb0(v0: i32, v1: i32, v2: i32, v3: i64):
     v53 = iconst.i32 0
     v547 = ifcmp_imm v53, -1
     brif eq v547, ebb30
+    jump ebb29
+ebb29:
     trap user0
 
 ebb30:
     v75 = iconst.i32 0
     v581 = ifcmp_imm v75, -1
     brif eq v581, ebb42
+    jump ebb41
+ebb41:
     trap user0
 
 ebb42:
     v136 = iconst.i32 0
     v691 = ifcmp_imm v136, -1
     brif eq v691, ebb81
+    jump ebb80
+
+ebb80:
     trap user0
 
 ebb81:
     v158 = iconst.i32 0
     v725 = ifcmp_imm v158, -1
     brif eq v725, ebb93
+    jump ebb92
+
+ebb92:
     trap user0
 
 ebb93:
@@ -54,6 +64,9 @@ ebb106(v175: i32):
     v183 = iconst.i32 0
     v766 = ifcmp_imm v183, -1
     brif eq v766, ebb108
+    jump ebb107
+
+ebb107:
     trap user0
 
 ebb108:
@@ -65,6 +78,9 @@ ebb109(v184: i32):
     v193 -> v785
     v791 = ifcmp_imm v193, -1
     brif eq v791, ebb117
+    jump ebb116
+
+ebb116:
     trap user0
 
 ebb117:
@@ -77,12 +93,18 @@ ebb118(v194: i32):
     v207 -> v809
     v815 = ifcmp_imm v207, -1
     brif eq v815, ebb126
+    jump ebb125
+
+ebb125:
     trap user0
 
 ebb126:
     v209 = iconst.i32 0
     v823 = ifcmp_imm v209, -1
     brif eq v823, ebb129
+    jump ebb128
+
+ebb128:
     trap user0
 
 ebb129:


### PR DESCRIPTION
Filetests now have to be valid as basic blocks, but these tests were written against a revision before that was default. Fixes #1152.