### PR TITLE
Bump version to 0.48.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-tools"
 authors = ["The Cranelift Project Developers"]
-version = "0.47.0"
+version = "0.48.0"
 description = "Binaries for testing the Cranelift libraries"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -19,20 +19,20 @@ path = "src/clif-util.rs"
 
 [dependencies]
 cfg-if = "0.1"
-cranelift-codegen = { path = "cranelift-codegen", version = "0.47.0" }
-cranelift-entity = { path = "cranelift-entity", version = "0.47.0" }
-cranelift-reader = { path = "cranelift-reader", version = "0.47.0" }
-cranelift-frontend = { path = "cranelift-frontend", version = "0.47.0" }
-cranelift-serde = { path = "cranelift-serde", version = "0.47.0", optional = true }
-cranelift-wasm = { path = "cranelift-wasm", version = "0.47.0", optional = true }
-cranelift-native = { path = "cranelift-native", version = "0.47.0" }
-cranelift-filetests = { path = "cranelift-filetests", version = "0.47.0" }
-cranelift-module = { path = "cranelift-module", version = "0.47.0" }
-cranelift-faerie = { path = "cranelift-faerie", version = "0.47.0" }
-cranelift-object = { path = "cranelift-object", version = "0.47.0" }
-cranelift-simplejit = { path = "cranelift-simplejit", version = "0.47.0" }
-cranelift-preopt = { path = "cranelift-preopt", version = "0.47.0" }
-cranelift = { path = "cranelift-umbrella", version = "0.47.0" }
+cranelift-codegen = { path = "cranelift-codegen", version = "0.48.0" }
+cranelift-entity = { path = "cranelift-entity", version = "0.48.0" }
+cranelift-reader = { path = "cranelift-reader", version = "0.48.0" }
+cranelift-frontend = { path = "cranelift-frontend", version = "0.48.0" }
+cranelift-serde = { path = "cranelift-serde", version = "0.48.0", optional = true }
+cranelift-wasm = { path = "cranelift-wasm", version = "0.48.0", optional = true }
+cranelift-native = { path = "cranelift-native", version = "0.48.0" }
+cranelift-filetests = { path = "cranelift-filetests", version = "0.48.0" }
+cranelift-module = { path = "cranelift-module", version = "0.48.0" }
+cranelift-faerie = { path = "cranelift-faerie", version = "0.48.0" }
+cranelift-object = { path = "cranelift-object", version = "0.48.0" }
+cranelift-simplejit = { path = "cranelift-simplejit", version = "0.48.0" }
+cranelift-preopt = { path = "cranelift-preopt", version = "0.48.0" }
+cranelift = { path = "cranelift-umbrella", version = "0.48.0" }
 filecheck = "0.4.0"
 clap = "2.32.0"
 serde = "1.0.8"

--- a/cranelift-bforest/Cargo.toml
+++ b/cranelift-bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.47.0"
+version = "0.48.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -12,7 +12,7 @@ keywords = ["btree", "forest", "set", "map"]
 edition = "2018"
 
 [dependencies]
-cranelift-entity = { path = "../cranelift-entity", version = "0.47.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.48.0", default-features = false }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.47.0"
+version = "0.48.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -13,9 +13,9 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen-shared = { path = "./shared", version = "0.47.0" }
-cranelift-entity = { path = "../cranelift-entity", version = "0.47.0" }
-cranelift-bforest = { path = "../cranelift-bforest", version = "0.47.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.48.0" }
+cranelift-entity = { path = "../cranelift-entity", version = "0.48.0" }
+cranelift-bforest = { path = "../cranelift-bforest", version = "0.48.0" }
 hashbrown = { version = "0.6", optional = true }
 target-lexicon = "0.8.1"
 log = { version = "0.4.6", default-features = false }
@@ -29,7 +29,7 @@ byteorder = { version = "1.3.2", default-features = false }
 # accomodated in `tests`.
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.47.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.48.0" }
 
 [features]
 default = ["std", "basic-blocks"]

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -22,7 +22,7 @@ log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 smallvec = { version = "1.0.0" }
 thiserror = "1.0.4"
-byteorder = { version = "1.3.2", default-features = false }
+byteorder = { version = "1.3.2" }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift-codegen/meta/Cargo.toml
+++ b/cranelift-codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.47.0"
+version = "0.48.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/CraneStation/cranelift"
@@ -9,8 +9,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.47.0" }
-cranelift-entity = { path = "../../cranelift-entity", version = "0.47.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.48.0" }
+cranelift-entity = { path = "../../cranelift-entity", version = "0.48.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-codegen/shared/Cargo.toml
+++ b/cranelift-codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.47.0"
+version = "0.48.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/CraneStation/cranelift"

--- a/cranelift-entity/Cargo.toml
+++ b/cranelift-entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.47.0"
+version = "0.48.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"

--- a/cranelift-faerie/Cargo.toml
+++ b/cranelift-faerie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-faerie"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with Faerie"
 repository = "https://github.com/CraneStation/cranelift"
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-module = { path = "../cranelift-module", version = "0.47.0" }
+cranelift-module = { path = "../cranelift-module", version = "0.48.0" }
 faerie = "0.11.0"
 goblin = "0.1.0"
 failure = "0.1.2"
@@ -18,7 +18,7 @@ target-lexicon = "0.8.1"
 
 [dependencies.cranelift-codegen]
 path = "../cranelift-codegen"
-version = "0.47.0"
+version = "0.48.0"
 default-features = false
 features = ["std"]
 

--- a/cranelift-filetests/Cargo.toml
+++ b/cranelift-filetests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-filetests"
 authors = ["The Cranelift Project Developers"]
-version = "0.47.0"
+version = "0.48.0"
 description = "Test driver and implementations of the filetest commands"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/en/latest/testing.html#file-tests"
@@ -10,10 +10,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.47.0", features = ["testing_hooks"] }
-cranelift-native = { path = "../cranelift-native", version = "0.47.0" }
-cranelift-reader = { path = "../cranelift-reader", version = "0.47.0" }
-cranelift-preopt = { path = "../cranelift-preopt", version = "0.47.0" }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0", features = ["testing_hooks"] }
+cranelift-native = { path = "../cranelift-native", version = "0.48.0" }
+cranelift-reader = { path = "../cranelift-reader", version = "0.48.0" }
+cranelift-preopt = { path = "../cranelift-preopt", version = "0.48.0" }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.4.0"
 log = "0.4.6"

--- a/cranelift-frontend/Cargo.toml
+++ b/cranelift-frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.47.0"
+version = "0.48.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.47.0", default-features = false }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0", default-features = false }
 target-lexicon = "0.8.1"
 log = { version = "0.4.6", default-features = false }
 hashbrown = { version = "0.6", optional = true }

--- a/cranelift-module/Cargo.toml
+++ b/cranelift-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/CraneStation/cranelift"
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.47.0", default-features = false }
-cranelift-entity = { path = "../cranelift-entity", version = "0.47.0" }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.48.0" }
 hashbrown = { version = "0.6", optional = true }
 log = { version = "0.4.6", default-features = false }
 thiserror = "1.0.4"

--- a/cranelift-native/Cargo.toml
+++ b/cranelift-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 repository = "https://github.com/CraneStation/cranelift"
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.47.0", default-features = false }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0", default-features = false }
 target-lexicon = "0.8.1"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]

--- a/cranelift-object/Cargo.toml
+++ b/cranelift-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/CraneStation/cranelift"
@@ -10,13 +10,13 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-module = { path = "../cranelift-module", version = "0.47.0" }
+cranelift-module = { path = "../cranelift-module", version = "0.48.0" }
 object = { version = "0.15.0", default-features = false, features = ["write"] }
 target-lexicon = "0.8.1"
 
 [dependencies.cranelift-codegen]
 path = "../cranelift-codegen"
-version = "0.47.0"
+version = "0.48.0"
 default-features = false
 features = ["std"]
 

--- a/cranelift-preopt/Cargo.toml
+++ b/cranelift-preopt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-preopt"
-version = "0.47.0"
+version = "0.48.0"
 description = "Support for optimizations in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -12,8 +12,8 @@ keywords = ["optimize", "compile", "compiler", "jit"]
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.47.0", default-features = false }
-cranelift-entity = { path = "../cranelift-entity", version = "0.47.0" }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.48.0" }
 # This is commented out because it doesn't build on Rust 1.25.0, which
 # cranelift currently supports.
 # rustc_apfloat = { version = "0.1.2", default-features = false }

--- a/cranelift-reader/Cargo.toml
+++ b/cranelift-reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.47.0"
+version = "0.48.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.47.0" }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0" }
 target-lexicon = "0.8.1"
 
 [badges]

--- a/cranelift-serde/Cargo.toml
+++ b/cranelift-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/CraneStation/cranelift"
@@ -18,8 +18,8 @@ clap = "2.32.0"
 serde = "1.0.8"
 serde_derive = "1.0.75"
 serde_json = "1.0.26"
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.47.0" }
-cranelift-reader = { path = "../cranelift-reader", version = "0.47.0" }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0" }
+cranelift-reader = { path = "../cranelift-reader", version = "0.48.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-simplejit/Cargo.toml
+++ b/cranelift-simplejit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-simplejit"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["The Cranelift Project Developers"]
 description = "A simple JIT library backed by Cranelift"
 repository = "https://github.com/CraneStation/cranelift"
@@ -10,8 +10,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-module = { path = "../cranelift-module", version = "0.47.0" }
-cranelift-native = { path = "../cranelift-native", version = "0.47.0" }
+cranelift-module = { path = "../cranelift-module", version = "0.48.0" }
+cranelift-native = { path = "../cranelift-native", version = "0.48.0" }
 region = "2.0.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
@@ -20,7 +20,7 @@ memmap = { version = "0.7.0", optional = true }
 
 [dependencies.cranelift-codegen]
 path = "../cranelift-codegen"
-version = "0.47.0"
+version = "0.48.0"
 default-features = false
 features = ["std"]
 
@@ -32,9 +32,9 @@ selinux-fix = ['memmap']
 default = []
 
 [dev-dependencies]
-cranelift = { path = "../cranelift-umbrella", version = "0.47.0" }
-cranelift-frontend = { path = "../cranelift-frontend", version = "0.47.0" }
-cranelift-entity = { path = "../cranelift-entity", version = "0.47.0" }
+cranelift = { path = "../cranelift-umbrella", version = "0.48.0" }
+cranelift-frontend = { path = "../cranelift-frontend", version = "0.48.0" }
+cranelift-entity = { path = "../cranelift-entity", version = "0.48.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-umbrella/Cargo.toml
+++ b/cranelift-umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.47.0"
+version = "0.48.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -12,8 +12,8 @@ keywords = ["compile", "compiler", "jit"]
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.47.0", default-features = false }
-cranelift-frontend = { path = "../cranelift-frontend", version = "0.47.0", default-features = false }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0", default-features = false }
+cranelift-frontend = { path = "../cranelift-frontend", version = "0.48.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 repository = "https://github.com/CraneStation/cranelift"
@@ -12,9 +12,9 @@ edition = "2018"
 
 [dependencies]
 wasmparser = { version = "0.39.2", default-features = false }
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.47.0", default-features = false }
-cranelift-entity = { path = "../cranelift-entity", version = "0.47.0" }
-cranelift-frontend = { path = "../cranelift-frontend", version = "0.47.0", default-features = false }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.48.0" }
+cranelift-frontend = { path = "../cranelift-frontend", version = "0.48.0", default-features = false }
 hashbrown = { version = "0.6", optional = true }
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }

--- a/publish-all.sh
+++ b/publish-all.sh
@@ -9,7 +9,7 @@ topdir=$(dirname "$0")
 cd "$topdir"
 
 # All the cranelift-* crates have the same version number
-version="0.47.0"
+version="0.48.0"
 
 # Update all of the Cargo.toml files.
 #


### PR DESCRIPTION
Also, this includes a fix for building cranelift-codegen with the `byteorder` dependency.