### PR TITLE
Fix build errors in x86 unwind info when building no_std.

### DIFF
--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -22,7 +22,7 @@ log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 smallvec = { version = "1.0.0" }
 thiserror = "1.0.4"
-byteorder = { version = "1.3.2" }
+byteorder = { version = "1.3.2", default-features = false }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -836,6 +836,6 @@ pub fn emit_unwind_info(func: &ir::Function, isa: &dyn TargetIsa, mem: &mut Vec<
     // Assumption: RBP is being used as the frame pointer
     // In the future, Windows fastcall codegen should usually omit the frame pointer
     if let Some(info) = UnwindInfo::try_from_func(func, isa, Some(RU::rbp.into())) {
-        info.emit(mem).expect("failed to emit unwind information");
+        info.emit(mem);
     }
 }


### PR DESCRIPTION
This PR fixes the build errors in the unwind info implementation for
the x86 ABI by changing `byteorder` to build `no_std`.

This copies two simple functions from the `WriteBytesExt` trait so that
we can easily write to a `Vec<u8>` with a particular endianness.

Fixes #1203.

cc @sunfishcode for review.