### PR TITLE
Remove dynamic name indirections for formats

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/encodings.rs
+++ b/cranelift-codegen/meta/src/cdsl/encodings.rs
@@ -1,4 +1,3 @@
-use crate::cdsl::formats::FormatRegistry;
 use crate::cdsl::instructions::{
     InstSpec, Instruction, InstructionPredicate, InstructionPredicateNode,
     InstructionPredicateNumber, InstructionPredicateRegistry, ValueTypeOrAny,
@@ -62,12 +61,7 @@ pub(crate) struct EncodingBuilder {
 }
 
 impl EncodingBuilder {
-    pub fn new(
-        inst: InstSpec,
-        recipe: EncodingRecipeNumber,
-        encbits: u16,
-        formats: &FormatRegistry,
-    ) -> Self {
+    pub fn new(inst: InstSpec, recipe: EncodingRecipeNumber, encbits: u16) -> Self {
         let (inst_predicate, bound_type) = match &inst {
             InstSpec::Bound(inst) => {
                 let other_typevars = &inst.inst.polymorphic_info.as_ref().unwrap().other_typevars;
@@ -98,7 +92,7 @@ impl EncodingBuilder {
                     .zip(inst.inst.operands_in.iter().filter(|o| o.is_immediate()))
                 {
                     let immediate_predicate = InstructionPredicate::new_is_field_equal(
-                        formats.get(inst.inst.format),
+                        &inst.inst.format,
                         immediate_operand.name,
                         immediate_value.to_string(),
                     );
@@ -158,7 +152,7 @@ impl EncodingBuilder {
 
         let inst = self.inst.inst();
         assert!(
-            inst.format == recipes[self.recipe].format,
+            Rc::ptr_eq(&inst.format, &recipes[self.recipe].format),
             format!(
                 "Inst {} and recipe {} must have the same format!",
                 inst.name, recipes[self.recipe].name

--- a/cranelift-codegen/meta/src/cdsl/formats.rs
+++ b/cranelift-codegen/meta/src/cdsl/formats.rs
@@ -1,9 +1,6 @@
-use crate::cdsl::operands::{Operand, OperandKind};
-
-use std::collections::{HashMap, HashSet};
+use crate::cdsl::operands::OperandKind;
 use std::fmt;
 use std::rc::Rc;
-use std::slice;
 
 /// An immediate field in an instruction format.
 ///
@@ -30,7 +27,7 @@ pub struct FormatField {
 ///
 /// All instruction formats must be predefined in the meta shared/formats.rs module.
 #[derive(Debug)]
-pub struct InstructionFormat {
+pub(crate) struct InstructionFormat {
     /// Instruction format name in CamelCase. This is used as a Rust variant name in both the
     /// `InstructionData` and `InstructionFormat` enums.
     pub name: &'static str,
@@ -45,6 +42,14 @@ pub struct InstructionFormat {
     /// default, this is `0`, the first `value` operand. The index is relative to the values only,
     /// ignoring immediate operands.
     pub typevar_operand: Option<usize>,
+}
+
+/// A tuple serving as a key to deduplicate InstructionFormat.
+#[derive(Hash, PartialEq, Eq)]
+pub(crate) struct FormatStructure {
+    pub num_value_operands: usize,
+    pub has_value_list: bool,
+    pub imm_field_names: Vec<&'static str>,
 }
 
 impl fmt::Display for InstructionFormat {
@@ -75,9 +80,22 @@ impl InstructionFormat {
                 )
             })
     }
+
+    /// Returns a tuple that uniquely identifies the structure.
+    pub fn structure(&self) -> FormatStructure {
+        FormatStructure {
+            num_value_operands: self.num_value_operands,
+            has_value_list: self.has_value_list,
+            imm_field_names: self
+                .imm_fields
+                .iter()
+                .map(|field| field.kind.name)
+                .collect::<Vec<_>>(),
+        }
+    }
 }
 
-pub struct InstructionFormatBuilder {
+pub(crate) struct InstructionFormatBuilder {
     name: &'static str,
     num_value_operands: usize,
     has_value_list: bool,
@@ -131,7 +149,7 @@ impl InstructionFormatBuilder {
         self
     }
 
-    pub fn build(self) -> InstructionFormat {
+    pub fn build(self) -> Rc<InstructionFormat> {
         let typevar_operand = if self.typevar_operand.is_some() {
             self.typevar_operand
         } else if self.has_value_list || self.num_value_operands > 0 {
@@ -141,98 +159,12 @@ impl InstructionFormatBuilder {
             None
         };
 
-        InstructionFormat {
+        Rc::new(InstructionFormat {
             name: self.name,
             num_value_operands: self.num_value_operands,
             has_value_list: self.has_value_list,
             imm_fields: self.imm_fields,
             typevar_operand,
-        }
-    }
-}
-
-pub struct FormatRegistry {
-    /// Map (immediate kinds names, number of values, has varargs) to an instruction format.
-    sig_to_index: HashMap<(Vec<String>, usize, bool), usize>,
-    formats: Vec<Rc<InstructionFormat>>,
-    name_set: HashSet<&'static str>,
-}
-
-impl FormatRegistry {
-    pub fn new() -> Self {
-        Self {
-            sig_to_index: HashMap::new(),
-            formats: Vec::new(),
-            name_set: HashSet::new(),
-        }
-    }
-
-    /// Find an existing instruction format that matches the given lists of instruction inputs and
-    /// outputs.
-    pub fn lookup(&self, operands_in: &Vec<Operand>) -> &Rc<InstructionFormat> {
-        let mut imm_keys = Vec::new();
-        let mut num_values = 0;
-        let mut has_varargs = false;
-
-        for operand in operands_in.iter() {
-            if operand.is_value() {
-                num_values += 1;
-            }
-            if !has_varargs {
-                has_varargs = operand.is_varargs();
-            }
-            if let Some(imm_key) = operand.kind.imm_key() {
-                imm_keys.push(imm_key);
-            }
-        }
-
-        let sig = (imm_keys, num_values, has_varargs);
-        let index = *self
-            .sig_to_index
-            .get(&sig)
-            .expect("unknown InstructionFormat; please define it in shared/formats.rs first");
-        &self.formats[index]
-    }
-
-    pub fn by_name(&self, name: &str) -> &Rc<InstructionFormat> {
-        &self
-            .formats
-            .iter()
-            .find(|format| format.name == name)
-            .unwrap_or_else(|| panic!("format with name '{}' doesn't exist", name))
-    }
-
-    pub fn insert(&mut self, inst_format: InstructionFormatBuilder) {
-        let name = &inst_format.name;
-        if !self.name_set.insert(name) {
-            panic!(
-                "Trying to add an InstructionFormat named {}, but it already exists!",
-                name
-            );
-        }
-
-        let format = inst_format.build();
-
-        // Compute key.
-        let imm_keys = format
-            .imm_fields
-            .iter()
-            .map(|field| field.kind.imm_key().unwrap())
-            .collect();
-        let key = (imm_keys, format.num_value_operands, format.has_value_list);
-
-        let index = self.formats.len();
-        self.formats.push(Rc::new(format));
-        if let Some(already_inserted) = self.sig_to_index.insert(key, index) {
-            panic!(
-                "duplicate InstructionFormat: trying to insert '{}' while '{}' already has the same structure.",
-                self.formats[index].name,
-                self.formats[already_inserted].name
-            );
-        }
-    }
-
-    pub fn iter(&self) -> slice::Iter<Rc<InstructionFormat>> {
-        self.formats.iter()
+        })
     }
 }

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -23,8 +23,6 @@ entity_impl!(OpcodeNumber);
 pub(crate) type AllInstructions = PrimaryMap<OpcodeNumber, Instruction>;
 
 pub(crate) struct InstructionGroupBuilder<'format_reg, 'all_inst> {
-    _name: &'static str,
-    _doc: &'static str,
     format_registry: &'format_reg FormatRegistry,
     all_instructions: &'all_inst mut AllInstructions,
     own_instructions: Vec<Instruction>,
@@ -32,14 +30,10 @@ pub(crate) struct InstructionGroupBuilder<'format_reg, 'all_inst> {
 
 impl<'format_reg, 'all_inst> InstructionGroupBuilder<'format_reg, 'all_inst> {
     pub fn new(
-        name: &'static str,
-        doc: &'static str,
         all_instructions: &'all_inst mut AllInstructions,
         format_registry: &'format_reg FormatRegistry,
     ) -> Self {
         Self {
-            _name: name,
-            _doc: doc,
             format_registry,
             all_instructions,
             own_instructions: Vec::new(),
@@ -56,8 +50,6 @@ impl<'format_reg, 'all_inst> InstructionGroupBuilder<'format_reg, 'all_inst> {
 
     pub fn build(self) -> InstructionGroup {
         InstructionGroup {
-            _name: self._name,
-            _doc: self._doc,
             instructions: self.own_instructions,
         }
     }
@@ -67,8 +59,6 @@ impl<'format_reg, 'all_inst> InstructionGroupBuilder<'format_reg, 'all_inst> {
 /// target architecture can support instructions from multiple groups, and it
 /// does not necessarily support all instructions in a group.
 pub(crate) struct InstructionGroup {
-    _name: &'static str,
-    _doc: &'static str,
     instructions: Vec<Instruction>,
 }
 

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -3,7 +3,6 @@ use cranelift_entity::{entity_impl, PrimaryMap};
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Display, Error, Formatter};
-use std::ops;
 use std::rc::Rc;
 
 use crate::cdsl::camel_case;
@@ -152,19 +151,7 @@ pub(crate) struct InstructionContent {
     pub writes_cpu_flags: bool,
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct Instruction {
-    content: Rc<InstructionContent>,
-}
-
-impl ops::Deref for Instruction {
-    type Target = InstructionContent;
-    fn deref(&self) -> &Self::Target {
-        &*self.content
-    }
-}
-
-impl Instruction {
+impl InstructionContent {
     pub fn snake_name(&self) -> &str {
         if &self.name == "return" {
             "return_"
@@ -185,13 +172,15 @@ impl Instruction {
     }
 }
 
+pub(crate) type Instruction = Rc<InstructionContent>;
+
 impl Bindable for Instruction {
     fn bind(&self, parameter: impl Into<BindParameter>) -> BoundInstruction {
         BoundInstruction::new(self).bind(parameter)
     }
 }
 
-impl fmt::Display for Instruction {
+impl fmt::Display for InstructionContent {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         if self.operands_out.len() > 0 {
             let operands_out = self
@@ -352,33 +341,31 @@ impl InstructionBuilder {
 
         let camel_name = camel_case(&self.name);
 
-        Instruction {
-            content: Rc::new(InstructionContent {
-                name: self.name,
-                camel_name,
-                opcode_number,
-                doc: self.doc,
-                operands_in,
-                operands_out,
-                constraints: self.constraints.unwrap_or_else(Vec::new),
-                format: format_index,
-                polymorphic_info,
-                value_opnums,
-                value_results,
-                imm_opnums,
-                is_terminator: self.is_terminator,
-                is_branch: self.is_branch,
-                is_indirect_branch: self.is_indirect_branch,
-                is_call: self.is_call,
-                is_return: self.is_return,
-                is_ghost: self.is_ghost,
-                can_load: self.can_load,
-                can_store: self.can_store,
-                can_trap: self.can_trap,
-                other_side_effects: self.other_side_effects,
-                writes_cpu_flags,
-            }),
-        }
+        Rc::new(InstructionContent {
+            name: self.name,
+            camel_name,
+            opcode_number,
+            doc: self.doc,
+            operands_in,
+            operands_out,
+            constraints: self.constraints.unwrap_or_else(Vec::new),
+            format: format_index,
+            polymorphic_info,
+            value_opnums,
+            value_results,
+            imm_opnums,
+            is_terminator: self.is_terminator,
+            is_branch: self.is_branch,
+            is_indirect_branch: self.is_indirect_branch,
+            is_call: self.is_call,
+            is_return: self.is_return,
+            is_ghost: self.is_ghost,
+            can_load: self.can_load,
+            can_store: self.can_store,
+            can_trap: self.can_trap,
+            other_side_effects: self.other_side_effects,
+            writes_cpu_flags,
+        })
     }
 }
 

--- a/cranelift-codegen/meta/src/cdsl/operands.rs
+++ b/cranelift-codegen/meta/src/cdsl/operands.rs
@@ -138,11 +138,11 @@ pub struct OperandKind {
 }
 
 impl OperandKind {
-    pub fn imm_key(&self) -> Option<String> {
+    pub fn imm_name(&self) -> Option<&str> {
         match self.fields {
             OperandKindFields::ImmEnum(_)
             | OperandKindFields::ImmValue
-            | OperandKindFields::EntityRef => Some(self.name.to_string()),
+            | OperandKindFields::EntityRef => Some(&self.name),
             _ => None,
         }
     }

--- a/cranelift-codegen/meta/src/cdsl/xform.rs
+++ b/cranelift-codegen/meta/src/cdsl/xform.rs
@@ -471,7 +471,7 @@ fn test_double_custom_legalization() {
     let mut dummy_all = AllInstructions::new();
     let mut format = FormatRegistry::new();
     format.insert(InstructionFormatBuilder::new("nullary"));
-    let mut inst_group = InstructionGroupBuilder::new("test", "", &mut dummy_all, &format);
+    let mut inst_group = InstructionGroupBuilder::new(&mut dummy_all, &format);
     inst_group.push(InstructionBuilder::new("dummy", "doc"));
     let inst_group = inst_group.build();
     let dummy_inst = inst_group.by_name("dummy");

--- a/cranelift-codegen/meta/src/cdsl/xform.rs
+++ b/cranelift-codegen/meta/src/cdsl/xform.rs
@@ -465,14 +465,15 @@ impl TransformGroups {
 #[test]
 #[should_panic]
 fn test_double_custom_legalization() {
-    use crate::cdsl::formats::{FormatRegistry, InstructionFormatBuilder};
+    use crate::cdsl::formats::InstructionFormatBuilder;
     use crate::cdsl::instructions::{AllInstructions, InstructionBuilder, InstructionGroupBuilder};
 
+    let nullary = InstructionFormatBuilder::new("nullary").build();
+
     let mut dummy_all = AllInstructions::new();
-    let mut format = FormatRegistry::new();
-    format.insert(InstructionFormatBuilder::new("nullary"));
-    let mut inst_group = InstructionGroupBuilder::new(&mut dummy_all, &format);
-    inst_group.push(InstructionBuilder::new("dummy", "doc"));
+    let mut inst_group = InstructionGroupBuilder::new(&mut dummy_all);
+    inst_group.push(InstructionBuilder::new("dummy", "doc", &nullary));
+
     let inst_group = inst_group.build();
     let dummy_inst = inst_group.by_name("dummy");
 

--- a/cranelift-codegen/meta/src/isa/arm32/mod.rs
+++ b/cranelift-codegen/meta/src/isa/arm32/mod.rs
@@ -53,11 +53,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = define_settings(&shared_defs.settings);
     let regs = define_regs();
 
-    let inst_group = InstructionGroupBuilder::new(
-        &mut shared_defs.all_instructions,
-        &shared_defs.format_registry,
-    )
-    .build();
+    let inst_group = InstructionGroupBuilder::new(&mut shared_defs.all_instructions).build();
 
     // CPU modes for 32-bit ARM and Thumb2.
     let mut a32 = CpuMode::new("A32");

--- a/cranelift-codegen/meta/src/isa/arm32/mod.rs
+++ b/cranelift-codegen/meta/src/isa/arm32/mod.rs
@@ -54,8 +54,6 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let regs = define_regs();
 
     let inst_group = InstructionGroupBuilder::new(
-        "arm32",
-        "arm32 specific instruction set",
         &mut shared_defs.all_instructions,
         &shared_defs.format_registry,
     )

--- a/cranelift-codegen/meta/src/isa/arm64/mod.rs
+++ b/cranelift-codegen/meta/src/isa/arm64/mod.rs
@@ -50,8 +50,6 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let regs = define_registers();
 
     let inst_group = InstructionGroupBuilder::new(
-        "arm64",
-        "arm64 specific instruction set",
         &mut shared_defs.all_instructions,
         &shared_defs.format_registry,
     )

--- a/cranelift-codegen/meta/src/isa/arm64/mod.rs
+++ b/cranelift-codegen/meta/src/isa/arm64/mod.rs
@@ -49,11 +49,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = define_settings(&shared_defs.settings);
     let regs = define_registers();
 
-    let inst_group = InstructionGroupBuilder::new(
-        &mut shared_defs.all_instructions,
-        &shared_defs.format_registry,
-    )
-    .build();
+    let inst_group = InstructionGroupBuilder::new(&mut shared_defs.all_instructions).build();
 
     let mut a64 = CpuMode::new("A64");
 

--- a/cranelift-codegen/meta/src/isa/riscv/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/encodings.rs
@@ -13,24 +13,21 @@ use crate::shared::types::Reference::{R32, R64};
 use crate::shared::Definitions as SharedDefinitions;
 
 use super::recipes::RecipeGroup;
-use crate::cdsl::formats::FormatRegistry;
 
 pub(crate) struct PerCpuModeEncodings<'defs> {
     pub inst_pred_reg: InstructionPredicateRegistry,
     pub enc32: Vec<Encoding>,
     pub enc64: Vec<Encoding>,
     recipes: &'defs Recipes,
-    formats: &'defs FormatRegistry,
 }
 
 impl<'defs> PerCpuModeEncodings<'defs> {
-    fn new(recipes: &'defs Recipes, formats: &'defs FormatRegistry) -> Self {
+    fn new(recipes: &'defs Recipes) -> Self {
         Self {
             inst_pred_reg: InstructionPredicateRegistry::new(),
             enc32: Vec::new(),
             enc64: Vec::new(),
             recipes,
-            formats,
         }
     }
     fn enc(
@@ -39,7 +36,7 @@ impl<'defs> PerCpuModeEncodings<'defs> {
         recipe: EncodingRecipeNumber,
         bits: u16,
     ) -> EncodingBuilder {
-        EncodingBuilder::new(inst.into(), recipe, bits, self.formats)
+        EncodingBuilder::new(inst.into(), recipe, bits)
     }
     fn add32(&mut self, encoding: EncodingBuilder) {
         self.enc32
@@ -176,7 +173,7 @@ pub(crate) fn define<'defs>(
     let use_m = isa_settings.predicate_by_name("use_m");
 
     // Definitions.
-    let mut e = PerCpuModeEncodings::new(&recipes.recipes, &shared_defs.format_registry);
+    let mut e = PerCpuModeEncodings::new(&recipes.recipes);
 
     // Basic arithmetic binary instructions are encoded in an R-type instruction.
     for &(inst, inst_imm, f3, f7) in &[
@@ -242,7 +239,7 @@ pub(crate) fn define<'defs>(
                 bound_inst.clone().into(),
                 vec![Expr::Literal(cc), Expr::Var(x), Expr::Var(y)],
             )
-            .inst_predicate(&shared_defs.format_registry, &var_pool)
+            .inst_predicate(&var_pool)
             .unwrap()
         };
 
@@ -339,7 +336,7 @@ pub(crate) fn define<'defs>(
                     Expr::Var(args),
                 ],
             )
-            .inst_predicate(&shared_defs.format_registry, &var_pool)
+            .inst_predicate(&var_pool)
             .unwrap()
         };
 

--- a/cranelift-codegen/meta/src/isa/riscv/mod.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/mod.rs
@@ -90,8 +90,6 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let regs = define_registers();
 
     let inst_group = InstructionGroupBuilder::new(
-        "riscv",
-        "riscv specific instruction set",
         &mut shared_defs.all_instructions,
         &shared_defs.format_registry,
     )

--- a/cranelift-codegen/meta/src/isa/riscv/mod.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/mod.rs
@@ -89,11 +89,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = define_settings(&shared_defs.settings);
     let regs = define_registers();
 
-    let inst_group = InstructionGroupBuilder::new(
-        &mut shared_defs.all_instructions,
-        &shared_defs.format_registry,
-    )
-    .build();
+    let inst_group = InstructionGroupBuilder::new(&mut shared_defs.all_instructions).build();
 
     // CPU modes for 32-bit and 64-bit operation.
     let mut rv_32 = CpuMode::new("RV32");

--- a/cranelift-codegen/meta/src/isa/riscv/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/recipes.rs
@@ -46,23 +46,7 @@ impl RecipeGroup {
 }
 
 pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeGroup {
-    // Format shorthands.
-    let formats = &shared_defs.format_registry;
-
-    let f_binary = formats.by_name("Binary");
-    let f_binary_imm = formats.by_name("BinaryImm");
-    let f_branch = formats.by_name("Branch");
-    let f_branch_icmp = formats.by_name("BranchIcmp");
-    let f_call = formats.by_name("Call");
-    let f_call_indirect = formats.by_name("CallIndirect");
-    let f_copy_to_ssa = formats.by_name("CopyToSsa");
-    let f_int_compare = formats.by_name("IntCompare");
-    let f_int_compare_imm = formats.by_name("IntCompareImm");
-    let f_jump = formats.by_name("Jump");
-    let f_multiary = formats.by_name("MultiAry");
-    let f_regmove = formats.by_name("RegMove");
-    let f_unary = formats.by_name("Unary");
-    let f_unary_imm = formats.by_name("UnaryImm");
+    let formats = &shared_defs.formats;
 
     // Register classes shorthands.
     let gpr = regs.class_by_name("GPR");
@@ -73,7 +57,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
     // R-type 32-bit instructions: These are mostly binary arithmetic instructions.
     // The encbits are `opcode[6:2] | (funct3 << 5) | (funct7 << 8)
     recipes.push(
-        EncodingRecipeBuilder::new("R", f_binary, 4)
+        EncodingRecipeBuilder::new("R", &formats.binary, 4)
             .operands_in(vec![gpr, gpr])
             .operands_out(vec![gpr])
             .emit("put_r(bits, in_reg0, in_reg1, out_reg0, sink);"),
@@ -81,7 +65,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // R-type with an immediate shift amount instead of rs2.
     recipes.push(
-        EncodingRecipeBuilder::new("Rshamt", f_binary_imm, 4)
+        EncodingRecipeBuilder::new("Rshamt", &formats.binary_imm, 4)
             .operands_in(vec![gpr])
             .operands_out(vec![gpr])
             .emit("put_rshamt(bits, in_reg0, imm.into(), out_reg0, sink);"),
@@ -89,18 +73,18 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // R-type encoding of an integer comparison.
     recipes.push(
-        EncodingRecipeBuilder::new("Ricmp", f_int_compare, 4)
+        EncodingRecipeBuilder::new("Ricmp", &formats.int_compare, 4)
             .operands_in(vec![gpr, gpr])
             .operands_out(vec![gpr])
             .emit("put_r(bits, in_reg0, in_reg1, out_reg0, sink);"),
     );
 
     recipes.push(
-        EncodingRecipeBuilder::new("Ii", f_binary_imm, 4)
+        EncodingRecipeBuilder::new("Ii", &formats.binary_imm, 4)
             .operands_in(vec![gpr])
             .operands_out(vec![gpr])
             .inst_predicate(InstructionPredicate::new_is_signed_int(
-                &*f_binary_imm,
+                &*formats.binary_imm,
                 "imm",
                 12,
                 0,
@@ -110,10 +94,10 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // I-type instruction with a hardcoded %x0 rs1.
     recipes.push(
-        EncodingRecipeBuilder::new("Iz", f_unary_imm, 4)
+        EncodingRecipeBuilder::new("Iz", &formats.unary_imm, 4)
             .operands_out(vec![gpr])
             .inst_predicate(InstructionPredicate::new_is_signed_int(
-                &*f_unary_imm,
+                &*&formats.unary_imm,
                 "imm",
                 12,
                 0,
@@ -123,11 +107,11 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // I-type encoding of an integer comparison.
     recipes.push(
-        EncodingRecipeBuilder::new("Iicmp", f_int_compare_imm, 4)
+        EncodingRecipeBuilder::new("Iicmp", &formats.int_compare_imm, 4)
             .operands_in(vec![gpr])
             .operands_out(vec![gpr])
             .inst_predicate(InstructionPredicate::new_is_signed_int(
-                &*f_int_compare_imm,
+                &*&formats.int_compare_imm,
                 "imm",
                 12,
                 0,
@@ -137,8 +121,9 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // I-type encoding for `jalr` as a return instruction. We won't use the immediate offset.  The
     // variable return values are not encoded.
-    recipes.push(EncodingRecipeBuilder::new("Iret", f_multiary, 4).emit(
-        r#"
+    recipes.push(
+        EncodingRecipeBuilder::new("Iret", &formats.multiary, 4).emit(
+            r#"
                     // Return instructions are always a jalr to %x1.
                     // The return address is provided as a special-purpose link argument.
                     put_i(
@@ -149,11 +134,12 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
                         sink,
                     );
                 "#,
-    ));
+        ),
+    );
 
     // I-type encoding for `jalr` as a call_indirect.
     recipes.push(
-        EncodingRecipeBuilder::new("Icall", f_call_indirect, 4)
+        EncodingRecipeBuilder::new("Icall", &formats.call_indirect, 4)
             .operands_in(vec![gpr])
             .emit(
                 r#"
@@ -171,7 +157,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // Copy of a GPR is implemented as addi x, 0.
     recipes.push(
-        EncodingRecipeBuilder::new("Icopy", f_unary, 4)
+        EncodingRecipeBuilder::new("Icopy", &formats.unary, 4)
             .operands_in(vec![gpr])
             .operands_out(vec![gpr])
             .emit("put_i(bits, in_reg0, 0, out_reg0, sink);"),
@@ -179,14 +165,14 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // Same for a GPR regmove.
     recipes.push(
-        EncodingRecipeBuilder::new("Irmov", f_regmove, 4)
+        EncodingRecipeBuilder::new("Irmov", &formats.reg_move, 4)
             .operands_in(vec![gpr])
             .emit("put_i(bits, src, 0, dst, sink);"),
     );
 
     // Same for copy-to-SSA -- GPR regmove.
     recipes.push(
-        EncodingRecipeBuilder::new("copytossa", f_copy_to_ssa, 4)
+        EncodingRecipeBuilder::new("copytossa", &formats.copy_to_ssa, 4)
             // No operands_in to mention, because a source register is specified directly.
             .operands_out(vec![gpr])
             .emit("put_i(bits, src, 0, out_reg0, sink);"),
@@ -194,10 +180,10 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // U-type instructions have a 20-bit immediate that targets bits 12-31.
     recipes.push(
-        EncodingRecipeBuilder::new("U", f_unary_imm, 4)
+        EncodingRecipeBuilder::new("U", &formats.unary_imm, 4)
             .operands_out(vec![gpr])
             .inst_predicate(InstructionPredicate::new_is_signed_int(
-                &*f_unary_imm,
+                &*&formats.unary_imm,
                 "imm",
                 32,
                 12,
@@ -207,7 +193,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // UJ-type unconditional branch instructions.
     recipes.push(
-        EncodingRecipeBuilder::new("UJ", f_jump, 4)
+        EncodingRecipeBuilder::new("UJ", &formats.jump, 4)
             .branch_range((0, 21))
             .emit(
                 r#"
@@ -218,7 +204,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
             ),
     );
 
-    recipes.push(EncodingRecipeBuilder::new("UJcall", f_call, 4).emit(
+    recipes.push(EncodingRecipeBuilder::new("UJcall", &formats.call, 4).emit(
         r#"
                     sink.reloc_external(Reloc::RiscvCall,
                                         &func.dfg.ext_funcs[func_ref].name,
@@ -230,7 +216,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // SB-type branch instructions.
     recipes.push(
-        EncodingRecipeBuilder::new("SB", f_branch_icmp, 4)
+        EncodingRecipeBuilder::new("SB", &formats.branch_icmp, 4)
             .operands_in(vec![gpr, gpr])
             .branch_range((0, 13))
             .emit(
@@ -244,7 +230,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // SB-type branch instruction with rs2 fixed to zero.
     recipes.push(
-        EncodingRecipeBuilder::new("SBzero", f_branch, 4)
+        EncodingRecipeBuilder::new("SBzero", &formats.branch, 4)
             .operands_in(vec![gpr])
             .branch_range((0, 13))
             .emit(
@@ -258,7 +244,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // Spill of a GPR.
     recipes.push(
-        EncodingRecipeBuilder::new("GPsp", f_unary, 4)
+        EncodingRecipeBuilder::new("GPsp", &formats.unary, 4)
             .operands_in(vec![gpr])
             .operands_out(vec![Stack::new(gpr)])
             .emit("unimplemented!();"),
@@ -266,7 +252,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // Fill of a GPR.
     recipes.push(
-        EncodingRecipeBuilder::new("GPfi", f_unary, 4)
+        EncodingRecipeBuilder::new("GPfi", &formats.unary, 4)
             .operands_in(vec![Stack::new(gpr)])
             .operands_out(vec![gpr])
             .emit("unimplemented!();"),
@@ -274,7 +260,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // Stack-slot to same stack-slot copy, which is guaranteed to turn into a no-op.
     recipes.push(
-        EncodingRecipeBuilder::new("stacknull", f_unary, 0)
+        EncodingRecipeBuilder::new("stacknull", &formats.unary, 0)
             .operands_in(vec![Stack::new(gpr)])
             .operands_out(vec![Stack::new(gpr)])
             .emit(""),
@@ -282,7 +268,7 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     // No-op fills, created by late-stage redundant-fill removal.
     recipes.push(
-        EncodingRecipeBuilder::new("fillnull", f_unary, 0)
+        EncodingRecipeBuilder::new("fillnull", &formats.unary, 0)
             .operands_in(vec![Stack::new(gpr)])
             .operands_out(vec![gpr])
             .clobbers_flags(false)

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -20,27 +20,24 @@ use crate::shared::Definitions as SharedDefinitions;
 use crate::isa::x86::opcodes::*;
 
 use super::recipes::{RecipeGroup, Template};
-use crate::cdsl::formats::FormatRegistry;
 use crate::cdsl::instructions::BindParameter::Any;
 
-pub(crate) struct PerCpuModeEncodings<'defs> {
+pub(crate) struct PerCpuModeEncodings {
     pub enc32: Vec<Encoding>,
     pub enc64: Vec<Encoding>,
     pub recipes: Recipes,
     recipes_by_name: HashMap<String, EncodingRecipeNumber>,
     pub inst_pred_reg: InstructionPredicateRegistry,
-    formats: &'defs FormatRegistry,
 }
 
-impl<'defs> PerCpuModeEncodings<'defs> {
-    fn new(formats: &'defs FormatRegistry) -> Self {
+impl PerCpuModeEncodings {
+    fn new() -> Self {
         Self {
             enc32: Vec::new(),
             enc64: Vec::new(),
             recipes: Recipes::new(),
             recipes_by_name: HashMap::new(),
             inst_pred_reg: InstructionPredicateRegistry::new(),
-            formats,
         }
     }
 
@@ -73,7 +70,7 @@ impl<'defs> PerCpuModeEncodings<'defs> {
     {
         let (recipe, bits) = template.build();
         let recipe_number = self.add_recipe(recipe);
-        let builder = EncodingBuilder::new(inst.into(), recipe_number, bits, self.formats);
+        let builder = EncodingBuilder::new(inst.into(), recipe_number, bits);
         builder_closure(builder).build(&self.recipes, &mut self.inst_pred_reg)
     }
 
@@ -105,7 +102,7 @@ impl<'defs> PerCpuModeEncodings<'defs> {
     }
     fn enc32_rec(&mut self, inst: impl Into<InstSpec>, recipe: &EncodingRecipe, bits: u16) {
         let recipe_number = self.add_recipe(recipe.clone());
-        let builder = EncodingBuilder::new(inst.into(), recipe_number, bits, self.formats);
+        let builder = EncodingBuilder::new(inst.into(), recipe_number, bits);
         let encoding = builder.build(&self.recipes, &mut self.inst_pred_reg);
         self.enc32.push(encoding);
     }
@@ -138,7 +135,7 @@ impl<'defs> PerCpuModeEncodings<'defs> {
     }
     fn enc64_rec(&mut self, inst: impl Into<InstSpec>, recipe: &EncodingRecipe, bits: u16) {
         let recipe_number = self.add_recipe(recipe.clone());
-        let builder = EncodingBuilder::new(inst.into(), recipe_number, bits, self.formats);
+        let builder = EncodingBuilder::new(inst.into(), recipe_number, bits);
         let encoding = builder.build(&self.recipes, &mut self.inst_pred_reg);
         self.enc64.push(encoding);
     }
@@ -370,12 +367,12 @@ impl<'defs> PerCpuModeEncodings<'defs> {
 
 // Definitions.
 
-pub(crate) fn define<'defs>(
-    shared_defs: &'defs SharedDefinitions,
+pub(crate) fn define(
+    shared_defs: &SharedDefinitions,
     settings: &SettingGroup,
     x86: &InstructionGroup,
     r: &RecipeGroup,
-) -> PerCpuModeEncodings<'defs> {
+) -> PerCpuModeEncodings {
     let shared = &shared_defs.instructions;
     let formats = &shared_defs.format_registry;
 
@@ -688,7 +685,7 @@ pub(crate) fn define<'defs>(
     let use_sse41_simd = settings.predicate_by_name("use_sse41_simd");
 
     // Definitions.
-    let mut e = PerCpuModeEncodings::new(formats);
+    let mut e = PerCpuModeEncodings::new();
 
     // The pinned reg is fixed to a certain value entirely user-controlled, so it generates nothing!
     e.enc64_rec(get_pinned_reg.bind(I64), rec_get_pinned_reg, 0);
@@ -777,8 +774,8 @@ pub(crate) fn define<'defs>(
     e.enc64(iconst.bind(I32), rec_pu_id.opcodes(&MOV_IMM));
 
     // The 32-bit immediate movl also zero-extends to 64 bits.
-    let f_unary_imm = formats.get(formats.by_name("UnaryImm"));
-    let is_unsigned_int32 = InstructionPredicate::new_is_unsigned_int(f_unary_imm, "imm", 32, 0);
+    let f_unary_imm = formats.by_name("UnaryImm");
+    let is_unsigned_int32 = InstructionPredicate::new_is_unsigned_int(&*f_unary_imm, "imm", 32, 0);
 
     e.enc64_func(
         iconst.bind(I64),
@@ -883,8 +880,8 @@ pub(crate) fn define<'defs>(
     e.enc64_isap(ctz.bind(I32), rec_urm.opcodes(&TZCNT), use_bmi1);
 
     // Loads and stores.
-    let f_load_complex = formats.get(formats.by_name("LoadComplex"));
-    let is_load_complex_length_two = InstructionPredicate::new_length_equals(f_load_complex, 2);
+    let f_load_complex = formats.by_name("LoadComplex");
+    let is_load_complex_length_two = InstructionPredicate::new_length_equals(&*f_load_complex, 2);
 
     for recipe in &[rec_ldWithIndex, rec_ldWithIndexDisp8, rec_ldWithIndexDisp32] {
         e.enc_i32_i64_instp(
@@ -928,8 +925,9 @@ pub(crate) fn define<'defs>(
         );
     }
 
-    let f_store_complex = formats.get(formats.by_name("StoreComplex"));
-    let is_store_complex_length_three = InstructionPredicate::new_length_equals(f_store_complex, 3);
+    let f_store_complex = formats.by_name("StoreComplex");
+    let is_store_complex_length_three =
+        InstructionPredicate::new_length_equals(&*f_store_complex, 3);
 
     for recipe in &[rec_stWithIndex, rec_stWithIndexDisp8, rec_stWithIndexDisp32] {
         e.enc_i32_i64_instp(
@@ -1235,8 +1233,8 @@ pub(crate) fn define<'defs>(
     );
 
     // 64-bit, colocated, both PIC and non-PIC. Use the lea instruction's pc-relative field.
-    let f_func_addr = formats.get(formats.by_name("FuncAddr"));
-    let is_colocated_func = InstructionPredicate::new_is_colocated_func(f_func_addr, "func_ref");
+    let f_func_addr = formats.by_name("FuncAddr");
+    let is_colocated_func = InstructionPredicate::new_is_colocated_func(&*f_func_addr, "func_ref");
     e.enc64_instp(
         func_addr.bind(I64),
         rec_pcrel_fnaddr8.opcodes(&LEA).rex().w(),
@@ -1295,8 +1293,8 @@ pub(crate) fn define<'defs>(
     e.enc32(call, rec_call_id.opcodes(&CALL_RELATIVE));
 
     // 64-bit, colocated, both PIC and non-PIC. Use the call instruction's pc-relative field.
-    let f_call = formats.get(formats.by_name("Call"));
-    let is_colocated_func = InstructionPredicate::new_is_colocated_func(f_call, "func_ref");
+    let f_call = formats.by_name("Call");
+    let is_colocated_func = InstructionPredicate::new_is_colocated_func(&*f_call, "func_ref");
     e.enc64_instp(call, rec_call_id.opcodes(&CALL_RELATIVE), is_colocated_func);
 
     // 64-bit, non-colocated, PIC. There is no 64-bit non-colocated non-PIC version, since non-PIC
@@ -1566,16 +1564,18 @@ pub(crate) fn define<'defs>(
 
     // Floating-point constants equal to 0.0 can be encoded using either `xorps` or `xorpd`, for
     // 32-bit and 64-bit floats respectively.
-    let f_unary_ieee32 = formats.get(formats.by_name("UnaryIeee32"));
-    let is_zero_32_bit_float = InstructionPredicate::new_is_zero_32bit_float(f_unary_ieee32, "imm");
+    let f_unary_ieee32 = formats.by_name("UnaryIeee32");
+    let is_zero_32_bit_float =
+        InstructionPredicate::new_is_zero_32bit_float(&*f_unary_ieee32, "imm");
     e.enc32_instp(
         f32const,
         rec_f32imm_z.opcodes(&XORPS),
         is_zero_32_bit_float.clone(),
     );
 
-    let f_unary_ieee64 = formats.get(formats.by_name("UnaryIeee64"));
-    let is_zero_64_bit_float = InstructionPredicate::new_is_zero_64bit_float(f_unary_ieee64, "imm");
+    let f_unary_ieee64 = formats.by_name("UnaryIeee64");
+    let is_zero_64_bit_float =
+        InstructionPredicate::new_is_zero_64bit_float(&*f_unary_ieee64, "imm");
     e.enc32_instp(
         f64const,
         rec_f64imm_z.opcodes(&XORPD),
@@ -1847,18 +1847,18 @@ pub(crate) fn define<'defs>(
     // this must be encoded prior to the MOVUPS implementation (below) so the compiler sees this
     // encoding first
     for ty in ValueType::all_lane_types().filter(allowed_simd_type) {
-        let f_unary_const = formats.get(formats.by_name("UnaryConst"));
+        let f_unary_const = formats.by_name("UnaryConst");
         let instruction = vconst.bind(vector(ty, sse_vector_size));
 
         let is_zero_128bit =
-            InstructionPredicate::new_is_all_zeroes(f_unary_const, "constant_handle");
+            InstructionPredicate::new_is_all_zeroes(&*f_unary_const, "constant_handle");
         let template = rec_vconst_optimized.nonrex().opcodes(&PXOR);
         e.enc_32_64_func(instruction.clone(), template, |builder| {
             builder.inst_predicate(is_zero_128bit)
         });
 
         let is_ones_128bit =
-            InstructionPredicate::new_is_all_ones(f_unary_const, "constant_handle");
+            InstructionPredicate::new_is_all_ones(&*f_unary_const, "constant_handle");
         let template = rec_vconst_optimized.nonrex().opcodes(&PCMPEQB);
         e.enc_32_64_func(instruction, template, |builder| {
             builder.inst_predicate(is_ones_128bit)
@@ -2038,9 +2038,9 @@ pub(crate) fn define<'defs>(
         };
 
         let instruction = icmp.bind(vector(ty, sse_vector_size));
-        let f_int_compare = formats.get(formats.by_name("IntCompare"));
+        let f_int_compare = formats.by_name("IntCompare");
         let has_eq_condition_code =
-            InstructionPredicate::new_has_condition_code(f_int_compare, IntCC::Equal, "cond");
+            InstructionPredicate::new_has_condition_code(&*f_int_compare, IntCC::Equal, "cond");
         let template = rec_icscc_fpr.nonrex().opcodes(opcodes);
         e.enc_32_64_func(instruction, template, |builder| {
             let builder = builder.inst_predicate(has_eq_condition_code);

--- a/cranelift-codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift-codegen/meta/src/isa/x86/instructions.rs
@@ -15,12 +15,7 @@ pub(crate) fn define(
     format_registry: &FormatRegistry,
     immediates: &Immediates,
 ) -> InstructionGroup {
-    let mut ig = InstructionGroupBuilder::new(
-        "x86",
-        "x86 specific instruction set",
-        &mut all_instructions,
-        format_registry,
-    );
+    let mut ig = InstructionGroupBuilder::new(&mut all_instructions, format_registry);
 
     let iflags: &TypeVar = &ValueType::Special(types::Flag::IFlags.into()).into();
 

--- a/cranelift-codegen/meta/src/isa/x86/mod.rs
+++ b/cranelift-codegen/meta/src/isa/x86/mod.rs
@@ -20,7 +20,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
 
     let inst_group = instructions::define(
         &mut shared_defs.all_instructions,
-        &shared_defs.format_registry,
+        &shared_defs.formats,
         &shared_defs.imm,
     );
     legalize::define(shared_defs, &inst_group);

--- a/cranelift-codegen/meta/src/lib.rs
+++ b/cranelift-codegen/meta/src/lib.rs
@@ -39,13 +39,7 @@ pub fn generate(isas: &Vec<isa::Isa>, out_dir: &str) -> Result<(), error::Error>
 
     gen_inst::generate(&shared_defs, "opcodes.rs", "inst_builder.rs", &out_dir)?;
 
-    gen_legalizer::generate(
-        &isas,
-        &shared_defs.format_registry,
-        &shared_defs.transform_groups,
-        "legalize",
-        &out_dir,
-    )?;
+    gen_legalizer::generate(&isas, &shared_defs.transform_groups, "legalize", &out_dir)?;
 
     for isa in isas {
         gen_registers::generate(&isa, &format!("registers-{}.rs", isa.name), &out_dir)?;
@@ -65,7 +59,6 @@ pub fn generate(isas: &Vec<isa::Isa>, out_dir: &str) -> Result<(), error::Error>
         )?;
 
         gen_binemit::generate(
-            &shared_defs.format_registry,
             &isa.name,
             &isa.recipes,
             &format!("binemit-{}.rs", isa.name),

--- a/cranelift-codegen/meta/src/shared/formats.rs
+++ b/cranelift-codegen/meta/src/shared/formats.rs
@@ -1,226 +1,303 @@
-use crate::cdsl::formats::{FormatRegistry, InstructionFormatBuilder as Builder};
+use crate::cdsl::formats::{InstructionFormat, InstructionFormatBuilder as Builder};
 use crate::shared::{entities::EntityRefs, immediates::Immediates};
+use std::rc::Rc;
 
-pub(crate) fn define(imm: &Immediates, entities: &EntityRefs) -> FormatRegistry {
-    let mut registry = FormatRegistry::new();
+pub(crate) struct Formats {
+    pub(crate) binary: Rc<InstructionFormat>,
+    pub(crate) binary_imm: Rc<InstructionFormat>,
+    pub(crate) branch: Rc<InstructionFormat>,
+    pub(crate) branch_float: Rc<InstructionFormat>,
+    pub(crate) branch_icmp: Rc<InstructionFormat>,
+    pub(crate) branch_int: Rc<InstructionFormat>,
+    pub(crate) branch_table: Rc<InstructionFormat>,
+    pub(crate) branch_table_base: Rc<InstructionFormat>,
+    pub(crate) branch_table_entry: Rc<InstructionFormat>,
+    pub(crate) call: Rc<InstructionFormat>,
+    pub(crate) call_indirect: Rc<InstructionFormat>,
+    pub(crate) cond_trap: Rc<InstructionFormat>,
+    pub(crate) copy_special: Rc<InstructionFormat>,
+    pub(crate) copy_to_ssa: Rc<InstructionFormat>,
+    pub(crate) extract_lane: Rc<InstructionFormat>,
+    pub(crate) float_compare: Rc<InstructionFormat>,
+    pub(crate) float_cond: Rc<InstructionFormat>,
+    pub(crate) float_cond_trap: Rc<InstructionFormat>,
+    pub(crate) func_addr: Rc<InstructionFormat>,
+    pub(crate) heap_addr: Rc<InstructionFormat>,
+    pub(crate) indirect_jump: Rc<InstructionFormat>,
+    pub(crate) insert_lane: Rc<InstructionFormat>,
+    pub(crate) int_compare: Rc<InstructionFormat>,
+    pub(crate) int_compare_imm: Rc<InstructionFormat>,
+    pub(crate) int_cond: Rc<InstructionFormat>,
+    pub(crate) int_cond_trap: Rc<InstructionFormat>,
+    pub(crate) int_select: Rc<InstructionFormat>,
+    pub(crate) jump: Rc<InstructionFormat>,
+    pub(crate) load: Rc<InstructionFormat>,
+    pub(crate) load_complex: Rc<InstructionFormat>,
+    pub(crate) multiary: Rc<InstructionFormat>,
+    pub(crate) nullary: Rc<InstructionFormat>,
+    pub(crate) reg_fill: Rc<InstructionFormat>,
+    pub(crate) reg_move: Rc<InstructionFormat>,
+    pub(crate) reg_spill: Rc<InstructionFormat>,
+    pub(crate) shuffle: Rc<InstructionFormat>,
+    pub(crate) stack_load: Rc<InstructionFormat>,
+    pub(crate) stack_store: Rc<InstructionFormat>,
+    pub(crate) store: Rc<InstructionFormat>,
+    pub(crate) store_complex: Rc<InstructionFormat>,
+    pub(crate) table_addr: Rc<InstructionFormat>,
+    pub(crate) ternary: Rc<InstructionFormat>,
+    pub(crate) trap: Rc<InstructionFormat>,
+    pub(crate) unary: Rc<InstructionFormat>,
+    pub(crate) unary_bool: Rc<InstructionFormat>,
+    pub(crate) unary_const: Rc<InstructionFormat>,
+    pub(crate) unary_global_value: Rc<InstructionFormat>,
+    pub(crate) unary_ieee32: Rc<InstructionFormat>,
+    pub(crate) unary_ieee64: Rc<InstructionFormat>,
+    pub(crate) unary_imm: Rc<InstructionFormat>,
+}
 
-    registry.insert(Builder::new("Unary").value());
-    registry.insert(Builder::new("UnaryImm").imm(&imm.imm64));
-    registry.insert(Builder::new("UnaryIeee32").imm(&imm.ieee32));
-    registry.insert(Builder::new("UnaryIeee64").imm(&imm.ieee64));
-    registry.insert(Builder::new("UnaryBool").imm(&imm.boolean));
-    registry.insert(Builder::new("UnaryConst").imm(&imm.pool_constant));
-    registry.insert(Builder::new("UnaryGlobalValue").imm(&entities.global_value));
+impl Formats {
+    pub fn new(imm: &Immediates, entities: &EntityRefs) -> Self {
+        Self {
+            unary: Builder::new("Unary").value().build(),
 
-    registry.insert(Builder::new("Binary").value().value());
-    registry.insert(Builder::new("BinaryImm").value().imm(&imm.imm64));
+            unary_imm: Builder::new("UnaryImm").imm(&imm.imm64).build(),
 
-    // The select instructions are controlled by the second VALUE operand.
-    // The first VALUE operand is the controlling flag which has a derived type.
-    // The fma instruction has the same constraint on all inputs.
-    registry.insert(
-        Builder::new("Ternary")
-            .value()
-            .value()
-            .value()
-            .typevar_operand(1),
-    );
+            unary_ieee32: Builder::new("UnaryIeee32").imm(&imm.ieee32).build(),
 
-    // Catch-all for instructions with many outputs and inputs and no immediate
-    // operands.
-    registry.insert(Builder::new("MultiAry").varargs());
+            unary_ieee64: Builder::new("UnaryIeee64").imm(&imm.ieee64).build(),
 
-    registry.insert(Builder::new("NullAry"));
+            unary_bool: Builder::new("UnaryBool").imm(&imm.boolean).build(),
 
-    registry.insert(
-        Builder::new("InsertLane")
-            .value()
-            .imm_with_name("lane", &imm.uimm8)
-            .value(),
-    );
-    registry.insert(
-        Builder::new("ExtractLane")
-            .value()
-            .imm_with_name("lane", &imm.uimm8),
-    );
-    registry.insert(
-        Builder::new("Shuffle")
-            .value()
-            .value()
-            .imm_with_name("mask", &imm.uimm128),
-    );
+            unary_const: Builder::new("UnaryConst").imm(&imm.pool_constant).build(),
 
-    registry.insert(Builder::new("IntCompare").imm(&imm.intcc).value().value());
-    registry.insert(
-        Builder::new("IntCompareImm")
-            .imm(&imm.intcc)
-            .value()
-            .imm(&imm.imm64),
-    );
-    registry.insert(Builder::new("IntCond").imm(&imm.intcc).value());
+            unary_global_value: Builder::new("UnaryGlobalValue")
+                .imm(&entities.global_value)
+                .build(),
 
-    registry.insert(
-        Builder::new("FloatCompare")
-            .imm(&imm.floatcc)
-            .value()
-            .value(),
-    );
-    registry.insert(Builder::new("FloatCond").imm(&imm.floatcc).value());
+            binary: Builder::new("Binary").value().value().build(),
 
-    registry.insert(
-        Builder::new("IntSelect")
-            .imm(&imm.intcc)
-            .value()
-            .value()
-            .value(),
-    );
+            binary_imm: Builder::new("BinaryImm").value().imm(&imm.imm64).build(),
 
-    registry.insert(Builder::new("Jump").imm(&entities.ebb).varargs());
-    registry.insert(Builder::new("Branch").value().imm(&entities.ebb).varargs());
-    registry.insert(
-        Builder::new("BranchInt")
-            .imm(&imm.intcc)
-            .value()
-            .imm(&entities.ebb)
-            .varargs(),
-    );
-    registry.insert(
-        Builder::new("BranchFloat")
-            .imm(&imm.floatcc)
-            .value()
-            .imm(&entities.ebb)
-            .varargs(),
-    );
-    registry.insert(
-        Builder::new("BranchIcmp")
-            .imm(&imm.intcc)
-            .value()
-            .value()
-            .imm(&entities.ebb)
-            .varargs(),
-    );
-    registry.insert(
-        Builder::new("BranchTable")
-            .value()
-            .imm(&entities.ebb)
-            .imm(&entities.jump_table),
-    );
-    registry.insert(
-        Builder::new("BranchTableEntry")
-            .value()
-            .value()
-            .imm(&imm.uimm8)
-            .imm(&entities.jump_table),
-    );
-    registry.insert(Builder::new("BranchTableBase").imm(&entities.jump_table));
-    registry.insert(
-        Builder::new("IndirectJump")
-            .value()
-            .imm(&entities.jump_table),
-    );
+            // The select instructions are controlled by the second VALUE operand.
+            // The first VALUE operand is the controlling flag which has a derived type.
+            // The fma instruction has the same constraint on all inputs.
+            ternary: Builder::new("Ternary")
+                .value()
+                .value()
+                .value()
+                .typevar_operand(1)
+                .build(),
 
-    registry.insert(Builder::new("Call").imm(&entities.func_ref).varargs());
-    registry.insert(
-        Builder::new("CallIndirect")
-            .imm(&entities.sig_ref)
-            .value()
-            .varargs(),
-    );
-    registry.insert(Builder::new("FuncAddr").imm(&entities.func_ref));
+            // Catch-all for instructions with many outputs and inputs and no immediate
+            // operands.
+            multiary: Builder::new("MultiAry").varargs().build(),
 
-    registry.insert(
-        Builder::new("Load")
-            .imm(&imm.memflags)
-            .value()
-            .imm(&imm.offset32),
-    );
-    registry.insert(
-        Builder::new("LoadComplex")
-            .imm(&imm.memflags)
-            .varargs()
-            .imm(&imm.offset32),
-    );
-    registry.insert(
-        Builder::new("Store")
-            .imm(&imm.memflags)
-            .value()
-            .value()
-            .imm(&imm.offset32),
-    );
-    registry.insert(
-        Builder::new("StoreComplex")
-            .imm(&imm.memflags)
-            .value()
-            .varargs()
-            .imm(&imm.offset32),
-    );
-    registry.insert(
-        Builder::new("StackLoad")
-            .imm(&entities.stack_slot)
-            .imm(&imm.offset32),
-    );
-    registry.insert(
-        Builder::new("StackStore")
-            .value()
-            .imm(&entities.stack_slot)
-            .imm(&imm.offset32),
-    );
+            nullary: Builder::new("NullAry").build(),
 
-    // Accessing a WebAssembly heap.
-    registry.insert(
-        Builder::new("HeapAddr")
-            .imm(&entities.heap)
-            .value()
-            .imm(&imm.uimm32),
-    );
+            insert_lane: Builder::new("InsertLane")
+                .value()
+                .imm_with_name("lane", &imm.uimm8)
+                .value()
+                .build(),
 
-    // Accessing a WebAssembly table.
-    registry.insert(
-        Builder::new("TableAddr")
-            .imm(&entities.table)
-            .value()
-            .imm(&imm.offset32),
-    );
+            extract_lane: Builder::new("ExtractLane")
+                .value()
+                .imm_with_name("lane", &imm.uimm8)
+                .build(),
 
-    registry.insert(
-        Builder::new("RegMove")
-            .value()
-            .imm_with_name("src", &imm.regunit)
-            .imm_with_name("dst", &imm.regunit),
-    );
-    registry.insert(
-        Builder::new("CopySpecial")
-            .imm_with_name("src", &imm.regunit)
-            .imm_with_name("dst", &imm.regunit),
-    );
-    registry.insert(Builder::new("CopyToSsa").imm_with_name("src", &imm.regunit));
-    registry.insert(
-        Builder::new("RegSpill")
-            .value()
-            .imm_with_name("src", &imm.regunit)
-            .imm_with_name("dst", &entities.stack_slot),
-    );
-    registry.insert(
-        Builder::new("RegFill")
-            .value()
-            .imm_with_name("src", &entities.stack_slot)
-            .imm_with_name("dst", &imm.regunit),
-    );
+            shuffle: Builder::new("Shuffle")
+                .value()
+                .value()
+                .imm_with_name("mask", &imm.uimm128)
+                .build(),
 
-    registry.insert(Builder::new("Trap").imm(&imm.trapcode));
-    registry.insert(Builder::new("CondTrap").value().imm(&imm.trapcode));
-    registry.insert(
-        Builder::new("IntCondTrap")
-            .imm(&imm.intcc)
-            .value()
-            .imm(&imm.trapcode),
-    );
-    registry.insert(
-        Builder::new("FloatCondTrap")
-            .imm(&imm.floatcc)
-            .value()
-            .imm(&imm.trapcode),
-    );
+            int_compare: Builder::new("IntCompare")
+                .imm(&imm.intcc)
+                .value()
+                .value()
+                .build(),
 
-    registry
+            int_compare_imm: Builder::new("IntCompareImm")
+                .imm(&imm.intcc)
+                .value()
+                .imm(&imm.imm64)
+                .build(),
+
+            int_cond: Builder::new("IntCond").imm(&imm.intcc).value().build(),
+
+            float_compare: Builder::new("FloatCompare")
+                .imm(&imm.floatcc)
+                .value()
+                .value()
+                .build(),
+
+            float_cond: Builder::new("FloatCond").imm(&imm.floatcc).value().build(),
+
+            int_select: Builder::new("IntSelect")
+                .imm(&imm.intcc)
+                .value()
+                .value()
+                .value()
+                .build(),
+
+            jump: Builder::new("Jump").imm(&entities.ebb).varargs().build(),
+
+            branch: Builder::new("Branch")
+                .value()
+                .imm(&entities.ebb)
+                .varargs()
+                .build(),
+
+            branch_int: Builder::new("BranchInt")
+                .imm(&imm.intcc)
+                .value()
+                .imm(&entities.ebb)
+                .varargs()
+                .build(),
+
+            branch_float: Builder::new("BranchFloat")
+                .imm(&imm.floatcc)
+                .value()
+                .imm(&entities.ebb)
+                .varargs()
+                .build(),
+
+            branch_icmp: Builder::new("BranchIcmp")
+                .imm(&imm.intcc)
+                .value()
+                .value()
+                .imm(&entities.ebb)
+                .varargs()
+                .build(),
+
+            branch_table: Builder::new("BranchTable")
+                .value()
+                .imm(&entities.ebb)
+                .imm(&entities.jump_table)
+                .build(),
+
+            branch_table_entry: Builder::new("BranchTableEntry")
+                .value()
+                .value()
+                .imm(&imm.uimm8)
+                .imm(&entities.jump_table)
+                .build(),
+
+            branch_table_base: Builder::new("BranchTableBase")
+                .imm(&entities.jump_table)
+                .build(),
+
+            indirect_jump: Builder::new("IndirectJump")
+                .value()
+                .imm(&entities.jump_table)
+                .build(),
+
+            call: Builder::new("Call")
+                .imm(&entities.func_ref)
+                .varargs()
+                .build(),
+
+            call_indirect: Builder::new("CallIndirect")
+                .imm(&entities.sig_ref)
+                .value()
+                .varargs()
+                .build(),
+
+            func_addr: Builder::new("FuncAddr").imm(&entities.func_ref).build(),
+
+            load: Builder::new("Load")
+                .imm(&imm.memflags)
+                .value()
+                .imm(&imm.offset32)
+                .build(),
+
+            load_complex: Builder::new("LoadComplex")
+                .imm(&imm.memflags)
+                .varargs()
+                .imm(&imm.offset32)
+                .build(),
+
+            store: Builder::new("Store")
+                .imm(&imm.memflags)
+                .value()
+                .value()
+                .imm(&imm.offset32)
+                .build(),
+
+            store_complex: Builder::new("StoreComplex")
+                .imm(&imm.memflags)
+                .value()
+                .varargs()
+                .imm(&imm.offset32)
+                .build(),
+
+            stack_load: Builder::new("StackLoad")
+                .imm(&entities.stack_slot)
+                .imm(&imm.offset32)
+                .build(),
+
+            stack_store: Builder::new("StackStore")
+                .value()
+                .imm(&entities.stack_slot)
+                .imm(&imm.offset32)
+                .build(),
+
+            // Accessing a WebAssembly heap.
+            heap_addr: Builder::new("HeapAddr")
+                .imm(&entities.heap)
+                .value()
+                .imm(&imm.uimm32)
+                .build(),
+
+            // Accessing a WebAssembly table.
+            table_addr: Builder::new("TableAddr")
+                .imm(&entities.table)
+                .value()
+                .imm(&imm.offset32)
+                .build(),
+
+            reg_move: Builder::new("RegMove")
+                .value()
+                .imm_with_name("src", &imm.regunit)
+                .imm_with_name("dst", &imm.regunit)
+                .build(),
+
+            copy_special: Builder::new("CopySpecial")
+                .imm_with_name("src", &imm.regunit)
+                .imm_with_name("dst", &imm.regunit)
+                .build(),
+
+            copy_to_ssa: Builder::new("CopyToSsa")
+                .imm_with_name("src", &imm.regunit)
+                .build(),
+
+            reg_spill: Builder::new("RegSpill")
+                .value()
+                .imm_with_name("src", &imm.regunit)
+                .imm_with_name("dst", &entities.stack_slot)
+                .build(),
+
+            reg_fill: Builder::new("RegFill")
+                .value()
+                .imm_with_name("src", &entities.stack_slot)
+                .imm_with_name("dst", &imm.regunit)
+                .build(),
+
+            trap: Builder::new("Trap").imm(&imm.trapcode).build(),
+
+            cond_trap: Builder::new("CondTrap").value().imm(&imm.trapcode).build(),
+
+            int_cond_trap: Builder::new("IntCondTrap")
+                .imm(&imm.intcc)
+                .value()
+                .imm(&imm.trapcode)
+                .build(),
+
+            float_cond_trap: Builder::new("FloatCondTrap")
+                .imm(&imm.floatcc)
+                .value()
+                .imm(&imm.trapcode)
+                .build(),
+        }
+    }
 }

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -17,12 +17,7 @@ pub(crate) fn define(
     imm: &Immediates,
     entities: &EntityRefs,
 ) -> InstructionGroup {
-    let mut ig = InstructionGroupBuilder::new(
-        "base",
-        "Shared base instruction set",
-        all_instructions,
-        format_registry,
-    );
+    let mut ig = InstructionGroupBuilder::new(all_instructions, format_registry);
 
     // Operand kind shorthands.
     let iflags: &TypeVar = &ValueType::Special(types::Flag::IFlags.into()).into();

--- a/cranelift-codegen/meta/src/shared/mod.rs
+++ b/cranelift-codegen/meta/src/shared/mod.rs
@@ -8,20 +8,25 @@ pub mod legalize;
 pub mod settings;
 pub mod types;
 
-use crate::cdsl::formats::FormatRegistry;
+use crate::cdsl::formats::{FormatStructure, InstructionFormat};
 use crate::cdsl::instructions::{AllInstructions, InstructionGroup};
 use crate::cdsl::settings::SettingGroup;
 use crate::cdsl::xform::TransformGroups;
 
 use crate::shared::entities::EntityRefs;
+use crate::shared::formats::Formats;
 use crate::shared::immediates::Immediates;
+
+use std::collections::HashMap;
+use std::iter::FromIterator;
+use std::rc::Rc;
 
 pub(crate) struct Definitions {
     pub settings: SettingGroup,
     pub all_instructions: AllInstructions,
     pub instructions: InstructionGroup,
     pub imm: Immediates,
-    pub format_registry: FormatRegistry,
+    pub formats: Formats,
     pub transform_groups: TransformGroups,
 }
 
@@ -30,13 +35,9 @@ pub(crate) fn define() -> Definitions {
 
     let immediates = Immediates::new();
     let entities = EntityRefs::new();
-    let format_registry = formats::define(&immediates, &entities);
-    let instructions = instructions::define(
-        &mut all_instructions,
-        &format_registry,
-        &immediates,
-        &entities,
-    );
+    let formats = Formats::new(&immediates, &entities);
+    let instructions =
+        instructions::define(&mut all_instructions, &formats, &immediates, &entities);
     let transform_groups = legalize::define(&instructions, &immediates);
 
     Definitions {
@@ -44,7 +45,53 @@ pub(crate) fn define() -> Definitions {
         all_instructions,
         instructions,
         imm: immediates,
-        format_registry,
+        formats,
         transform_groups,
+    }
+}
+
+impl Definitions {
+    /// Verifies certain properties of formats.
+    ///
+    /// - Formats must be uniquely named: if two formats have the same name, they must refer to the
+    /// same data. Otherwise, two format variants in the codegen crate would have the same name.
+    /// - Formats must be structurally different from each other. Otherwise, this would lead to
+    /// code duplicate in the codegen crate.
+    ///
+    /// Returns a list of all the instruction formats effectively used.
+    pub fn verify_instruction_formats(&self) -> Vec<&InstructionFormat> {
+        let mut format_names: HashMap<&'static str, &Rc<InstructionFormat>> = HashMap::new();
+
+        // A structure is: number of input value operands / whether there's varargs or not / names
+        // of immediate fields.
+        let mut format_structures: HashMap<FormatStructure, &InstructionFormat> = HashMap::new();
+
+        for inst in self.all_instructions.values() {
+            // Check name.
+            if let Some(existing_format) = format_names.get(&inst.format.name) {
+                assert!(
+                    Rc::ptr_eq(&existing_format, &inst.format),
+                    "formats must uniquely named; there's a\
+                     conflict on the name '{}', please make sure it is used only once.",
+                    existing_format.name
+                );
+            } else {
+                format_names.insert(inst.format.name, &inst.format);
+            }
+
+            // Check structure.
+            let key = inst.format.structure();
+            if let Some(existing_format) = format_structures.get(&key) {
+                assert_eq!(
+                    existing_format.name, inst.format.name,
+                    "duplicate instruction formats {} and {}; please remove one.",
+                    existing_format.name, inst.format.name
+                );
+            } else {
+                format_structures.insert(key, &inst.format);
+            }
+        }
+
+        Vec::from_iter(format_structures.into_iter().map(|(_, v)| v))
     }
 }


### PR DESCRIPTION
This does what's been discussed in #955 regarding formats. Now they're static attributes of a big structure containing all of them, so there's no risk of using an incorrect format by mistake. Sorry for the last commit which is kind of big; there's some fundamental changes in there, but most of it is pretty mechanical (pass explicit format to instructions).

@abrown, are you interested in reviewing this?