### PR TITLE
update everything to target-lexicon 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde = "1.0.8"
 term = "0.6.1"
 capstone = { version = "0.6.0", optional = true }
 wabt = { version = "0.9.1", optional = true }
-target-lexicon = "0.8.1"
+target-lexicon = "0.9"
 pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.2"
 indicatif = "0.13.0"

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -17,7 +17,7 @@ cranelift-codegen-shared = { path = "./shared", version = "0.48.0" }
 cranelift-entity = { path = "../cranelift-entity", version = "0.48.0" }
 cranelift-bforest = { path = "../cranelift-bforest", version = "0.48.0" }
 hashbrown = { version = "0.6", optional = true }
-target-lexicon = "0.8.1"
+target-lexicon = "0.9"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 smallvec = { version = "1.0.0" }

--- a/cranelift-faerie/Cargo.toml
+++ b/cranelift-faerie/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2018"
 
 [dependencies]
 cranelift-module = { path = "../cranelift-module", version = "0.48.0" }
-faerie = "0.11.0"
+faerie = "0.11.1"
 goblin = "0.1.0"
 failure = "0.1.2"
-target-lexicon = "0.8.1"
+target-lexicon = "0.9"
 
 [dependencies.cranelift-codegen]
 path = "../cranelift-codegen"

--- a/cranelift-frontend/Cargo.toml
+++ b/cranelift-frontend/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0", default-features = false }
-target-lexicon = "0.8.1"
+target-lexicon = "0.9"
 log = { version = "0.4.6", default-features = false }
 hashbrown = { version = "0.6", optional = true }
 smallvec = { version = "1.0.0" }

--- a/cranelift-native/Cargo.toml
+++ b/cranelift-native/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0", default-features = false }
-target-lexicon = "0.8.1"
+target-lexicon = "0.9"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 raw-cpuid = "7.0.3"

--- a/cranelift-object/Cargo.toml
+++ b/cranelift-object/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dependencies]
 cranelift-module = { path = "../cranelift-module", version = "0.48.0" }
-object = { version = "0.15.0", default-features = false, features = ["write"] }
-target-lexicon = "0.8.1"
+object = { git = "https://github.com/gimli-rs/object", rev = "cba3ed4932e4c594c5eab4f5ef6c51838f4a5056", default-features = false, features = ["write"] }
+target-lexicon = "0.9"
 
 [dependencies.cranelift-codegen]
 path = "../cranelift-codegen"

--- a/cranelift-reader/Cargo.toml
+++ b/cranelift-reader/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.48.0" }
-target-lexicon = "0.8.1"
+target-lexicon = "0.9"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-simplejit/Cargo.toml
+++ b/cranelift-simplejit/Cargo.toml
@@ -15,7 +15,7 @@ cranelift-native = { path = "../cranelift-native", version = "0.48.0" }
 region = "2.0.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
-target-lexicon = "0.8.1"
+target-lexicon = "0.9"
 memmap = { version = "0.7.0", optional = true }
 
 [dependencies.cranelift-codegen]

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0.4"
 
 [dev-dependencies]
 wabt = "0.9.1"
-target-lexicon = "0.8.1"
+target-lexicon = "0.9"
 
 [features]
 default = ["std", "basic-blocks"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 cranelift-codegen = { path = "../cranelift-codegen" }
 cranelift-wasm = { path = "../cranelift-wasm" }
 cranelift-reader = { path = "../cranelift-reader" }
-target-lexicon = "0.8.1"
+target-lexicon = "0.9"
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
Cont'd from #1205.

For some context, see [this comment](https://github.com/CraneStation/cranelift/pull/1205#issuecomment-550266079). We need to update a bit quicker than forecast because the `faerie` update was published as a patch version, so Cargo picks it up when collecting dependencies, and this results in conflicting versions of `target-lexicon` used throughout the code.