### PR TITLE
Pass Encoding to compute_size() for runtime Encoding inspection. #1156

### DIFF
--- a/cranelift-codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift-codegen/src/isa/x86/enc_tables.rs
@@ -10,7 +10,7 @@ use crate::ir::{self, Function, Inst, InstBuilder};
 use crate::isa::constraints::*;
 use crate::isa::enc_tables::*;
 use crate::isa::encoding::base_size;
-use crate::isa::encoding::RecipeSizing;
+use crate::isa::encoding::{Encoding, RecipeSizing};
 use crate::isa::RegUnit;
 use crate::isa::{self, TargetIsa};
 use crate::predicates;
@@ -46,6 +46,7 @@ fn additional_size_if(
 
 fn size_plus_maybe_offset_for_in_reg_0(
     sizing: &RecipeSizing,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
@@ -54,6 +55,7 @@ fn size_plus_maybe_offset_for_in_reg_0(
 }
 fn size_plus_maybe_offset_for_in_reg_1(
     sizing: &RecipeSizing,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
@@ -62,6 +64,7 @@ fn size_plus_maybe_offset_for_in_reg_1(
 }
 fn size_plus_maybe_sib_for_in_reg_0(
     sizing: &RecipeSizing,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
@@ -70,6 +73,7 @@ fn size_plus_maybe_sib_for_in_reg_0(
 }
 fn size_plus_maybe_sib_for_in_reg_1(
     sizing: &RecipeSizing,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
@@ -78,6 +82,7 @@ fn size_plus_maybe_sib_for_in_reg_1(
 }
 fn size_plus_maybe_sib_or_offset_for_in_reg_0(
     sizing: &RecipeSizing,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
@@ -86,6 +91,7 @@ fn size_plus_maybe_sib_or_offset_for_in_reg_0(
 }
 fn size_plus_maybe_sib_or_offset_for_in_reg_1(
     sizing: &RecipeSizing,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,


### PR DESCRIPTION
In some cases, compute_size() is used to choose between various different Encodings before one has been assigned to an instruction. For x86, the REX.W bit is stored in the Encoding. To share recipes between REX/non-REX, that bit must be inspected by compute_size().

This is a simple change related to https://github.com/CraneStation/cranelift/pull/1173 and https://github.com/CraneStation/cranelift/issues/1156. The runtime REX code needs to be able to inspect the hardcoded REX.W bit, because it's not derivable directly from type information (and anyway, that's silly).

Asking review from @abrown because @bnjbvr has a lot of reviews already :)