### PR TITLE
Rename Operand::is_immediate + remove bitvector functionality

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/encodings.rs
+++ b/cranelift-codegen/meta/src/cdsl/encodings.rs
@@ -86,11 +86,12 @@ impl EncodingBuilder {
                 }
 
                 // Add immediate value predicates
-                for (immediate_value, immediate_operand) in inst
-                    .immediate_values
-                    .iter()
-                    .zip(inst.inst.operands_in.iter().filter(|o| o.is_immediate()))
-                {
+                for (immediate_value, immediate_operand) in inst.immediate_values.iter().zip(
+                    inst.inst
+                        .operands_in
+                        .iter()
+                        .filter(|o| o.is_pure_immediate()),
+                ) {
                     let immediate_predicate = InstructionPredicate::new_is_field_equal(
                         &inst.inst.format,
                         immediate_operand

--- a/cranelift-codegen/meta/src/cdsl/encodings.rs
+++ b/cranelift-codegen/meta/src/cdsl/encodings.rs
@@ -86,12 +86,11 @@ impl EncodingBuilder {
                 }
 
                 // Add immediate value predicates
-                for (immediate_value, immediate_operand) in inst.immediate_values.iter().zip(
-                    inst.inst
-                        .operands_in
-                        .iter()
-                        .filter(|o| o.is_pure_immediate()),
-                ) {
+                for (immediate_value, immediate_operand) in inst
+                    .immediate_values
+                    .iter()
+                    .zip(inst.inst.operands_in.iter().filter(|o| o.is_immediate()))
+                {
                     let immediate_predicate = InstructionPredicate::new_is_field_equal(
                         &inst.inst.format,
                         immediate_operand

--- a/cranelift-codegen/meta/src/cdsl/formats.rs
+++ b/cranelift-codegen/meta/src/cdsl/formats.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 /// This corresponds to a single member of a variant of the `InstructionData`
 /// data type.
 #[derive(Debug)]
-pub struct FormatField {
+pub(crate) struct FormatField {
     /// Immediate operand kind.
     pub kind: OperandKind,
 

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -322,7 +322,7 @@ impl InstructionBuilder {
         for (i, op) in operands_in.iter().enumerate() {
             if op.is_value() {
                 value_opnums.push(i);
-            } else if op.is_immediate() {
+            } else if op.is_immediate_or_entityref() {
                 imm_opnums.push(i);
             } else {
                 assert!(op.is_varargs());
@@ -500,7 +500,7 @@ impl BoundInstruction {
             .inst
             .operands_in
             .iter()
-            .filter(|o| o.is_immediate())
+            .filter(|o| o.is_immediate_or_entityref())
             .count();
         if self.immediate_values.len() > immediate_count {
             return Err(format!(

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -393,7 +393,7 @@ impl ValueTypeOrAny {
 type VectorBitWidth = u64;
 
 /// An parameter used for binding instructions to specific types or values
-pub enum BindParameter {
+pub(crate) enum BindParameter {
     Any,
     Lane(LaneType),
     Vector(LaneType, VectorBitWidth),
@@ -402,7 +402,7 @@ pub enum BindParameter {
 }
 
 /// Constructor for more easily building vector parameters from any lane type
-pub fn vector(parameter: impl Into<LaneType>, vector_size: VectorBitWidth) -> BindParameter {
+pub(crate) fn vector(parameter: impl Into<LaneType>, vector_size: VectorBitWidth) -> BindParameter {
     BindParameter::Vector(parameter.into(), vector_size)
 }
 
@@ -443,7 +443,7 @@ impl From<Immediate> for BindParameter {
 }
 
 #[derive(Clone)]
-pub enum Immediate {
+pub(crate) enum Immediate {
     // When needed, this enum should be expanded to include other immediate types (e.g. u8, u128).
     IntCC(IntCC),
 }
@@ -750,7 +750,7 @@ fn is_ctrl_typevar_candidate(
 }
 
 #[derive(Clone, Hash, PartialEq, Eq)]
-pub enum FormatPredicateKind {
+pub(crate) enum FormatPredicateKind {
     /// Is the field member equal to the expected value (stored here)?
     IsEqual(String),
 
@@ -791,7 +791,7 @@ pub enum FormatPredicateKind {
 }
 
 #[derive(Clone, Hash, PartialEq, Eq)]
-pub struct FormatPredicateNode {
+pub(crate) struct FormatPredicateNode {
     format_name: &'static str,
     member_name: &'static str,
     kind: FormatPredicateKind,
@@ -879,7 +879,7 @@ impl FormatPredicateNode {
 }
 
 #[derive(Clone, Hash, PartialEq, Eq)]
-pub enum TypePredicateNode {
+pub(crate) enum TypePredicateNode {
     /// Is the value argument (at the index designated by the first member) the same type as the
     /// type name (second member)?
     TypeVarCheck(usize, String),
@@ -905,7 +905,7 @@ impl TypePredicateNode {
 
 /// A basic node in an instruction predicate: either an atom, or an AND of two conditions.
 #[derive(Clone, Hash, PartialEq, Eq)]
-pub enum InstructionPredicateNode {
+pub(crate) enum InstructionPredicateNode {
     FormatPredicate(FormatPredicateNode),
 
     TypePredicate(TypePredicateNode),

--- a/cranelift-codegen/meta/src/cdsl/operands.rs
+++ b/cranelift-codegen/meta/src/cdsl/operands.rs
@@ -56,7 +56,7 @@ impl Operand {
     }
 
     /// Returns true if the operand has an immediate kind.
-    pub fn is_pure_immediate(&self) -> bool {
+    pub fn is_immediate(&self) -> bool {
         match self.kind.fields {
             OperandKindFields::ImmEnum(_) | OperandKindFields::ImmValue => true,
             _ => false,

--- a/cranelift-codegen/meta/src/cdsl/operands.rs
+++ b/cranelift-codegen/meta/src/cdsl/operands.rs
@@ -46,8 +46,7 @@ impl Operand {
     }
 
     /// Returns true if the operand has an immediate kind or is an EntityRef.
-    // TODO inherited name from the python, rename to is_immediate_or_entityref later.
-    pub fn is_immediate(&self) -> bool {
+    pub fn is_immediate_or_entityref(&self) -> bool {
         match self.kind.fields {
             OperandKindFields::ImmEnum(_)
             | OperandKindFields::ImmValue

--- a/cranelift-codegen/meta/src/cdsl/operands.rs
+++ b/cranelift-codegen/meta/src/cdsl/operands.rs
@@ -17,7 +17,7 @@ use crate::cdsl::typevar::TypeVar;
 /// 4. An `EntityRefKind` instance indicates an operand that references another entity in the
 ///    function, typically something declared in the function preamble.
 #[derive(Clone, Debug)]
-pub struct Operand {
+pub(crate) struct Operand {
     pub name: &'static str,
     pub doc: Option<String>,
     pub kind: OperandKind,
@@ -75,7 +75,7 @@ impl Operand {
     }
 }
 
-pub struct OperandBuilder {
+pub(crate) struct OperandBuilder {
     name: &'static str,
     doc: Option<String>,
     kind: OperandKind,
@@ -114,7 +114,7 @@ impl OperandBuilder {
 type EnumValues = HashMap<&'static str, &'static str>;
 
 #[derive(Clone, Debug)]
-pub enum OperandKindFields {
+pub(crate) enum OperandKindFields {
     EntityRef,
     VariableArgs,
     ImmValue,
@@ -123,7 +123,7 @@ pub enum OperandKindFields {
 }
 
 #[derive(Clone, Debug)]
-pub struct OperandKind {
+pub(crate) struct OperandKind {
     pub name: &'static str,
 
     doc: Option<String>,
@@ -145,16 +145,9 @@ impl OperandKind {
             _ => None,
         }
     }
-
-    pub fn type_var(&self) -> TypeVar {
-        match &self.fields {
-            OperandKindFields::TypeVar(tvar) => tvar.clone(),
-            _ => panic!("not a typevar"),
-        }
-    }
 }
 
-pub struct OperandKindBuilder {
+pub(crate) struct OperandKindBuilder {
     name: &'static str,
 
     doc: Option<String>,
@@ -270,12 +263,12 @@ impl Into<OperandKind> for &OperandKind {
 }
 
 /// Helper to create an operand in definitions files.
-pub fn create_operand(name: &'static str, kind: impl Into<OperandKind>) -> Operand {
+pub(crate) fn create_operand(name: &'static str, kind: impl Into<OperandKind>) -> Operand {
     OperandBuilder::new(name, kind.into()).build()
 }
 
 /// Helper to create an operand with a documentation in definitions files.
-pub fn create_operand_doc(
+pub(crate) fn create_operand_doc(
     name: &'static str,
     kind: impl Into<OperandKind>,
     doc: &'static str,

--- a/cranelift-codegen/meta/src/cdsl/recipes.rs
+++ b/cranelift-codegen/meta/src/cdsl/recipes.rs
@@ -18,7 +18,7 @@ use crate::cdsl::settings::SettingPredicateNumber;
 /// Register instances can be created with the constructor, or accessed as
 /// attributes on the register class: `GPR.rcx`.
 #[derive(Copy, Clone, Hash, PartialEq, Eq)]
-pub struct Register {
+pub(crate) struct Register {
     pub regclass: RegClassIndex,
     pub unit: u8,
 }
@@ -34,7 +34,7 @@ impl Register {
 /// A `Stack` object can be used to indicate an operand constraint for a value
 /// operand that must live in a stack slot.
 #[derive(Copy, Clone, Hash, PartialEq)]
-pub struct Stack {
+pub(crate) struct Stack {
     pub regclass: RegClassIndex,
 }
 
@@ -49,13 +49,13 @@ impl Stack {
 }
 
 #[derive(Clone, Hash, PartialEq)]
-pub struct BranchRange {
+pub(crate) struct BranchRange {
     pub inst_size: u64,
     pub range: u64,
 }
 
 #[derive(Copy, Clone, Hash, PartialEq)]
-pub enum OperandConstraint {
+pub(crate) enum OperandConstraint {
     RegClass(RegClassIndex),
     FixedReg(Register),
     TiedInput(usize),

--- a/cranelift-codegen/meta/src/cdsl/regs.rs
+++ b/cranelift-codegen/meta/src/cdsl/regs.rs
@@ -2,10 +2,10 @@ use cranelift_codegen_shared::constants;
 use cranelift_entity::{entity_impl, EntityRef, PrimaryMap};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RegBankIndex(u32);
+pub(crate) struct RegBankIndex(u32);
 entity_impl!(RegBankIndex);
 
-pub struct RegBank {
+pub(crate) struct RegBank {
     pub name: &'static str,
     pub first_unit: u8,
     pub units: u8,
@@ -73,10 +73,10 @@ impl RegBank {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
-pub struct RegClassIndex(u32);
+pub(crate) struct RegClassIndex(u32);
 entity_impl!(RegClassIndex);
 
-pub struct RegClass {
+pub(crate) struct RegClass {
     pub name: &'static str,
     pub index: RegClassIndex,
     pub width: u8,
@@ -130,12 +130,12 @@ impl RegClass {
     }
 }
 
-pub enum RegClassProto {
+pub(crate) enum RegClassProto {
     TopLevel(RegBankIndex),
     SubClass(RegClassIndex),
 }
 
-pub struct RegClassBuilder {
+pub(crate) struct RegClassBuilder {
     pub name: &'static str,
     pub width: u8,
     pub count: u8,
@@ -181,7 +181,7 @@ impl RegClassBuilder {
     }
 }
 
-pub struct RegBankBuilder {
+pub(crate) struct RegBankBuilder {
     pub name: &'static str,
     pub units: u8,
     pub names: Vec<&'static str>,
@@ -220,7 +220,7 @@ impl RegBankBuilder {
     }
 }
 
-pub struct IsaRegsBuilder {
+pub(crate) struct IsaRegsBuilder {
     pub banks: PrimaryMap<RegBankIndex, RegBank>,
     pub classes: PrimaryMap<RegClassIndex, RegClass>,
 }
@@ -384,7 +384,7 @@ impl IsaRegsBuilder {
     }
 }
 
-pub struct IsaRegs {
+pub(crate) struct IsaRegs {
     pub banks: PrimaryMap<RegBankIndex, RegBank>,
     pub classes: PrimaryMap<RegClassIndex, RegClass>,
 }

--- a/cranelift-codegen/meta/src/cdsl/settings.rs
+++ b/cranelift-codegen/meta/src/cdsl/settings.rs
@@ -1,24 +1,24 @@
 use std::iter;
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
-pub struct BoolSettingIndex(usize);
+pub(crate) struct BoolSettingIndex(usize);
 
 #[derive(Hash, PartialEq, Eq)]
-pub struct BoolSetting {
+pub(crate) struct BoolSetting {
     pub default: bool,
     pub bit_offset: u8,
     pub predicate_number: u8,
 }
 
 #[derive(Hash, PartialEq, Eq)]
-pub enum SpecificSetting {
+pub(crate) enum SpecificSetting {
     Bool(BoolSetting),
     Enum(Vec<&'static str>),
     Num(u8),
 }
 
 #[derive(Hash, PartialEq, Eq)]
-pub struct Setting {
+pub(crate) struct Setting {
     pub name: &'static str,
     pub comment: &'static str,
     pub specific: SpecificSetting,
@@ -66,10 +66,10 @@ impl Setting {
 }
 
 #[derive(Hash, PartialEq, Eq)]
-pub struct PresetIndex(usize);
+pub(crate) struct PresetIndex(usize);
 
 #[derive(Hash, PartialEq, Eq)]
-pub enum PresetType {
+pub(crate) enum PresetType {
     BoolSetting(BoolSettingIndex),
     OtherPreset(PresetIndex),
 }
@@ -86,7 +86,7 @@ impl Into<PresetType> for PresetIndex {
 }
 
 #[derive(Hash, PartialEq, Eq)]
-pub struct Preset {
+pub(crate) struct Preset {
     pub name: &'static str,
     values: Vec<BoolSettingIndex>,
 }
@@ -110,7 +110,7 @@ impl Preset {
     }
 }
 
-pub struct SettingGroup {
+pub(crate) struct SettingGroup {
     pub name: &'static str,
     pub settings: Vec<Setting>,
     pub bool_start_byte_offset: u8,
@@ -160,7 +160,7 @@ impl SettingGroup {
 
 /// This is the basic information needed to track the specific parts of a setting when building
 /// them.
-pub enum ProtoSpecificSetting {
+pub(crate) enum ProtoSpecificSetting {
     Bool(bool),
     Enum(Vec<&'static str>),
     Num(u8),
@@ -174,7 +174,7 @@ struct ProtoSetting {
 }
 
 #[derive(Hash, PartialEq, Eq)]
-pub enum PredicateNode {
+pub(crate) enum PredicateNode {
     OwnedBool(BoolSettingIndex),
     SharedBool(&'static str, &'static str),
     Not(Box<PredicateNode>),
@@ -217,9 +217,9 @@ struct ProtoPredicate {
     node: PredicateNode,
 }
 
-pub type SettingPredicateNumber = u8;
+pub(crate) type SettingPredicateNumber = u8;
 
-pub struct Predicate {
+pub(crate) struct Predicate {
     pub name: &'static str,
     node: PredicateNode,
     pub number: SettingPredicateNumber,
@@ -231,7 +231,7 @@ impl Predicate {
     }
 }
 
-pub struct SettingGroupBuilder {
+pub(crate) struct SettingGroupBuilder {
     name: &'static str,
     settings: Vec<ProtoSetting>,
     presets: Vec<Preset>,

--- a/cranelift-codegen/meta/src/cdsl/types.rs
+++ b/cranelift-codegen/meta/src/cdsl/types.rs
@@ -15,7 +15,7 @@ static _RUST_NAME_PREFIX: &str = "ir::types::";
 /// All SSA values have a type that is described by an instance of `ValueType`
 /// or one of its subclasses.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum ValueType {
+pub(crate) enum ValueType {
     BV(BVType),
     Lane(LaneType),
     Reference(ReferenceType),
@@ -151,7 +151,7 @@ impl From<VectorType> for ValueType {
 
 /// A concrete scalar type that can appear as a vector lane too.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub enum LaneType {
+pub(crate) enum LaneType {
     BoolType(shared_types::Bool),
     FloatType(shared_types::Float),
     IntType(shared_types::Int),
@@ -319,7 +319,7 @@ impl From<shared_types::Int> for LaneType {
 }
 
 /// An iterator for different lane types.
-pub struct LaneTypeIterator {
+pub(crate) struct LaneTypeIterator {
     bool_iter: shared_types::BoolIterator,
     int_iter: shared_types::IntIterator,
     float_iter: shared_types::FloatIterator,
@@ -356,7 +356,7 @@ impl Iterator for LaneTypeIterator {
 /// A vector type has a lane type which is an instance of `LaneType`,
 /// and a positive number of lanes.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct VectorType {
+pub(crate) struct VectorType {
     base: LaneType,
     lanes: u64,
 }
@@ -422,7 +422,7 @@ impl fmt::Debug for VectorType {
 
 /// A flat bitvector type. Used for semantics description only.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct BVType {
+pub(crate) struct BVType {
     bits: u64,
 }
 
@@ -459,7 +459,7 @@ impl fmt::Debug for BVType {
 ///
 /// Special types cannot be used to form vectors.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub enum SpecialType {
+pub(crate) enum SpecialType {
     Flag(shared_types::Flag),
 }
 
@@ -521,7 +521,7 @@ impl From<shared_types::Flag> for SpecialType {
     }
 }
 
-pub struct SpecialTypeIterator {
+pub(crate) struct SpecialTypeIterator {
     flag_iter: shared_types::FlagIterator,
 }
 
@@ -546,7 +546,7 @@ impl Iterator for SpecialTypeIterator {
 
 /// Reference type is scalar type, but not lane type.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ReferenceType(pub shared_types::Reference);
+pub(crate) struct ReferenceType(pub shared_types::Reference);
 
 impl ReferenceType {
     /// Return a string containing the documentation comment for this reference type.
@@ -600,7 +600,7 @@ impl From<shared_types::Reference> for ReferenceType {
 }
 
 /// An iterator for different reference types.
-pub struct ReferenceTypeIterator {
+pub(crate) struct ReferenceTypeIterator {
     reference_iter: shared_types::ReferenceIterator,
 }
 

--- a/cranelift-codegen/meta/src/cdsl/types.rs
+++ b/cranelift-codegen/meta/src/cdsl/types.rs
@@ -16,7 +16,6 @@ static _RUST_NAME_PREFIX: &str = "ir::types::";
 /// or one of its subclasses.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum ValueType {
-    BV(BVType),
     Lane(LaneType),
     Reference(ReferenceType),
     Special(SpecialType),
@@ -41,7 +40,6 @@ impl ValueType {
     /// Return a string containing the documentation comment for this type.
     pub fn doc(&self) -> String {
         match *self {
-            ValueType::BV(ref b) => b.doc(),
             ValueType::Lane(l) => l.doc(),
             ValueType::Reference(r) => r.doc(),
             ValueType::Special(s) => s.doc(),
@@ -52,7 +50,6 @@ impl ValueType {
     /// Return the number of bits in a lane.
     pub fn lane_bits(&self) -> u64 {
         match *self {
-            ValueType::BV(ref b) => b.lane_bits(),
             ValueType::Lane(l) => l.lane_bits(),
             ValueType::Reference(r) => r.lane_bits(),
             ValueType::Special(s) => s.lane_bits(),
@@ -76,7 +73,6 @@ impl ValueType {
     /// Find the unique number associated with this type.
     pub fn number(&self) -> Option<u8> {
         match *self {
-            ValueType::BV(_) => None,
             ValueType::Lane(l) => Some(l.number()),
             ValueType::Reference(r) => Some(r.number()),
             ValueType::Special(s) => Some(s.number()),
@@ -105,19 +101,11 @@ impl ValueType {
 impl fmt::Display for ValueType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ValueType::BV(ref b) => b.fmt(f),
             ValueType::Lane(l) => l.fmt(f),
             ValueType::Reference(r) => r.fmt(f),
             ValueType::Special(s) => s.fmt(f),
             ValueType::Vector(ref v) => v.fmt(f),
         }
-    }
-}
-
-/// Create a ValueType from a given bitvector type.
-impl From<BVType> for ValueType {
-    fn from(bv: BVType) -> Self {
-        ValueType::BV(bv)
     }
 }
 
@@ -260,13 +248,6 @@ impl LaneType {
     pub fn is_int(self) -> bool {
         match self {
             LaneType::IntType(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn is_bool(self) -> bool {
-        match self {
-            LaneType::BoolType(_) => true,
             _ => false,
         }
     }
@@ -417,41 +398,6 @@ impl fmt::Debug for VectorType {
             self.base,
             self.lane_count()
         )
-    }
-}
-
-/// A flat bitvector type. Used for semantics description only.
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub(crate) struct BVType {
-    bits: u64,
-}
-
-impl BVType {
-    /// Initialize a new bitvector type with `n` bits.
-    pub fn new(bits: u16) -> Self {
-        Self { bits: bits.into() }
-    }
-
-    /// Return a string containing the documentation comment for this bitvector type.
-    pub fn doc(&self) -> String {
-        format!("A bitvector type with {} bits.", self.bits)
-    }
-
-    /// Return the number of bits in a lane.
-    pub fn lane_bits(&self) -> u64 {
-        self.bits
-    }
-}
-
-impl fmt::Display for BVType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "bv{}", self.bits)
-    }
-}
-
-impl fmt::Debug for BVType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "BVType(bits={})", self.lane_bits())
     }
 }
 

--- a/cranelift-codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift-codegen/meta/src/cdsl/typevar.rs
@@ -21,7 +21,7 @@ const MAX_BITVEC: u16 = MAX_BITS * MAX_LANES;
 /// types and whether the type variable can assume scalar or vector types, or
 /// both.
 #[derive(Debug)]
-pub struct TypeVarContent {
+pub(crate) struct TypeVarContent {
     /// Short name of type variable used in instruction descriptions.
     pub name: String,
 
@@ -37,7 +37,7 @@ pub struct TypeVarContent {
 }
 
 #[derive(Clone, Debug)]
-pub struct TypeVar {
+pub(crate) struct TypeVar {
     content: Rc<RefCell<TypeVarContent>>,
 }
 
@@ -336,7 +336,7 @@ impl ops::Deref for TypeVar {
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
-pub enum DerivedFunc {
+pub(crate) enum DerivedFunc {
     LaneOf,
     AsBool,
     HalfWidth,
@@ -372,7 +372,7 @@ impl DerivedFunc {
 }
 
 #[derive(Debug, Hash)]
-pub struct TypeVarParent {
+pub(crate) struct TypeVarParent {
     pub type_var: TypeVar,
     pub derived_func: DerivedFunc,
 }
@@ -406,7 +406,7 @@ macro_rules! num_set {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct TypeSet {
+pub(crate) struct TypeSet {
     pub lanes: NumSet,
     pub ints: NumSet,
     pub floats: NumSet,
@@ -784,7 +784,7 @@ impl fmt::Debug for TypeSet {
     }
 }
 
-pub struct TypeSetBuilder {
+pub(crate) struct TypeSetBuilder {
     ints: Interval,
     floats: Interval,
     bools: Interval,
@@ -883,7 +883,7 @@ impl TypeSetBuilder {
 }
 
 #[derive(PartialEq)]
-pub enum Interval {
+pub(crate) enum Interval {
     None,
     All,
     Range(Range),

--- a/cranelift-codegen/meta/src/gen_inst.rs
+++ b/cranelift-codegen/meta/src/gen_inst.rs
@@ -910,7 +910,7 @@ fn gen_inst_builder(inst: &Instruction, format: &InstructionFormat, fmt: &mut Fo
     let mut tmpl_types = Vec::new();
     let mut into_args = Vec::new();
     for op in &inst.operands_in {
-        let t = if op.is_pure_immediate() {
+        let t = if op.is_immediate() {
             let t = format!("T{}{}", tmpl_types.len() + 1, op.kind.name);
             tmpl_types.push(format!("{}: Into<{}>", t, op.kind.rust_type));
             into_args.push(op.name);

--- a/cranelift-codegen/meta/src/gen_inst.rs
+++ b/cranelift-codegen/meta/src/gen_inst.rs
@@ -650,9 +650,6 @@ fn typeset_to_string(ts: &TypeSet) -> String {
     if !ts.bools.is_empty() {
         result += &format!(", bools={}", iterable_to_string(&ts.bools));
     }
-    if !ts.bitvecs.is_empty() {
-        result += &format!(", bitvecs={}", iterable_to_string(&ts.bitvecs));
-    }
     if !ts.specials.is_empty() {
         result += &format!(", specials=[{}]", iterable_to_string(&ts.specials));
     }
@@ -680,7 +677,6 @@ pub(crate) fn gen_typesets_table(type_sets: &UniqueTable<TypeSet>, fmt: &mut For
         for ts in type_sets.iter() {
             fmt.line("ir::instructions::ValueTypeSet {");
             fmt.indent(|fmt| {
-                assert!(ts.bitvecs.is_empty(), "Bitvector types are not emittable.");
                 fmt.comment(typeset_to_string(ts));
                 gen_bitset(&ts.lanes, "lanes", 16, fmt);
                 gen_bitset(&ts.ints, "ints", 8, fmt);

--- a/cranelift-codegen/meta/src/gen_inst.rs
+++ b/cranelift-codegen/meta/src/gen_inst.rs
@@ -664,7 +664,7 @@ fn typeset_to_string(ts: &TypeSet) -> String {
 }
 
 /// Generate the table of ValueTypeSets described by type_sets.
-pub fn gen_typesets_table(type_sets: &UniqueTable<TypeSet>, fmt: &mut Formatter) {
+pub(crate) fn gen_typesets_table(type_sets: &UniqueTable<TypeSet>, fmt: &mut Formatter) {
     if type_sets.len() == 0 {
         return;
     }

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -66,7 +66,7 @@ fn unwrap_inst(transform: &Transform, fmt: &mut Formatter) -> bool {
         let mut imm_and_varargs = inst
             .operands_in
             .iter()
-            .filter(|op| op.is_immediate())
+            .filter(|op| op.is_immediate_or_entityref())
             .count();
         if iform.has_value_list {
             imm_and_varargs += 1;
@@ -115,7 +115,7 @@ fn unwrap_inst(transform: &Transform, fmt: &mut Formatter) -> bool {
         let emit_one_value =
             |fmt: &mut Formatter, needs_comma: bool, op_num: usize, op: &Operand| {
                 let comma = if needs_comma { "," } else { "" };
-                if op.is_immediate() {
+                if op.is_immediate_or_entityref() {
                     let n = inst.imm_opnums.iter().position(|&i| i == op_num).unwrap();
                     fmtln!(fmt, "{}{}", iform.imm_fields[n].member, comma);
                 } else if op.is_value() {

--- a/cranelift-codegen/meta/src/gen_settings.rs
+++ b/cranelift-codegen/meta/src/gen_settings.rs
@@ -10,7 +10,7 @@ use crate::error;
 use crate::srcgen::{Formatter, Match};
 use crate::unique_table::UniqueSeqTable;
 
-pub enum ParentGroup {
+pub(crate) enum ParentGroup {
     None,
     Shared,
 }

--- a/cranelift-codegen/meta/src/isa/x86/registers.rs
+++ b/cranelift-codegen/meta/src/isa/x86/registers.rs
@@ -1,6 +1,6 @@
 use crate::cdsl::regs::{IsaRegs, IsaRegsBuilder, RegBankBuilder, RegClassBuilder};
 
-pub fn define() -> IsaRegs {
+pub(crate) fn define() -> IsaRegs {
     let mut regs = IsaRegsBuilder::new();
 
     let builder = RegBankBuilder::new("IntRegs", "r")

--- a/cranelift-codegen/meta/src/isa/x86/settings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/settings.rs
@@ -1,6 +1,6 @@
 use crate::cdsl::settings::{PredicateNode, SettingGroup, SettingGroupBuilder};
 
-pub fn define(shared: &SettingGroup) -> SettingGroup {
+pub(crate) fn define(shared: &SettingGroup) -> SettingGroup {
     let mut settings = SettingGroupBuilder::new("x86");
 
     // CPUID.01H:ECX

--- a/cranelift-codegen/meta/src/shared/entities.rs
+++ b/cranelift-codegen/meta/src/shared/entities.rs
@@ -1,35 +1,35 @@
 use crate::cdsl::operands::{OperandKind, OperandKindBuilder as Builder, OperandKindFields};
 
-pub struct EntityRefs {
+pub(crate) struct EntityRefs {
     /// A reference to an extended basic block in the same function.
     /// This is primarliy used in control flow instructions.
-    pub ebb: OperandKind,
+    pub(crate) ebb: OperandKind,
 
     /// A reference to a stack slot declared in the function preamble.
-    pub stack_slot: OperandKind,
+    pub(crate) stack_slot: OperandKind,
 
     /// A reference to a global value.
-    pub global_value: OperandKind,
+    pub(crate) global_value: OperandKind,
 
     /// A reference to a function signature declared in the function preamble.
     /// This is used to provide the call signature in a call_indirect instruction.
-    pub sig_ref: OperandKind,
+    pub(crate) sig_ref: OperandKind,
 
     /// A reference to an external function declared in the function preamble.
     /// This is used to provide the callee and signature in a call instruction.
-    pub func_ref: OperandKind,
+    pub(crate) func_ref: OperandKind,
 
     /// A reference to a jump table declared in the function preamble.
-    pub jump_table: OperandKind,
+    pub(crate) jump_table: OperandKind,
 
     /// A reference to a heap declared in the function preamble.
-    pub heap: OperandKind,
+    pub(crate) heap: OperandKind,
 
     /// A reference to a table declared in the function preamble.
-    pub table: OperandKind,
+    pub(crate) table: OperandKind,
 
     /// A variable-sized list of value operands. Use for Ebb and function call arguments.
-    pub varargs: OperandKind,
+    pub(crate) varargs: OperandKind,
 }
 
 impl EntityRefs {

--- a/cranelift-codegen/meta/src/shared/settings.rs
+++ b/cranelift-codegen/meta/src/shared/settings.rs
@@ -1,6 +1,6 @@
 use crate::cdsl::settings::{SettingGroup, SettingGroupBuilder};
 
-pub fn define() -> SettingGroup {
+pub(crate) fn define() -> SettingGroup {
     let mut settings = SettingGroupBuilder::new("shared");
 
     settings.add_enum(

--- a/cranelift-codegen/meta/src/shared/types.rs
+++ b/cranelift-codegen/meta/src/shared/types.rs
@@ -1,7 +1,7 @@
 //! This module predefines all the Cranelift scalar types.
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub enum Bool {
+pub(crate) enum Bool {
     /// 1-bit bool.
     B1 = 1,
     /// 8-bit bool.
@@ -17,7 +17,7 @@ pub enum Bool {
 }
 
 /// This provides an iterator through all of the supported bool variants.
-pub struct BoolIterator {
+pub(crate) struct BoolIterator {
     index: u8,
 }
 
@@ -45,7 +45,7 @@ impl Iterator for BoolIterator {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub enum Int {
+pub(crate) enum Int {
     /// 8-bit int.
     I8 = 8,
     /// 16-bit int.
@@ -59,7 +59,7 @@ pub enum Int {
 }
 
 /// This provides an iterator through all of the supported int variants.
-pub struct IntIterator {
+pub(crate) struct IntIterator {
     index: u8,
 }
 
@@ -86,13 +86,13 @@ impl Iterator for IntIterator {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub enum Float {
+pub(crate) enum Float {
     F32 = 32,
     F64 = 64,
 }
 
 /// Iterator through the variants of the Float enum.
-pub struct FloatIterator {
+pub(crate) struct FloatIterator {
     index: u8,
 }
 
@@ -120,7 +120,7 @@ impl Iterator for FloatIterator {
 ///
 /// Flags can't be stored in memory.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub enum Flag {
+pub(crate) enum Flag {
     /// CPU flags from an integer comparison.
     IFlags,
     /// CPU flags from a floating point comparison.
@@ -128,7 +128,7 @@ pub enum Flag {
 }
 
 /// Iterator through the variants of the Flag enum.
-pub struct FlagIterator {
+pub(crate) struct FlagIterator {
     index: u8,
 }
 
@@ -152,7 +152,7 @@ impl Iterator for FlagIterator {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub enum Reference {
+pub(crate) enum Reference {
     /// 32-bit reference.
     R32 = 32,
     /// 64-bit reference.
@@ -160,7 +160,7 @@ pub enum Reference {
 }
 
 /// This provides an iterator through all of the supported reference variants.
-pub struct ReferenceIterator {
+pub(crate) struct ReferenceIterator {
     index: u8,
 }
 

--- a/cranelift-codegen/meta/src/srcgen.rs
+++ b/cranelift-codegen/meta/src/srcgen.rs
@@ -35,7 +35,7 @@ macro_rules! fmtln {
     };
 }
 
-pub struct Formatter {
+pub(crate) struct Formatter {
     indent: usize,
     lines: Vec<String>,
 }
@@ -260,7 +260,7 @@ fn parse_multiline(s: &str) -> Vec<String> {
 /// Note that this class is ignorant of Rust types, and considers two fields
 /// with the same name to be equivalent. BTreeMap/BTreeSet are used to
 /// represent the arms in order to make the order deterministic.
-pub struct Match {
+pub(crate) struct Match {
     expr: String,
     arms: BTreeMap<(Vec<String>, String), BTreeSet<String>>,
     /// The clause for the placeholder pattern _.

--- a/cranelift-codegen/meta/src/unique_table.rs
+++ b/cranelift-codegen/meta/src/unique_table.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use std::slice;
 
 /// Collect items into the `table` list, removing duplicates.
-pub struct UniqueTable<'entries, T: Eq + Hash> {
+pub(crate) struct UniqueTable<'entries, T: Eq + Hash> {
     table: Vec<&'entries T>,
     map: HashMap<&'entries T, usize>,
 }
@@ -40,7 +40,7 @@ impl<'entries, T: Eq + Hash> UniqueTable<'entries, T> {
 }
 
 /// A table of sequences which tries to avoid common subsequences.
-pub struct UniqueSeqTable<T: PartialEq + Clone> {
+pub(crate) struct UniqueSeqTable<T: PartialEq + Clone> {
     table: Vec<T>,
 }
 


### PR DESCRIPTION
No issue:
  - trivial renaming mentioned in a TODO of the meta code.
  - finish adding "pub(crate)" declarations everywhere in the meta crate, and remove dead code.
  - remove "bit vector" functionality, unused since the transition of the meta crate to rust. Note it's not the feature for emitting SIMD constants; but a different feature to model every type variable as a bit-vector.
