### PR TITLE
Add x86 SIMD float comparisons

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -610,6 +610,7 @@ pub(crate) fn define(
     let rec_null_fpr = r.recipe("null_fpr");
     let rec_pcrel_fnaddr8 = r.template("pcrel_fnaddr8");
     let rec_pcrel_gvaddr8 = r.template("pcrel_gvaddr8");
+    let rec_pfcmp = r.template("pfcmp");
     let rec_popq = r.template("popq");
     let rec_pu_id = r.template("pu_id");
     let rec_pu_id_bool = r.template("pu_id_bool");
@@ -2069,6 +2070,16 @@ pub(crate) fn define(
         let inst_ = inst.bind(vector(*ty, sse_vector_size));
         e.enc_32_64_maybe_isap(inst_, rec_fa.opcodes(opcodes), *isa_predicate);
     }
+
+    // SIMD float comparisons
+    e.enc_both(
+        fcmp.bind(vector(F32, sse_vector_size)),
+        rec_pfcmp.opcodes(&CMPPS),
+    );
+    e.enc_both(
+        fcmp.bind(vector(F64, sse_vector_size)),
+        rec_pfcmp.opcodes(&CMPPD),
+    );
 
     // Reference type instructions
 

--- a/cranelift-codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/opcodes.rs
@@ -61,6 +61,14 @@ pub static CMP_IMM8: [u8; 1] = [0x83];
 /// Compare r{16,32,64} with r/m of the same size.
 pub static CMP_REG: [u8; 1] = [0x39];
 
+/// Compare packed double-precision floating-point value in xmm2/m32 and xmm1 using bits 2:0 of
+/// imm8 as comparison predicate (SSE2).
+pub static CMPPD: [u8; 3] = [0x66, 0x0f, 0xc2];
+
+/// Compare packed single-precision floating-point value in xmm2/m32 and xmm1 using bits 2:0 of
+/// imm8 as comparison predicate (SSE).
+pub static CMPPS: [u8; 2] = [0x0f, 0xc2];
+
 /// Convert scalar double-precision floating-point value to scalar single-precision
 /// floating-point value.
 pub static CVTSD2SS: [u8; 3] = [0xf2, 0x0f, 0x5a];

--- a/cranelift-reader/src/lexer.rs
+++ b/cranelift-reader/src/lexer.rs
@@ -488,7 +488,13 @@ impl<'a> Lexer<'a> {
                     }
                 }
                 Some(ch) if ch.is_digit(10) => Some(self.scan_number()),
-                Some(ch) if ch.is_alphabetic() => Some(self.scan_word()),
+                Some(ch) if ch.is_alphabetic() => {
+                    if self.looking_at("NaN") || self.looking_at("Inf") {
+                        Some(self.scan_number())
+                    } else {
+                        Some(self.scan_word())
+                    }
+                }
                 Some('%') => Some(self.scan_name()),
                 Some('"') => Some(self.scan_string()),
                 Some('#') => Some(self.scan_hex_sequence()),
@@ -593,7 +599,7 @@ mod tests {
 
     #[test]
     fn lex_numbers() {
-        let mut lex = Lexer::new(" 0 2_000 -1,0xf -0x0 0.0 0x0.4p-34 +5");
+        let mut lex = Lexer::new(" 0 2_000 -1,0xf -0x0 0.0 0x0.4p-34 NaN +5");
         assert_eq!(lex.next(), token(Token::Integer("0"), 1));
         assert_eq!(lex.next(), token(Token::Integer("2_000"), 1));
         assert_eq!(lex.next(), token(Token::Integer("-1"), 1));
@@ -602,6 +608,7 @@ mod tests {
         assert_eq!(lex.next(), token(Token::Integer("-0x0"), 1));
         assert_eq!(lex.next(), token(Token::Float("0.0"), 1));
         assert_eq!(lex.next(), token(Token::Float("0x0.4p-34"), 1));
+        assert_eq!(lex.next(), token(Token::Float("NaN"), 1));
         assert_eq!(lex.next(), token(Token::Integer("+5"), 1));
         assert_eq!(lex.next(), None);
     }

--- a/cranelift-reader/src/parser.rs
+++ b/cranelift-reader/src/parser.rs
@@ -896,7 +896,7 @@ impl<'a> Parser<'a> {
                 I16 => consume!(ty, self.match_imm16("Expected a 16-bit integer")?),
                 I32 => consume!(ty, self.match_imm32("Expected a 32-bit integer")?),
                 I64 => consume!(ty, self.match_imm64("Expected a 64-bit integer")?),
-                F32 => consume!(ty, self.match_ieee32("Expected a 32-bit float...")?),
+                F32 => consume!(ty, self.match_ieee32("Expected a 32-bit float")?),
                 F64 => consume!(ty, self.match_ieee64("Expected a 64-bit float")?),
                 b if b.is_bool() => consume!(
                     ty,

--- a/filetests/isa/x86/simd-comparison-binemit.clif
+++ b/filetests/isa/x86/simd-comparison-binemit.clif
@@ -52,3 +52,29 @@ ebb0(v0: i32x4 [%xmm2], v1: i32x4 [%xmm4]):
 [-, %xmm2]  v5 = x86_pminu v0, v1     ; bin: 66 0f 38 3b d4
             return
 }
+
+function %fcmp_f32x4(f32x4, f32x4) {
+ebb0(v0: f32x4 [%xmm2], v1: f32x4 [%xmm4]):
+[-, %xmm2]  v2 = fcmp eq v0, v1     ; bin: 40 0f c2 d4 00
+[-, %xmm2]  v3 = fcmp lt v0, v1     ; bin: 40 0f c2 d4 01
+[-, %xmm2]  v4 = fcmp le v0, v1     ; bin: 40 0f c2 d4 02
+[-, %xmm2]  v5 = fcmp uno v0, v1    ; bin: 40 0f c2 d4 03
+[-, %xmm2]  v6 = fcmp ne v0, v1     ; bin: 40 0f c2 d4 04
+[-, %xmm2]  v7 = fcmp ge v0, v1     ; bin: 40 0f c2 d4 05
+[-, %xmm2]  v8 = fcmp gt v0, v1     ; bin: 40 0f c2 d4 06
+[-, %xmm2]  v9 = fcmp ord v0, v1    ; bin: 40 0f c2 d4 07
+            return
+}
+
+function %fcmp_f64x2(f64x2, f64x2) {
+ebb0(v0: f64x2 [%xmm2], v1: f64x2 [%xmm0]):
+[-, %xmm2]  v2 = fcmp eq v0, v1     ; bin: 66 40 0f c2 d0 00
+[-, %xmm2]  v3 = fcmp lt v0, v1     ; bin: 66 40 0f c2 d0 01
+[-, %xmm2]  v4 = fcmp le v0, v1     ; bin: 66 40 0f c2 d0 02
+[-, %xmm2]  v5 = fcmp uno v0, v1    ; bin: 66 40 0f c2 d0 03
+[-, %xmm2]  v6 = fcmp ne v0, v1     ; bin: 66 40 0f c2 d0 04
+[-, %xmm2]  v7 = fcmp ge v0, v1     ; bin: 66 40 0f c2 d0 05
+[-, %xmm2]  v8 = fcmp gt v0, v1     ; bin: 66 40 0f c2 d0 06
+[-, %xmm2]  v9 = fcmp ord v0, v1    ; bin: 66 40 0f c2 d0 07
+            return
+}

--- a/filetests/isa/x86/simd-comparison-run.clif
+++ b/filetests/isa/x86/simd-comparison-run.clif
@@ -177,3 +177,43 @@ ebb0:
     return v8
 }
 ; run
+
+function %fcmp_eq_f32x4() -> b1 {
+ebb0:
+    v0 = vconst.f32x4 [0.0 -0x4.2 0x0.33333 -0.0]
+    v1 = vconst.f32x4 [0.0 -0x4.2 0x0.33333 -0.0]
+    v2 = fcmp eq v0, v1
+    v8 = vall_true v2
+    return v8
+}
+; run
+
+function %fcmp_lt_f32x4() -> b1 {
+ebb0:
+    v0 = vconst.f32x4 [0.0      -0x4.2  0x0.0       -0.0]
+    v1 = vconst.f32x4 [0x0.001  0x4.2   0x0.33333   0x1.0]
+    v2 = fcmp lt v0, v1
+    v8 = vall_true v2
+    return v8
+}
+; run
+
+function %fcmp_ge_f64x2() -> b1 {
+ebb0:
+    v0 = vconst.f64x2 [0x0.0  0x4.2]
+    v1 = vconst.f64x2 [0.0    0x4.1]
+    v2 = fcmp ge v0, v1
+    v8 = vall_true v2
+    return v8
+}
+; run
+
+function %fcmp_uno_f64x2() -> b1 {
+ebb0:
+    v0 = vconst.f64x2 [0.0  NaN]
+    v1 = vconst.f64x2 [NaN  0x4.1]
+    v2 = fcmp uno v0, v1
+    v8 = vall_true v2
+    return v8
+}
+; run


### PR DESCRIPTION
This builds on work in #1171; wait to review until that is merged.

- [x] This has been discussed in issue #..., or if not, please tell us why
  here: _no issue, just continued SIMD implementation_
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first: _see title_
- [x] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->
