### PR TITLE
Don't force enable basic-blocks feature

### DIFF
--- a/cranelift-faerie/Cargo.toml
+++ b/cranelift-faerie/Cargo.toml
@@ -10,12 +10,17 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.46.1" }
 cranelift-module = { path = "../cranelift-module", version = "0.46.1" }
 faerie = "0.11.0"
 goblin = "0.0.24"
 failure = "0.1.2"
 target-lexicon = "0.8.1"
+
+[dependencies.cranelift-codegen]
+path = "../cranelift-codegen"
+version = "0.46.1"
+default-features = false
+features = ["std"]
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-object/Cargo.toml
+++ b/cranelift-object/Cargo.toml
@@ -10,10 +10,15 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.46.1" }
 cranelift-module = { path = "../cranelift-module", version = "0.46.1" }
 object = { version = "0.14.0", default-features = false, features = ["write"] }
 target-lexicon = "0.8.1"
+
+[dependencies.cranelift-codegen]
+path = "../cranelift-codegen"
+version = "0.46.1"
+default-features = false
+features = ["std"]
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-simplejit/Cargo.toml
+++ b/cranelift-simplejit/Cargo.toml
@@ -10,14 +10,19 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.46.1" }
 cranelift-module = { path = "../cranelift-module", version = "0.46.1" }
 cranelift-native = { path = "../cranelift-native", version = "0.46.1" }
 region = "2.0.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
 target-lexicon = "0.8.1"
-memmap = { version = "0.7.0", optional = true } 
+memmap = { version = "0.7.0", optional = true }
+
+[dependencies.cranelift-codegen]
+path = "../cranelift-codegen"
+version = "0.46.1"
+default-features = false
+features = ["std"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["winbase", "memoryapi"] }


### PR DESCRIPTION
Fixes #1179

- [x] This has been discussed in issue #1179
- [x] A short description of what this does. This prevents cranelift-faerie, cranelift-object and cranelift-simplejit from enabling the basic-blocks feature.
- [ ] This PR contains test cases, if meaningful. N/A
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.